### PR TITLE
Fix article sharing error on Android app

### DIFF
--- a/android/app/src/main/java/com/lionreader/ShareReceiverActivity.kt
+++ b/android/app/src/main/java/com/lionreader/ShareReceiverActivity.kt
@@ -154,16 +154,40 @@ class ShareReceiverActivity : ComponentActivity() {
         // Find the first URL in the text
         val match = urlPattern.find(text)
         if (match != null) {
-            return match.value
+            return cleanUrl(match.value)
         }
 
         // If the entire text looks like a URL (without protocol), add https://
         val trimmed = text.trim()
         if (trimmed.contains(".") && !trimmed.contains(" ")) {
-            return "https://$trimmed"
+            return cleanUrl("https://$trimmed")
         }
 
         return null
+    }
+
+    /**
+     * Cleans trailing punctuation from a URL that may have been captured
+     * when extracting from surrounding text (e.g., "Check out https://example.com.")
+     */
+    private fun cleanUrl(url: String): String {
+        var cleaned = url
+
+        // Remove trailing punctuation that's likely not part of the URL
+        // Common cases: periods, commas, semicolons, colons (but not as part of port)
+        while (cleaned.isNotEmpty()) {
+            val lastChar = cleaned.last()
+            if (lastChar in ".,:;!?") {
+                cleaned = cleaned.dropLast(1)
+            } else if (lastChar == ')' && !cleaned.contains('(')) {
+                // Remove trailing ) only if there's no matching (
+                cleaned = cleaned.dropLast(1)
+            } else {
+                break
+            }
+        }
+
+        return cleaned
     }
 
     private data class SharedContent(

--- a/android/app/src/main/java/com/lionreader/data/api/ApiClient.kt
+++ b/android/app/src/main/java/com/lionreader/data/api/ApiClient.kt
@@ -55,6 +55,7 @@ class ApiClient
                 isLenient = true
                 encodeDefaults = true
                 coerceInputValues = true
+                explicitNulls = false // Don't encode null values - server expects omitted fields, not null
             }
 
         val httpClient: HttpClient =


### PR DESCRIPTION
When sharing URLs from Firefox (and other apps), the shared text often includes trailing punctuation like periods from sentences (e.g., "Check out https://example.com."). The URL regex was capturing this trailing punctuation, resulting in invalid URLs like "https://example.com." that failed the server's Zod URL validation.

Added a cleanUrl() function that strips trailing punctuation (.,:;!?) and unbalanced closing parentheses from extracted URLs.