### PR TITLE
Fix saved articles summaries including CSS markup

### DIFF
--- a/src/server/feed/entry-processor.ts
+++ b/src/server/feed/entry-processor.ts
@@ -8,6 +8,7 @@
 
 import { createHash } from "crypto";
 import { eq, and, isNull, inArray } from "drizzle-orm";
+import { JSDOM } from "jsdom";
 import { db } from "../db";
 import {
   entries,
@@ -116,9 +117,18 @@ function truncate(text: string, maxLength: number): string {
 
 /**
  * Strips HTML tags from a string for use in summaries.
+ * Uses JSDOM to properly parse HTML and extract text content,
+ * which handles edge cases like nested tags and malformed HTML.
  */
 function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, "").trim();
+  const dom = new JSDOM(html);
+  const document = dom.window.document;
+
+  // Remove script and style elements before extracting text
+  document.querySelectorAll("script, style").forEach((el) => el.remove());
+
+  // Get text content - this naturally strips all HTML tags
+  return (document.body.textContent ?? "").trim();
 }
 
 /**

--- a/tests/integration/entry-processor.test.ts
+++ b/tests/integration/entry-processor.test.ts
@@ -160,6 +160,23 @@ describe("Entry Processor", () => {
       expect(generateSummary(entry)).toBe("This is bold text.");
     });
 
+    it("removes style tags and their content", () => {
+      const entry: ParsedEntry = {
+        content: "<style>#content img { max-width: 100% }</style><p>Actual content here.</p>",
+      };
+
+      expect(generateSummary(entry)).toBe("Actual content here.");
+    });
+
+    it("removes script tags and their content", () => {
+      const entry: ParsedEntry = {
+        content:
+          '<script>alert("bad")</script><p>Visible text.</p><script type="text/javascript">more code</script>',
+      };
+
+      expect(generateSummary(entry)).toBe("Visible text.");
+    });
+
     it("truncates long content to 300 characters", () => {
       const longContent = "A".repeat(500);
       const entry: ParsedEntry = {


### PR DESCRIPTION
The stripHtml function was only removing HTML tags but not their content, causing <style> and <script> tag contents to appear in article summaries.

Updated to use JSDOM for proper HTML parsing - removing script/style elements before extracting text content. This is more robust than regex for edge cases like nested tags and malformed HTML.