### PR TITLE
Check feed refetch minimum time logic

### DIFF
--- a/src/server/feed/index.ts
+++ b/src/server/feed/index.ts
@@ -3,7 +3,7 @@
  * Exports types and parsers for RSS, Atom, and JSON Feed formats.
  */
 
-export type { ParsedFeed, ParsedEntry } from "./types";
+export type { ParsedFeed, ParsedEntry, SyndicationHints } from "./types";
 export { parseRssFeed, parseRssDate } from "./rss-parser";
 export { parseAtomFeed } from "./atom-parser";
 export {
@@ -46,11 +46,14 @@ export {
   calculateNextFetch,
   calculateFailureBackoff,
   getNextFetchTime,
-  MIN_FETCH_INTERVAL_SECONDS,
+  syndicationToSeconds,
+  getMinFetchIntervalSeconds,
+  DEFAULT_MIN_FETCH_INTERVAL_SECONDS,
   MAX_FETCH_INTERVAL_SECONDS,
   DEFAULT_FETCH_INTERVAL_SECONDS,
   MAX_CONSECUTIVE_FAILURES,
   type CalculateNextFetchOptions,
+  type FeedHints,
   type NextFetchResult,
   type NextFetchReason,
 } from "./scheduling";

--- a/src/server/feed/types.ts
+++ b/src/server/feed/types.ts
@@ -24,6 +24,25 @@ export interface ParsedEntry {
 }
 
 /**
+ * Update interval hints from RSS Syndication namespace.
+ * Used to calculate refresh intervals based on feed-provided hints.
+ *
+ * @see http://web.resource.org/rss/1.0/modules/syndication/
+ */
+export interface SyndicationHints {
+  /**
+   * Period for updates: "hourly", "daily", "weekly", "monthly", "yearly"
+   * @example "daily" means the feed updates once per day
+   */
+  updatePeriod?: "hourly" | "daily" | "weekly" | "monthly" | "yearly";
+  /**
+   * Frequency of updates within the period.
+   * @example updatePeriod="daily" + updateFrequency=2 means twice per day
+   */
+  updateFrequency?: number;
+}
+
+/**
  * A parsed feed from any format (RSS, Atom, JSON Feed).
  */
 export interface ParsedFeed {
@@ -42,4 +61,17 @@ export interface ParsedFeed {
   hubUrl?: string;
   /** Self link URL (canonical URL of the feed) */
   selfUrl?: string;
+
+  /**
+   * RSS 2.0 <ttl> element: time-to-live in minutes.
+   * Indicates how long a channel can be cached before refreshing.
+   * @see https://www.rssboard.org/rss-specification#ltttlgtSubelementOfLtchannelgt
+   */
+  ttlMinutes?: number;
+
+  /**
+   * Syndication namespace hints for update frequency.
+   * @see http://web.resource.org/rss/1.0/modules/syndication/
+   */
+  syndication?: SyndicationHints;
 }

--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -175,9 +175,13 @@ async function processFetchResult(feed: Feed, result: FetchFeedResult): Promise<
       // Process entries (create new, update changed)
       const processResult = await processEntries(feed.id, parsedFeed, { fetchedAt: now });
 
-      // Calculate next fetch time based on cache headers
+      // Calculate next fetch time based on cache headers and feed hints
       const nextFetch = calculateNextFetch({
         cacheControl: result.cacheHeaders.cacheControl,
+        feedHints: {
+          ttlMinutes: parsedFeed.ttlMinutes,
+          syndication: parsedFeed.syndication,
+        },
         consecutiveFailures: 0, // Reset failures on success
         now,
       });


### PR DESCRIPTION
- Change default minimum refetch interval from 1 minute to 60 minutes
- Make minimum configurable via FEED_MIN_FETCH_INTERVAL_MINUTES env var
- Parse RSS <ttl> element for refresh interval hints
- Parse sy:updatePeriod and sy:updateFrequency from Syndication namespace
- Use feed hints in scheduling when no Cache-Control headers present
- Priority: failures > Cache-Control > TTL > syndication > default

This reduces unnecessary polling load on feed servers. Conditional requests (If-None-Match/If-Modified-Since) were already implemented.