### PR TITLE
Add keyboard shortcuts for entry navigation

### DIFF
--- a/src/components/keyboard/KeyboardShortcutsModal.tsx
+++ b/src/components/keyboard/KeyboardShortcutsModal.tsx
@@ -30,8 +30,8 @@ const SHORTCUT_SECTIONS: ShortcutSection[] = [
   {
     title: "Navigation",
     shortcuts: [
-      { keys: ["j"], description: "Next entry" },
-      { keys: ["k"], description: "Previous entry" },
+      { keys: ["j"], description: "Next entry (in list or when viewing)" },
+      { keys: ["k"], description: "Previous entry (in list or when viewing)" },
       { keys: ["o"], description: "Open selected entry" },
       { keys: ["Enter"], description: "Open selected entry" },
       { keys: ["Escape"], description: "Close entry / deselect" },

--- a/src/lib/hooks/useKeyboardShortcuts.ts
+++ b/src/lib/hooks/useKeyboardShortcuts.ts
@@ -5,7 +5,7 @@
  * Uses react-hotkeys-hook for keyboard event handling.
  *
  * Features:
- * - j/k navigation (next/previous entry)
+ * - j/k navigation (next/previous entry in list, or navigate between entries when viewing)
  * - o/Enter to open selected entry
  * - Escape to close entry or deselect
  * - m to toggle read/unread
@@ -256,6 +256,46 @@ export function useKeyboardShortcuts(
     // If already at the first entry, do nothing
   }, [entryIds, getSelectedIndex]);
 
+  // Navigate to and open the next entry (for use when viewing an entry)
+  const goToNextEntry = useCallback(() => {
+    if (entryIds.length === 0 || !onOpenEntry) return;
+
+    const currentIndex = getSelectedIndex();
+
+    if (currentIndex === -1) {
+      // Nothing selected, go to the first entry
+      const nextId = entryIds[0];
+      setSelectedEntryId(nextId);
+      onOpenEntry(nextId);
+    } else if (currentIndex < entryIds.length - 1) {
+      // Go to next entry
+      const nextId = entryIds[currentIndex + 1];
+      setSelectedEntryId(nextId);
+      onOpenEntry(nextId);
+    }
+    // If already at the last entry, do nothing
+  }, [entryIds, getSelectedIndex, onOpenEntry]);
+
+  // Navigate to and open the previous entry (for use when viewing an entry)
+  const goToPreviousEntry = useCallback(() => {
+    if (entryIds.length === 0 || !onOpenEntry) return;
+
+    const currentIndex = getSelectedIndex();
+
+    if (currentIndex === -1) {
+      // Nothing selected, go to the last entry
+      const prevId = entryIds[entryIds.length - 1];
+      setSelectedEntryId(prevId);
+      onOpenEntry(prevId);
+    } else if (currentIndex > 0) {
+      // Go to previous entry
+      const prevId = entryIds[currentIndex - 1];
+      setSelectedEntryId(prevId);
+      onOpenEntry(prevId);
+    }
+    // If already at the first entry, do nothing
+  }, [entryIds, getSelectedIndex, onOpenEntry]);
+
   // Open the currently selected entry
   const openSelected = useCallback(() => {
     if (selectedEntryId && onOpenEntry) {
@@ -292,32 +332,40 @@ export function useKeyboardShortcuts(
   }, [effectiveSelectedEntryId]);
 
   // Keyboard shortcuts
-  // j - next entry (only when entry is not open)
+  // j - next entry (select in list, or navigate to next when viewing)
   useHotkeys(
     "j",
     (e) => {
       e.preventDefault();
-      selectNext();
+      if (isEntryOpen) {
+        goToNextEntry();
+      } else {
+        selectNext();
+      }
     },
     {
-      enabled: enabled && !isEntryOpen,
+      enabled: enabled,
       enableOnFormTags: false,
     },
-    [selectNext, isEntryOpen, enabled]
+    [selectNext, goToNextEntry, isEntryOpen, enabled]
   );
 
-  // k - previous entry (only when entry is not open)
+  // k - previous entry (select in list, or navigate to previous when viewing)
   useHotkeys(
     "k",
     (e) => {
       e.preventDefault();
-      selectPrevious();
+      if (isEntryOpen) {
+        goToPreviousEntry();
+      } else {
+        selectPrevious();
+      }
     },
     {
-      enabled: enabled && !isEntryOpen,
+      enabled: enabled,
       enableOnFormTags: false,
     },
-    [selectPrevious, isEntryOpen, enabled]
+    [selectPrevious, goToPreviousEntry, isEntryOpen, enabled]
   );
 
   // o - open selected entry (only when entry is not open)

--- a/src/lib/hooks/useSavedArticleKeyboardShortcuts.ts
+++ b/src/lib/hooks/useSavedArticleKeyboardShortcuts.ts
@@ -5,7 +5,7 @@
  * Similar to useKeyboardShortcuts but adapted for saved articles.
  *
  * Features:
- * - j/k navigation (next/previous article)
+ * - j/k navigation (next/previous article in list, or navigate between articles when viewing)
  * - o/Enter to open selected article
  * - Escape to close article or deselect
  * - m to toggle read/unread
@@ -226,6 +226,46 @@ export function useSavedArticleKeyboardShortcuts(
     // If already at the first article, do nothing
   }, [articleIds, getSelectedIndex]);
 
+  // Navigate to and open the next article (for use when viewing an article)
+  const goToNextArticle = useCallback(() => {
+    if (articleIds.length === 0 || !onOpenArticle) return;
+
+    const currentIndex = getSelectedIndex();
+
+    if (currentIndex === -1) {
+      // Nothing selected, go to the first article
+      const nextId = articleIds[0];
+      setSelectedArticleId(nextId);
+      onOpenArticle(nextId);
+    } else if (currentIndex < articleIds.length - 1) {
+      // Go to next article
+      const nextId = articleIds[currentIndex + 1];
+      setSelectedArticleId(nextId);
+      onOpenArticle(nextId);
+    }
+    // If already at the last article, do nothing
+  }, [articleIds, getSelectedIndex, onOpenArticle]);
+
+  // Navigate to and open the previous article (for use when viewing an article)
+  const goToPreviousArticle = useCallback(() => {
+    if (articleIds.length === 0 || !onOpenArticle) return;
+
+    const currentIndex = getSelectedIndex();
+
+    if (currentIndex === -1) {
+      // Nothing selected, go to the last article
+      const prevId = articleIds[articleIds.length - 1];
+      setSelectedArticleId(prevId);
+      onOpenArticle(prevId);
+    } else if (currentIndex > 0) {
+      // Go to previous article
+      const prevId = articleIds[currentIndex - 1];
+      setSelectedArticleId(prevId);
+      onOpenArticle(prevId);
+    }
+    // If already at the first article, do nothing
+  }, [articleIds, getSelectedIndex, onOpenArticle]);
+
   // Open the currently selected article
   const openSelected = useCallback(() => {
     if (selectedArticleId && onOpenArticle) {
@@ -263,32 +303,40 @@ export function useSavedArticleKeyboardShortcuts(
   }, [effectiveSelectedArticleId]);
 
   // Keyboard shortcuts
-  // j - next article (only when article is not open)
+  // j - next article (select in list, or navigate to next when viewing)
   useHotkeys(
     "j",
     (e) => {
       e.preventDefault();
-      selectNext();
+      if (isArticleOpen) {
+        goToNextArticle();
+      } else {
+        selectNext();
+      }
     },
     {
-      enabled: enabled && !isArticleOpen,
+      enabled: enabled,
       enableOnFormTags: false,
     },
-    [selectNext, isArticleOpen, enabled]
+    [selectNext, goToNextArticle, isArticleOpen, enabled]
   );
 
-  // k - previous article (only when article is not open)
+  // k - previous article (select in list, or navigate to previous when viewing)
   useHotkeys(
     "k",
     (e) => {
       e.preventDefault();
-      selectPrevious();
+      if (isArticleOpen) {
+        goToPreviousArticle();
+      } else {
+        selectPrevious();
+      }
     },
     {
-      enabled: enabled && !isArticleOpen,
+      enabled: enabled,
       enableOnFormTags: false,
     },
-    [selectPrevious, isArticleOpen, enabled]
+    [selectPrevious, goToPreviousArticle, isArticleOpen, enabled]
   );
 
   // o - open selected article (only when article is not open)


### PR DESCRIPTION
Enable j and k keys to navigate to next/previous entry while viewing entry content, matching their behavior in the entry list. Previously these shortcuts only worked in the list view.

Also updates the keyboard shortcuts modal to clarify the behavior works in both contexts.