### PR TITLE
Fix bookmarked articles not appearing without refresh

### DIFF
--- a/src/app/api/v1/events/route.ts
+++ b/src/app/api/v1/events/route.ts
@@ -7,6 +7,8 @@
  * Events:
  * - new_entry: A new entry was added to a subscribed feed
  * - entry_updated: An existing entry's content was updated
+ * - subscription_created: User subscribed to a new feed
+ * - saved_article_created: User saved a new article via bookmarklet
  *
  * Heartbeat: Sent every 30 seconds as a comment (: heartbeat)
  */
@@ -262,7 +264,7 @@ export async function GET(req: Request): Promise<Response> {
 
         // Handle incoming messages
         subscriber.on("message", (channel: string, message: string) => {
-          // Handle user events (subscription_created)
+          // Handle user events (subscription_created, saved_article_created)
           if (channel === userEventsChannel) {
             const event = parseUserEvent(message);
             if (!event) return;
@@ -271,6 +273,10 @@ export async function GET(req: Request): Promise<Response> {
               // Subscribe to the new feed's channel
               subscribeToFeed(event.feedId);
 
+              // Forward the event to the client
+              send(formatSSEUserEvent(event));
+              trackSSEEventSent(event.type);
+            } else if (event.type === "saved_article_created") {
               // Forward the event to the client
               send(formatSSEUserEvent(event));
               trackSSEEventSent(event.type);

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -29,6 +29,7 @@ import { generateUuidv7 } from "@/lib/uuidv7";
 import { cleanContent } from "@/server/feed/content-cleaner";
 import { getOrCreateSavedFeed } from "@/server/feed/saved-feed";
 import { logger } from "@/lib/logger";
+import { publishSavedArticleCreated } from "@/server/redis/pubsub";
 
 // ============================================================================
 // Constants
@@ -335,6 +336,9 @@ export const savedRouter = createTRPCRouter({
         readAt: null,
         starredAt: null,
       });
+
+      // Publish event to notify other browser windows/tabs
+      await publishSavedArticleCreated(userId, entryId);
 
       return {
         article: {


### PR DESCRIPTION
When saving an article via bookmarklet, the main web app window wouldn't show the new article until refresh. This was because the bookmarklet runs in a separate popup window, and there was no mechanism to notify the main app window about the new saved article.

This adds:
- A new `saved_article_created` user event type in the pub/sub system
- Publishing this event after successfully saving an article
- SSE handling to forward the event to connected clients
- Client-side handler to invalidate the saved articles list cache