### PR TITLE
Fix SQLite foreign key error on Android login

### DIFF
--- a/android/app/src/main/java/com/lionreader/data/db/LionReaderDatabase.kt
+++ b/android/app/src/main/java/com/lionreader/data/db/LionReaderDatabase.kt
@@ -28,6 +28,7 @@ import com.lionreader.data.db.entities.TagEntity
  *
  * Database version history:
  * - Version 1: Initial schema with all core entities
+ * - Version 2: Remove foreign key from entries.feedId to feeds.id
  */
 @Database(
     entities = [
@@ -75,7 +76,7 @@ abstract class LionReaderDatabase : RoomDatabase() {
          *
          * Increment when schema changes require a migration.
          */
-        const val VERSION = 1
+        const val VERSION = 2
 
         /**
          * Database file name.

--- a/android/app/src/main/java/com/lionreader/data/db/entities/EntryEntity.kt
+++ b/android/app/src/main/java/com/lionreader/data/db/entities/EntryEntity.kt
@@ -1,7 +1,6 @@
 package com.lionreader.data.db.entities
 
 import androidx.room.Entity
-import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
@@ -10,17 +9,13 @@ import androidx.room.PrimaryKey
  *
  * Contains all content and metadata for a single entry from a feed.
  * Both original and cleaned content versions are stored for offline reading.
+ *
+ * Note: feedId is not a foreign key because entries can exist for feeds
+ * the user is no longer subscribed to (e.g., starred entries from old
+ * subscriptions). Feed metadata is denormalized in feedTitle.
  */
 @Entity(
     tableName = "entries",
-    foreignKeys = [
-        ForeignKey(
-            entity = FeedEntity::class,
-            parentColumns = ["id"],
-            childColumns = ["feedId"],
-            onDelete = ForeignKey.CASCADE,
-        ),
-    ],
     indices = [
         Index("feedId"),
         Index("fetchedAt"),


### PR DESCRIPTION
Entries can exist for feeds the user is no longer subscribed to (e.g., starred entries from old subscriptions). This was causing SQLite foreign key errors on Android when syncing entries that referenced feeds not in the local database.

The feedId is kept as a regular column with an index for filtering, and feed metadata is already denormalized in feedTitle/feedUrl.