### PR TITLE
Track entry visibility in feed fetches

### DIFF
--- a/drizzle/0015_entry_last_seen_at.sql
+++ b/drizzle/0015_entry_last_seen_at.sql
@@ -1,0 +1,21 @@
+-- Add last_seen_at to entries table for tracking which entries are in the current feed
+-- This enables subscribing to an existing feed without re-fetching it.
+--
+-- For rss/atom/json entries: last_seen_at = feed.last_fetched_at means entry is in current feed
+-- For email/saved entries: last_seen_at is always NULL (not applicable)
+
+-- Step 1: Add the column (nullable initially for backfill)
+ALTER TABLE "entries" ADD COLUMN "last_seen_at" timestamp with time zone;
+
+-- Step 2: Backfill rss/atom/json entries with fetched_at
+-- This assumes all existing entries were in the feed when they were last fetched
+UPDATE "entries" SET "last_seen_at" = "fetched_at" WHERE "type" IN ('rss', 'atom', 'json');
+
+-- Step 3: Add check constraint - last_seen_at required for fetched feeds, NULL for others
+ALTER TABLE "entries" ADD CONSTRAINT "entries_last_seen_only_fetched"
+  CHECK ((type IN ('rss', 'atom', 'json')) = (last_seen_at IS NOT NULL));
+
+-- Step 4: Index for efficient visibility queries when subscribing
+-- Only index feed types that use this field
+CREATE INDEX "idx_entries_last_seen" ON "entries" ("feed_id", "last_seen_at")
+  WHERE "type" IN ('rss', 'atom', 'json');

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1767220000000,
       "tag": "0014_job_queue_refactor",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1767230000000,
+      "tag": "0015_entry_last_seen_at",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -237,6 +237,9 @@ export const entries = pgTable(
     // Timestamps
     publishedAt: timestamp("published_at", { withTimezone: true }), // from feed (may be null/inaccurate)
     fetchedAt: timestamp("fetched_at", { withTimezone: true }).notNull(), // when we first saw it
+    // Last time this entry was seen in a feed fetch (rss/atom/json only, NULL for email/saved)
+    // Used to determine visibility: entry.lastSeenAt = feed.lastFetchedAt means it's in the current feed
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true }),
 
     // Version tracking
     contentHash: text("content_hash").notNull(), // for detecting updates
@@ -268,6 +271,7 @@ export const entries = pgTable(
     // - entries_spam_only_email: spam fields only for email entries
     // - entries_unsubscribe_only_email: unsubscribe fields only for email entries
     // - entries_saved_metadata_only_saved: site_name/image_url only for saved entries
+    // - entries_last_seen_only_fetched: last_seen_at required for rss/atom/json, NULL for email/saved
   ]
 );
 

--- a/tests/integration/entry-processor.test.ts
+++ b/tests/integration/entry-processor.test.ts
@@ -186,12 +186,14 @@ describe("Entry Processor", () => {
       const guid = "entry-123";
 
       // Create entry directly
+      const now = new Date();
       await db.insert(entries).values({
         id: generateUuidv7(),
         feedId: feed.id,
         type: "rss",
         guid,
-        fetchedAt: new Date(),
+        fetchedAt: now,
+        lastSeenAt: now,
         contentHash: "abc123",
       });
 
@@ -214,12 +216,14 @@ describe("Entry Processor", () => {
       const guid = "shared-guid";
 
       // Create entry in feed1
+      const now = new Date();
       await db.insert(entries).values({
         id: generateUuidv7(),
         feedId: feed1.id,
         type: "rss",
         guid,
-        fetchedAt: new Date(),
+        fetchedAt: now,
+        lastSeenAt: now,
         contentHash: "abc123",
       });
 

--- a/tests/integration/tags.test.ts
+++ b/tests/integration/tags.test.ts
@@ -136,6 +136,7 @@ async function createTestEntry(
     title: options.title ?? `Entry ${entryId}`,
     contentHash: `hash-${entryId}`,
     fetchedAt: now,
+    lastSeenAt: now, // Required for rss/atom/json entries
     createdAt: now,
     updatedAt: now,
   });


### PR DESCRIPTION
…ribe

When subscribing to an existing feed, we previously had to re-fetch it to determine which entries are currently visible (for privacy - entries that have been removed from the feed shouldn't be shown to new subscribers).

This adds a `last_seen_at` timestamp to entries that tracks when an entry was last seen in a feed fetch. For rss/atom/json feeds, this timestamp is set to the same value as `feed.last_fetched_at`, enabling exact equality comparison to determine visibility.

Changes:
- Add `last_seen_at` column to entries table (required for rss/atom/json, NULL for email/saved entries)
- Update entry processor to set `last_seen_at` during fetch
- Refactor subscription flow to skip network request when subscribing to an existing feed, using `last_seen_at` query instead of GUID matching