### PR TITLE
Add swipe controls to entry view

### DIFF
--- a/src/app/(app)/all/page.tsx
+++ b/src/app/(app)/all/page.tsx
@@ -39,20 +39,21 @@ function AllEntriesContent() {
     listFilters: { unreadOnly: showUnreadOnly, sortOrder },
   });
 
-  // Keyboard navigation and actions
-  const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
-    entries,
-    onOpenEntry: setOpenEntryId,
-    onClose: closeEntry,
-    isEntryOpen: !!openEntryId,
-    enabled: keyboardShortcutsEnabled,
-    onToggleRead: toggleRead,
-    onToggleStar: toggleStar,
-    onRefresh: () => {
-      utils.entries.list.invalidate();
-    },
-    onToggleUnreadOnly: toggleShowUnreadOnly,
-  });
+  // Keyboard navigation and actions (also provides swipe navigation functions)
+  const { selectedEntryId, setSelectedEntryId, goToNextEntry, goToPreviousEntry } =
+    useKeyboardShortcuts({
+      entries,
+      onOpenEntry: setOpenEntryId,
+      onClose: closeEntry,
+      isEntryOpen: !!openEntryId,
+      enabled: keyboardShortcutsEnabled,
+      onToggleRead: toggleRead,
+      onToggleStar: toggleStar,
+      onRefresh: () => {
+        utils.entries.list.invalidate();
+      },
+      onToggleUnreadOnly: toggleShowUnreadOnly,
+    });
 
   const handleEntryClick = useCallback(
     (entryId: string) => {
@@ -73,7 +74,15 @@ function AllEntriesContent() {
   // If an entry is open, show the full content view
   // Key forces remount when entryId changes, ensuring fresh refs and mutation state
   if (openEntryId) {
-    return <EntryContent key={openEntryId} entryId={openEntryId} onBack={handleBack} />;
+    return (
+      <EntryContent
+        key={openEntryId}
+        entryId={openEntryId}
+        onBack={handleBack}
+        onSwipeNext={goToNextEntry}
+        onSwipePrevious={goToPreviousEntry}
+      />
+    );
   }
 
   // Otherwise, show the entry list

--- a/src/app/(app)/feed/[feedId]/page.tsx
+++ b/src/app/(app)/feed/[feedId]/page.tsx
@@ -102,20 +102,21 @@ function SingleFeedContent() {
     listFilters: { feedId, unreadOnly: showUnreadOnly, sortOrder },
   });
 
-  // Keyboard navigation and actions
-  const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
-    entries,
-    onOpenEntry: setOpenEntryId,
-    onClose: closeEntry,
-    isEntryOpen: !!openEntryId,
-    enabled: keyboardShortcutsEnabled,
-    onToggleRead: toggleRead,
-    onToggleStar: toggleStar,
-    onRefresh: () => {
-      utils.entries.list.invalidate();
-    },
-    onToggleUnreadOnly: toggleShowUnreadOnly,
-  });
+  // Keyboard navigation and actions (also provides swipe navigation functions)
+  const { selectedEntryId, setSelectedEntryId, goToNextEntry, goToPreviousEntry } =
+    useKeyboardShortcuts({
+      entries,
+      onOpenEntry: setOpenEntryId,
+      onClose: closeEntry,
+      isEntryOpen: !!openEntryId,
+      enabled: keyboardShortcutsEnabled,
+      onToggleRead: toggleRead,
+      onToggleStar: toggleStar,
+      onRefresh: () => {
+        utils.entries.list.invalidate();
+      },
+      onToggleUnreadOnly: toggleShowUnreadOnly,
+    });
 
   // Fetch subscription info to get feed title and validate access
   const subscriptionsQuery = trpc.subscriptions.list.useQuery();
@@ -142,7 +143,15 @@ function SingleFeedContent() {
   // If an entry is open, show the full content view
   // Key forces remount when entryId changes, ensuring fresh refs and mutation state
   if (openEntryId) {
-    return <EntryContent key={openEntryId} entryId={openEntryId} onBack={handleBack} />;
+    return (
+      <EntryContent
+        key={openEntryId}
+        entryId={openEntryId}
+        onBack={handleBack}
+        onSwipeNext={goToNextEntry}
+        onSwipePrevious={goToPreviousEntry}
+      />
+    );
   }
 
   // Show loading state while checking subscription

--- a/src/app/(app)/saved/page.tsx
+++ b/src/app/(app)/saved/page.tsx
@@ -40,22 +40,23 @@ function SavedArticlesContent() {
     listFilters: { unreadOnly: showUnreadOnly, sortOrder },
   });
 
-  // Keyboard navigation and actions
-  const { selectedArticleId, setSelectedArticleId } = useSavedArticleKeyboardShortcuts({
-    articles,
-    onOpenArticle: setOpenArticleId,
-    onClose: closeArticle,
-    isArticleOpen: !!openArticleId,
-    enabled: keyboardShortcutsEnabled,
-    onToggleRead: toggleRead,
-    onToggleStar: toggleStar,
-    onRefresh: () => {
-      // Invalidate entries queries with saved type filter
-      utils.entries.list.invalidate({ type: "saved" });
-      utils.entries.count.invalidate({ type: "saved" });
-    },
-    onToggleUnreadOnly: toggleShowUnreadOnly,
-  });
+  // Keyboard navigation and actions (also provides swipe navigation functions)
+  const { selectedArticleId, setSelectedArticleId, goToNextArticle, goToPreviousArticle } =
+    useSavedArticleKeyboardShortcuts({
+      articles,
+      onOpenArticle: setOpenArticleId,
+      onClose: closeArticle,
+      isArticleOpen: !!openArticleId,
+      enabled: keyboardShortcutsEnabled,
+      onToggleRead: toggleRead,
+      onToggleStar: toggleStar,
+      onRefresh: () => {
+        // Invalidate entries queries with saved type filter
+        utils.entries.list.invalidate({ type: "saved" });
+        utils.entries.count.invalidate({ type: "saved" });
+      },
+      onToggleUnreadOnly: toggleShowUnreadOnly,
+    });
 
   const handleArticleClick = useCallback(
     (articleId: string) => {
@@ -77,7 +78,13 @@ function SavedArticlesContent() {
   // Key forces remount when articleId changes, ensuring fresh refs and mutation state
   if (openArticleId) {
     return (
-      <SavedArticleContent key={openArticleId} articleId={openArticleId} onBack={handleBack} />
+      <SavedArticleContent
+        key={openArticleId}
+        articleId={openArticleId}
+        onBack={handleBack}
+        onSwipeNext={goToNextArticle}
+        onSwipePrevious={goToPreviousArticle}
+      />
     );
   }
 

--- a/src/app/(app)/starred/page.tsx
+++ b/src/app/(app)/starred/page.tsx
@@ -38,20 +38,21 @@ function StarredEntriesContent() {
     listFilters: { starredOnly: true, unreadOnly: showUnreadOnly, sortOrder },
   });
 
-  // Keyboard navigation and actions
-  const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
-    entries,
-    onOpenEntry: setOpenEntryId,
-    onClose: closeEntry,
-    isEntryOpen: !!openEntryId,
-    enabled: keyboardShortcutsEnabled,
-    onToggleRead: toggleRead,
-    onToggleStar: toggleStar,
-    onRefresh: () => {
-      utils.entries.list.invalidate();
-    },
-    onToggleUnreadOnly: toggleShowUnreadOnly,
-  });
+  // Keyboard navigation and actions (also provides swipe navigation functions)
+  const { selectedEntryId, setSelectedEntryId, goToNextEntry, goToPreviousEntry } =
+    useKeyboardShortcuts({
+      entries,
+      onOpenEntry: setOpenEntryId,
+      onClose: closeEntry,
+      isEntryOpen: !!openEntryId,
+      enabled: keyboardShortcutsEnabled,
+      onToggleRead: toggleRead,
+      onToggleStar: toggleStar,
+      onRefresh: () => {
+        utils.entries.list.invalidate();
+      },
+      onToggleUnreadOnly: toggleShowUnreadOnly,
+    });
 
   const handleEntryClick = useCallback(
     (entryId: string) => {
@@ -72,7 +73,15 @@ function StarredEntriesContent() {
   // If an entry is open, show the full content view
   // Key forces remount when entryId changes, ensuring fresh refs and mutation state
   if (openEntryId) {
-    return <EntryContent key={openEntryId} entryId={openEntryId} onBack={handleBack} />;
+    return (
+      <EntryContent
+        key={openEntryId}
+        entryId={openEntryId}
+        onBack={handleBack}
+        onSwipeNext={goToNextEntry}
+        onSwipePrevious={goToPreviousEntry}
+      />
+    );
   }
 
   // Otherwise, show the starred entries list

--- a/src/app/(app)/tag/[tagId]/page.tsx
+++ b/src/app/(app)/tag/[tagId]/page.tsx
@@ -102,20 +102,21 @@ function TagEntriesContent() {
     listFilters: { tagId, unreadOnly: showUnreadOnly, sortOrder },
   });
 
-  // Keyboard navigation and actions
-  const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
-    entries,
-    onOpenEntry: setOpenEntryId,
-    onClose: closeEntry,
-    isEntryOpen: !!openEntryId,
-    enabled: keyboardShortcutsEnabled,
-    onToggleRead: toggleRead,
-    onToggleStar: toggleStar,
-    onRefresh: () => {
-      utils.entries.list.invalidate();
-    },
-    onToggleUnreadOnly: toggleShowUnreadOnly,
-  });
+  // Keyboard navigation and actions (also provides swipe navigation functions)
+  const { selectedEntryId, setSelectedEntryId, goToNextEntry, goToPreviousEntry } =
+    useKeyboardShortcuts({
+      entries,
+      onOpenEntry: setOpenEntryId,
+      onClose: closeEntry,
+      isEntryOpen: !!openEntryId,
+      enabled: keyboardShortcutsEnabled,
+      onToggleRead: toggleRead,
+      onToggleStar: toggleStar,
+      onRefresh: () => {
+        utils.entries.list.invalidate();
+      },
+      onToggleUnreadOnly: toggleShowUnreadOnly,
+    });
 
   // Fetch tag info
   const tagsQuery = trpc.tags.list.useQuery();
@@ -142,7 +143,15 @@ function TagEntriesContent() {
   // If an entry is open, show the full content view
   // Key forces remount when entryId changes, ensuring fresh refs and mutation state
   if (openEntryId) {
-    return <EntryContent key={openEntryId} entryId={openEntryId} onBack={handleBack} />;
+    return (
+      <EntryContent
+        key={openEntryId}
+        entryId={openEntryId}
+        onBack={handleBack}
+        onSwipeNext={goToNextEntry}
+        onSwipePrevious={goToPreviousEntry}
+      />
+    );
   }
 
   // Show loading state while checking tag

--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -30,6 +30,16 @@ interface EntryContentProps {
    * Optional callback when the back button is clicked.
    */
   onBack?: () => void;
+
+  /**
+   * Optional callback when swiping to next entry.
+   */
+  onSwipeNext?: () => void;
+
+  /**
+   * Optional callback when swiping to previous entry.
+   */
+  onSwipePrevious?: () => void;
 }
 
 /**
@@ -38,7 +48,7 @@ interface EntryContentProps {
  * Fetches and displays the full content of an entry.
  * Marks the entry as read on mount.
  */
-export function EntryContent({ entryId, onBack }: EntryContentProps) {
+export function EntryContent({ entryId, onBack, onSwipeNext, onSwipePrevious }: EntryContentProps) {
   const hasMarkedRead = useRef(false);
   const [showOriginal, setShowOriginal] = useState(false);
 
@@ -123,6 +133,8 @@ export function EntryContent({ entryId, onBack }: EntryContentProps) {
       setShowOriginal={setShowOriginal}
       narrationArticleType="entry"
       footerLinkDomain={entry.feedUrl ? getDomain(entry.feedUrl) : undefined}
+      onSwipeNext={onSwipeNext}
+      onSwipePrevious={onSwipePrevious}
     />
   );
 }

--- a/src/components/saved/SavedArticleContent.tsx
+++ b/src/components/saved/SavedArticleContent.tsx
@@ -30,6 +30,16 @@ interface SavedArticleContentProps {
    * Optional callback when the back button is clicked.
    */
   onBack?: () => void;
+
+  /**
+   * Optional callback when swiping to next article.
+   */
+  onSwipeNext?: () => void;
+
+  /**
+   * Optional callback when swiping to previous article.
+   */
+  onSwipePrevious?: () => void;
 }
 
 /**
@@ -38,7 +48,12 @@ interface SavedArticleContentProps {
  * Fetches and displays the full content of a saved article.
  * Marks the article as read on mount.
  */
-export function SavedArticleContent({ articleId, onBack }: SavedArticleContentProps) {
+export function SavedArticleContent({
+  articleId,
+  onBack,
+  onSwipeNext,
+  onSwipePrevious,
+}: SavedArticleContentProps) {
   const hasMarkedRead = useRef(false);
   const [showOriginal, setShowOriginal] = useState(false);
 
@@ -122,6 +137,8 @@ export function SavedArticleContent({ articleId, onBack }: SavedArticleContentPr
       showOriginal={showOriginal}
       setShowOriginal={setShowOriginal}
       narrationArticleType="saved"
+      onSwipeNext={onSwipeNext}
+      onSwipePrevious={onSwipePrevious}
     />
   );
 }

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -58,3 +58,9 @@ export {
 } from "./useSavedArticleMutations";
 
 export { useEntryUrlState, type UseEntryUrlStateResult } from "./useEntryUrlState";
+
+export {
+  useSwipeGestures,
+  type UseSwipeGesturesOptions,
+  type UseSwipeGesturesResult,
+} from "./useSwipeGestures";

--- a/src/lib/hooks/useKeyboardShortcuts.ts
+++ b/src/lib/hooks/useKeyboardShortcuts.ts
@@ -125,6 +125,18 @@ export interface UseKeyboardShortcutsResult {
    * Clear selection.
    */
   clearSelection: () => void;
+
+  /**
+   * Navigate to and open the next entry.
+   * Used for swipe gestures and keyboard navigation when viewing an entry.
+   */
+  goToNextEntry: () => void;
+
+  /**
+   * Navigate to and open the previous entry.
+   * Used for swipe gestures and keyboard navigation when viewing an entry.
+   */
+  goToPreviousEntry: () => void;
 }
 
 /**
@@ -567,5 +579,7 @@ export function useKeyboardShortcuts(
     selectPrevious,
     openSelected,
     clearSelection,
+    goToNextEntry,
+    goToPreviousEntry,
   };
 }

--- a/src/lib/hooks/useSavedArticleKeyboardShortcuts.ts
+++ b/src/lib/hooks/useSavedArticleKeyboardShortcuts.ts
@@ -125,6 +125,18 @@ export interface UseSavedArticleKeyboardShortcutsResult {
    * Clear selection.
    */
   clearSelection: () => void;
+
+  /**
+   * Navigate to and open the next article.
+   * Used for swipe gestures and keyboard navigation when viewing an article.
+   */
+  goToNextArticle: () => void;
+
+  /**
+   * Navigate to and open the previous article.
+   * Used for swipe gestures and keyboard navigation when viewing an article.
+   */
+  goToPreviousArticle: () => void;
 }
 
 /**
@@ -538,5 +550,7 @@ export function useSavedArticleKeyboardShortcuts(
     selectPrevious,
     openSelected,
     clearSelection,
+    goToNextArticle,
+    goToPreviousArticle,
   };
 }

--- a/src/lib/hooks/useSwipeGestures.ts
+++ b/src/lib/hooks/useSwipeGestures.ts
@@ -1,0 +1,210 @@
+/**
+ * useSwipeGestures Hook
+ *
+ * Provides touch swipe gesture navigation for entry views.
+ * Similar to the j/k keyboard navigation, but for touch devices.
+ *
+ * Features:
+ * - Swipe left to go to next entry
+ * - Swipe right to go to previous entry
+ * - Configurable swipe threshold
+ * - Only active when entry is open
+ */
+
+"use client";
+
+import { useCallback, useRef, RefObject } from "react";
+
+/**
+ * Configuration options for swipe gestures.
+ */
+export interface UseSwipeGesturesOptions {
+  /**
+   * Array of entry IDs in the current list (in display order).
+   */
+  entryIds: string[];
+
+  /**
+   * The currently open entry ID.
+   */
+  currentEntryId: string | null;
+
+  /**
+   * Callback when navigating to an entry.
+   */
+  onNavigateToEntry?: (entryId: string) => void;
+
+  /**
+   * Whether swipe gestures are enabled.
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Minimum horizontal distance (in pixels) for a swipe to be recognized.
+   * @default 50
+   */
+  swipeThreshold?: number;
+
+  /**
+   * Maximum vertical distance (in pixels) allowed for a horizontal swipe.
+   * If exceeded, the gesture is treated as a scroll, not a swipe.
+   * @default 100
+   */
+  maxVerticalDistance?: number;
+}
+
+/**
+ * Result returned by the useSwipeGestures hook.
+ */
+export interface UseSwipeGesturesResult {
+  /**
+   * Touch event handlers to attach to the swipeable element.
+   */
+  handlers: {
+    onTouchStart: (e: React.TouchEvent) => void;
+    onTouchEnd: (e: React.TouchEvent) => void;
+  };
+
+  /**
+   * Ref to attach to the swipeable container element.
+   * This is used to check if the user is at scroll boundaries.
+   */
+  containerRef: RefObject<HTMLDivElement | null>;
+
+  /**
+   * Navigate to the next entry.
+   */
+  goToNext: () => void;
+
+  /**
+   * Navigate to the previous entry.
+   */
+  goToPrevious: () => void;
+}
+
+/**
+ * Hook for swipe gesture navigation in entry views.
+ *
+ * @example
+ * ```tsx
+ * function EntryView({ entryId, entries, onNavigate }) {
+ *   const { handlers, containerRef } = useSwipeGestures({
+ *     entryIds: entries.map(e => e.id),
+ *     currentEntryId: entryId,
+ *     onNavigateToEntry: onNavigate,
+ *     enabled: true,
+ *   });
+ *
+ *   return (
+ *     <div ref={containerRef} {...handlers}>
+ *       <ArticleContent />
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useSwipeGestures(options: UseSwipeGesturesOptions): UseSwipeGesturesResult {
+  const {
+    entryIds,
+    currentEntryId,
+    onNavigateToEntry,
+    enabled = true,
+    swipeThreshold = 50,
+    maxVerticalDistance = 100,
+  } = options;
+
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Get the current index of the open entry
+  const getCurrentIndex = useCallback((): number => {
+    if (!currentEntryId) return -1;
+    return entryIds.indexOf(currentEntryId);
+  }, [currentEntryId, entryIds]);
+
+  // Navigate to the next entry
+  const goToNext = useCallback(() => {
+    if (!onNavigateToEntry || entryIds.length === 0) return;
+
+    const currentIndex = getCurrentIndex();
+
+    if (currentIndex === -1) {
+      // Nothing selected, go to first
+      onNavigateToEntry(entryIds[0]);
+    } else if (currentIndex < entryIds.length - 1) {
+      // Go to next
+      onNavigateToEntry(entryIds[currentIndex + 1]);
+    }
+    // If at the last entry, do nothing
+  }, [entryIds, getCurrentIndex, onNavigateToEntry]);
+
+  // Navigate to the previous entry
+  const goToPrevious = useCallback(() => {
+    if (!onNavigateToEntry || entryIds.length === 0) return;
+
+    const currentIndex = getCurrentIndex();
+
+    if (currentIndex === -1) {
+      // Nothing selected, go to last
+      onNavigateToEntry(entryIds[entryIds.length - 1]);
+    } else if (currentIndex > 0) {
+      // Go to previous
+      onNavigateToEntry(entryIds[currentIndex - 1]);
+    }
+    // If at the first entry, do nothing
+  }, [entryIds, getCurrentIndex, onNavigateToEntry]);
+
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (!enabled || !currentEntryId) return;
+
+      const touch = e.touches[0];
+      touchStartRef.current = { x: touch.clientX, y: touch.clientY };
+    },
+    [enabled, currentEntryId]
+  );
+
+  const onTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (!enabled || !currentEntryId || !touchStartRef.current) return;
+
+      const touch = e.changedTouches[0];
+      const deltaX = touch.clientX - touchStartRef.current.x;
+      const deltaY = touch.clientY - touchStartRef.current.y;
+
+      // Reset touch start
+      touchStartRef.current = null;
+
+      // Check if vertical movement is too large (user is scrolling, not swiping)
+      if (Math.abs(deltaY) > maxVerticalDistance) {
+        return;
+      }
+
+      // Check if horizontal movement meets threshold
+      if (Math.abs(deltaX) < swipeThreshold) {
+        return;
+      }
+
+      // Determine swipe direction
+      if (deltaX < 0) {
+        // Swipe left -> next entry
+        goToNext();
+      } else {
+        // Swipe right -> previous entry
+        goToPrevious();
+      }
+    },
+    [enabled, currentEntryId, swipeThreshold, maxVerticalDistance, goToNext, goToPrevious]
+  );
+
+  return {
+    handlers: {
+      onTouchStart,
+      onTouchEnd,
+    },
+    containerRef,
+    goToNext,
+    goToPrevious,
+  };
+}


### PR DESCRIPTION
Similar to the j/k keyboard shortcuts and Android app behavior:
- Swipe left to go to next entry
- Swipe right to go to previous entry

Implemented by:
- Adding touch event handlers to ArticleContentBody
- Exposing goToNextEntry/goToPreviousEntry from keyboard hooks
- Passing navigation callbacks through EntryContent/SavedArticleContent
- Integrating with all entry pages (all, starred, saved, feed, tag)