### PR TITLE
Redirect signed-in users away from auth page

### DIFF
--- a/src/app/(auth)/AuthLayoutContent.tsx
+++ b/src/app/(auth)/AuthLayoutContent.tsx
@@ -1,0 +1,33 @@
+/**
+ * Auth Layout Content
+ *
+ * Client component with the authentication layout UI.
+ * Provides a clean, centered layout for auth pages (login, register).
+ */
+
+"use client";
+
+import type { ReactNode } from "react";
+
+interface AuthLayoutContentProps {
+  children: ReactNode;
+}
+
+export function AuthLayoutContent({ children }: AuthLayoutContentProps) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 py-12 dark:bg-zinc-950">
+      <div className="w-full max-w-md">
+        {/* Logo / Brand */}
+        <div className="mb-8 text-center">
+          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">Lion Reader</h1>
+          <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">A modern feed reader</p>
+        </div>
+
+        {/* Auth card */}
+        <div className="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,36 +1,37 @@
 /**
  * Auth Layout
  *
- * Centered layout for authentication pages (login, register).
- * Provides a clean, focused UI for auth flows.
+ * Server component wrapper for authentication pages.
+ * Redirects authenticated users to /all.
  */
 
-"use client";
-
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import { TRPCProvider } from "@/lib/trpc/provider";
+import { validateSession } from "@/server/auth/session";
+import { AuthLayoutContent } from "./AuthLayoutContent";
 
 interface AuthLayoutProps {
   children: ReactNode;
 }
 
-export default function AuthLayout({ children }: AuthLayoutProps) {
+export default async function AuthLayout({ children }: AuthLayoutProps) {
+  // Check if user is already authenticated
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get("session")?.value;
+
+  if (sessionToken) {
+    const session = await validateSession(sessionToken);
+    if (session) {
+      // User is already signed in, redirect to the app
+      redirect("/all");
+    }
+  }
+
   return (
     <TRPCProvider>
-      <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 py-12 dark:bg-zinc-950">
-        <div className="w-full max-w-md">
-          {/* Logo / Brand */}
-          <div className="mb-8 text-center">
-            <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">Lion Reader</h1>
-            <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">A modern feed reader</p>
-          </div>
-
-          {/* Auth card */}
-          <div className="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-            {children}
-          </div>
-        </div>
-      </div>
+      <AuthLayoutContent>{children}</AuthLayoutContent>
     </TRPCProvider>
   );
 }


### PR DESCRIPTION
When an authenticated user visits /login or /register, they are now automatically redirected to /all instead of seeing the auth page.