### PR TITLE
Add tag support to Android app

### DIFF
--- a/android/app/src/main/java/com/lionreader/data/api/models/TagModels.kt
+++ b/android/app/src/main/java/com/lionreader/data/api/models/TagModels.kt
@@ -13,6 +13,8 @@ data class TagDto(
     val color: String? = null, // hex color like "#ff6b6b"
     @SerialName("feedCount")
     val feedCount: Int = 0,
+    @SerialName("unreadCount")
+    val unreadCount: Int = 0,
 )
 
 /**
@@ -20,5 +22,5 @@ data class TagDto(
  */
 @Serializable
 data class TagsResponse(
-    val tags: List<TagDto>,
+    val items: List<TagDto>,
 )

--- a/android/app/src/main/java/com/lionreader/data/db/LionReaderDatabase.kt
+++ b/android/app/src/main/java/com/lionreader/data/db/LionReaderDatabase.kt
@@ -29,6 +29,7 @@ import com.lionreader.data.db.entities.TagEntity
  * Database version history:
  * - Version 1: Initial schema with all core entities
  * - Version 2: Remove foreign key from entries.feedId to feeds.id
+ * - Version 3: Add unreadCount column to tags table
  */
 @Database(
     entities = [
@@ -76,7 +77,7 @@ abstract class LionReaderDatabase : RoomDatabase() {
          *
          * Increment when schema changes require a migration.
          */
-        const val VERSION = 2
+        const val VERSION = 3
 
         /**
          * Database file name.

--- a/android/app/src/main/java/com/lionreader/data/db/entities/TagEntity.kt
+++ b/android/app/src/main/java/com/lionreader/data/db/entities/TagEntity.kt
@@ -18,4 +18,6 @@ data class TagEntity(
     val color: String?,
     /** Number of subscriptions with this tag */
     val feedCount: Int,
+    /** Number of unread entries across all subscriptions with this tag */
+    val unreadCount: Int,
 )

--- a/android/app/src/main/java/com/lionreader/data/repository/EntryRepository.kt
+++ b/android/app/src/main/java/com/lionreader/data/repository/EntryRepository.kt
@@ -649,7 +649,8 @@ class EntryRepository
                             id = tagDto.id,
                             name = tagDto.name,
                             color = tagDto.color,
-                            feedCount = 0, // Will be calculated separately if needed
+                            feedCount = 0, // Will be calculated separately from tags sync
+                            unreadCount = 0, // Will be calculated separately from tags sync
                         )
                     // Store subscription-tag relationship
                     subscriptionTags.add(
@@ -679,7 +680,7 @@ class EntryRepository
         private suspend fun syncTags(): SyncResult =
             when (val result = api.listTags()) {
                 is ApiResult.Success -> {
-                    val tags = result.data.tags
+                    val tags = result.data.items
                     updateLocalTags(tags)
                     SyncResult.Success
                 }
@@ -708,6 +709,7 @@ class EntryRepository
                         name = dto.name,
                         color = dto.color,
                         feedCount = dto.feedCount,
+                        unreadCount = dto.unreadCount,
                     )
                 }
             tagDao.insertAll(tagEntities)

--- a/android/app/src/main/java/com/lionreader/data/repository/SubscriptionRepository.kt
+++ b/android/app/src/main/java/com/lionreader/data/repository/SubscriptionRepository.kt
@@ -151,7 +151,8 @@ class SubscriptionRepository
                             id = tagDto.id,
                             name = tagDto.name,
                             color = tagDto.color,
-                            feedCount = 0, // Will be calculated separately if needed
+                            feedCount = 0, // Will be calculated separately from tags sync
+                            unreadCount = 0, // Will be calculated separately from tags sync
                         )
                     // Store subscription-tag relationship
                     subscriptionTags.add(

--- a/android/app/src/main/java/com/lionreader/data/repository/TagRepository.kt
+++ b/android/app/src/main/java/com/lionreader/data/repository/TagRepository.kt
@@ -59,7 +59,7 @@ class TagRepository
         suspend fun syncTags(): SyncResult =
             when (val result = api.listTags()) {
                 is ApiResult.Success -> {
-                    val tags = result.data.tags
+                    val tags = result.data.items
                     updateLocalDatabase(tags)
                     SyncResult.Success
                 }
@@ -88,6 +88,7 @@ class TagRepository
                         name = dto.name,
                         color = dto.color,
                         feedCount = dto.feedCount,
+                        unreadCount = dto.unreadCount,
                     )
                 }
             tagDao.insertAll(tagEntities)

--- a/android/app/src/main/java/com/lionreader/ui/main/AppDrawer.kt
+++ b/android/app/src/main/java/com/lionreader/ui/main/AppDrawer.kt
@@ -139,12 +139,10 @@ fun AppDrawer(
                             TagColorIndicator(color = tag.color)
                         },
                         badge = {
-                            if (tag.feedCount > 0) {
-                                Text(
-                                    text = tag.feedCount.toString(),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
+                            if (tag.unreadCount > 0) {
+                                Badge {
+                                    Text(formatCount(tag.unreadCount))
+                                }
                             }
                         },
                         selected = currentRoute == tagRoute,


### PR DESCRIPTION
Enable viewing entries by tag in the Android app:
- Fix TagsResponse to use 'items' field (matching server API)
- Add unreadCount field to TagDto and TagEntity
- Update TagRepository to sync unreadCount from server
- Update AppDrawer to display unread count badge for tags
- Bump database version to 3 for schema migration

The existing infrastructure (Screen.Tag route, EntryListViewModel tag filtering, EntryDao SQL join, AppDrawer tag navigation) was already in place. These fixes complete the tag viewing feature by correctly deserializing the server response and displaying the unread count badge.