### PR TITLE
Fix unread count display across feeds and tags

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -35,6 +35,7 @@ export function Sidebar({ onClose }: SidebarProps) {
   const subscriptionsQuery = trpc.subscriptions.list.useQuery();
   const tagsQuery = trpc.tags.list.useQuery();
   const savedCountQuery = trpc.saved.count.useQuery({});
+  const starredCountQuery = trpc.entries.starredCount.useQuery({});
   const utils = trpc.useUtils();
 
   const unsubscribeMutation = trpc.subscriptions.delete.useMutation({
@@ -100,13 +101,18 @@ export function Sidebar({ onClose }: SidebarProps) {
           <Link
             href="/starred"
             onClick={handleClose}
-            className={`flex min-h-[44px] items-center rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+            className={`flex min-h-[44px] items-center justify-between rounded-md px-3 py-2 text-sm font-medium transition-colors ${
               isActiveLink("/starred")
                 ? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
                 : "text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
             }`}
           >
-            Starred
+            <span>Starred</span>
+            {starredCountQuery.data && starredCountQuery.data.unread > 0 && (
+              <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-400">
+                ({starredCountQuery.data.unread})
+              </span>
+            )}
           </Link>
 
           <Link
@@ -305,9 +311,9 @@ export function Sidebar({ onClose }: SidebarProps) {
                           aria-hidden="true"
                         />
                         <span className="truncate">{tag.name}</span>
-                        {tag.feedCount > 0 && (
+                        {tag.unreadCount > 0 && (
                           <span className="ml-auto shrink-0 text-xs text-zinc-500 dark:text-zinc-400">
-                            ({tag.feedCount})
+                            ({tag.unreadCount})
                           </span>
                         )}
                       </Link>

--- a/src/lib/hooks/useEntryMutations.ts
+++ b/src/lib/hooks/useEntryMutations.ts
@@ -177,6 +177,10 @@ export function useEntryMutations(options?: UseEntryMutationsOptions): UseEntryM
     onSettled: () => {
       // Invalidate subscription counts as they need server data
       utils.subscriptions.list.invalidate();
+      // Invalidate tag unread counts
+      utils.tags.list.invalidate();
+      // Invalidate starred count as it may have changed
+      utils.entries.starredCount.invalidate();
     },
   });
 
@@ -220,6 +224,8 @@ export function useEntryMutations(options?: UseEntryMutationsOptions): UseEntryM
       utils.entries.list.invalidate({ starredOnly: true });
       // Invalidate subscriptions to update unread counts
       utils.subscriptions.list.invalidate();
+      // Invalidate starred count
+      utils.entries.starredCount.invalidate();
     },
   });
 
@@ -263,6 +269,8 @@ export function useEntryMutations(options?: UseEntryMutationsOptions): UseEntryM
       utils.entries.list.invalidate({ starredOnly: true });
       // Invalidate subscriptions to update unread counts
       utils.subscriptions.list.invalidate();
+      // Invalidate starred count
+      utils.entries.starredCount.invalidate();
     },
   });
 


### PR DESCRIPTION
- Add entries.starredCount procedure to provide unread count for starred
- Add unreadCount field to tags.list to show unread entries per tag
- Update Sidebar to display starred unread count
- Update Sidebar to show tag unread count instead of feed count
- Add cache invalidation for starred count and tags on mutations