### PR TITLE
Build custom migration runner for Drizzle

### DIFF
--- a/scripts/run-migrations.ts
+++ b/scripts/run-migrations.ts
@@ -1,0 +1,326 @@
+/**
+ * Custom migration runner that replaces drizzle-kit migrate.
+ *
+ * Key differences from drizzle-kit:
+ * - Each migration runs in its own transaction (drizzle-kit runs all in one)
+ * - Better error messages and hash verification
+ * - Compatible with existing drizzle migration format
+ */
+
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+
+import { Pool, PoolClient } from "pg";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+export interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+interface AppliedMigration {
+  id: number;
+  hash: string;
+  created_at: bigint;
+}
+
+export interface MigrationOptions {
+  /** Directory containing migration SQL files and meta/_journal.json */
+  migrationsDir?: string;
+  /** Schema name for migrations table (default: "drizzle") */
+  migrationsSchema?: string;
+  /** Table name for migrations tracking (default: "__drizzle_migrations") */
+  migrationsTable?: string;
+  /** Whether to log progress (default: true) */
+  verbose?: boolean;
+}
+
+interface ResolvedOptions {
+  migrationsDir: string;
+  migrationsSchema: string;
+  migrationsTable: string;
+  verbose: boolean;
+}
+
+// ============================================================================
+// Pure Functions (exported for testing)
+// ============================================================================
+
+/**
+ * Compute the hash of a migration file the same way drizzle-kit does.
+ * Drizzle uses SHA-256 of the SQL content.
+ */
+export function computeHash(sql: string): string {
+  return crypto.createHash("sha256").update(sql).digest("hex");
+}
+
+/**
+ * Split a migration SQL file into individual statements.
+ * Drizzle uses "--> statement-breakpoint" as a separator.
+ */
+export function splitStatements(sql: string): string[] {
+  return sql
+    .split("--> statement-breakpoint")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Parse a journal JSON string into a Journal object.
+ */
+export function parseJournal(content: string): Journal {
+  return JSON.parse(content) as Journal;
+}
+
+// ============================================================================
+// File System Functions
+// ============================================================================
+
+/**
+ * Load the migration journal from disk.
+ */
+function loadJournal(migrationsDir: string): Journal {
+  const journalPath = path.join(migrationsDir, "meta", "_journal.json");
+  const content = fs.readFileSync(journalPath, "utf-8");
+  return parseJournal(content);
+}
+
+/**
+ * Load a migration SQL file from disk.
+ */
+function loadMigrationSql(migrationsDir: string, tag: string): string {
+  const filePath = path.join(migrationsDir, `${tag}.sql`);
+  return fs.readFileSync(filePath, "utf-8");
+}
+
+// ============================================================================
+// Database Functions
+// ============================================================================
+
+/**
+ * Ensure the migrations schema and table exist.
+ * Table structure matches drizzle-kit exactly for compatibility.
+ */
+async function ensureMigrationsTable(
+  client: PoolClient,
+  schema: string,
+  table: string
+): Promise<void> {
+  await client.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`);
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS "${schema}"."${table}" (
+      id SERIAL PRIMARY KEY,
+      hash text NOT NULL,
+      created_at bigint
+    )
+  `);
+}
+
+/**
+ * Get all applied migrations from the database.
+ */
+async function getAppliedMigrations(
+  client: PoolClient,
+  schema: string,
+  table: string
+): Promise<AppliedMigration[]> {
+  const result = await client.query<AppliedMigration>(`
+    SELECT id, hash, created_at
+    FROM "${schema}"."${table}"
+    ORDER BY id ASC
+  `);
+  return result.rows;
+}
+
+/**
+ * Run a single migration in a transaction.
+ * The migrations table is updated in the same transaction.
+ */
+async function runMigration(
+  pool: Pool,
+  schema: string,
+  table: string,
+  sql: string,
+  hash: string,
+  folderMillis: number
+): Promise<void> {
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+
+    // Split and execute each statement
+    const statements = splitStatements(sql);
+    for (const statement of statements) {
+      await client.query(statement);
+    }
+
+    // Record the migration in the same transaction
+    // Use folderMillis (from journal.when) as created_at for drizzle compatibility
+    await client.query(`INSERT INTO "${schema}"."${table}" (hash, created_at) VALUES ($1, $2)`, [
+      hash,
+      folderMillis,
+    ]);
+
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+// ============================================================================
+// Main Migration Runner
+// ============================================================================
+
+function resolveOptions(options?: MigrationOptions): ResolvedOptions {
+  return {
+    migrationsDir: options?.migrationsDir ?? path.join(process.cwd(), "drizzle"),
+    migrationsSchema: options?.migrationsSchema ?? "drizzle",
+    migrationsTable: options?.migrationsTable ?? "__drizzle_migrations",
+    verbose: options?.verbose ?? true,
+  };
+}
+
+/**
+ * Main migration runner.
+ */
+export async function runMigrations(
+  databaseUrl: string,
+  options?: MigrationOptions
+): Promise<{ applied: string[]; skipped: string[] }> {
+  const opts = resolveOptions(options);
+  const pool = new Pool({ connectionString: databaseUrl });
+  const applied: string[] = [];
+  const skipped: string[] = [];
+
+  const log = opts.verbose ? console.log.bind(console) : () => {};
+
+  try {
+    // Ensure migrations table exists
+    const client = await pool.connect();
+    try {
+      await ensureMigrationsTable(client, opts.migrationsSchema, opts.migrationsTable);
+      const appliedMigrations = await getAppliedMigrations(
+        client,
+        opts.migrationsSchema,
+        opts.migrationsTable
+      );
+
+      // Load journal to get list of all migrations
+      const journal = loadJournal(opts.migrationsDir);
+
+      // Verify already-applied migrations have matching hashes
+      for (let i = 0; i < appliedMigrations.length; i++) {
+        const appliedMigration = appliedMigrations[i];
+        const journalEntry = journal.entries[i];
+
+        if (!journalEntry) {
+          throw new Error(
+            `Migration ${i} exists in database but not in journal. ` +
+              `This may indicate a corrupted migration state.`
+          );
+        }
+
+        const sql = loadMigrationSql(opts.migrationsDir, journalEntry.tag);
+        const expectedHash = computeHash(sql);
+
+        if (appliedMigration.hash !== expectedHash) {
+          throw new Error(
+            `Hash mismatch for migration ${journalEntry.tag}:\n` +
+              `  Expected: ${expectedHash}\n` +
+              `  Found:    ${appliedMigration.hash}\n` +
+              `This may indicate the migration file was modified after being applied.`
+          );
+        }
+
+        skipped.push(journalEntry.tag);
+      }
+
+      // Get pending migrations
+      const pendingMigrations = journal.entries.slice(appliedMigrations.length);
+
+      if (pendingMigrations.length === 0) {
+        log("No pending migrations.");
+        return { applied, skipped };
+      }
+
+      log(`Found ${pendingMigrations.length} pending migration(s).`);
+
+      // Run each pending migration
+      for (const entry of pendingMigrations) {
+        log(`Running migration: ${entry.tag}...`);
+
+        const sql = loadMigrationSql(opts.migrationsDir, entry.tag);
+        const hash = computeHash(sql);
+
+        await runMigration(
+          pool,
+          opts.migrationsSchema,
+          opts.migrationsTable,
+          sql,
+          hash,
+          entry.when
+        );
+
+        applied.push(entry.tag);
+        log(`  ✓ Applied ${entry.tag}`);
+      }
+    } finally {
+      client.release();
+    }
+
+    return { applied, skipped };
+  } finally {
+    await pool.end();
+  }
+}
+
+// ============================================================================
+// CLI Entry Point
+// ============================================================================
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    console.error("DATABASE_URL environment variable is not set");
+    process.exit(1);
+  }
+
+  console.log("Running database migrations...\n");
+
+  try {
+    const { applied, skipped } = await runMigrations(databaseUrl);
+
+    if (applied.length > 0) {
+      console.log(`\n✓ Applied ${applied.length} migration(s)`);
+    }
+    if (skipped.length > 0) {
+      console.log(`  Skipped ${skipped.length} already-applied migration(s)`);
+    }
+  } catch (error) {
+    console.error("\nMigration failed:", error);
+    process.exit(1);
+  }
+}
+
+// Run if executed directly
+if (require.main === module) {
+  main();
+}

--- a/tests/integration/migration-runner.test.ts
+++ b/tests/integration/migration-runner.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Integration tests for the custom migration runner.
+ *
+ * These tests create a temporary database and migration files to verify:
+ * - Migrations are applied correctly
+ * - Each migration runs in its own transaction (per-transaction rollback)
+ * - Hash verification detects modified migration files
+ * - Already-applied migrations are skipped
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { Pool } from "pg";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  computeHash,
+  parseJournal,
+  runMigrations,
+  splitStatements,
+} from "../../scripts/run-migrations";
+
+// ============================================================================
+// Test Configuration
+// ============================================================================
+
+const TEST_DB_NAME = "migration_runner_test";
+
+/**
+ * Parse DATABASE_URL to derive admin and test database URLs.
+ * The admin URL connects to 'postgres' database for creating/dropping test databases.
+ */
+function getDatabaseUrls(): { adminUrl: string; testUrl: string } {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL environment variable is required for integration tests");
+  }
+
+  const url = new URL(databaseUrl);
+  const baseUrl = `${url.protocol}//${url.username}:${url.password}@${url.host}`;
+
+  return {
+    adminUrl: `${baseUrl}/postgres`,
+    testUrl: `${baseUrl}/${TEST_DB_NAME}`,
+  };
+}
+
+const { adminUrl: ADMIN_DB_URL, testUrl: TEST_DB_URL } = getDatabaseUrls();
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+function createTestMigrationsDir(): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "migration-test-"));
+  fs.mkdirSync(path.join(tmpDir, "meta"));
+  return tmpDir;
+}
+
+function writeJournal(migrationsDir: string, entries: Array<{ tag: string; when: number }>): void {
+  const journal = {
+    version: "7",
+    dialect: "postgresql",
+    entries: entries.map((e, idx) => ({
+      idx,
+      version: "7",
+      when: e.when,
+      tag: e.tag,
+      breakpoints: true,
+    })),
+  };
+  fs.writeFileSync(
+    path.join(migrationsDir, "meta", "_journal.json"),
+    JSON.stringify(journal, null, 2)
+  );
+}
+
+function writeMigration(migrationsDir: string, tag: string, sql: string): void {
+  fs.writeFileSync(path.join(migrationsDir, `${tag}.sql`), sql);
+}
+
+function cleanupMigrationsDir(migrationsDir: string): void {
+  fs.rmSync(migrationsDir, { recursive: true, force: true });
+}
+
+// ============================================================================
+// Unit Tests for Pure Functions
+// ============================================================================
+
+describe("migration runner pure functions", () => {
+  describe("computeHash", () => {
+    it("computes SHA-256 hash of SQL content", () => {
+      const sql = "CREATE TABLE test (id int);";
+      const hash = computeHash(sql);
+
+      // SHA-256 produces 64 hex characters
+      expect(hash).toHaveLength(64);
+      expect(hash).toMatch(/^[a-f0-9]+$/);
+    });
+
+    it("produces same hash for same content", () => {
+      const sql = "CREATE TABLE test (id int);";
+      expect(computeHash(sql)).toBe(computeHash(sql));
+    });
+
+    it("produces different hash for different content", () => {
+      const sql1 = "CREATE TABLE test1 (id int);";
+      const sql2 = "CREATE TABLE test2 (id int);";
+      expect(computeHash(sql1)).not.toBe(computeHash(sql2));
+    });
+  });
+
+  describe("splitStatements", () => {
+    it("splits on statement-breakpoint marker", () => {
+      const sql = `
+CREATE TABLE a (id int);
+--> statement-breakpoint
+CREATE TABLE b (id int);
+--> statement-breakpoint
+CREATE INDEX idx ON a (id);
+      `.trim();
+
+      const statements = splitStatements(sql);
+      expect(statements).toHaveLength(3);
+      expect(statements[0]).toBe("CREATE TABLE a (id int);");
+      expect(statements[1]).toBe("CREATE TABLE b (id int);");
+      expect(statements[2]).toBe("CREATE INDEX idx ON a (id);");
+    });
+
+    it("handles single statement without breakpoints", () => {
+      const sql = "CREATE TABLE test (id int);";
+      const statements = splitStatements(sql);
+      expect(statements).toHaveLength(1);
+      expect(statements[0]).toBe(sql);
+    });
+
+    it("filters out empty statements", () => {
+      const sql = `
+CREATE TABLE a (id int);
+--> statement-breakpoint
+--> statement-breakpoint
+CREATE TABLE b (id int);
+      `.trim();
+
+      const statements = splitStatements(sql);
+      expect(statements).toHaveLength(2);
+    });
+  });
+
+  describe("parseJournal", () => {
+    it("parses valid journal JSON", () => {
+      const content = JSON.stringify({
+        version: "7",
+        dialect: "postgresql",
+        entries: [{ idx: 0, version: "7", when: 1234567890, tag: "0000_test", breakpoints: true }],
+      });
+
+      const journal = parseJournal(content);
+      expect(journal.version).toBe("7");
+      expect(journal.dialect).toBe("postgresql");
+      expect(journal.entries).toHaveLength(1);
+      expect(journal.entries[0].tag).toBe("0000_test");
+    });
+  });
+});
+
+// ============================================================================
+// Integration Tests
+// ============================================================================
+
+describe("migration runner integration", () => {
+  let adminPool: Pool;
+  let migrationsDir: string;
+
+  beforeAll(async () => {
+    adminPool = new Pool({ connectionString: ADMIN_DB_URL });
+
+    // Create test database
+    await adminPool.query(`DROP DATABASE IF EXISTS ${TEST_DB_NAME}`);
+    await adminPool.query(`CREATE DATABASE ${TEST_DB_NAME}`);
+  });
+
+  afterAll(async () => {
+    // Drop test database
+    await adminPool.query(`DROP DATABASE IF EXISTS ${TEST_DB_NAME}`);
+    await adminPool.end();
+  });
+
+  beforeEach(async () => {
+    // Create fresh migrations directory for each test
+    migrationsDir = createTestMigrationsDir();
+
+    // Reset the test database schema
+    const testPool = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await testPool.query("DROP SCHEMA IF EXISTS drizzle CASCADE");
+      await testPool.query("DROP SCHEMA IF EXISTS public CASCADE");
+      await testPool.query("CREATE SCHEMA public");
+    } finally {
+      await testPool.end();
+    }
+  });
+
+  afterAll(() => {
+    if (migrationsDir) {
+      cleanupMigrationsDir(migrationsDir);
+    }
+  });
+
+  it("applies migrations to empty database", async () => {
+    writeJournal(migrationsDir, [
+      { tag: "0001_create_users", when: 1000000000000 },
+      { tag: "0002_create_posts", when: 1000000001000 },
+    ]);
+
+    writeMigration(
+      migrationsDir,
+      "0001_create_users",
+      "CREATE TABLE users (id serial PRIMARY KEY, name text NOT NULL);"
+    );
+    writeMigration(
+      migrationsDir,
+      "0002_create_posts",
+      "CREATE TABLE posts (id serial PRIMARY KEY, user_id int REFERENCES users(id));"
+    );
+
+    const result = await runMigrations(TEST_DB_URL, {
+      migrationsDir,
+      verbose: false,
+    });
+
+    expect(result.applied).toEqual(["0001_create_users", "0002_create_posts"]);
+    expect(result.skipped).toEqual([]);
+
+    // Verify tables exist
+    const testPool = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      const tables = await testPool.query(`
+        SELECT table_name FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+        ORDER BY table_name
+      `);
+      expect(tables.rows.map((r) => r.table_name)).toEqual(["posts", "users"]);
+    } finally {
+      await testPool.end();
+    }
+  });
+
+  it("skips already-applied migrations", async () => {
+    writeJournal(migrationsDir, [
+      { tag: "0001_create_users", when: 1000000000000 },
+      { tag: "0002_create_posts", when: 1000000001000 },
+    ]);
+
+    writeMigration(
+      migrationsDir,
+      "0001_create_users",
+      "CREATE TABLE users (id serial PRIMARY KEY, name text NOT NULL);"
+    );
+    writeMigration(
+      migrationsDir,
+      "0002_create_posts",
+      "CREATE TABLE posts (id serial PRIMARY KEY, user_id int REFERENCES users(id));"
+    );
+
+    // Run migrations first time
+    await runMigrations(TEST_DB_URL, { migrationsDir, verbose: false });
+
+    // Run migrations second time
+    const result = await runMigrations(TEST_DB_URL, {
+      migrationsDir,
+      verbose: false,
+    });
+
+    expect(result.applied).toEqual([]);
+    expect(result.skipped).toEqual(["0001_create_users", "0002_create_posts"]);
+  });
+
+  it("applies only new migrations when some already exist", async () => {
+    // First, apply initial migration
+    writeJournal(migrationsDir, [{ tag: "0001_create_users", when: 1000000000000 }]);
+    writeMigration(
+      migrationsDir,
+      "0001_create_users",
+      "CREATE TABLE users (id serial PRIMARY KEY, name text NOT NULL);"
+    );
+    await runMigrations(TEST_DB_URL, { migrationsDir, verbose: false });
+
+    // Add new migration to journal
+    writeJournal(migrationsDir, [
+      { tag: "0001_create_users", when: 1000000000000 },
+      { tag: "0002_create_posts", when: 1000000001000 },
+    ]);
+    writeMigration(
+      migrationsDir,
+      "0002_create_posts",
+      "CREATE TABLE posts (id serial PRIMARY KEY, user_id int REFERENCES users(id));"
+    );
+
+    // Run migrations again
+    const result = await runMigrations(TEST_DB_URL, {
+      migrationsDir,
+      verbose: false,
+    });
+
+    expect(result.applied).toEqual(["0002_create_posts"]);
+    expect(result.skipped).toEqual(["0001_create_users"]);
+  });
+
+  it("rolls back failed migration but preserves successful ones", async () => {
+    writeJournal(migrationsDir, [
+      { tag: "0001_create_users", when: 1000000000000 },
+      { tag: "0002_will_fail", when: 1000000001000 },
+    ]);
+
+    writeMigration(
+      migrationsDir,
+      "0001_create_users",
+      "CREATE TABLE users (id serial PRIMARY KEY, name text NOT NULL);"
+    );
+    writeMigration(
+      migrationsDir,
+      "0002_will_fail",
+      `
+ALTER TABLE users ADD COLUMN email text;
+--> statement-breakpoint
+ALTER TABLE nonexistent_table ADD COLUMN foo text;
+      `.trim()
+    );
+
+    // Run migrations - should fail on second migration
+    await expect(runMigrations(TEST_DB_URL, { migrationsDir, verbose: false })).rejects.toThrow();
+
+    // Verify first migration was committed (users table exists)
+    const testPool = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      const tables = await testPool.query(`
+        SELECT table_name FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+      `);
+      expect(tables.rows.map((r) => r.table_name)).toContain("users");
+
+      // Verify second migration was rolled back (email column doesn't exist)
+      const columns = await testPool.query(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'users'
+      `);
+      expect(columns.rows.map((r) => r.column_name)).not.toContain("email");
+
+      // Verify migrations table only has first migration
+      const migrations = await testPool.query(`
+        SELECT hash FROM drizzle.__drizzle_migrations ORDER BY id
+      `);
+      expect(migrations.rows).toHaveLength(1);
+    } finally {
+      await testPool.end();
+    }
+  });
+
+  it("detects hash mismatch for modified migration file", async () => {
+    writeJournal(migrationsDir, [{ tag: "0001_create_users", when: 1000000000000 }]);
+    writeMigration(
+      migrationsDir,
+      "0001_create_users",
+      "CREATE TABLE users (id serial PRIMARY KEY, name text NOT NULL);"
+    );
+
+    // Apply migration
+    await runMigrations(TEST_DB_URL, { migrationsDir, verbose: false });
+
+    // Modify the migration file
+    writeMigration(
+      migrationsDir,
+      "0001_create_users",
+      "CREATE TABLE users (id serial PRIMARY KEY, name text NOT NULL, email text);"
+    );
+
+    // Running again should fail with hash mismatch
+    await expect(runMigrations(TEST_DB_URL, { migrationsDir, verbose: false })).rejects.toThrow(
+      /Hash mismatch/
+    );
+  });
+
+  it("handles empty migrations directory", async () => {
+    writeJournal(migrationsDir, []);
+
+    const result = await runMigrations(TEST_DB_URL, {
+      migrationsDir,
+      verbose: false,
+    });
+
+    expect(result.applied).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it("records correct created_at timestamp from journal", async () => {
+    const timestamp = 1234567890123;
+    writeJournal(migrationsDir, [{ tag: "0001_test", when: timestamp }]);
+    writeMigration(migrationsDir, "0001_test", "CREATE TABLE test (id int);");
+
+    await runMigrations(TEST_DB_URL, { migrationsDir, verbose: false });
+
+    const testPool = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      const result = await testPool.query("SELECT created_at FROM drizzle.__drizzle_migrations");
+      expect(result.rows[0].created_at).toBe(timestamp.toString());
+    } finally {
+      await testPool.end();
+    }
+  });
+});


### PR DESCRIPTION
Replace drizzle-kit migrate with a custom runner that:
- Runs each migration in its own transaction (drizzle-kit runs all in one)
- Verifies hashes of already-applied migrations
- Uses same hash algorithm (SHA-256) and table format as drizzle-kit
- Updates version table in same transaction as migration

The runner is now configurable for testing with options for:
- Custom migrations directory
- Custom schema/table names
- Verbose logging toggle

Includes comprehensive integration tests that:
- Create a temporary test database dynamically
- Test per-transaction rollback behavior
- Verify hash mismatch detection
- Test skipping already-applied migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)