### PR TITLE
Fix flaky saved article mutations and add sort toggle

### DIFF
--- a/src/components/saved/SavedArticleList.tsx
+++ b/src/components/saved/SavedArticleList.tsx
@@ -32,6 +32,11 @@ export interface SavedArticleListFilters {
    * Show only starred articles.
    */
   starredOnly?: boolean;
+
+  /**
+   * Sort order: "newest" (default) or "oldest".
+   */
+  sortOrder?: "newest" | "oldest";
 }
 
 /**
@@ -105,6 +110,7 @@ export function SavedArticleList({
     {
       unreadOnly: filters.unreadOnly,
       starredOnly: filters.starredOnly,
+      sortOrder: filters.sortOrder,
       limit: pageSize,
     },
     {

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -50,4 +50,11 @@ export {
   type UseEntryMutationsResult,
 } from "./useEntryMutations";
 
+export {
+  useSavedArticleMutations,
+  type SavedArticleListFilters,
+  type UseSavedArticleMutationsOptions,
+  type UseSavedArticleMutationsResult,
+} from "./useSavedArticleMutations";
+
 export { useEntryUrlState, type UseEntryUrlStateResult } from "./useEntryUrlState";

--- a/src/lib/hooks/useSavedArticleMutations.ts
+++ b/src/lib/hooks/useSavedArticleMutations.ts
@@ -1,0 +1,291 @@
+/**
+ * useSavedArticleMutations Hook
+ *
+ * Provides saved article mutations (markRead, star, unstar) with optimistic updates.
+ * Consolidates mutation logic from page components.
+ */
+
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { toast } from "sonner";
+import { trpc } from "@/lib/trpc/client";
+
+/**
+ * Filters for the current saved article list.
+ * Used to target optimistic updates to the correct cache entry.
+ */
+export interface SavedArticleListFilters {
+  /**
+   * Show only unread articles.
+   */
+  unreadOnly?: boolean;
+
+  /**
+   * Show only starred articles.
+   */
+  starredOnly?: boolean;
+
+  /**
+   * Sort order for articles.
+   */
+  sortOrder?: "newest" | "oldest";
+}
+
+/**
+ * Options for the useSavedArticleMutations hook.
+ */
+export interface UseSavedArticleMutationsOptions {
+  /**
+   * Query filters for optimistic updates to the current list.
+   * If not provided, mutations will work but without list optimistic updates.
+   */
+  listFilters?: SavedArticleListFilters;
+}
+
+/**
+ * Result of the useSavedArticleMutations hook.
+ */
+export interface UseSavedArticleMutationsResult {
+  /**
+   * Mark one or more articles as read or unread.
+   */
+  markRead: (ids: string[], read: boolean) => void;
+
+  /**
+   * Toggle the read status of an article.
+   */
+  toggleRead: (articleId: string, currentlyRead: boolean) => void;
+
+  /**
+   * Star an article.
+   */
+  star: (articleId: string) => void;
+
+  /**
+   * Unstar an article.
+   */
+  unstar: (articleId: string) => void;
+
+  /**
+   * Toggle the starred status of an article.
+   */
+  toggleStar: (articleId: string, currentlyStarred: boolean) => void;
+
+  /**
+   * Whether any mutation is currently in progress.
+   */
+  isPending: boolean;
+
+  /**
+   * Whether the markRead mutation is pending.
+   */
+  isMarkReadPending: boolean;
+
+  /**
+   * Whether the star/unstar mutation is pending.
+   */
+  isStarPending: boolean;
+}
+
+/**
+ * Hook that provides saved article mutations with optimistic updates.
+ *
+ * Consolidates the mutation logic that was previously duplicated
+ * across page components.
+ *
+ * @param options - Options including list filters for optimistic updates
+ * @returns Object with mutation functions and pending state
+ */
+export function useSavedArticleMutations(
+  options?: UseSavedArticleMutationsOptions
+): UseSavedArticleMutationsResult {
+  const utils = trpc.useUtils();
+  const listFilters = options?.listFilters;
+
+  // Build the query key for the saved articles list
+  const queryFilters = useMemo(
+    () => ({
+      unreadOnly: listFilters?.unreadOnly,
+      starredOnly: listFilters?.starredOnly,
+      sortOrder: listFilters?.sortOrder,
+    }),
+    [listFilters?.unreadOnly, listFilters?.starredOnly, listFilters?.sortOrder]
+  );
+
+  // markRead mutation with optimistic updates
+  const markReadMutation = trpc.saved.markRead.useMutation({
+    onMutate: async (variables) => {
+      // Skip optimistic updates if no list filters provided
+      if (!listFilters) {
+        return { previousData: undefined };
+      }
+
+      // Cancel any in-flight queries
+      await utils.saved.list.cancel();
+
+      // Snapshot current state for rollback
+      const previousData = utils.saved.list.getInfiniteData(queryFilters);
+
+      // Optimistically update list (normy propagates to saved.get automatically)
+      utils.saved.list.setInfiniteData(queryFilters, (oldData) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          pages: oldData.pages.map((page) => ({
+            ...page,
+            items: page.items.map((item) =>
+              variables.ids.includes(item.id) ? { ...item, read: variables.read } : item
+            ),
+          })),
+        };
+      });
+
+      return { previousData };
+    },
+    onError: (_error, _variables, context) => {
+      // Rollback to previous state
+      if (context?.previousData && listFilters) {
+        utils.saved.list.setInfiniteData(queryFilters, context.previousData);
+      }
+      toast.error("Failed to update read status");
+    },
+    onSettled: () => {
+      // Invalidate count as it needs server data
+      utils.saved.count.invalidate();
+    },
+  });
+
+  // star mutation with optimistic updates
+  const starMutation = trpc.saved.star.useMutation({
+    onMutate: async (variables) => {
+      // Skip optimistic updates if no list filters provided
+      if (!listFilters) {
+        return { previousData: undefined };
+      }
+
+      await utils.saved.list.cancel();
+
+      const previousData = utils.saved.list.getInfiniteData(queryFilters);
+
+      // Optimistically update list (normy propagates to saved.get automatically)
+      utils.saved.list.setInfiniteData(queryFilters, (oldData) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          pages: oldData.pages.map((page) => ({
+            ...page,
+            items: page.items.map((item) =>
+              item.id === variables.id ? { ...item, starred: true } : item
+            ),
+          })),
+        };
+      });
+
+      return { previousData };
+    },
+    onError: (_error, _variables, context) => {
+      // Rollback list
+      if (context?.previousData && listFilters) {
+        utils.saved.list.setInfiniteData(queryFilters, context.previousData);
+      }
+      toast.error("Failed to star article");
+    },
+  });
+
+  // unstar mutation with optimistic updates
+  const unstarMutation = trpc.saved.unstar.useMutation({
+    onMutate: async (variables) => {
+      // Skip optimistic updates if no list filters provided
+      if (!listFilters) {
+        return { previousData: undefined };
+      }
+
+      await utils.saved.list.cancel();
+
+      const previousData = utils.saved.list.getInfiniteData(queryFilters);
+
+      // Optimistically update list (normy propagates to saved.get automatically)
+      utils.saved.list.setInfiniteData(queryFilters, (oldData) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          pages: oldData.pages.map((page) => ({
+            ...page,
+            items: page.items.map((item) =>
+              item.id === variables.id ? { ...item, starred: false } : item
+            ),
+          })),
+        };
+      });
+
+      return { previousData };
+    },
+    onError: (_error, _variables, context) => {
+      // Rollback list
+      if (context?.previousData && listFilters) {
+        utils.saved.list.setInfiniteData(queryFilters, context.previousData);
+      }
+      toast.error("Failed to unstar article");
+    },
+  });
+
+  // Convenience wrapper functions
+  const markRead = useCallback(
+    (ids: string[], read: boolean) => {
+      markReadMutation.mutate({ ids, read });
+    },
+    [markReadMutation]
+  );
+
+  const toggleRead = useCallback(
+    (articleId: string, currentlyRead: boolean) => {
+      markReadMutation.mutate({ ids: [articleId], read: !currentlyRead });
+    },
+    [markReadMutation]
+  );
+
+  const star = useCallback(
+    (articleId: string) => {
+      starMutation.mutate({ id: articleId });
+    },
+    [starMutation]
+  );
+
+  const unstar = useCallback(
+    (articleId: string) => {
+      unstarMutation.mutate({ id: articleId });
+    },
+    [unstarMutation]
+  );
+
+  const toggleStar = useCallback(
+    (articleId: string, currentlyStarred: boolean) => {
+      if (currentlyStarred) {
+        unstarMutation.mutate({ id: articleId });
+      } else {
+        starMutation.mutate({ id: articleId });
+      }
+    },
+    [starMutation, unstarMutation]
+  );
+
+  const isPending =
+    markReadMutation.isPending || starMutation.isPending || unstarMutation.isPending;
+  const isMarkReadPending = markReadMutation.isPending;
+  const isStarPending = starMutation.isPending || unstarMutation.isPending;
+
+  return useMemo(
+    () => ({
+      markRead,
+      toggleRead,
+      star,
+      unstar,
+      toggleStar,
+      isPending,
+      isMarkReadPending,
+      isStarPending,
+    }),
+    [markRead, toggleRead, star, unstar, toggleStar, isPending, isMarkReadPending, isStarPending]
+  );
+}

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -388,7 +388,8 @@ describe("Saved Articles API", () => {
       const caller = createCaller(ctx);
 
       const result = await caller.saved.markRead({ ids: [id1, id2], read: true });
-      expect(result).toEqual({});
+      expect(result.articles).toHaveLength(2);
+      expect(result.articles.every((a) => a.read === true)).toBe(true);
 
       // Verify both are read
       const articles = await db
@@ -408,7 +409,8 @@ describe("Saved Articles API", () => {
       const caller = createCaller(ctx);
 
       const result = await caller.saved.markRead({ ids: [id1, id2], read: false });
-      expect(result).toEqual({});
+      expect(result.articles).toHaveLength(2);
+      expect(result.articles.every((a) => a.read === false)).toBe(true);
 
       // Verify both are unread
       const articles = await db
@@ -431,7 +433,10 @@ describe("Saved Articles API", () => {
         ids: [validId, generateUuidv7()],
         read: true,
       });
-      expect(result).toEqual({});
+      // Only the valid article is returned
+      expect(result.articles).toHaveLength(1);
+      expect(result.articles[0].id).toBe(validId);
+      expect(result.articles[0].read).toBe(true);
 
       // Verify valid article is updated
       const dbArticle = await db
@@ -471,7 +476,7 @@ describe("Saved Articles API", () => {
       expect(otherResult[0].read).toBe(false);
     });
 
-    it("returns empty object when no valid IDs provided", async () => {
+    it("returns empty articles array when no valid IDs provided", async () => {
       const userId = await createTestUser();
       const ctx = createAuthContext(userId);
       const caller = createCaller(ctx);
@@ -480,7 +485,7 @@ describe("Saved Articles API", () => {
         ids: [generateUuidv7()],
         read: true,
       });
-      expect(result).toEqual({});
+      expect(result.articles).toEqual([]);
     });
   });
 
@@ -493,9 +498,11 @@ describe("Saved Articles API", () => {
       const caller = createCaller(ctx);
 
       const result = await caller.saved.star({ id: articleId });
-      expect(result).toEqual({});
+      expect(result.article.id).toBe(articleId);
+      expect(result.article.starred).toBe(true);
+      expect(result.article.read).toBe(false);
 
-      // Verify starred
+      // Verify starred in DB
       const dbArticle = await db
         .select()
         .from(savedArticles)
@@ -545,9 +552,11 @@ describe("Saved Articles API", () => {
       const caller = createCaller(ctx);
 
       const result = await caller.saved.unstar({ id: articleId });
-      expect(result).toEqual({});
+      expect(result.article.id).toBe(articleId);
+      expect(result.article.starred).toBe(false);
+      expect(result.article.read).toBe(false);
 
-      // Verify unstarred
+      // Verify unstarred in DB
       const dbArticle = await db
         .select()
         .from(savedArticles)


### PR DESCRIPTION
- Update saved router mutations (markRead, star, unstar) to return article data for normy cache normalization
- Create useSavedArticleMutations hook to consolidate mutation logic
- Refactor SavedArticleContent and SavedArticlesPage to use the hook
- Add sortOrder support to saved.list query with proper cursor handling
- Add sort toggle to saved articles page UI

The root cause of the flaky mark read/unread button was that mutations returned empty objects, preventing normy from propagating updates. Now mutations return the updated article state like entries do.