### PR TITLE
Check image positioning in web and Android apps

### DIFF
--- a/android/app/src/main/java/com/lionreader/ui/entries/EntryDetailScreen.kt
+++ b/android/app/src/main/java/com/lionreader/ui/entries/EntryDetailScreen.kt
@@ -418,6 +418,7 @@ private fun EntryDetailContent(
         HtmlContent(
             html = content,
             onLinkClick = onLinkClick,
+            baseUrl = entry.entry.url,
             modifier = Modifier.fillMaxWidth(),
         )
 

--- a/android/app/src/main/java/com/lionreader/ui/entries/HtmlContent.kt
+++ b/android/app/src/main/java/com/lionreader/ui/entries/HtmlContent.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.viewinterop.AndroidView
  *
  * @param html The HTML content to render
  * @param onLinkClick Callback when a link is clicked in the content
+ * @param baseUrl Optional base URL for resolving relative URLs in the content (e.g., image src)
  * @param modifier Modifier for the WebView container
  */
 @SuppressLint("SetJavaScriptEnabled")
@@ -28,6 +29,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 fun HtmlContent(
     html: String,
     onLinkClick: (String) -> Unit,
+    baseUrl: String? = null,
     modifier: Modifier = Modifier,
 ) {
     val isDarkTheme = isSystemInDarkTheme()
@@ -79,7 +81,7 @@ fun HtmlContent(
         },
         update = { webView ->
             webView.loadDataWithBaseURL(
-                null,
+                baseUrl,
                 styledHtml,
                 "text/html",
                 "UTF-8",

--- a/android/app/src/main/java/com/lionreader/ui/saved/SavedArticleDetailScreen.kt
+++ b/android/app/src/main/java/com/lionreader/ui/saved/SavedArticleDetailScreen.kt
@@ -283,6 +283,7 @@ private fun SavedArticleDetailContent(
         HtmlContent(
             html = content,
             onLinkClick = onLinkClick,
+            baseUrl = article.url,
             modifier = Modifier.fillMaxWidth(),
         )
 

--- a/src/server/feed/entry-processor.ts
+++ b/src/server/feed/entry-processor.ts
@@ -21,7 +21,12 @@ import {
 import { generateUuidv7 } from "../../lib/uuidv7";
 import { publishNewEntry, publishEntryUpdated } from "../redis/pubsub";
 import type { ParsedEntry, ParsedFeed } from "./types";
-import { cleanContent, generateCleanedSummary, type CleanedContent } from "./content-cleaner";
+import {
+  cleanContent,
+  generateCleanedSummary,
+  absolutizeUrls,
+  type CleanedContent,
+} from "./content-cleaner";
 import { logger } from "@/lib/logger";
 
 /**
@@ -200,8 +205,14 @@ export function cleanEntryContent(
     summary = truncate(stripHtml(originalContent), 300);
   }
 
+  // Absolutize relative URLs in original content if we have a base URL
+  // (cleaned content is already absolutized in cleanContent)
+  const absolutizedOriginal = entryUrl
+    ? absolutizeUrls(originalContent, entryUrl)
+    : originalContent;
+
   return {
-    contentOriginal: originalContent,
+    contentOriginal: absolutizedOriginal,
     contentCleaned: cleaned?.content ?? null,
     summary,
   };

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -279,7 +279,7 @@ export const savedRouter = createTRPCRouter({
       // Extract metadata
       const metadata = extractMetadata(html, input.url);
 
-      // Run Readability for clean content
+      // Run Readability for clean content (also absolutizes URLs internally)
       const cleaned = cleanContent(html, { url: input.url });
 
       // Generate excerpt


### PR DESCRIPTION
Feed content often contains relative image URLs that break when displayed outside the original context. This change:

- Adds absolutizeUrls() function to convert relative src, href, poster, and srcset attributes to absolute URLs using the entry's URL as base
- Applies URL absolutizing to both contentOriginal and contentCleaned
- Updates Android WebView to pass entry URL as baseUrl for fallback
- Adds comprehensive tests for URL absolutizing logic

Fixes image display in both web app (when viewing original content) and Android app.