### PR TITLE
Fix article starring not persisting on refresh

### DIFF
--- a/android/app/src/main/java/com/lionreader/data/db/dao/EntryDao.kt
+++ b/android/app/src/main/java/com/lionreader/data/db/dao/EntryDao.kt
@@ -1,9 +1,8 @@
 package com.lionreader.data.db.dao
 
 import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Upsert
 import com.lionreader.data.db.entities.EntryEntity
 import com.lionreader.data.db.relations.EntryWithState
 import kotlinx.coroutines.flow.Flow
@@ -85,11 +84,15 @@ interface EntryDao {
     fun getEntryWithState(id: String): Flow<EntryWithState?>
 
     /**
-     * Inserts or replaces a list of entries.
+     * Inserts or updates a list of entries.
      *
-     * @param entries The entries to insert
+     * Uses @Upsert to update existing rows instead of delete+insert.
+     * This is critical because delete+insert would cascade delete
+     * pending actions due to foreign key constraints.
+     *
+     * @param entries The entries to insert or update
      */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertEntries(entries: List<EntryEntity>)
 
     /**


### PR DESCRIPTION
The issue was that EntryDao.insertEntries used OnConflictStrategy.REPLACE, which performs a DELETE then INSERT when updating existing entries. This triggered a cascade delete of pending actions (star/unstar) due to the foreign key constraint on PendingActionEntity.

When a user starred an article and then refreshed:
1. Star action was queued as a pending action
2. Entries were synced from server using REPLACE strategy
3. REPLACE deleted the entry row, cascading to delete the pending action
4. Star was never synced to server
5. Next sync returned unstarred state from server

Fixed by using @Upsert instead of @Insert(onConflict = REPLACE). Upsert updates existing rows in-place without delete, preserving foreign key references to pending actions.