### PR TITLE
Investigate read/unread and starred update logic

### DIFF
--- a/src/components/articles/ArticleContentBody.tsx
+++ b/src/components/articles/ArticleContentBody.tsx
@@ -248,10 +248,6 @@ export interface ArticleContentBodyProps {
   onToggleRead: () => void;
   /** Callback to toggle star status */
   onToggleStar: () => void;
-  /** Whether star mutation is in progress */
-  isStarLoading: boolean;
-  /** Whether read mutation is in progress */
-  isReadLoading: boolean;
   /** Whether to show original content */
   showOriginal: boolean;
   /** Callback to set show original state */
@@ -290,8 +286,6 @@ export function ArticleContentBody({
   onBack,
   onToggleRead,
   onToggleStar,
-  isStarLoading,
-  isReadLoading,
   showOriginal,
   setShowOriginal,
   narrationArticleType,
@@ -518,7 +512,6 @@ export function ArticleContentBody({
             variant={starred ? "primary" : "secondary"}
             size="sm"
             onClick={onToggleStar}
-            disabled={isStarLoading}
             className={
               starred
                 ? "bg-amber-500 text-white hover:bg-amber-600 dark:bg-amber-500 dark:text-white dark:hover:bg-amber-600"
@@ -535,7 +528,6 @@ export function ArticleContentBody({
             variant="secondary"
             size="sm"
             onClick={onToggleRead}
-            disabled={isReadLoading}
             aria-label={read ? "Mark as unread" : "Mark as read"}
             title="Keyboard shortcut: m"
           >

--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -58,7 +58,7 @@ export function EntryContent({ entryId, onBack, onSwipeNext, onSwipePrevious }: 
   // Entry mutations without list filters (this component operates on a single entry)
   // Note: optimistic updates happen at the list level in parent components,
   // normy automatically propagates changes to entries.get when server responds
-  const { markRead, star, unstar, isStarPending, isMarkReadPending } = useEntryMutations();
+  const { markRead, star, unstar } = useEntryMutations();
 
   const entry = data?.entry;
 
@@ -127,8 +127,6 @@ export function EntryContent({ entryId, onBack, onSwipeNext, onSwipePrevious }: 
       onBack={onBack}
       onToggleRead={handleReadToggle}
       onToggleStar={handleStarToggle}
-      isStarLoading={isStarPending}
-      isReadLoading={isMarkReadPending}
       showOriginal={showOriginal}
       setShowOriginal={setShowOriginal}
       narrationArticleType="entry"

--- a/src/components/saved/SavedArticleContent.tsx
+++ b/src/components/saved/SavedArticleContent.tsx
@@ -62,7 +62,7 @@ export function SavedArticleContent({
 
   // Use the consolidated mutations hook (no list filters since we're in single article view)
   // normy automatically propagates changes to entries.get when server responds
-  const { markRead, star, unstar, isStarPending, isMarkReadPending } = useSavedArticleMutations();
+  const { markRead, star, unstar } = useSavedArticleMutations();
 
   const article = data?.entry;
 
@@ -132,8 +132,6 @@ export function SavedArticleContent({
       onBack={onBack}
       onToggleRead={handleReadToggle}
       onToggleStar={handleStarToggle}
-      isStarLoading={isStarPending}
-      isReadLoading={isMarkReadPending}
       showOriginal={showOriginal}
       setShowOriginal={setShowOriginal}
       narrationArticleType="saved"


### PR DESCRIPTION
Optimistic updates already provide instant UI feedback, making the disabled states during in-flight requests unnecessary. This aligns the detail view behavior with the list view, which never had disabled states on these buttons.