### PR TITLE
Auto-update views when unsubscribing from feeds

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -40,6 +40,7 @@ export function Sidebar({ onClose }: SidebarProps) {
   const unsubscribeMutation = trpc.subscriptions.delete.useMutation({
     onSuccess: () => {
       utils.subscriptions.list.invalidate();
+      utils.entries.list.invalidate();
       setUnsubscribeTarget(null);
     },
     onError: () => {


### PR DESCRIPTION
When unsubscribing from a feed, the entries.list cache wasn't being invalidated, causing "All Items" and tag views to show stale data until a page refresh. Now both subscriptions.list and entries.list caches are invalidated on unsubscribe.