### PR TITLE
Add URL routing for individual entry views

### DIFF
--- a/src/app/(app)/all/page.tsx
+++ b/src/app/(app)/all/page.tsx
@@ -20,12 +20,13 @@ import {
   useKeyboardShortcuts,
   useViewPreferences,
   useEntryMutations,
+  useEntryUrlState,
   type KeyboardEntryData,
 } from "@/lib/hooks";
 import { trpc } from "@/lib/trpc/client";
 
 export default function AllEntriesPage() {
-  const [openEntryId, setOpenEntryId] = useState<string | null>(null);
+  const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
   const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
 
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
@@ -41,8 +42,8 @@ export default function AllEntriesPage() {
   // Keyboard navigation and actions
   const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
     entries,
-    onOpenEntry: (entryId) => setOpenEntryId(entryId),
-    onClose: () => setOpenEntryId(null),
+    onOpenEntry: setOpenEntryId,
+    onClose: closeEntry,
     isEntryOpen: !!openEntryId,
     enabled: keyboardShortcutsEnabled,
     onToggleRead: toggleRead,
@@ -58,12 +59,12 @@ export default function AllEntriesPage() {
       setSelectedEntryId(entryId);
       setOpenEntryId(entryId);
     },
-    [setSelectedEntryId]
+    [setSelectedEntryId, setOpenEntryId]
   );
 
   const handleBack = useCallback(() => {
-    setOpenEntryId(null);
-  }, []);
+    closeEntry();
+  }, [closeEntry]);
 
   const handleEntriesLoaded = useCallback((loadedEntries: EntryListEntryData[]) => {
     setEntries(loadedEntries);

--- a/src/app/(app)/feed/[feedId]/page.tsx
+++ b/src/app/(app)/feed/[feedId]/page.tsx
@@ -22,6 +22,7 @@ import {
   useKeyboardShortcuts,
   useViewPreferences,
   useEntryMutations,
+  useEntryUrlState,
   type KeyboardEntryData,
 } from "@/lib/hooks";
 
@@ -86,7 +87,7 @@ export default function SingleFeedPage() {
   const params = useParams<{ feedId: string }>();
   const feedId = params.feedId;
 
-  const [openEntryId, setOpenEntryId] = useState<string | null>(null);
+  const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
   const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
 
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
@@ -104,8 +105,8 @@ export default function SingleFeedPage() {
   // Keyboard navigation and actions
   const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
     entries,
-    onOpenEntry: (entryId) => setOpenEntryId(entryId),
-    onClose: () => setOpenEntryId(null),
+    onOpenEntry: setOpenEntryId,
+    onClose: closeEntry,
     isEntryOpen: !!openEntryId,
     enabled: keyboardShortcutsEnabled,
     onToggleRead: toggleRead,
@@ -127,12 +128,12 @@ export default function SingleFeedPage() {
       setSelectedEntryId(entryId);
       setOpenEntryId(entryId);
     },
-    [setSelectedEntryId]
+    [setSelectedEntryId, setOpenEntryId]
   );
 
   const handleBack = useCallback(() => {
-    setOpenEntryId(null);
-  }, []);
+    closeEntry();
+  }, [closeEntry]);
 
   const handleEntriesLoaded = useCallback((loadedEntries: EntryListEntryData[]) => {
     setEntries(loadedEntries);

--- a/src/app/(app)/saved/page.tsx
+++ b/src/app/(app)/saved/page.tsx
@@ -15,11 +15,19 @@ import {
 } from "@/components/saved";
 import { UnreadToggle } from "@/components/entries";
 import { useKeyboardShortcutsContext } from "@/components/keyboard";
-import { useSavedArticleKeyboardShortcuts, useViewPreferences } from "@/lib/hooks";
+import {
+  useSavedArticleKeyboardShortcuts,
+  useViewPreferences,
+  useEntryUrlState,
+} from "@/lib/hooks";
 import { trpc } from "@/lib/trpc/client";
 
 export default function SavedArticlesPage() {
-  const [openArticleId, setOpenArticleId] = useState<string | null>(null);
+  const {
+    openEntryId: openArticleId,
+    setOpenEntryId: setOpenArticleId,
+    closeEntry: closeArticle,
+  } = useEntryUrlState();
   const [articles, setArticles] = useState<SavedArticleListEntryData[]>([]);
 
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
@@ -166,8 +174,8 @@ export default function SavedArticlesPage() {
   // Keyboard navigation and actions
   const { selectedArticleId, setSelectedArticleId } = useSavedArticleKeyboardShortcuts({
     articles,
-    onOpenArticle: (articleId) => setOpenArticleId(articleId),
-    onClose: () => setOpenArticleId(null),
+    onOpenArticle: setOpenArticleId,
+    onClose: closeArticle,
     isArticleOpen: !!openArticleId,
     enabled: keyboardShortcutsEnabled,
     onToggleRead: (articleId, currentlyRead) => {
@@ -192,12 +200,12 @@ export default function SavedArticlesPage() {
       setSelectedArticleId(articleId);
       setOpenArticleId(articleId);
     },
-    [setSelectedArticleId]
+    [setSelectedArticleId, setOpenArticleId]
   );
 
   const handleBack = useCallback(() => {
-    setOpenArticleId(null);
-  }, []);
+    closeArticle();
+  }, [closeArticle]);
 
   const handleArticlesLoaded = useCallback((loadedArticles: SavedArticleListEntryData[]) => {
     setArticles(loadedArticles);

--- a/src/app/(app)/starred/page.tsx
+++ b/src/app/(app)/starred/page.tsx
@@ -19,12 +19,13 @@ import {
   useKeyboardShortcuts,
   useViewPreferences,
   useEntryMutations,
+  useEntryUrlState,
   type KeyboardEntryData,
 } from "@/lib/hooks";
 import { trpc } from "@/lib/trpc/client";
 
 export default function StarredEntriesPage() {
-  const [openEntryId, setOpenEntryId] = useState<string | null>(null);
+  const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
   const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
 
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
@@ -40,8 +41,8 @@ export default function StarredEntriesPage() {
   // Keyboard navigation and actions
   const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
     entries,
-    onOpenEntry: (entryId) => setOpenEntryId(entryId),
-    onClose: () => setOpenEntryId(null),
+    onOpenEntry: setOpenEntryId,
+    onClose: closeEntry,
     isEntryOpen: !!openEntryId,
     enabled: keyboardShortcutsEnabled,
     onToggleRead: toggleRead,
@@ -57,12 +58,12 @@ export default function StarredEntriesPage() {
       setSelectedEntryId(entryId);
       setOpenEntryId(entryId);
     },
-    [setSelectedEntryId]
+    [setSelectedEntryId, setOpenEntryId]
   );
 
   const handleBack = useCallback(() => {
-    setOpenEntryId(null);
-  }, []);
+    closeEntry();
+  }, [closeEntry]);
 
   const handleEntriesLoaded = useCallback((loadedEntries: EntryListEntryData[]) => {
     setEntries(loadedEntries);

--- a/src/app/(app)/tag/[tagId]/page.tsx
+++ b/src/app/(app)/tag/[tagId]/page.tsx
@@ -22,6 +22,7 @@ import {
   useKeyboardShortcuts,
   useViewPreferences,
   useEntryMutations,
+  useEntryUrlState,
   type KeyboardEntryData,
 } from "@/lib/hooks";
 
@@ -86,7 +87,7 @@ export default function TagEntriesPage() {
   const params = useParams<{ tagId: string }>();
   const tagId = params.tagId;
 
-  const [openEntryId, setOpenEntryId] = useState<string | null>(null);
+  const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
   const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
 
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
@@ -104,8 +105,8 @@ export default function TagEntriesPage() {
   // Keyboard navigation and actions
   const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
     entries,
-    onOpenEntry: (entryId) => setOpenEntryId(entryId),
-    onClose: () => setOpenEntryId(null),
+    onOpenEntry: setOpenEntryId,
+    onClose: closeEntry,
     isEntryOpen: !!openEntryId,
     enabled: keyboardShortcutsEnabled,
     onToggleRead: toggleRead,
@@ -127,12 +128,12 @@ export default function TagEntriesPage() {
       setSelectedEntryId(entryId);
       setOpenEntryId(entryId);
     },
-    [setSelectedEntryId]
+    [setSelectedEntryId, setOpenEntryId]
   );
 
   const handleBack = useCallback(() => {
-    setOpenEntryId(null);
-  }, []);
+    closeEntry();
+  }, [closeEntry]);
 
   const handleEntriesLoaded = useCallback((loadedEntries: EntryListEntryData[]) => {
     setEntries(loadedEntries);

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -49,3 +49,5 @@ export {
   type UseEntryMutationsOptions,
   type UseEntryMutationsResult,
 } from "./useEntryMutations";
+
+export { useEntryUrlState, type UseEntryUrlStateResult } from "./useEntryUrlState";

--- a/src/lib/hooks/useEntryUrlState.ts
+++ b/src/lib/hooks/useEntryUrlState.ts
@@ -1,0 +1,83 @@
+/**
+ * useEntryUrlState Hook
+ *
+ * Manages entry viewing state synchronized with URL query parameters.
+ * When an entry is opened, the URL updates to include `?entry=entryId`,
+ * allowing the page to be refreshed or shared while preserving state.
+ */
+
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+
+export interface UseEntryUrlStateResult {
+  /** The currently open entry ID, or null if no entry is open */
+  openEntryId: string | null;
+  /** Set the open entry ID (updates the URL) */
+  setOpenEntryId: (entryId: string | null) => void;
+  /** Close the entry (removes from URL) */
+  closeEntry: () => void;
+}
+
+/**
+ * Hook for managing entry viewing state via URL query parameters.
+ *
+ * This enables:
+ * - Refreshing the page without losing the current entry view
+ * - Browser back/forward navigation between entries
+ * - Shareable URLs that link directly to an entry
+ *
+ * @example
+ * ```tsx
+ * const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
+ *
+ * // Open an entry (updates URL to ?entry=123)
+ * setOpenEntryId("123");
+ *
+ * // Close the entry (removes ?entry from URL)
+ * closeEntry();
+ * ```
+ */
+export function useEntryUrlState(): UseEntryUrlStateResult {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Get the current entry ID from the URL
+  const openEntryId = useMemo(() => {
+    return searchParams.get("entry");
+  }, [searchParams]);
+
+  // Update the URL with a new entry ID (or remove it)
+  const setOpenEntryId = useCallback(
+    (entryId: string | null) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      if (entryId) {
+        params.set("entry", entryId);
+      } else {
+        params.delete("entry");
+      }
+
+      const queryString = params.toString();
+      const newUrl = queryString ? `${pathname}?${queryString}` : pathname;
+
+      // Use replace to avoid adding to browser history for every entry click
+      // Users can still use back button to go from entry view to list
+      router.replace(newUrl, { scroll: false });
+    },
+    [searchParams, pathname, router]
+  );
+
+  // Convenience function to close the entry
+  const closeEntry = useCallback(() => {
+    setOpenEntryId(null);
+  }, [setOpenEntryId]);
+
+  return {
+    openEntryId,
+    setOpenEntryId,
+    closeEntry,
+  };
+}


### PR DESCRIPTION
When viewing an entry, the URL now updates to include ?entry=entryId, which allows refreshing the page to preserve the current entry view. This works across all views: All Items, Starred, Saved, Feeds, and Tags.