### PR TITLE
Add unread count for starred articles

### DIFF
--- a/android/app/src/main/java/com/lionreader/data/api/LionReaderApi.kt
+++ b/android/app/src/main/java/com/lionreader/data/api/LionReaderApi.kt
@@ -7,6 +7,7 @@ import com.lionreader.data.api.models.LoginResponse
 import com.lionreader.data.api.models.MarkReadRequest
 import com.lionreader.data.api.models.ProvidersResponse
 import com.lionreader.data.api.models.SortOrder
+import com.lionreader.data.api.models.StarredCountResponse
 import com.lionreader.data.api.models.SubscriptionsResponse
 import com.lionreader.data.api.models.TagsResponse
 import com.lionreader.data.api.models.UserResponse
@@ -135,6 +136,13 @@ interface LionReaderApi {
      * @param id Entry ID to unstar
      */
     suspend fun unstar(id: String): ApiResult<Unit>
+
+    /**
+     * Get the count of starred entries.
+     *
+     * @return StarredCountResponse with total and unread counts
+     */
+    suspend fun getStarredCount(): ApiResult<StarredCountResponse>
 }
 
 /**
@@ -214,4 +222,6 @@ class LionReaderApiImpl
         override suspend fun star(id: String): ApiResult<Unit> = apiClient.postNoContent(path = "entries/$id/star")
 
         override suspend fun unstar(id: String): ApiResult<Unit> = apiClient.deleteNoContent(path = "entries/$id/star")
+
+        override suspend fun getStarredCount(): ApiResult<StarredCountResponse> = apiClient.get(path = "entries/starred/count")
     }

--- a/android/app/src/main/java/com/lionreader/data/api/models/EntryModels.kt
+++ b/android/app/src/main/java/com/lionreader/data/api/models/EntryModels.kt
@@ -67,3 +67,12 @@ enum class SortOrder(
     NEWEST("newest"),
     OLDEST("oldest"),
 }
+
+/**
+ * Response from starred entries count endpoint.
+ */
+@Serializable
+data class StarredCountResponse(
+    val total: Int,
+    val unread: Int,
+)

--- a/android/app/src/main/java/com/lionreader/data/repository/EntryRepository.kt
+++ b/android/app/src/main/java/com/lionreader/data/repository/EntryRepository.kt
@@ -5,6 +5,7 @@ import com.lionreader.data.api.ApiResult
 import com.lionreader.data.api.LionReaderApi
 import com.lionreader.data.api.models.EntryDto
 import com.lionreader.data.api.models.SortOrder
+import com.lionreader.data.api.models.StarredCountResponse
 import com.lionreader.data.api.models.SubscriptionWithFeedDto
 import com.lionreader.data.api.models.TagDto
 import com.lionreader.data.db.dao.EntryDao
@@ -129,6 +130,17 @@ class EntryRepository
          * @return Flow of the entry with state or null
          */
         fun getEntryFlow(id: String): Flow<EntryWithState?> = entryDao.getEntryWithState(id)
+
+        /**
+         * Fetches the starred entries count from the server.
+         *
+         * @return StarredCountResponse with total and unread counts, or null on failure
+         */
+        suspend fun fetchStarredCount(): StarredCountResponse? =
+            when (val result = api.getStarredCount()) {
+                is ApiResult.Success -> result.data
+                else -> null
+            }
 
         /**
          * Gets a single entry by ID, fetching from server if not in local database.

--- a/android/app/src/main/java/com/lionreader/ui/main/AppDrawer.kt
+++ b/android/app/src/main/java/com/lionreader/ui/main/AppDrawer.kt
@@ -50,6 +50,7 @@ import com.lionreader.ui.navigation.Screen
  * @param tags List of tags to display
  * @param currentRoute Current navigation route for selection state
  * @param totalUnreadCount Total unread count for "All" item badge
+ * @param starredUnreadCount Unread count for starred entries badge
  * @param onNavigate Callback when a navigation item is selected
  * @param onSignOut Callback when sign out is clicked
  * @param modifier Modifier for the drawer sheet
@@ -60,6 +61,7 @@ fun AppDrawer(
     tags: List<TagEntity>,
     currentRoute: String,
     totalUnreadCount: Int,
+    starredUnreadCount: Int,
     onNavigate: (String) -> Unit,
     onSignOut: () -> Unit,
     modifier: Modifier = Modifier,
@@ -105,6 +107,13 @@ fun AppDrawer(
                         imageVector = Icons.Default.Star,
                         contentDescription = null,
                     )
+                },
+                badge = {
+                    if (starredUnreadCount > 0) {
+                        Badge {
+                            Text(formatCount(starredUnreadCount))
+                        }
+                    }
                 },
                 selected = currentRoute == Screen.Starred.route,
                 onClick = { onNavigate(Screen.Starred.route) },

--- a/android/app/src/main/java/com/lionreader/ui/main/MainScreen.kt
+++ b/android/app/src/main/java/com/lionreader/ui/main/MainScreen.kt
@@ -36,6 +36,7 @@ fun MainScreen(
     val subscriptions by drawerViewModel.subscriptions.collectAsStateWithLifecycle()
     val tags by drawerViewModel.tags.collectAsStateWithLifecycle()
     val totalUnreadCount by drawerViewModel.totalUnreadCount.collectAsStateWithLifecycle()
+    val starredUnreadCount by drawerViewModel.starredUnreadCount.collectAsStateWithLifecycle()
 
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
@@ -60,6 +61,7 @@ fun MainScreen(
                 tags = tags,
                 currentRoute = uiState.currentRoute,
                 totalUnreadCount = totalUnreadCount,
+                starredUnreadCount = starredUnreadCount,
                 onNavigate = { route ->
                     mainViewModel.navigateTo(route)
                     scope.launch {

--- a/android/app/src/test/java/com/lionreader/data/api/ApiContractTest.kt
+++ b/android/app/src/test/java/com/lionreader/data/api/ApiContractTest.kt
@@ -56,6 +56,7 @@ class ApiContractTest {
             PathWithMethod("POST", "entries/mark-read"),
             PathWithMethod("POST", "entries/{id}/star"),
             PathWithMethod("DELETE", "entries/{id}/star"),
+            PathWithMethod("GET", "entries/starred/count"),
         )
 
     @BeforeAll


### PR DESCRIPTION
Display the unread count for starred entries in the navigation drawer, matching the behavior of the web app. The count is fetched from the server via the existing /entries/starred/count endpoint.

Changes:
- Add StarredCountResponse model for the API response
- Add getStarredCount endpoint to LionReaderApi
- Add fetchStarredCount method to EntryRepository
- Update DrawerViewModel to expose starredUnreadCount and fetch it when refreshData() is called
- Update AppDrawer to display the starred unread count badge