### PR TITLE
Fix unread count for saved articles

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -49,10 +49,10 @@ export function Sidebar({ onClose }: SidebarProps) {
     },
   });
 
-  // Calculate total unread count
+  // Calculate total unread count (subscriptions + saved articles)
   const totalUnreadCount =
-    subscriptionsQuery.data?.items.reduce((sum, item) => sum + item.subscription.unreadCount, 0) ??
-    0;
+    (subscriptionsQuery.data?.items.reduce((sum, item) => sum + item.subscription.unreadCount, 0) ??
+      0) + (savedCountQuery.data?.unread ?? 0);
 
   const isActiveLink = (href: string) => {
     if (href === "/all") {


### PR DESCRIPTION
The sidebar's "All Items" unread count was only summing subscription counts, but the All Items view actually shows saved articles too. Add the saved articles unread count to the total.