### PR TITLE
Refactor job queue to use persistent jobs instead of ephemeral runs

### DIFF
--- a/docs/job-queue-design.md
+++ b/docs/job-queue-design.md
@@ -1,0 +1,198 @@
+# Job Queue Design
+
+The job queue manages recurring background tasks like feed fetching and WebSub renewal. It uses a simple Postgres-based model with one row per scheduled task.
+
+## Design Principles
+
+1. **One job per task**: Each feed has exactly one `fetch_feed` job row. There's one `renew_websub` job for all WebSub renewals. Jobs are persistent, not ephemeral.
+
+2. **Declarative scheduling**: The `next_run_at` column declares when a job should run next. The worker polls for due jobs.
+
+3. **Enable/disable over create/delete**: When a feed has no subscribers, we disable its job rather than deleting it. Re-subscribing re-enables it.
+
+4. **Stale job recovery**: Jobs track `running_since` timestamp. Jobs running for > 5 minutes are assumed crashed and become claimable again.
+
+## Schema
+
+```sql
+CREATE TABLE jobs (
+  id UUID PRIMARY KEY,
+  type TEXT NOT NULL,              -- 'fetch_feed', 'renew_websub'
+  payload JSONB NOT NULL,          -- { feedId: '...' } for fetch_feed
+
+  -- Scheduling state
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  next_run_at TIMESTAMPTZ,
+  running_since TIMESTAMPTZ,       -- NULL = not running
+
+  -- Tracking
+  last_run_at TIMESTAMPTZ,
+  last_error TEXT,
+  consecutive_failures INT NOT NULL DEFAULT 0,
+
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL
+);
+
+-- Index for polling: enabled jobs that are due
+CREATE INDEX idx_jobs_polling ON jobs (next_run_at) WHERE enabled = true;
+
+-- Index for looking up feed jobs by feedId
+CREATE INDEX idx_jobs_feed_id ON jobs ((payload->>'feedId')) WHERE type = 'fetch_feed';
+```
+
+## Job Types
+
+### `fetch_feed`
+
+Fetches a feed and processes new entries.
+
+**Payload**: `{ feedId: string }`
+
+**Lifecycle**:
+
+1. Created when first user subscribes to a feed
+2. Runs at `next_run_at`, updates entries, calculates next fetch time
+3. Disabled when last subscriber unsubscribes
+4. Re-enabled when someone subscribes again
+
+**Failure handling**: Failures tracked on `feeds.consecutive_failures`. Backoff applied to `next_run_at`.
+
+### `renew_websub`
+
+Renews expiring WebSub subscriptions.
+
+**Payload**: `{}` (empty)
+
+**Lifecycle**:
+
+1. Created at application startup if it doesn't exist
+2. Runs daily, renews all WebSub subscriptions expiring within 24 hours
+3. Always enabled
+
+**Failure handling**: Failures tracked on `jobs.consecutive_failures` since there's no associated feed.
+
+## Worker Behavior
+
+### Claiming Jobs
+
+```sql
+UPDATE jobs
+SET running_since = now()
+WHERE id = (
+  SELECT id FROM jobs
+  WHERE enabled = true
+    AND next_run_at <= now()
+    AND (running_since IS NULL OR running_since < now() - interval '5 minutes')
+  ORDER BY next_run_at ASC
+  LIMIT 1
+  FOR UPDATE SKIP LOCKED
+)
+RETURNING *
+```
+
+The query:
+
+- Only claims enabled jobs
+- Only claims jobs where `next_run_at` is in the past
+- Skips jobs currently running (`running_since` is recent)
+- Reclaims jobs running > 5 minutes (assumed crashed)
+- Uses `FOR UPDATE SKIP LOCKED` for concurrent workers
+
+### Finishing Jobs
+
+**On success**:
+
+```sql
+UPDATE jobs SET
+  running_since = NULL,
+  last_run_at = now(),
+  next_run_at = :calculated_next_run,
+  last_error = NULL,
+  consecutive_failures = 0,
+  updated_at = now()
+WHERE id = :job_id
+```
+
+**On failure**:
+
+```sql
+UPDATE jobs SET
+  running_since = NULL,
+  last_run_at = now(),
+  next_run_at = :backoff_next_run,
+  last_error = :error,
+  consecutive_failures = consecutive_failures + 1,
+  updated_at = now()
+WHERE id = :job_id
+```
+
+## Subscription Integration
+
+### When user subscribes to a new feed
+
+1. Create feed row
+2. Create job with `enabled = true`, `next_run_at = now()`
+3. Create subscription
+
+### When user subscribes to an existing feed
+
+1. Enable job (idempotent):
+   ```sql
+   UPDATE jobs SET enabled = true, updated_at = now()
+   WHERE payload->>'feedId' = :feed_id AND type = 'fetch_feed'
+   RETURNING next_run_at
+   ```
+2. Copy `next_run_at` to `feeds.next_fetch_at` (for UI/debugging)
+3. Create subscription
+
+### When user unsubscribes
+
+1. Soft-delete subscription
+2. Sync job enabled state atomically:
+   ```sql
+   UPDATE jobs SET
+     enabled = EXISTS (
+       SELECT 1 FROM subscriptions
+       WHERE feed_id = :feed_id AND unsubscribed_at IS NULL
+     ),
+     updated_at = now()
+   WHERE payload->>'feedId' = :feed_id AND type = 'fetch_feed'
+   RETURNING enabled
+   ```
+3. If job became disabled, set `feeds.next_fetch_at = NULL`
+
+This atomic query ensures the job is only disabled when the last subscriber leaves.
+
+## Comparison with Previous Design
+
+| Aspect          | Previous                                        | Current                                       |
+| --------------- | ----------------------------------------------- | --------------------------------------------- |
+| Jobs per feed   | Many (one per fetch)                            | One                                           |
+| Job lifecycle   | Create → Run → Complete → Create new            | Create → Run → Update same row                |
+| Status tracking | `status` enum: pending/running/completed/failed | `enabled` boolean + `running_since` timestamp |
+| Cleanup needed  | Yes (completed jobs accumulate)                 | No                                            |
+| On unsubscribe  | Job runs, finds no subscribers, skips           | Disable job immediately                       |
+| On resubscribe  | Bug: no job created                             | Enable existing job                           |
+
+## Edge Cases
+
+### Disabling a running job
+
+A job can be disabled while running (`enabled = false` but `running_since` is set). The job completes its current run normally. On the next poll cycle, it won't be claimed because `enabled = false`.
+
+### Creating a job for a feed that already has one
+
+`createFeedJob` is idempotent. If a job already exists for the feed, it enables it (if disabled) rather than creating a duplicate.
+
+### Job for feed with no subscribers
+
+When the last subscriber leaves, we disable the job but keep its `next_run_at`. When someone resubscribes, we re-enable it. The next run happens at the previously scheduled time (or immediately if that time has passed).
+
+### feeds.next_fetch_at synchronization
+
+The `feeds.next_fetch_at` column mirrors the job's `next_run_at` for UI and debugging purposes:
+
+- On disable: `feeds.next_fetch_at = NULL`
+- On enable: `feeds.next_fetch_at = jobs.next_run_at`
+- After job runs: both are updated to the calculated next time

--- a/drizzle/0013_job_queue_refactor.sql
+++ b/drizzle/0013_job_queue_refactor.sql
@@ -1,0 +1,44 @@
+-- Job queue refactor: one persistent job per feed instead of one job per fetch
+-- See docs/job-queue-design.md for details
+
+-- Step 1: Add new columns
+ALTER TABLE "jobs" ADD COLUMN "enabled" boolean NOT NULL DEFAULT true;--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "next_run_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "running_since" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "last_run_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "consecutive_failures" integer NOT NULL DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "updated_at" timestamp with time zone NOT NULL DEFAULT now();--> statement-breakpoint
+
+-- Step 2: Migrate data - copy scheduled_for to next_run_at for pending jobs
+UPDATE "jobs" SET "next_run_at" = "scheduled_for" WHERE "status" = 'pending';--> statement-breakpoint
+
+-- Step 3: For fetch_feed jobs, keep only the earliest pending one per feed
+-- First, delete all non-pending jobs (completed, failed, running)
+DELETE FROM "jobs" WHERE "status" != 'pending';--> statement-breakpoint
+
+-- Then delete duplicate fetch_feed jobs, keeping only the earliest per feedId
+DELETE FROM "jobs" WHERE "type" = 'fetch_feed' AND "id" NOT IN (
+  SELECT DISTINCT ON (payload::json->>'feedId') id
+  FROM "jobs"
+  WHERE "type" = 'fetch_feed'
+  ORDER BY payload::json->>'feedId', "next_run_at" ASC NULLS LAST
+);--> statement-breakpoint
+
+-- Step 4: Drop old columns
+ALTER TABLE "jobs" DROP COLUMN "status";--> statement-breakpoint
+ALTER TABLE "jobs" DROP COLUMN "scheduled_for";--> statement-breakpoint
+ALTER TABLE "jobs" DROP COLUMN "started_at";--> statement-breakpoint
+ALTER TABLE "jobs" DROP COLUMN "completed_at";--> statement-breakpoint
+ALTER TABLE "jobs" DROP COLUMN "attempts";--> statement-breakpoint
+ALTER TABLE "jobs" DROP COLUMN "max_attempts";--> statement-breakpoint
+
+-- Step 5: Drop job_status enum
+DROP TYPE "job_status";--> statement-breakpoint
+
+-- Step 6: Drop old indexes
+DROP INDEX IF EXISTS "idx_jobs_pending";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_jobs_status";--> statement-breakpoint
+
+-- Step 7: Create new indexes
+CREATE INDEX "idx_jobs_polling" ON "jobs" USING btree ("next_run_at") WHERE "enabled" = true;--> statement-breakpoint
+CREATE INDEX "idx_jobs_feed_id" ON "jobs" USING btree ((payload::json->>'feedId')) WHERE "type" = 'fetch_feed';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1767119886600,
       "tag": "0012_email_subscriptions",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1767210000000,
+      "tag": "0013_job_queue_refactor",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -159,11 +159,15 @@ async function seed() {
 
   // Create a sample job
   console.log("\nCreating sample job...");
+  const now = new Date();
   await db.insert(schema.jobs).values({
     id: generateUuidv7(),
     type: "fetch_feed",
     payload: JSON.stringify({ feedId: feeds[0].id }),
-    scheduledFor: new Date(),
+    enabled: true,
+    nextRunAt: now,
+    createdAt: now,
+    updatedAt: now,
   });
   console.log("  Created 1 sample job");
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -40,8 +40,6 @@ export interface ParagraphMapping {
 
 export const feedTypeEnum = pgEnum("feed_type", ["rss", "atom", "json", "email"]);
 
-export const jobStatusEnum = pgEnum("job_status", ["pending", "running", "completed", "failed"]);
-
 export const websubStateEnum = pgEnum("websub_state", ["pending", "active", "unsubscribed"]);
 
 // ============================================================================
@@ -387,35 +385,40 @@ export const userEntries = pgTable(
 
 // ============================================================================
 // JOB QUEUE
+// See docs/job-queue-design.md for detailed documentation.
 // ============================================================================
 
 /**
  * Jobs table - Postgres-based job queue for background processing.
- * Jobs are idempotent and safe to retry.
+ *
+ * One job per scheduled task (e.g., one per feed for fetch_feed jobs).
+ * Jobs are persistent and reused across runs, not created/completed per execution.
  */
 export const jobs = pgTable(
   "jobs",
   {
     id: uuid("id").primaryKey(),
-    type: text("type").notNull(), // 'fetch_feed', 'cleanup', etc.
+    type: text("type").notNull(), // 'fetch_feed', 'renew_websub'
     payload: text("payload").notNull().default("{}"), // JSON payload
 
-    // Scheduling
-    scheduledFor: timestamp("scheduled_for", { withTimezone: true }).notNull().defaultNow(),
-    startedAt: timestamp("started_at", { withTimezone: true }),
-    completedAt: timestamp("completed_at", { withTimezone: true }),
+    // Scheduling state
+    enabled: boolean("enabled").notNull().default(true),
+    nextRunAt: timestamp("next_run_at", { withTimezone: true }),
+    runningSince: timestamp("running_since", { withTimezone: true }), // NULL = not running
 
-    // Status and retries
-    status: jobStatusEnum("status").notNull().default("pending"),
-    attempts: integer("attempts").notNull().default(0),
-    maxAttempts: integer("max_attempts").notNull().default(3),
+    // Tracking
+    lastRunAt: timestamp("last_run_at", { withTimezone: true }),
     lastError: text("last_error"),
+    consecutiveFailures: integer("consecutive_failures").notNull().default(0),
 
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_jobs_pending").on(table.scheduledFor),
-    index("idx_jobs_status").on(table.status),
+    // Index for polling: enabled jobs that are due
+    index("idx_jobs_polling").on(table.nextRunAt),
+    // Index for looking up feed jobs by feedId
+    index("idx_jobs_feed_id").on(sql`(${table.payload}->>'feedId')`),
   ]
 );
 

--- a/src/server/jobs/index.ts
+++ b/src/server/jobs/index.ts
@@ -1,36 +1,40 @@
 /**
  * Job queue module exports.
+ *
+ * See docs/job-queue-design.md for the overall architecture.
  */
 
 export {
   // Core queue functions
   createJob,
   claimJob,
-  completeJob,
-  failJob,
+  finishJob,
   getJob,
   getJobPayload,
   listJobs,
 
-  // Maintenance functions
-  deleteCompletedJobs,
-  resetStaleJobs,
+  // Feed job functions
+  getFeedJob,
+  createOrEnableFeedJob,
+  enableFeedJob,
+  syncFeedJobEnabled,
+  updateFeedJobNextRun,
 
-  // Utility functions
-  calculateBackoff,
+  // System job functions
+  ensureRenewWebsubJobExists,
 
   // Types
   type JobPayloads,
   type JobType,
   type CreateJobOptions,
   type ClaimJobOptions,
+  type FinishJobOptions,
 } from "./queue";
 
 export {
   // Job handlers
   handleFetchFeed,
-  handleCleanup,
-  createInitialFetchJob,
+  handleRenewWebsub,
 
   // Types
   type JobHandlerResult,


### PR DESCRIPTION
Previously, each feed fetch created a new job row, and jobs accumulated requiring periodic cleanup. This caused issues where:
- The cleanup job needed to run to prevent table bloat
- Unsubscribe/resubscribe could lose sync state if jobs were cleared
- Job state was spread between feeds.next_fetch_at and jobs table

The new model uses one persistent job per feed:
- Jobs are enabled/disabled rather than created/deleted
- Job tracks enabled, running_since, last_run_at, consecutive_failures
- Unsubscribe atomically disables job when no subscribers remain
- Resubscribe enables the existing job, preserving its schedule
- No cleanup job needed since jobs don't accumulate

Also removes the status enum in favor of:
- enabled: whether job should run
- running_since: set when claimed, cleared when finished (NULL = not running)
- Stale job detection: reclaim jobs where running_since > 5 minutes ago

🤖 Generated with [Claude Code](https://claude.com/claude-code)