### PR TITLE
Investigate Android offline functionality and sync behavior

### DIFF
--- a/android/app/src/main/java/com/lionreader/data/sync/SyncErrorNotifier.kt
+++ b/android/app/src/main/java/com/lionreader/data/sync/SyncErrorNotifier.kt
@@ -1,0 +1,73 @@
+package com.lionreader.data.sync
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Data class representing a sync error to be displayed to the user.
+ */
+data class SyncError(
+    val message: String,
+    val isAuthError: Boolean = false,
+)
+
+/**
+ * Singleton for emitting sync errors that UI components can observe.
+ *
+ * This allows background sync operations (SyncWorker, SyncRepository) to
+ * communicate errors to the UI layer without direct coupling.
+ *
+ * Usage:
+ * ```kotlin
+ * // In repository/worker - emit an error
+ * syncErrorNotifier.emit(SyncError("Sync error: Failed to connect"))
+ *
+ * // In ViewModel/Screen - observe errors
+ * syncErrorNotifier.errors.collect { error ->
+ *     showToast(error.message)
+ * }
+ * ```
+ */
+@Singleton
+class SyncErrorNotifier
+    @Inject
+    constructor() {
+        private val _errors =
+            MutableSharedFlow<SyncError>(
+                replay = 0,
+                extraBufferCapacity = 10,
+            )
+
+        /**
+         * Flow of sync errors for UI components to observe.
+         *
+         * Errors are emitted once and not replayed, so each error is
+         * shown only once even if multiple collectors are active.
+         */
+        val errors: SharedFlow<SyncError> = _errors.asSharedFlow()
+
+        /**
+         * Emits a sync error to be displayed to the user.
+         *
+         * @param error The sync error to emit
+         */
+        suspend fun emit(error: SyncError) {
+            _errors.emit(error)
+        }
+
+        /**
+         * Emits a sync error with just a message.
+         *
+         * @param message The error message to display
+         * @param isAuthError Whether this is an authentication error
+         */
+        suspend fun emit(
+            message: String,
+            isAuthError: Boolean = false,
+        ) {
+            _errors.emit(SyncError(message, isAuthError))
+        }
+    }

--- a/android/app/src/main/java/com/lionreader/di/RepositoryModule.kt
+++ b/android/app/src/main/java/com/lionreader/di/RepositoryModule.kt
@@ -13,6 +13,7 @@ import com.lionreader.data.repository.SubscriptionRepository
 import com.lionreader.data.repository.SyncRepository
 import com.lionreader.data.repository.TagRepository
 import com.lionreader.data.sync.ConnectivityMonitor
+import com.lionreader.data.sync.SyncErrorNotifier
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -113,5 +114,6 @@ object RepositoryModule {
         api: LionReaderApi,
         pendingActionDao: PendingActionDao,
         entryStateDao: EntryStateDao,
-    ): SyncRepository = SyncRepository(api, pendingActionDao, entryStateDao)
+        syncErrorNotifier: SyncErrorNotifier,
+    ): SyncRepository = SyncRepository(api, pendingActionDao, entryStateDao, syncErrorNotifier)
 }

--- a/android/app/src/main/java/com/lionreader/ui/entries/EntryListViewModel.kt
+++ b/android/app/src/main/java/com/lionreader/ui/entries/EntryListViewModel.kt
@@ -10,6 +10,7 @@ import com.lionreader.data.repository.EntryRepository
 import com.lionreader.data.repository.SubscriptionRepository
 import com.lionreader.data.repository.TagRepository
 import com.lionreader.data.sync.ConnectivityMonitorInterface
+import com.lionreader.data.sync.SyncErrorNotifier
 import com.lionreader.ui.navigation.Screen
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -48,6 +49,7 @@ class EntryListViewModel
         private val subscriptionRepository: SubscriptionRepository,
         private val tagRepository: TagRepository,
         private val connectivityMonitor: ConnectivityMonitorInterface,
+        private val syncErrorNotifier: SyncErrorNotifier,
     ) : ViewModel() {
         companion object {
             private const val PAGE_SIZE = 50
@@ -147,6 +149,13 @@ class EntryListViewModel
             viewModelScope.launch {
                 connectivityMonitor.isOnline.collect { isOnline ->
                     _uiState.value = _uiState.value.copy(isOnline = isOnline)
+                }
+            }
+
+            // Observe sync errors
+            viewModelScope.launch {
+                syncErrorNotifier.errors.collect { error ->
+                    _uiState.value = _uiState.value.copy(errorMessage = error.message)
                 }
             }
 

--- a/android/app/src/test/java/com/lionreader/ui/entries/EntryListViewModelTest.kt
+++ b/android/app/src/test/java/com/lionreader/ui/entries/EntryListViewModelTest.kt
@@ -11,6 +11,7 @@ import com.lionreader.data.repository.SubscriptionRepository
 import com.lionreader.data.repository.SyncResult
 import com.lionreader.data.repository.TagRepository
 import com.lionreader.data.sync.ConnectivityMonitorInterface
+import com.lionreader.data.sync.SyncErrorNotifier
 import com.lionreader.ui.navigation.Screen
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -18,6 +19,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -51,6 +53,7 @@ class EntryListViewModelTest {
     private lateinit var subscriptionRepository: SubscriptionRepository
     private lateinit var tagRepository: TagRepository
     private lateinit var connectivityMonitor: ConnectivityMonitorInterface
+    private lateinit var syncErrorNotifier: SyncErrorNotifier
 
     private lateinit var viewModel: EntryListViewModel
 
@@ -86,9 +89,11 @@ class EntryListViewModelTest {
         subscriptionRepository = mockk(relaxed = true)
         tagRepository = mockk(relaxed = true)
         connectivityMonitor = mockk<ConnectivityMonitorInterface>(relaxed = true)
+        syncErrorNotifier = mockk<SyncErrorNotifier>(relaxed = true)
 
         // Default mock setup
         every { connectivityMonitor.isOnline } returns MutableStateFlow(true)
+        every { syncErrorNotifier.errors } returns MutableSharedFlow()
         every { connectivityMonitor.checkOnline() } returns true
         every { entryRepository.getEntries(any()) } returns flowOf(listOf(testEntry))
         coEvery { entryRepository.syncEntries(any(), any()) } returns
@@ -110,6 +115,7 @@ class EntryListViewModelTest {
             subscriptionRepository = subscriptionRepository,
             tagRepository = tagRepository,
             connectivityMonitor = connectivityMonitor,
+            syncErrorNotifier = syncErrorNotifier,
         )
 
     @Nested


### PR DESCRIPTION
Sync errors from background sync operations are now surfaced to the user via snackbar notifications. This helps with debugging sync issues by making them visible instead of only logging them.

Changes:
- Add SyncErrorNotifier singleton with SharedFlow for error events
- Integrate error emission into SyncRepository and SyncWorker
- Update EntryListViewModel and EntryDetailViewModel to observe errors
- Existing snackbar infrastructure in screens handles display