### PR TITLE
Fix mark unread button after navigation

### DIFF
--- a/src/app/(app)/all/page.tsx
+++ b/src/app/(app)/all/page.tsx
@@ -70,25 +70,10 @@ function AllEntriesContent() {
     setEntries(loadedEntries);
   }, []);
 
-  // Handler to toggle read status (passed to EntryContent)
-  const handleToggleRead = useCallback(
-    (entryId: string, currentlyRead: boolean) => {
-      toggleRead(entryId, currentlyRead);
-    },
-    [toggleRead]
-  );
-
   // If an entry is open, show the full content view
   // Key forces remount when entryId changes, ensuring fresh refs and mutation state
   if (openEntryId) {
-    return (
-      <EntryContent
-        key={openEntryId}
-        entryId={openEntryId}
-        onBack={handleBack}
-        onToggleRead={handleToggleRead}
-      />
-    );
+    return <EntryContent key={openEntryId} entryId={openEntryId} onBack={handleBack} />;
   }
 
   // Otherwise, show the entry list

--- a/src/app/(app)/feed/[feedId]/page.tsx
+++ b/src/app/(app)/feed/[feedId]/page.tsx
@@ -139,25 +139,10 @@ function SingleFeedContent() {
     setEntries(loadedEntries);
   }, []);
 
-  // Handler to toggle read status (passed to EntryContent)
-  const handleToggleRead = useCallback(
-    (entryId: string, currentlyRead: boolean) => {
-      toggleRead(entryId, currentlyRead);
-    },
-    [toggleRead]
-  );
-
   // If an entry is open, show the full content view
   // Key forces remount when entryId changes, ensuring fresh refs and mutation state
   if (openEntryId) {
-    return (
-      <EntryContent
-        key={openEntryId}
-        entryId={openEntryId}
-        onBack={handleBack}
-        onToggleRead={handleToggleRead}
-      />
-    );
+    return <EntryContent key={openEntryId} entryId={openEntryId} onBack={handleBack} />;
   }
 
   // Show loading state while checking subscription

--- a/src/app/(app)/starred/page.tsx
+++ b/src/app/(app)/starred/page.tsx
@@ -69,25 +69,10 @@ function StarredEntriesContent() {
     setEntries(loadedEntries);
   }, []);
 
-  // Handler to toggle read status (passed to EntryContent)
-  const handleToggleRead = useCallback(
-    (entryId: string, currentlyRead: boolean) => {
-      toggleRead(entryId, currentlyRead);
-    },
-    [toggleRead]
-  );
-
   // If an entry is open, show the full content view
   // Key forces remount when entryId changes, ensuring fresh refs and mutation state
   if (openEntryId) {
-    return (
-      <EntryContent
-        key={openEntryId}
-        entryId={openEntryId}
-        onBack={handleBack}
-        onToggleRead={handleToggleRead}
-      />
-    );
+    return <EntryContent key={openEntryId} entryId={openEntryId} onBack={handleBack} />;
   }
 
   // Otherwise, show the starred entries list

--- a/src/app/(app)/tag/[tagId]/page.tsx
+++ b/src/app/(app)/tag/[tagId]/page.tsx
@@ -139,25 +139,10 @@ function TagEntriesContent() {
     setEntries(loadedEntries);
   }, []);
 
-  // Handler to toggle read status (passed to EntryContent)
-  const handleToggleRead = useCallback(
-    (entryId: string, currentlyRead: boolean) => {
-      toggleRead(entryId, currentlyRead);
-    },
-    [toggleRead]
-  );
-
   // If an entry is open, show the full content view
   // Key forces remount when entryId changes, ensuring fresh refs and mutation state
   if (openEntryId) {
-    return (
-      <EntryContent
-        key={openEntryId}
-        entryId={openEntryId}
-        onBack={handleBack}
-        onToggleRead={handleToggleRead}
-      />
-    );
+    return <EntryContent key={openEntryId} entryId={openEntryId} onBack={handleBack} />;
   }
 
   // Show loading state while checking tag

--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -30,12 +30,6 @@ interface EntryContentProps {
    * Optional callback when the back button is clicked.
    */
   onBack?: () => void;
-
-  /**
-   * Optional callback when read status should be toggled.
-   * Receives the entry ID and its current read status.
-   */
-  onToggleRead?: (entryId: string, currentlyRead: boolean) => void;
 }
 
 /**
@@ -44,7 +38,7 @@ interface EntryContentProps {
  * Fetches and displays the full content of an entry.
  * Marks the entry as read on mount.
  */
-export function EntryContent({ entryId, onBack, onToggleRead }: EntryContentProps) {
+export function EntryContent({ entryId, onBack }: EntryContentProps) {
   const hasMarkedRead = useRef(false);
   const [showOriginal, setShowOriginal] = useState(false);
 
@@ -80,10 +74,10 @@ export function EntryContent({ entryId, onBack, onToggleRead }: EntryContentProp
     }
   };
 
-  // Handle read toggle
+  // Handle read toggle - use local mutation for consistent loading state
   const handleReadToggle = () => {
-    if (!entry || !onToggleRead) return;
-    onToggleRead(entryId, entry.read);
+    if (!entry) return;
+    markRead([entryId], !entry.read);
   };
 
   // Loading state


### PR DESCRIPTION
The button's disabled state was tied to EntryContent's local useEntryMutations hook, but the button action was calling the parent's mutation via onToggleRead. This mismatch caused the button to be disabled in dev mode when re-opening an entry that had been marked unread (since the auto-mark-read effect would fire using the local mutation, setting isMarkReadPending=true).

Fixed by making handleReadToggle use the local markRead mutation directly, matching how handleStarToggle already worked. Removed the now-unused onToggleRead prop and related handlers from page components.