### PR TITLE
Replace HTML regex patterns with JSDom

### DIFF
--- a/src/lib/narration/html-to-narration-input.ts
+++ b/src/lib/narration/html-to-narration-input.ts
@@ -260,8 +260,29 @@ export function htmlToNarrationInput(html: string): HtmlToNarrationInputResult {
 }
 
 /**
+ * Block elements that should have paragraph breaks before them.
+ */
+const BLOCK_TAGS_FOR_PLAIN_TEXT = new Set([
+  "p",
+  "div",
+  "br",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "li",
+  "tr",
+  "blockquote",
+  "pre",
+  "figure",
+  "table",
+]);
+
+/**
  * Converts HTML to plain text for fallback mode.
- * Basic conversion that strips tags but preserves structure.
+ * Uses JSDOM for proper HTML parsing.
  *
  * @param html - HTML content to convert
  * @returns Plain text with paragraph breaks
@@ -271,32 +292,59 @@ export function htmlToNarrationInput(html: string): HtmlToNarrationInputResult {
  * // Returns "Hello\n\nWorld"
  */
 export function htmlToPlainText(html: string): string {
-  return (
-    html
-      // Extract alt text from standalone images (not in figures/paragraphs) and replace with text
-      .replace(/<img\s+[^>]*alt=["']([^"']*)["'][^>]*>/gi, "\n\n[Image: $1]\n\n")
-      .replace(/<img\s+[^>]*>/gi, "\n\n[Image]\n\n") // Images without alt
-      // Add paragraph breaks before block elements
-      .replace(/<(p|div|br|h[1-6]|li|tr|blockquote|pre|figure|table)[^>]*>/gi, "\n\n")
-      // Remove all HTML tags
-      .replace(/<[^>]+>/g, "")
-      // Decode common HTML entities
-      .replace(/&nbsp;/g, " ")
-      .replace(/&amp;/g, "&")
-      .replace(/&lt;/g, "<")
-      .replace(/&gt;/g, ">")
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/&apos;/g, "'")
-      // Normalize whitespace: collapse multiple spaces to single space
-      .replace(/ +/g, " ")
-      // Normalize paragraph breaks: collapse multiple newlines to double newline
-      .replace(/\n{3,}/g, "\n\n")
-      // Trim whitespace from each line
-      .split("\n")
-      .map((line) => line.trim())
-      .join("\n")
-      // Final trim
-      .trim()
-  );
+  if (!html || html.trim() === "") {
+    return "";
+  }
+
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+
+  // Process the document to build plain text
+  const parts: string[] = [];
+
+  function processNode(node: Node): void {
+    if (node.nodeType === 3) {
+      // Text node
+      const text = node.textContent || "";
+      if (text.trim()) {
+        parts.push(text);
+      }
+    } else if (node.nodeType === 1) {
+      // Element node
+      const el = node as Element;
+      const tagName = el.tagName.toLowerCase();
+
+      // Add paragraph break before block elements
+      if (BLOCK_TAGS_FOR_PLAIN_TEXT.has(tagName)) {
+        parts.push("\n\n");
+      }
+
+      // Handle images - extract alt text
+      if (tagName === "img") {
+        const alt = el.getAttribute("alt");
+        if (alt) {
+          parts.push(`\n\n[Image: ${alt}]\n\n`);
+        } else {
+          parts.push("\n\n[Image]\n\n");
+        }
+        return;
+      }
+
+      // Recursively process child nodes
+      el.childNodes.forEach((child) => processNode(child));
+    }
+  }
+
+  processNode(doc.body);
+
+  // Join and normalize the text
+  return parts
+    .join("")
+    .replace(/\u00A0/g, " ") // Convert nbsp to regular space
+    .replace(/ +/g, " ") // Collapse multiple spaces
+    .replace(/\n{3,}/g, "\n\n") // Collapse multiple newlines
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n")
+    .trim();
 }

--- a/src/server/email/process-inbound.ts
+++ b/src/server/email/process-inbound.ts
@@ -7,6 +7,7 @@
 
 import { createHash } from "crypto";
 import { eq, and } from "drizzle-orm";
+import { JSDOM } from "jsdom";
 import { db } from "../db";
 import {
   feeds,
@@ -192,13 +193,17 @@ export function generateEmailContentHash(subject: string, content: string): stri
 }
 
 /**
- * Strips HTML tags from a string.
+ * Strips HTML tags from a string using JSDOM.
  *
  * @param html - HTML string to strip
  * @returns Plain text string
  */
 function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, "").trim();
+  if (!html) {
+    return "";
+  }
+  const dom = new JSDOM(html);
+  return dom.window.document.body.textContent?.trim() || "";
 }
 
 /**

--- a/src/server/trpc/routers/feeds.ts
+++ b/src/server/trpc/routers/feeds.ts
@@ -5,6 +5,7 @@
  * Provides endpoints for fetching and parsing feeds without saving them.
  */
 
+import { JSDOM } from "jsdom";
 import { z } from "zod";
 
 import { createTRPCRouter, publicProcedure } from "../trpc";
@@ -157,18 +158,20 @@ function isHtmlContent(contentType: string, content: string): boolean {
 
 /**
  * Truncates text to a maximum length, adding ellipsis if needed.
+ * Uses JSDOM to strip HTML tags.
  *
- * @param text - The text to truncate
+ * @param text - The text to truncate (may contain HTML)
  * @param maxLength - Maximum length
- * @returns Truncated text
+ * @returns Truncated plain text
  */
 function truncateText(text: string | undefined, maxLength: number): string | null {
   if (!text) {
     return null;
   }
 
-  // Strip HTML tags for summary
-  const stripped = text.replace(/<[^>]*>/g, "").trim();
+  // Strip HTML tags using JSDOM
+  const dom = new JSDOM(text);
+  const stripped = dom.window.document.body.textContent?.trim() || "";
 
   if (stripped.length <= maxLength) {
     return stripped;

--- a/tests/unit/feed-discovery.test.ts
+++ b/tests/unit/feed-discovery.test.ts
@@ -460,9 +460,8 @@ describe("discoverFeeds", () => {
       const feeds = discoverFeeds(html, "https://example.com");
 
       expect(feeds).toHaveLength(1);
-      // Note: HTML entities are preserved as-is (not decoded)
-      // This is acceptable for MVP; full entity decoding would require a proper HTML parser
-      expect(feeds[0].title).toBe("Tom &amp; Jerry's Feed");
+      // JSDOM properly decodes HTML entities
+      expect(feeds[0].title).toBe("Tom & Jerry's Feed");
     });
   });
 


### PR DESCRIPTION
Replace regex-based HTML parsing with proper DOM parsing using JSDOM for better reliability and correctness:

- discovery.ts: Use querySelectorAll for finding <link> feed tags
- process-inbound.ts: Use JSDOM for stripHtml function
- feeds.ts: Use JSDOM for HTML stripping in truncateText
- html-to-narration-input.ts: Use JSDOM for fallback htmlToPlainText

This also improves HTML entity handling - entities like &amp; are now properly decoded rather than being preserved as-is.