### PR TITLE
Fix starred articles sync in Android app

### DIFF
--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -61,6 +61,20 @@ const limitSchema = z.number().int().min(1).max(MAX_LIMIT).optional();
  */
 const sortOrderSchema = z.enum(["newest", "oldest"]).optional();
 
+/**
+ * Boolean query parameter schema that handles string coercion.
+ * Query parameters come as strings from HTTP requests, so we need to
+ * handle both boolean and string inputs ("true"/"false").
+ */
+const booleanQueryParam = z
+  .union([z.boolean(), z.enum(["true", "false"])])
+  .optional()
+  .transform((val) => {
+    if (val === "true") return true;
+    if (val === "false") return false;
+    return val;
+  });
+
 // ============================================================================
 // Output Schemas
 // ============================================================================
@@ -215,8 +229,8 @@ export const entriesRouter = createTRPCRouter({
       z.object({
         feedId: uuidSchema.optional(),
         tagId: uuidSchema.optional(),
-        unreadOnly: z.boolean().optional(),
-        starredOnly: z.boolean().optional(),
+        unreadOnly: booleanQueryParam,
+        starredOnly: booleanQueryParam,
         sortOrder: sortOrderSchema,
         cursor: cursorSchema,
         limit: limitSchema,

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -59,6 +59,20 @@ const limitSchema = z.number().int().min(1).max(MAX_LIMIT).optional();
  */
 const urlSchema = z.string().url("Invalid URL");
 
+/**
+ * Boolean query parameter schema that handles string coercion.
+ * Query parameters come as strings from HTTP requests, so we need to
+ * handle both boolean and string inputs ("true"/"false").
+ */
+const booleanQueryParam = z
+  .union([z.boolean(), z.enum(["true", "false"])])
+  .optional()
+  .transform((val) => {
+    if (val === "true") return true;
+    if (val === "false") return false;
+    return val;
+  });
+
 // ============================================================================
 // Output Schemas
 // ============================================================================
@@ -386,8 +400,8 @@ export const savedRouter = createTRPCRouter({
     })
     .input(
       z.object({
-        unreadOnly: z.boolean().optional(),
-        starredOnly: z.boolean().optional(),
+        unreadOnly: booleanQueryParam,
+        starredOnly: booleanQueryParam,
         cursor: cursorSchema,
         limit: limitSchema,
       })


### PR DESCRIPTION
The Android app sends boolean query parameters as strings ("true"/"false") in HTTP requests. The Zod schemas for unreadOnly and starredOnly were defined as z.boolean().optional(), which doesn't automatically coerce string values to booleans.

This caused the starredOnly filter to not work correctly when called from the Android app, resulting in:
1. Starred articles list being empty even when entries were starred on server
2. Locally starred entries losing their star on refresh (because the filter wasn't applied correctly during sync)

Added a booleanQueryParam schema with z.preprocess() to handle both boolean and string inputs, converting "true"/"false" strings to their boolean equivalents before validation.