### PR TITLE
Add sort toggle for entry lists (newest/oldest)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1132,15 +1132,22 @@ const markRead = trpc.entries.markRead.useMutation({
 
 ### View Preferences
 
-Users can toggle between showing all entries or only unread entries. This preference is stored in localStorage and synced via URL query parameters for shareable links.
+Users can customize their reading experience with persistent view preferences stored in localStorage.
 
 **Show/Hide Read Items:**
 
 - Toggle in entry list header (eye icon or "Show read" checkbox)
 - Keyboard shortcut: `u` to toggle unread-only mode
 - Preference persisted in localStorage per-view (all, starred, feed, tag)
-- URL reflects current state: `/all?unread=true` or `/all?unread=false`
 - When hiding read items, newly-read entries fade out after a brief delay
+
+**Sort Order (Newest/Oldest):**
+
+- Toggle between newest-first and oldest-first sorting
+- Sort icon button in entry list header
+- Preference persisted in localStorage per-view
+- Default: newest first (reverse chronological order)
+- Uses UUIDv7 time-ordering for efficient sorting
 
 ```typescript
 // View preference hook
@@ -1150,13 +1157,24 @@ function useViewPreferences(viewKey: string) {
     true // default to unread only
   );
 
-  return { showUnreadOnly, setShowUnreadOnly };
+  const [sortOrder, setSortOrder] = useLocalStorage(
+    `view:${viewKey}:sortOrder`,
+    "newest" // default to newest first
+  );
+
+  return {
+    showUnreadOnly,
+    setShowUnreadOnly,
+    sortOrder,
+    setSortOrder,
+  };
 }
 
-// Query uses preference
+// Query uses preferences
 const { data: entries } = trpc.entries.list.useQuery({
   feedId,
   unreadOnly: showUnreadOnly,
+  sortOrder,
 });
 ```
 

--- a/src/app/(app)/all/page.tsx
+++ b/src/app/(app)/all/page.tsx
@@ -12,6 +12,7 @@ import {
   EntryList,
   EntryContent,
   UnreadToggle,
+  SortToggle,
   type EntryListEntryData,
 } from "@/components/entries";
 import { useKeyboardShortcutsContext } from "@/components/keyboard";
@@ -23,7 +24,7 @@ export default function AllEntriesPage() {
   const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
 
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
-  const { showUnreadOnly, toggleShowUnreadOnly } = useViewPreferences("all");
+  const { showUnreadOnly, toggleShowUnreadOnly, sortOrder, toggleSortOrder } = useViewPreferences("all");
   const utils = trpc.useUtils();
 
   // Mutations for keyboard actions
@@ -95,11 +96,14 @@ export default function AllEntriesPage() {
     <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
       <div className="mb-4 flex items-center justify-between sm:mb-6">
         <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">All Items</h1>
-        <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+        <div className="flex gap-2">
+          <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
+          <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+        </div>
       </div>
 
       <EntryList
-        filters={{ unreadOnly: showUnreadOnly }}
+        filters={{ unreadOnly: showUnreadOnly, sortOrder }}
         onEntryClick={handleEntryClick}
         selectedEntryId={selectedEntryId}
         onEntriesLoaded={handleEntriesLoaded}

--- a/src/app/(app)/feed/[feedId]/page.tsx
+++ b/src/app/(app)/feed/[feedId]/page.tsx
@@ -14,6 +14,7 @@ import {
   EntryList,
   EntryContent,
   UnreadToggle,
+  SortToggle,
   type EntryListEntryData,
 } from "@/components/entries";
 import { useKeyboardShortcutsContext } from "@/components/keyboard";
@@ -84,7 +85,7 @@ export default function SingleFeedPage() {
   const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
 
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
-  const { showUnreadOnly, toggleShowUnreadOnly } = useViewPreferences("feed", feedId);
+  const { showUnreadOnly, toggleShowUnreadOnly, sortOrder, toggleSortOrder } = useViewPreferences("feed", feedId);
   const utils = trpc.useUtils();
 
   // Mutations for keyboard actions
@@ -205,6 +206,7 @@ export default function SingleFeedPage() {
                 {unreadCount} unread
               </span>
             )}
+            <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
             <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
           </div>
         </div>
@@ -223,7 +225,7 @@ export default function SingleFeedPage() {
       </div>
 
       <EntryList
-        filters={{ feedId, unreadOnly: showUnreadOnly }}
+        filters={{ feedId, unreadOnly: showUnreadOnly, sortOrder }}
         onEntryClick={handleEntryClick}
         selectedEntryId={selectedEntryId}
         onEntriesLoaded={handleEntriesLoaded}

--- a/src/app/(app)/starred/page.tsx
+++ b/src/app/(app)/starred/page.tsx
@@ -11,6 +11,7 @@ import {
   EntryList,
   EntryContent,
   UnreadToggle,
+  SortToggle,
   type EntryListEntryData,
 } from "@/components/entries";
 import { useKeyboardShortcutsContext } from "@/components/keyboard";
@@ -22,7 +23,7 @@ export default function StarredEntriesPage() {
   const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
 
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
-  const { showUnreadOnly, toggleShowUnreadOnly } = useViewPreferences("starred");
+  const { showUnreadOnly, toggleShowUnreadOnly, sortOrder, toggleSortOrder } = useViewPreferences("starred");
   const utils = trpc.useUtils();
 
   // Mutations for keyboard actions
@@ -94,11 +95,14 @@ export default function StarredEntriesPage() {
     <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
       <div className="mb-4 flex items-center justify-between sm:mb-6">
         <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">Starred</h1>
-        <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+        <div className="flex gap-2">
+          <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
+          <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+        </div>
       </div>
 
       <EntryList
-        filters={{ starredOnly: true, unreadOnly: showUnreadOnly }}
+        filters={{ starredOnly: true, unreadOnly: showUnreadOnly, sortOrder }}
         onEntryClick={handleEntryClick}
         selectedEntryId={selectedEntryId}
         onEntriesLoaded={handleEntriesLoaded}

--- a/src/app/(app)/tag/[tagId]/page.tsx
+++ b/src/app/(app)/tag/[tagId]/page.tsx
@@ -14,6 +14,7 @@ import {
   EntryList,
   EntryContent,
   UnreadToggle,
+  SortToggle,
   type EntryListEntryData,
 } from "@/components/entries";
 import { useKeyboardShortcutsContext } from "@/components/keyboard";
@@ -84,7 +85,7 @@ export default function TagEntriesPage() {
   const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
 
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
-  const { showUnreadOnly, toggleShowUnreadOnly } = useViewPreferences("tag", tagId);
+  const { showUnreadOnly, toggleShowUnreadOnly, sortOrder, toggleSortOrder } = useViewPreferences("tag", tagId);
   const utils = trpc.useUtils();
 
   // Mutations for keyboard actions
@@ -207,12 +208,15 @@ export default function TagEntriesPage() {
               </span>
             )}
           </div>
-          <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+          <div className="flex gap-2">
+            <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
+            <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+          </div>
         </div>
       </div>
 
       <EntryList
-        filters={{ tagId, unreadOnly: showUnreadOnly }}
+        filters={{ tagId, unreadOnly: showUnreadOnly, sortOrder }}
         onEntryClick={handleEntryClick}
         selectedEntryId={selectedEntryId}
         onEntriesLoaded={handleEntriesLoaded}

--- a/src/components/entries/EntryList.tsx
+++ b/src/components/entries/EntryList.tsx
@@ -35,6 +35,11 @@ export interface EntryListFilters {
    * Show only starred entries.
    */
   starredOnly?: boolean;
+
+  /**
+   * Sort order: "newest" (default) or "oldest".
+   */
+  sortOrder?: "newest" | "oldest";
 }
 
 /**
@@ -202,6 +207,7 @@ export function EntryList({
       tagId: filters.tagId,
       unreadOnly: filters.unreadOnly,
       starredOnly: filters.starredOnly,
+      sortOrder: filters.sortOrder,
       limit: pageSize,
     },
     {

--- a/src/components/entries/SortToggle.tsx
+++ b/src/components/entries/SortToggle.tsx
@@ -1,0 +1,103 @@
+/**
+ * SortToggle Component
+ *
+ * A toggle button for switching between newest-first and oldest-first sorting.
+ * Displays a sort icon that changes based on the current state.
+ */
+
+"use client";
+
+import { type MouseEvent } from "react";
+
+interface SortToggleProps {
+  /**
+   * Current sort order: "newest" or "oldest".
+   */
+  sortOrder: "newest" | "oldest";
+
+  /**
+   * Callback when the toggle is clicked.
+   */
+  onToggle: () => void;
+
+  /**
+   * Optional class name for additional styling.
+   */
+  className?: string;
+}
+
+/**
+ * Sort descending icon (newest first) - bars from tall to short.
+ */
+function SortDescendingIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 4.5h14.25M3 9h9.75M3 13.5h9.75m4.5-4.5v12m0 0l-3.75-3.75M17.25 21L21 17.25"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Sort ascending icon (oldest first) - bars from short to tall.
+ */
+function SortAscendingIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 4.5h14.25M3 9h9.75M3 13.5h5.25m5.25-.75L17.25 9m0 0L21 12.75M17.25 9v12"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Toggle button for switching between newest and oldest sorting.
+ *
+ * When `sortOrder` is "newest" (default), shows descending icon.
+ * When `sortOrder` is "oldest", shows ascending icon.
+ */
+export function SortToggle({ sortOrder, onToggle, className = "" }: SortToggleProps) {
+  const handleClick = (e: MouseEvent) => {
+    e.preventDefault();
+    onToggle();
+  };
+
+  const label = sortOrder === "newest" ? "Sort oldest first" : "Sort newest first";
+  const Icon = sortOrder === "newest" ? SortDescendingIcon : SortAscendingIcon;
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400 ${className}`}
+      title={label}
+      aria-label={label}
+      aria-pressed={sortOrder === "oldest"}
+    >
+      <Icon className="h-5 w-5" />
+      <span className="ml-1.5 hidden text-sm sm:inline">
+        {sortOrder === "newest" ? "Newest" : "Oldest"}
+      </span>
+    </button>
+  );
+}

--- a/src/components/entries/index.ts
+++ b/src/components/entries/index.ts
@@ -9,3 +9,4 @@ export { EntryListSkeleton } from "./EntryListSkeleton";
 export { EntryList, type EntryListFilters, type EntryListEntryData } from "./EntryList";
 export { EntryContent } from "./EntryContent";
 export { UnreadToggle } from "./UnreadToggle";
+export { SortToggle } from "./SortToggle";


### PR DESCRIPTION
Add a UI toggle to switch between newest-first and oldest-first sorting for entry lists across all views (All, Starred, Feed, Tag). The sort preference defaults to newest and is persisted per-view in localStorage.

Backend changes:
- Add sortOrder parameter to entries.list tRPC endpoint
- Support "newest" (default) and "oldest" sort orders
- Use appropriate cursor comparison (lt/gt) and orderBy direction

Frontend changes:
- Create SortToggle component with sort icons
- Update useViewPreferences hook to include sortOrder
- Add sort toggle to all entry list pages
- Update EntryList component to pass sortOrder to API

Documentation:
- Update DESIGN.md View Preferences section