### PR TITLE
Add invite-only mode restrictions to auth pages

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -36,6 +36,9 @@ function LoginForm() {
   // Get success message from registration redirect
   const registered = searchParams.get("registered") === "true";
 
+  // Fetch signup configuration to determine if signup link should be shown
+  const { data: signupConfigData } = trpc.auth.signupConfig.useQuery();
+
   // Get OAuth error from callback redirect and map to user-friendly message
   const oauthError = searchParams.get("error");
   const oauthErrorMessage = useMemo(() => {
@@ -175,15 +178,17 @@ function LoginForm() {
         </Button>
       </form>
 
-      <p className="mt-6 text-center text-sm text-zinc-600 dark:text-zinc-400">
-        Don&apos;t have an account?{" "}
-        <Link
-          href="/register"
-          className="font-medium text-zinc-900 hover:underline dark:text-zinc-50"
-        >
-          Create one
-        </Link>
-      </p>
+      {!signupConfigData?.requiresInvite && (
+        <p className="mt-6 text-center text-sm text-zinc-600 dark:text-zinc-400">
+          Don&apos;t have an account?{" "}
+          <Link
+            href="/register"
+            className="font-medium text-zinc-900 hover:underline dark:text-zinc-50"
+          >
+            Create one
+          </Link>
+        </p>
+      )}
     </div>
   );
 }

--- a/src/server/trpc/routers/auth.ts
+++ b/src/server/trpc/routers/auth.ts
@@ -890,6 +890,33 @@ export const authRouter = createTRPCRouter({
     }),
 
   /**
+   * Get signup configuration.
+   *
+   * Returns whether signups require an invite token.
+   * UI uses this to show/hide signup links and display appropriate messages.
+   */
+  signupConfig: publicProcedure
+    .meta({
+      openapi: {
+        method: "GET",
+        path: "/v1/auth/signup-config",
+        tags: ["Auth"],
+        summary: "Get signup configuration",
+      },
+    })
+    .input(z.object({}).optional())
+    .output(
+      z.object({
+        requiresInvite: z.boolean(),
+      })
+    )
+    .query(() => {
+      return {
+        requiresInvite: !signupConfig.allowAllSignups,
+      };
+    }),
+
+  /**
    * Get the current authenticated user.
    *
    * Returns the user profile for the currently authenticated session.


### PR DESCRIPTION
When in invite-only mode (ALLOW_ALL_SIGNUPS=false):
- Hide signup link on login page
- Show error message on signup page when no invite token present
- Allow signup with valid invite token via ?invite=token parameter

Added auth.signupConfig endpoint to expose invite requirement to client.
This enables conditional UI rendering based on signup configuration.