### PR TITLE
Fix Android app entry sorting order

### DIFF
--- a/android/app/src/main/java/com/lionreader/data/db/dao/EntryDao.kt
+++ b/android/app/src/main/java/com/lionreader/data/db/dao/EntryDao.kt
@@ -42,7 +42,9 @@ interface EntryDao {
           AND (:unreadOnly = 0 OR COALESCE(s.read, 0) = 0)
           AND (:starredOnly = 0 OR COALESCE(s.starred, 0) = 1)
         ORDER BY
+            CASE WHEN :sortOrder = 'newest' THEN COALESCE(e.publishedAt, e.fetchedAt) END DESC,
             CASE WHEN :sortOrder = 'newest' THEN e.id END DESC,
+            CASE WHEN :sortOrder = 'oldest' THEN COALESCE(e.publishedAt, e.fetchedAt) END ASC,
             CASE WHEN :sortOrder = 'oldest' THEN e.id END ASC
         LIMIT :limit OFFSET :offset
         """,

--- a/android/app/src/test/java/com/lionreader/ui/entries/EntryListViewModelTest.kt
+++ b/android/app/src/test/java/com/lionreader/ui/entries/EntryListViewModelTest.kt
@@ -466,9 +466,14 @@ class EntryListViewModelTest {
         fun loadMoreDoesNothingWhenLoading() =
             runTest {
                 // Set up slow response to keep loading state
+                // Must include nextCursor so loadMore() proceeds (it requires a cursor)
                 coEvery { entryRepository.syncEntries(any(), any()) } coAnswers {
                     kotlinx.coroutines.delay(1000)
-                    EntrySyncResult(syncResult = SyncResult.Success, hasMore = true)
+                    EntrySyncResult(
+                        syncResult = SyncResult.Success,
+                        hasMore = true,
+                        nextCursor = "test-cursor",
+                    )
                 }
 
                 viewModel = createViewModel()


### PR DESCRIPTION
The entry list was sorting incorrectly (oldest-to-newest instead of newest-to-oldest) and pagination was broken when scrolling.

Two issues were fixed:

1. DAO sorting: Changed from sorting by entry ID (UUID string) to sorting by COALESCE(publishedAt, fetchedAt) with ID as tiebreaker. This matches the server-side sorting logic and ensures proper chronological ordering.

2. Pagination: Changed from offset-based to cursor-based pagination. The ViewModel now tracks the nextCursor returned from API responses and passes it when loading more entries. This ensures scrolling down fetches the next older entries instead of re-fetching the first page.