### PR TITLE
Fix narration syncing with non-paragraph elements

### DIFF
--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -312,6 +312,19 @@ function EntryContentBody({
   const sanitizedContent = useMemo(() => {
     if (!contentToDisplay) return null;
 
+    // If we have processed HTML from client-side narration, use it directly
+    // This ensures the data-para-id attributes exactly match the paragraph mapping
+    if (shouldProcessForHighlighting && narration.processedHtml) {
+      // The processed HTML already has data-para-id attributes added during
+      // htmlToClientNarration, so we just need to sanitize it
+      return DOMPurify.sanitize(narration.processedHtml, {
+        ADD_TAGS: ["iframe"],
+        ADD_ATTR: ["target", "allowfullscreen", "frameborder", "data-para-id"],
+        FORBID_TAGS: ["style", "script"],
+        FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover"],
+      });
+    }
+
     const sanitized = DOMPurify.sanitize(contentToDisplay, {
       // Allow safe tags and attributes, plus data-para-id for highlighting
       ADD_TAGS: ["iframe"],
@@ -320,13 +333,14 @@ function EntryContentBody({
       FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover"],
     });
 
-    // Process for highlighting if narration is active
+    // Process for highlighting if narration is active (server-side narration path)
+    // For client-side narration, we use processedHtml above
     if (shouldProcessForHighlighting) {
       return processHtmlForHighlighting(sanitized);
     }
 
     return sanitized;
-  }, [contentToDisplay, shouldProcessForHighlighting]);
+  }, [contentToDisplay, shouldProcessForHighlighting, narration.processedHtml]);
 
   // Auto-scroll to highlighted paragraph when playing
   // Note: Highlighting is now handled via CSS by NarrationHighlightStyles component


### PR DESCRIPTION
The narration highlighting was getting out of sync with the DOM elements when elements like images (without alt text) or code blocks were skipped in narration but still present in the DOM.

The root cause was that client-side narration (using browser voices without LLM cleanup) used `htmlToPlainText` which produces text that doesn't match the DOM element structure, and no paragraph map was created to track the relationship between narration paragraphs and DOM elements.

This fix:
1. Adds `htmlToClientNarration()` - a client-side function that uses the same DOM traversal logic as `addParagraphIdsToHtml()` but also produces narration text and a proper paragraph map
2. Updates `useNarration` to use the new function for client-side narration, returning both the paragraph map and processed HTML
3. Updates `EntryContent` and `SavedArticleContent` to use the processed HTML from narration when available, ensuring the data-para-id attributes exactly match the paragraph map

Key insight: Elements that produce no narration text (images without alt, code blocks, empty lists) still get data-para-id attributes in the DOM, but the paragraph map correctly skips them, mapping narration paragraphs to the right DOM element indices.