### PR TITLE
Add credits footer to login, register, and settings pages

### DIFF
--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -169,6 +169,37 @@ function SettingsContent() {
 
       {/* Keyboard Shortcuts Section */}
       <KeyboardShortcutsSettings />
+
+      {/* About Section */}
+      <section>
+        <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-50">About</h2>
+        <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            Lion Reader was created by{" "}
+            <a
+              href="https://www.brendanlong.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-zinc-900 hover:underline dark:text-zinc-50"
+            >
+              Brendan Long
+            </a>{" "}
+            and Claude.
+          </p>
+          <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+            View the source code on{" "}
+            <a
+              href="https://github.com/brendanlong/lion-reader"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-zinc-900 hover:underline dark:text-zinc-50"
+            >
+              GitHub
+            </a>
+            .
+          </p>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -189,6 +189,29 @@ function LoginForm() {
           </Link>
         </p>
       )}
+
+      <footer className="mt-8 border-t border-zinc-200 pt-6 dark:border-zinc-800">
+        <p className="text-center text-xs text-zinc-500 dark:text-zinc-500">
+          Created by{" "}
+          <a
+            href="https://www.brendanlong.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-zinc-900 hover:underline dark:hover:text-zinc-300"
+          >
+            Brendan Long
+          </a>{" "}
+          and Claude •{" "}
+          <a
+            href="https://github.com/brendanlong/lion-reader"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-zinc-900 hover:underline dark:hover:text-zinc-300"
+          >
+            View on GitHub
+          </a>
+        </p>
+      </footer>
     </div>
   );
 }

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -142,6 +142,29 @@ function RegisterForm() {
             Sign in
           </Link>
         </p>
+
+        <footer className="mt-8 border-t border-zinc-200 pt-6 dark:border-zinc-800">
+          <p className="text-center text-xs text-zinc-500 dark:text-zinc-500">
+            Created by{" "}
+            <a
+              href="https://www.brendanlong.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-zinc-900 hover:underline dark:hover:text-zinc-300"
+            >
+              Brendan Long
+            </a>{" "}
+            and Claude •{" "}
+            <a
+              href="https://github.com/brendanlong/lion-reader"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-zinc-900 hover:underline dark:hover:text-zinc-300"
+            >
+              View on GitHub
+            </a>
+          </p>
+        </footer>
       </div>
     );
   }
@@ -230,6 +253,29 @@ function RegisterForm() {
           Sign in
         </Link>
       </p>
+
+      <footer className="mt-8 border-t border-zinc-200 pt-6 dark:border-zinc-800">
+        <p className="text-center text-xs text-zinc-500 dark:text-zinc-500">
+          Created by{" "}
+          <a
+            href="https://www.brendanlong.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-zinc-900 hover:underline dark:hover:text-zinc-300"
+          >
+            Brendan Long
+          </a>{" "}
+          and Claude •{" "}
+          <a
+            href="https://github.com/brendanlong/lion-reader"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-zinc-900 hover:underline dark:hover:text-zinc-300"
+          >
+            View on GitHub
+          </a>
+        </p>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
- Added 'About' section to settings page with credits
- Added footer to login and register pages (including invite-required view)
- Credits mention Brendan Long (brendanlong.com) and Claude
- Includes link to GitHub repository