### PR TITLE
Async OPML import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,9 +113,12 @@ tests/
 
 ### Migrations
 
-- **Enum additions must be in their own migration file** - PostgreSQL doesn't allow using new enum values in the same transaction they were added. Create a separate migration that only adds the enum values, then a subsequent migration that uses them.
-- Run `pnpm drizzle-kit generate` to create migrations from schema changes
-- Review generated SQL before committing - drizzle may need manual adjustments
+- **Write SQL migrations manually** in `drizzle/` folder - we don't use `drizzle-kit generate`
+- Name migrations with incrementing prefix: `0016_descriptive_name.sql`
+- Use `--> statement-breakpoint` to separate SQL statements
+- **Enum additions must be in their own migration file** - PostgreSQL doesn't allow using new enum values in the same transaction they were added
+- Run migrations with `pnpm db:migrate`
+- Apply to test database with `pnpm db:migrate:test`
 
 ## API Conventions
 

--- a/drizzle/0016_opml_imports.sql
+++ b/drizzle/0016_opml_imports.sql
@@ -1,0 +1,24 @@
+-- OPML imports table for async background import processing
+-- Allows returning immediately to the user while processing feeds in the background
+
+CREATE TABLE "opml_imports" (
+  "id" uuid PRIMARY KEY,
+  "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "status" text NOT NULL DEFAULT 'pending',
+  "total_feeds" integer NOT NULL,
+  "imported_count" integer NOT NULL DEFAULT 0,
+  "skipped_count" integer NOT NULL DEFAULT 0,
+  "failed_count" integer NOT NULL DEFAULT 0,
+  "feeds_data" jsonb NOT NULL,
+  "results" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "error" text,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "completed_at" timestamp with time zone
+);--> statement-breakpoint
+
+-- Index for listing imports by user
+CREATE INDEX "idx_opml_imports_user" ON "opml_imports" USING btree ("user_id");--> statement-breakpoint
+
+-- Index for finding pending imports (for job polling)
+CREATE INDEX "idx_opml_imports_status" ON "opml_imports" USING btree ("status");

--- a/src/server/jobs/queue.ts
+++ b/src/server/jobs/queue.ts
@@ -58,6 +58,7 @@ function rowToJob(row: RawJobRow): Job {
 export interface JobPayloads {
   fetch_feed: { feedId: string };
   renew_websub: Record<string, never>; // Empty payload - renews all expiring subscriptions
+  process_opml_import: { importId: string }; // Process an OPML import in the background
 }
 
 export type JobType = keyof JobPayloads;

--- a/src/server/jobs/worker.ts
+++ b/src/server/jobs/worker.ts
@@ -11,7 +11,12 @@
  */
 
 import { claimJob, finishJob, getJobPayload, type JobType } from "./queue";
-import { handleFetchFeed, handleRenewWebsub, type JobHandlerResult } from "./handlers";
+import {
+  handleFetchFeed,
+  handleRenewWebsub,
+  handleProcessOpmlImport,
+  type JobHandlerResult,
+} from "./handlers";
 import type { Job } from "../db/schema";
 import { logger as appLogger } from "@/lib/logger";
 import * as Sentry from "@sentry/nextjs";
@@ -154,6 +159,11 @@ export function createWorker(config: WorkerConfig = {}): Worker {
         case "renew_websub": {
           const payload = getJobPayload<"renew_websub">(job);
           result = await handleRenewWebsub(payload);
+          break;
+        }
+        case "process_opml_import": {
+          const payload = getJobPayload<"process_opml_import">(job);
+          result = await handleProcessOpmlImport(payload);
           break;
         }
         default: {

--- a/src/server/trpc/root.ts
+++ b/src/server/trpc/root.ts
@@ -18,6 +18,7 @@ import {
   narrationRouter,
   ingestAddressesRouter,
   blockedSendersRouter,
+  importsRouter,
 } from "./routers";
 
 /**
@@ -36,6 +37,7 @@ export const appRouter = createTRPCRouter({
   narration: narrationRouter,
   ingestAddresses: ingestAddressesRouter,
   blockedSenders: blockedSendersRouter,
+  imports: importsRouter,
 });
 
 /**

--- a/src/server/trpc/routers/imports.ts
+++ b/src/server/trpc/routers/imports.ts
@@ -1,0 +1,185 @@
+/**
+ * Imports Router
+ *
+ * Handles OPML import status queries.
+ * Allows users to check the status of their async OPML imports.
+ */
+
+import { z } from "zod";
+import { eq, and, desc } from "drizzle-orm";
+
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { errors } from "../errors";
+import { opmlImports } from "@/server/db/schema";
+
+// ============================================================================
+// Validation Schemas
+// ============================================================================
+
+/**
+ * UUID validation schema for import IDs.
+ */
+const uuidSchema = z.string().uuid("Invalid import ID");
+
+// ============================================================================
+// Output Schemas
+// ============================================================================
+
+/**
+ * Import result item schema.
+ */
+const importResultSchema = z.object({
+  url: z.string(),
+  title: z.string().nullable(),
+  status: z.enum(["pending", "imported", "skipped", "failed"]),
+  error: z.string().optional(),
+  feedId: z.string().optional(),
+  subscriptionId: z.string().optional(),
+});
+
+/**
+ * Import output schema - what we return for an import.
+ */
+const importOutputSchema = z.object({
+  id: z.string(),
+  status: z.enum(["pending", "processing", "completed", "failed"]),
+  totalFeeds: z.number(),
+  importedCount: z.number(),
+  skippedCount: z.number(),
+  failedCount: z.number(),
+  results: z.array(importResultSchema),
+  error: z.string().nullable(),
+  createdAt: z.date(),
+  completedAt: z.date().nullable(),
+});
+
+/**
+ * Import summary schema (for list view, without full results).
+ */
+const importSummarySchema = z.object({
+  id: z.string(),
+  status: z.enum(["pending", "processing", "completed", "failed"]),
+  totalFeeds: z.number(),
+  importedCount: z.number(),
+  skippedCount: z.number(),
+  failedCount: z.number(),
+  error: z.string().nullable(),
+  createdAt: z.date(),
+  completedAt: z.date().nullable(),
+});
+
+// ============================================================================
+// Router
+// ============================================================================
+
+export const importsRouter = createTRPCRouter({
+  /**
+   * Get a specific import by ID.
+   *
+   * Returns the full import record including all results.
+   */
+  get: protectedProcedure
+    .meta({
+      openapi: {
+        method: "GET",
+        path: "/imports/{id}",
+        tags: ["Imports"],
+        summary: "Get import details",
+      },
+    })
+    .input(
+      z.object({
+        id: uuidSchema,
+      })
+    )
+    .output(importOutputSchema)
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const [importRecord] = await ctx.db
+        .select()
+        .from(opmlImports)
+        .where(and(eq(opmlImports.id, input.id), eq(opmlImports.userId, userId)))
+        .limit(1);
+
+      if (!importRecord) {
+        throw errors.notFound("Import not found");
+      }
+
+      return {
+        id: importRecord.id,
+        status: importRecord.status as "pending" | "processing" | "completed" | "failed",
+        totalFeeds: importRecord.totalFeeds,
+        importedCount: importRecord.importedCount,
+        skippedCount: importRecord.skippedCount,
+        failedCount: importRecord.failedCount,
+        results: importRecord.results,
+        error: importRecord.error,
+        createdAt: importRecord.createdAt,
+        completedAt: importRecord.completedAt,
+      };
+    }),
+
+  /**
+   * List recent imports for the current user.
+   *
+   * Returns imports ordered by creation date (newest first).
+   * Does not include full results to keep response size small.
+   */
+  list: protectedProcedure
+    .meta({
+      openapi: {
+        method: "GET",
+        path: "/imports",
+        tags: ["Imports"],
+        summary: "List imports",
+      },
+    })
+    .input(
+      z
+        .object({
+          limit: z.number().min(1).max(50).default(10),
+        })
+        .optional()
+    )
+    .output(
+      z.object({
+        items: z.array(importSummarySchema),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const limit = input?.limit ?? 10;
+
+      const imports = await ctx.db
+        .select({
+          id: opmlImports.id,
+          status: opmlImports.status,
+          totalFeeds: opmlImports.totalFeeds,
+          importedCount: opmlImports.importedCount,
+          skippedCount: opmlImports.skippedCount,
+          failedCount: opmlImports.failedCount,
+          error: opmlImports.error,
+          createdAt: opmlImports.createdAt,
+          completedAt: opmlImports.completedAt,
+        })
+        .from(opmlImports)
+        .where(eq(opmlImports.userId, userId))
+        .orderBy(desc(opmlImports.createdAt))
+        .limit(limit);
+
+      return {
+        items: imports.map((imp) => ({
+          id: imp.id,
+          status: imp.status as "pending" | "processing" | "completed" | "failed",
+          totalFeeds: imp.totalFeeds,
+          importedCount: imp.importedCount,
+          skippedCount: imp.skippedCount,
+          failedCount: imp.failedCount,
+          error: imp.error,
+          createdAt: imp.createdAt,
+          completedAt: imp.completedAt,
+        })),
+      };
+    }),
+});

--- a/src/server/trpc/routers/index.ts
+++ b/src/server/trpc/routers/index.ts
@@ -15,3 +15,4 @@ export { savedRouter } from "./saved";
 export { narrationRouter } from "./narration";
 export { ingestAddressesRouter } from "./ingestAddresses";
 export { blockedSendersRouter } from "./blockedSenders";
+export { importsRouter } from "./imports";


### PR DESCRIPTION
The OPML import was blocking the HTTP request while processing feeds sequentially, which could take a long time for large imports. This refactors it to:

1. Create an import record in the database with the parsed OPML feeds
2. Queue a background job to process the import
3. Return immediately with the import ID
4. Process feeds in the background, publishing progress events via Redis pub/sub
5. Client receives real-time progress updates via SSE

New components:
- opml_imports table to track import state and progress
- process_opml_import job type and handler
- import_progress and import_completed pub/sub events
- imports.get and imports.list tRPC routes
- Updated OpmlImportExport component with progress bar

Also updates CLAUDE.md to clarify that migrations are written manually (not generated via drizzle-kit).