### PR TITLE
Fix race condition with entry view buttons

### DIFF
--- a/src/app/(app)/all/page.tsx
+++ b/src/app/(app)/all/page.tsx
@@ -79,9 +79,15 @@ function AllEntriesContent() {
   );
 
   // If an entry is open, show the full content view
+  // Key forces remount when entryId changes, ensuring fresh refs and mutation state
   if (openEntryId) {
     return (
-      <EntryContent entryId={openEntryId} onBack={handleBack} onToggleRead={handleToggleRead} />
+      <EntryContent
+        key={openEntryId}
+        entryId={openEntryId}
+        onBack={handleBack}
+        onToggleRead={handleToggleRead}
+      />
     );
   }
 

--- a/src/app/(app)/feed/[feedId]/page.tsx
+++ b/src/app/(app)/feed/[feedId]/page.tsx
@@ -148,9 +148,15 @@ function SingleFeedContent() {
   );
 
   // If an entry is open, show the full content view
+  // Key forces remount when entryId changes, ensuring fresh refs and mutation state
   if (openEntryId) {
     return (
-      <EntryContent entryId={openEntryId} onBack={handleBack} onToggleRead={handleToggleRead} />
+      <EntryContent
+        key={openEntryId}
+        entryId={openEntryId}
+        onBack={handleBack}
+        onToggleRead={handleToggleRead}
+      />
     );
   }
 

--- a/src/app/(app)/saved/page.tsx
+++ b/src/app/(app)/saved/page.tsx
@@ -73,8 +73,11 @@ function SavedArticlesContent() {
   }, []);
 
   // If an article is open, show the full content view
+  // Key forces remount when articleId changes, ensuring fresh refs and mutation state
   if (openArticleId) {
-    return <SavedArticleContent articleId={openArticleId} onBack={handleBack} />;
+    return (
+      <SavedArticleContent key={openArticleId} articleId={openArticleId} onBack={handleBack} />
+    );
   }
 
   // Otherwise, show the saved articles list

--- a/src/app/(app)/starred/page.tsx
+++ b/src/app/(app)/starred/page.tsx
@@ -78,9 +78,15 @@ function StarredEntriesContent() {
   );
 
   // If an entry is open, show the full content view
+  // Key forces remount when entryId changes, ensuring fresh refs and mutation state
   if (openEntryId) {
     return (
-      <EntryContent entryId={openEntryId} onBack={handleBack} onToggleRead={handleToggleRead} />
+      <EntryContent
+        key={openEntryId}
+        entryId={openEntryId}
+        onBack={handleBack}
+        onToggleRead={handleToggleRead}
+      />
     );
   }
 

--- a/src/app/(app)/tag/[tagId]/page.tsx
+++ b/src/app/(app)/tag/[tagId]/page.tsx
@@ -148,9 +148,15 @@ function TagEntriesContent() {
   );
 
   // If an entry is open, show the full content view
+  // Key forces remount when entryId changes, ensuring fresh refs and mutation state
   if (openEntryId) {
     return (
-      <EntryContent entryId={openEntryId} onBack={handleBack} onToggleRead={handleToggleRead} />
+      <EntryContent
+        key={openEntryId}
+        entryId={openEntryId}
+        onBack={handleBack}
+        onToggleRead={handleToggleRead}
+      />
     );
   }
 


### PR DESCRIPTION
When navigating from one entry to another without going back to the list (e.g., via keyboard shortcuts), React was reusing the same EntryContent/SavedArticleContent component instance. This caused:

1. The hasMarkedRead ref to persist, preventing auto-mark-as-read for subsequent entries
2. Mutation pending states from the previous entry to incorrectly affect the new entry's button disabled states

Adding key={entryId} forces React to unmount and remount the component when the entry changes, ensuring fresh refs and mutation hook instances.