### PR TITLE
Make entry list indicators clickable controls

### DIFF
--- a/src/app/(app)/all/page.tsx
+++ b/src/app/(app)/all/page.tsx
@@ -101,6 +101,8 @@ function AllEntriesContent() {
         onEntryClick={handleEntryClick}
         selectedEntryId={selectedEntryId}
         onEntriesLoaded={handleEntriesLoaded}
+        onToggleRead={toggleRead}
+        onToggleStar={toggleStar}
         emptyMessage={
           showUnreadOnly
             ? "No unread entries. Toggle to show all items."

--- a/src/app/(app)/feed/[feedId]/page.tsx
+++ b/src/app/(app)/feed/[feedId]/page.tsx
@@ -225,6 +225,8 @@ function SingleFeedContent() {
         onEntryClick={handleEntryClick}
         selectedEntryId={selectedEntryId}
         onEntriesLoaded={handleEntriesLoaded}
+        onToggleRead={toggleRead}
+        onToggleStar={toggleStar}
         emptyMessage={
           showUnreadOnly
             ? "No unread entries in this feed. Toggle to show all items."

--- a/src/app/(app)/saved/page.tsx
+++ b/src/app/(app)/saved/page.tsx
@@ -93,6 +93,8 @@ function SavedArticlesContent() {
         onArticleClick={handleArticleClick}
         selectedArticleId={selectedArticleId}
         onArticlesLoaded={handleArticlesLoaded}
+        onToggleRead={toggleRead}
+        onToggleStar={toggleStar}
         emptyMessage={
           showUnreadOnly
             ? "No unread saved articles. Toggle to show all items."

--- a/src/app/(app)/starred/page.tsx
+++ b/src/app/(app)/starred/page.tsx
@@ -100,6 +100,8 @@ function StarredEntriesContent() {
         onEntryClick={handleEntryClick}
         selectedEntryId={selectedEntryId}
         onEntriesLoaded={handleEntriesLoaded}
+        onToggleRead={toggleRead}
+        onToggleStar={toggleStar}
         emptyMessage={
           showUnreadOnly
             ? "No unread starred entries. Toggle to show all starred items."

--- a/src/app/(app)/tag/[tagId]/page.tsx
+++ b/src/app/(app)/tag/[tagId]/page.tsx
@@ -216,6 +216,8 @@ function TagEntriesContent() {
         onEntryClick={handleEntryClick}
         selectedEntryId={selectedEntryId}
         onEntriesLoaded={handleEntriesLoaded}
+        onToggleRead={toggleRead}
+        onToggleStar={toggleStar}
         emptyMessage={
           showUnreadOnly
             ? `No unread entries from feeds tagged with "${tag.name}". Toggle to show all items.`

--- a/src/components/articles/ArticleListItem.tsx
+++ b/src/components/articles/ArticleListItem.tsx
@@ -32,6 +32,10 @@ export interface ArticleListItemProps {
   selected?: boolean;
   /** Callback when the article is clicked */
   onClick?: (id: string) => void;
+  /** Callback when the read status indicator is clicked */
+  onToggleRead?: (id: string, currentlyRead: boolean) => void;
+  /** Callback when the star indicator is clicked */
+  onToggleStar?: (id: string, currentlyStarred: boolean) => void;
 }
 
 /**
@@ -69,6 +73,8 @@ export const ArticleListItem = memo(function ArticleListItem({
   starred,
   selected = false,
   onClick,
+  onToggleRead,
+  onToggleStar,
 }: ArticleListItemProps) {
   const displayTitle = title ?? "Untitled";
 
@@ -81,6 +87,16 @@ export const ArticleListItem = memo(function ArticleListItem({
       e.preventDefault();
       onClick?.(id);
     }
+  };
+
+  const handleToggleRead = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onToggleRead?.(id, read);
+  };
+
+  const handleToggleStar = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onToggleStar?.(id, starred);
   };
 
   return (
@@ -96,14 +112,28 @@ export const ArticleListItem = memo(function ArticleListItem({
       <div className="flex items-start gap-3">
         {/* Read/Unread Indicator */}
         <div className="mt-1.5 shrink-0">
-          <span
-            className={`block h-2.5 w-2.5 rounded-full ${
-              read
-                ? "border border-zinc-300 bg-transparent dark:border-zinc-600"
-                : "bg-blue-500 dark:bg-blue-400"
-            }`}
-            aria-hidden="true"
-          />
+          {onToggleRead ? (
+            <button
+              type="button"
+              onClick={handleToggleRead}
+              className={`block h-2.5 w-2.5 rounded-full transition-colors ${
+                read
+                  ? "border border-zinc-300 bg-transparent hover:border-blue-400 hover:bg-blue-100 dark:border-zinc-600 dark:hover:border-blue-400 dark:hover:bg-blue-900/50"
+                  : "bg-blue-500 hover:bg-blue-600 dark:bg-blue-400 dark:hover:bg-blue-300"
+              }`}
+              aria-label={read ? "Mark as unread" : "Mark as read"}
+              title={read ? "Mark as unread" : "Mark as read"}
+            />
+          ) : (
+            <span
+              className={`block h-2.5 w-2.5 rounded-full ${
+                read
+                  ? "border border-zinc-300 bg-transparent dark:border-zinc-600"
+                  : "bg-blue-500 dark:bg-blue-400"
+              }`}
+              aria-hidden="true"
+            />
+          )}
         </div>
 
         <div className="min-w-0 flex-1">
@@ -120,12 +150,42 @@ export const ArticleListItem = memo(function ArticleListItem({
             </h3>
 
             {/* Starred Indicator */}
-            {starred && (
-              <span className="shrink-0 text-amber-500 dark:text-amber-400" aria-label="Starred">
-                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            {onToggleStar ? (
+              <button
+                type="button"
+                onClick={handleToggleStar}
+                className={`shrink-0 transition-colors ${
+                  starred
+                    ? "text-amber-500 hover:text-amber-600 dark:text-amber-400 dark:hover:text-amber-300"
+                    : "text-zinc-300 opacity-0 group-hover:opacity-100 hover:text-amber-400 dark:text-zinc-600 dark:hover:text-amber-400"
+                }`}
+                aria-label={starred ? "Remove from starred" : "Add to starred"}
+                title={starred ? "Remove from starred" : "Add to starred"}
+              >
+                <svg
+                  className="h-4 w-4"
+                  fill={starred ? "currentColor" : "none"}
+                  stroke="currentColor"
+                  strokeWidth={starred ? 0 : 1.5}
+                  viewBox="0 0 20 20"
+                  aria-hidden="true"
+                >
                   <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
                 </svg>
-              </span>
+              </button>
+            ) : (
+              starred && (
+                <span className="shrink-0 text-amber-500 dark:text-amber-400" aria-label="Starred">
+                  <svg
+                    className="h-4 w-4"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                    aria-hidden="true"
+                  >
+                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                  </svg>
+                </span>
+              )
             )}
           </div>
 

--- a/src/components/entries/EntryList.tsx
+++ b/src/components/entries/EntryList.tsx
@@ -90,6 +90,16 @@ interface EntryListProps {
    * Used by parent components for keyboard navigation and actions.
    */
   onEntriesLoaded?: (entries: EntryListEntryData[]) => void;
+
+  /**
+   * Callback when the read status indicator is clicked.
+   */
+  onToggleRead?: (entryId: string, currentlyRead: boolean) => void;
+
+  /**
+   * Callback when the star indicator is clicked.
+   */
+  onToggleStar?: (entryId: string, currentlyStarred: boolean) => void;
 }
 
 /**
@@ -102,6 +112,8 @@ export function EntryList({
   emptyMessage = "No entries to display",
   selectedEntryId,
   onEntriesLoaded,
+  onToggleRead,
+  onToggleStar,
 }: EntryListProps) {
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
@@ -205,6 +217,8 @@ export function EntryList({
           entry={entry as EntryListItemData}
           onClick={onEntryClick}
           selected={selectedEntryId === entry.id}
+          onToggleRead={onToggleRead}
+          onToggleStar={onToggleStar}
         />
       ))}
 

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -34,6 +34,14 @@ interface EntryListItemProps {
    * Whether this entry is currently selected (for keyboard navigation).
    */
   selected?: boolean;
+  /**
+   * Callback when the read status indicator is clicked.
+   */
+  onToggleRead?: (entryId: string, currentlyRead: boolean) => void;
+  /**
+   * Callback when the star indicator is clicked.
+   */
+  onToggleStar?: (entryId: string, currentlyStarred: boolean) => void;
 }
 
 /**
@@ -44,6 +52,8 @@ export const EntryListItem = memo(function EntryListItem({
   entry,
   onClick,
   selected = false,
+  onToggleRead,
+  onToggleStar,
 }: EntryListItemProps) {
   return (
     <ArticleListItem
@@ -56,6 +66,8 @@ export const EntryListItem = memo(function EntryListItem({
       starred={entry.starred}
       selected={selected}
       onClick={onClick}
+      onToggleRead={onToggleRead}
+      onToggleStar={onToggleStar}
     />
   );
 });

--- a/src/components/saved/SavedArticleList.tsx
+++ b/src/components/saved/SavedArticleList.tsx
@@ -81,6 +81,16 @@ interface SavedArticleListProps {
    * Used by parent components for keyboard navigation and actions.
    */
   onArticlesLoaded?: (articles: SavedArticleListEntryData[]) => void;
+
+  /**
+   * Callback when the read status indicator is clicked.
+   */
+  onToggleRead?: (articleId: string, currentlyRead: boolean) => void;
+
+  /**
+   * Callback when the star indicator is clicked.
+   */
+  onToggleStar?: (articleId: string, currentlyStarred: boolean) => void;
 }
 
 /**
@@ -93,6 +103,8 @@ export function SavedArticleList({
   emptyMessage = "No saved articles to display",
   selectedArticleId,
   onArticlesLoaded,
+  onToggleRead,
+  onToggleStar,
 }: SavedArticleListProps) {
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
@@ -194,6 +206,8 @@ export function SavedArticleList({
           article={article as SavedArticleListItemData}
           onClick={onArticleClick}
           selected={selectedArticleId === article.id}
+          onToggleRead={onToggleRead}
+          onToggleStar={onToggleStar}
         />
       ))}
 

--- a/src/components/saved/SavedArticleListItem.tsx
+++ b/src/components/saved/SavedArticleListItem.tsx
@@ -34,6 +34,14 @@ interface SavedArticleListItemProps {
    * Whether this article is currently selected (for keyboard navigation).
    */
   selected?: boolean;
+  /**
+   * Callback when the read status indicator is clicked.
+   */
+  onToggleRead?: (articleId: string, currentlyRead: boolean) => void;
+  /**
+   * Callback when the star indicator is clicked.
+   */
+  onToggleStar?: (articleId: string, currentlyStarred: boolean) => void;
 }
 
 /**
@@ -44,6 +52,8 @@ export const SavedArticleListItem = memo(function SavedArticleListItem({
   article,
   onClick,
   selected = false,
+  onToggleRead,
+  onToggleStar,
 }: SavedArticleListItemProps) {
   return (
     <ArticleListItem
@@ -56,6 +66,8 @@ export const SavedArticleListItem = memo(function SavedArticleListItem({
       starred={article.starred}
       selected={selected}
       onClick={onClick}
+      onToggleRead={onToggleRead}
+      onToggleStar={onToggleStar}
     />
   );
 });


### PR DESCRIPTION
Make the read/unread dot and star icon in the entry list items interactive controls that toggle read/starred state directly from the list view. The indicators now behave like buttons, integrating with the existing normy- based mutation system for consistent cache updates.

- Read indicator: blue dot when unread, hollow circle when read, clickable to toggle state with hover feedback
- Star indicator: filled amber star when starred, outline star on hover when not starred, visible on hover for unstarred items
- Both indicators prevent click bubbling to avoid opening the entry
- Works on all entry list views: All, Feed, Tag, Starred, and Saved pages