### PR TITLE
Fix star/read buttons incorrectly disabled during unrelated mutations

### DIFF
--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -54,7 +54,7 @@ export function EntryContent({ entryId, onBack, onToggleRead }: EntryContentProp
   // Entry mutations without list filters (this component operates on a single entry)
   // Note: optimistic updates happen at the list level in parent components,
   // normy automatically propagates changes to entries.get when server responds
-  const { markRead, star, unstar, isPending: isStarLoading } = useEntryMutations();
+  const { markRead, star, unstar, isStarPending, isMarkReadPending } = useEntryMutations();
 
   const entry = data?.entry;
 
@@ -123,8 +123,8 @@ export function EntryContent({ entryId, onBack, onToggleRead }: EntryContentProp
       onBack={onBack}
       onToggleRead={handleReadToggle}
       onToggleStar={handleStarToggle}
-      isStarLoading={isStarLoading}
-      isReadLoading={false}
+      isStarLoading={isStarPending}
+      isReadLoading={isMarkReadPending}
       showOriginal={showOriginal}
       setShowOriginal={setShowOriginal}
       narrationArticleType="entry"

--- a/src/lib/hooks/useEntryMutations.ts
+++ b/src/lib/hooks/useEntryMutations.ts
@@ -86,6 +86,16 @@ export interface UseEntryMutationsResult {
    * Whether any mutation is currently in progress.
    */
   isPending: boolean;
+
+  /**
+   * Whether the markRead mutation is pending.
+   */
+  isMarkReadPending: boolean;
+
+  /**
+   * Whether the star/unstar mutation is pending.
+   */
+  isStarPending: boolean;
 }
 
 /**
@@ -316,6 +326,8 @@ export function useEntryMutations(options?: UseEntryMutationsOptions): UseEntryM
 
   const isPending =
     markReadMutation.isPending || starMutation.isPending || unstarMutation.isPending;
+  const isMarkReadPending = markReadMutation.isPending;
+  const isStarPending = starMutation.isPending || unstarMutation.isPending;
 
   return useMemo(
     () => ({
@@ -325,7 +337,9 @@ export function useEntryMutations(options?: UseEntryMutationsOptions): UseEntryM
       unstar,
       toggleStar,
       isPending,
+      isMarkReadPending,
+      isStarPending,
     }),
-    [markRead, toggleRead, star, unstar, toggleStar, isPending]
+    [markRead, toggleRead, star, unstar, toggleStar, isPending, isMarkReadPending, isStarPending]
   );
 }


### PR DESCRIPTION
The star button in EntryContent was being disabled whenever any mutation (including markRead) was pending, because it used the combined `isPending` state. This caused the star button to be disabled when auto-mark-as-read fired on mount.

Split `isPending` into `isMarkReadPending` and `isStarPending` in useEntryMutations (matching useSavedArticleMutations), and use these separate states in EntryContent so each button only disables during its own mutation.