### PR TITLE
Fix missing Suspense boundary for useSearchParams

### DIFF
--- a/src/app/(app)/all/page.tsx
+++ b/src/app/(app)/all/page.tsx
@@ -7,7 +7,7 @@
 
 "use client";
 
-import { useState, useCallback } from "react";
+import { Suspense, useState, useCallback } from "react";
 import {
   EntryList,
   EntryContent,
@@ -25,7 +25,7 @@ import {
 } from "@/lib/hooks";
 import { trpc } from "@/lib/trpc/client";
 
-export default function AllEntriesPage() {
+function AllEntriesContent() {
   const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
   const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
 
@@ -108,5 +108,13 @@ export default function AllEntriesPage() {
         }
       />
     </div>
+  );
+}
+
+export default function AllEntriesPage() {
+  return (
+    <Suspense>
+      <AllEntriesContent />
+    </Suspense>
   );
 }

--- a/src/app/(app)/feed/[feedId]/page.tsx
+++ b/src/app/(app)/feed/[feedId]/page.tsx
@@ -6,7 +6,7 @@
 
 "use client";
 
-import { useState, useCallback } from "react";
+import { Suspense, useState, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { trpc } from "@/lib/trpc/client";
@@ -83,7 +83,7 @@ function FeedNotFound() {
   );
 }
 
-export default function SingleFeedPage() {
+function SingleFeedContent() {
   const params = useParams<{ feedId: string }>();
   const feedId = params.feedId;
 
@@ -232,5 +232,13 @@ export default function SingleFeedPage() {
         }
       />
     </div>
+  );
+}
+
+export default function SingleFeedPage() {
+  return (
+    <Suspense>
+      <SingleFeedContent />
+    </Suspense>
   );
 }

--- a/src/app/(app)/saved/page.tsx
+++ b/src/app/(app)/saved/page.tsx
@@ -6,7 +6,7 @@
 
 "use client";
 
-import { useState, useCallback } from "react";
+import { Suspense, useState, useCallback } from "react";
 import { toast } from "sonner";
 import {
   SavedArticleList,
@@ -22,7 +22,7 @@ import {
 } from "@/lib/hooks";
 import { trpc } from "@/lib/trpc/client";
 
-export default function SavedArticlesPage() {
+function SavedArticlesContent() {
   const {
     openEntryId: openArticleId,
     setOpenEntryId: setOpenArticleId,
@@ -236,5 +236,13 @@ export default function SavedArticlesPage() {
         }
       />
     </div>
+  );
+}
+
+export default function SavedArticlesPage() {
+  return (
+    <Suspense>
+      <SavedArticlesContent />
+    </Suspense>
   );
 }

--- a/src/app/(app)/starred/page.tsx
+++ b/src/app/(app)/starred/page.tsx
@@ -6,7 +6,7 @@
 
 "use client";
 
-import { useState, useCallback } from "react";
+import { Suspense, useState, useCallback } from "react";
 import {
   EntryList,
   EntryContent,
@@ -24,7 +24,7 @@ import {
 } from "@/lib/hooks";
 import { trpc } from "@/lib/trpc/client";
 
-export default function StarredEntriesPage() {
+function StarredEntriesContent() {
   const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
   const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
 
@@ -107,5 +107,13 @@ export default function StarredEntriesPage() {
         }
       />
     </div>
+  );
+}
+
+export default function StarredEntriesPage() {
+  return (
+    <Suspense>
+      <StarredEntriesContent />
+    </Suspense>
   );
 }

--- a/src/app/(app)/tag/[tagId]/page.tsx
+++ b/src/app/(app)/tag/[tagId]/page.tsx
@@ -6,7 +6,7 @@
 
 "use client";
 
-import { useState, useCallback } from "react";
+import { Suspense, useState, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { trpc } from "@/lib/trpc/client";
@@ -83,7 +83,7 @@ function TagNotFound() {
   );
 }
 
-export default function TagEntriesPage() {
+function TagEntriesContent() {
   const params = useParams<{ tagId: string }>();
   const tagId = params.tagId;
 
@@ -223,5 +223,13 @@ export default function TagEntriesPage() {
         }
       />
     </div>
+  );
+}
+
+export default function TagEntriesPage() {
+  return (
+    <Suspense>
+      <TagEntriesContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
Next.js requires useSearchParams() to be wrapped in a Suspense boundary to avoid CSR bailout errors during static rendering. All pages using useEntryUrlState (which internally uses useSearchParams) now properly wrap their content in a Suspense boundary.