### PR TITLE
Make LLM normalization optional and configurable

### DIFF
--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -291,6 +291,7 @@ function EntryContentBody({
     type: "entry",
     title: displayTitle,
     feedTitle: displayFeed,
+    content: contentToDisplay,
   });
 
   const { highlightedParagraphIds } = useNarrationHighlight({

--- a/src/components/narration/NarrationControls.tsx
+++ b/src/components/narration/NarrationControls.tsx
@@ -42,6 +42,11 @@ export interface NarrationControlsProps {
   /** Optional artwork URL for Media Session */
   artwork?: string;
   /**
+   * Optional HTML content for client-side processing.
+   * Used in uncontrolled mode when LLM normalization is disabled.
+   */
+  content?: string | null;
+  /**
    * Optional external narration state for controlled mode.
    * When provided, the component won't create its own useNarration hook.
    * This is used when the parent needs access to narration state (e.g., for highlighting).
@@ -154,6 +159,7 @@ export function NarrationControls({
   title,
   feedTitle,
   artwork,
+  content,
   narration,
 }: NarrationControlsProps) {
   // Don't render if narration is not supported
@@ -168,6 +174,7 @@ export function NarrationControls({
       title={title}
       feedTitle={feedTitle}
       artwork={artwork}
+      content={content}
       narration={narration}
     />
   );
@@ -183,6 +190,7 @@ function NarrationControlsInner({
   title,
   feedTitle,
   artwork,
+  content,
   narration: externalNarration,
 }: NarrationControlsProps) {
   // Use internal narration hook only when external state is not provided
@@ -192,6 +200,7 @@ function NarrationControlsInner({
     title,
     feedTitle,
     artwork,
+    content,
   });
 
   // Use external narration if provided, otherwise use internal

--- a/src/components/narration/NarrationSettings.tsx
+++ b/src/components/narration/NarrationSettings.tsx
@@ -421,6 +421,41 @@ export function NarrationSettings() {
               </div>
             </div>
 
+            {/* Processing Settings */}
+            <div className="space-y-4">
+              <h3 className="text-sm font-medium text-zinc-900 dark:text-zinc-50">Processing</h3>
+
+              {/* LLM Normalization Toggle */}
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-zinc-700 dark:text-zinc-300">Use AI text processing</p>
+                  <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                    Improves narration quality by expanding abbreviations and formatting content
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={settings.useLlmNormalization}
+                  onClick={() =>
+                    setSettings({ ...settings, useLlmNormalization: !settings.useLlmNormalization })
+                  }
+                  className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
+                    settings.useLlmNormalization
+                      ? "bg-zinc-900 dark:bg-zinc-50"
+                      : "bg-zinc-200 dark:bg-zinc-700"
+                  }`}
+                >
+                  <span
+                    aria-hidden="true"
+                    className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
+                      settings.useLlmNormalization ? "translate-x-5" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              </div>
+            </div>
+
             {/* Highlighting Settings */}
             <div className="space-y-4">
               <h3 className="text-sm font-medium text-zinc-900 dark:text-zinc-50">Highlighting</h3>

--- a/src/components/saved/SavedArticleContent.tsx
+++ b/src/components/saved/SavedArticleContent.tsx
@@ -262,6 +262,7 @@ function SavedArticleContentBody({
     type: "saved",
     title: displayTitle,
     feedTitle: displaySite,
+    content: contentToDisplay,
   });
 
   const { highlightedParagraphIds } = useNarrationHighlight({

--- a/src/lib/narration/html-to-plain-text.ts
+++ b/src/lib/narration/html-to-plain-text.ts
@@ -1,0 +1,47 @@
+/**
+ * Client-safe HTML to Plain Text Converter
+ *
+ * A simple regex-based converter that can run in both browser and server environments.
+ * For narration without LLM preprocessing.
+ *
+ * @module narration/html-to-plain-text
+ */
+
+/**
+ * Converts HTML to plain text for narration.
+ * Uses regex-based conversion that works in any JavaScript environment.
+ *
+ * @param html - HTML content to convert
+ * @returns Plain text with paragraph breaks
+ *
+ * @example
+ * const text = htmlToPlainText('<p>Hello</p><p>World</p>');
+ * // Returns "Hello\n\nWorld"
+ */
+export function htmlToPlainText(html: string): string {
+  return (
+    html
+      // Add paragraph breaks before block elements
+      .replace(/<(p|div|br|h[1-6]|li|tr|blockquote|pre)[^>]*>/gi, "\n\n")
+      // Remove all HTML tags
+      .replace(/<[^>]+>/g, "")
+      // Decode common HTML entities
+      .replace(/&nbsp;/g, " ")
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&apos;/g, "'")
+      // Normalize whitespace: collapse multiple spaces to single space
+      .replace(/ +/g, " ")
+      // Normalize paragraph breaks: collapse multiple newlines to double newline
+      .replace(/\n{3,}/g, "\n\n")
+      // Trim whitespace from each line
+      .split("\n")
+      .map((line) => line.trim())
+      .join("\n")
+      // Final trim
+      .trim()
+  );
+}

--- a/src/lib/narration/settings.ts
+++ b/src/lib/narration/settings.ts
@@ -64,6 +64,15 @@ export interface NarrationSettings {
    * Default: true
    */
   autoScrollEnabled: boolean;
+
+  /**
+   * Whether to use LLM preprocessing for narration.
+   * When enabled, content is processed by an LLM to improve TTS quality
+   * (expanding abbreviations, formatting URLs, etc.).
+   * When disabled, uses simple HTML-to-text conversion.
+   * Default: true (if available on server)
+   */
+  useLlmNormalization: boolean;
 }
 
 /**
@@ -77,6 +86,7 @@ export const DEFAULT_NARRATION_SETTINGS: NarrationSettings = {
   pitch: 1.0,
   highlightEnabled: true,
   autoScrollEnabled: true,
+  useLlmNormalization: true,
 };
 
 /**
@@ -152,6 +162,10 @@ export function loadNarrationSettings(): NarrationSettings {
         typeof parsed.autoScrollEnabled === "boolean"
           ? parsed.autoScrollEnabled
           : DEFAULT_NARRATION_SETTINGS.autoScrollEnabled,
+      useLlmNormalization:
+        typeof parsed.useLlmNormalization === "boolean"
+          ? parsed.useLlmNormalization
+          : DEFAULT_NARRATION_SETTINGS.useLlmNormalization,
     };
   } catch {
     // If parsing fails, return defaults

--- a/tests/unit/narration-settings.test.ts
+++ b/tests/unit/narration-settings.test.ts
@@ -267,6 +267,7 @@ describe("saveNarrationSettings", () => {
       pitch: 0.8,
       highlightEnabled: false,
       autoScrollEnabled: true,
+      useLlmNormalization: true,
     };
 
     saveNarrationSettings(settings);
@@ -286,6 +287,7 @@ describe("saveNarrationSettings", () => {
       pitch: 0.9,
       highlightEnabled: true,
       autoScrollEnabled: false,
+      useLlmNormalization: false,
     };
 
     saveNarrationSettings(originalSettings);


### PR DESCRIPTION
Allow users to disable LLM-based text preprocessing for narration. When disabled, narration uses simple HTML-to-text conversion client-side instead of calling the server with Groq API.

Key changes:
- Add useLlmNormalization setting to NarrationSettings (default: true)
- Create client-side htmlToPlainText utility for non-LLM conversion
- Update useNarration hook to skip server call when LLM disabled
- Add "Use AI text processing" toggle to settings UI
- Pass content to narration hook for client-side processing

This reduces server load and latency when users prefer simpler text processing without LLM enhancements.