### PR TITLE
Remove narrationArticleType since entries are unified

### DIFF
--- a/src/components/articles/ArticleContentBody.tsx
+++ b/src/components/articles/ArticleContentBody.tsx
@@ -252,8 +252,6 @@ export interface ArticleContentBodyProps {
   showOriginal: boolean;
   /** Callback to set show original state */
   setShowOriginal: (show: boolean) => void;
-  /** The article type for narration */
-  narrationArticleType: "entry" | "saved";
   /** Optional domain for footer link (defaults to extracting from url) */
   footerLinkDomain?: string;
   /** Callback when swiping to next article */
@@ -288,7 +286,6 @@ export function ArticleContentBody({
   onToggleStar,
   showOriginal,
   setShowOriginal,
-  narrationArticleType,
   footerLinkDomain,
   onSwipeNext,
   onSwipePrevious,
@@ -306,7 +303,6 @@ export function ArticleContentBody({
   const narrationSupported = isNarrationSupported();
   const narration = useNarration({
     id: articleId,
-    type: narrationArticleType,
     title,
     feedTitle: source,
     content: contentToDisplay,
@@ -563,7 +559,6 @@ export function ArticleContentBody({
           {/* Narration controls - pass narration state for controlled mode */}
           <NarrationControls
             articleId={articleId}
-            articleType={narrationArticleType}
             title={title}
             feedTitle={source}
             narration={narration}

--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -152,7 +152,6 @@ export function EntryContent({
       onToggleStar={handleStarToggle}
       showOriginal={showOriginal}
       setShowOriginal={setShowOriginal}
-      narrationArticleType="entry"
       footerLinkDomain={entry.feedUrl ? getDomain(entry.feedUrl) : undefined}
       onSwipeNext={onSwipeNext}
       onSwipePrevious={onSwipePrevious}

--- a/src/components/narration/NarrationControls.tsx
+++ b/src/components/narration/NarrationControls.tsx
@@ -13,7 +13,6 @@
  * ```tsx
  * <NarrationControls
  *   articleId="..."
- *   articleType="entry"
  *   title="Article Title"
  *   feedTitle="Feed Name"
  * />
@@ -33,8 +32,6 @@ import { Button } from "@/components/ui/button";
 export interface NarrationControlsProps {
   /** The article ID (entry or saved article) */
   articleId: string;
-  /** Type of article: 'entry' for feed entries, 'saved' for saved articles */
-  articleType: "entry" | "saved";
   /** Title of the article (for Media Session) */
   title: string;
   /** Feed or site name (for Media Session) */
@@ -155,7 +152,6 @@ function NarrationIcon() {
  */
 export function NarrationControls({
   articleId,
-  articleType,
   title,
   feedTitle,
   artwork,
@@ -170,7 +166,6 @@ export function NarrationControls({
   return (
     <NarrationControlsInner
       articleId={articleId}
-      articleType={articleType}
       title={title}
       feedTitle={feedTitle}
       artwork={artwork}
@@ -186,7 +181,6 @@ export function NarrationControls({
  */
 function NarrationControlsInner({
   articleId,
-  articleType,
   title,
   feedTitle,
   artwork,
@@ -196,7 +190,6 @@ function NarrationControlsInner({
   // Use internal narration hook only when external state is not provided
   const internalNarration = useNarration({
     id: articleId,
-    type: articleType,
     title,
     feedTitle,
     artwork,

--- a/src/components/narration/useNarration.ts
+++ b/src/components/narration/useNarration.ts
@@ -8,7 +8,7 @@
  * Usage:
  * ```tsx
  * function ArticleView({ articleId }: { articleId: string }) {
- *   const narration = useNarration({ id: articleId, type: 'entry', title: 'Article Title', feedTitle: 'Feed' });
+ *   const narration = useNarration({ id: articleId, title: 'Article Title', feedTitle: 'Feed' });
  *
  *   return (
  *     <NarrationControls
@@ -50,8 +50,6 @@ import { MIN_PREBUFFER_DURATION_SECONDS } from "@/lib/narration/audio-buffer-uti
 export interface UseNarrationConfig {
   /** The article ID (entry or saved article) */
   id: string;
-  /** Type of article: 'entry' for feed entries, 'saved' for saved articles */
-  type: "entry" | "saved";
   /** Title of the article (for Media Session) */
   title: string;
   /** Feed or site name (for Media Session) */
@@ -140,11 +138,11 @@ function splitIntoParagraphs(text: string): string[] {
  * - Integrating with Media Session API
  * - Using user's voice/rate/pitch preferences
  *
- * @param config - Configuration including article ID, type, and metadata
+ * @param config - Configuration including article ID and metadata
  * @returns Object with narration state and control functions
  */
 export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
-  const { id, type, title, feedTitle, artwork, content } = config;
+  const { id, title, feedTitle, artwork, content } = config;
 
   // State
   const [state, setState] = useState<NarrationState>(DEFAULT_STATE);
@@ -284,10 +282,7 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
       let nextIndex = currentIndex + 1;
 
       // Keep buffering until we have enough duration or run out of paragraphs
-      while (
-        bufferedDuration < MIN_PREBUFFER_DURATION_SECONDS &&
-        nextIndex < paragraphs.length
-      ) {
+      while (bufferedDuration < MIN_PREBUFFER_DURATION_SECONDS && nextIndex < paragraphs.length) {
         // Skip if already cached or being buffered
         if (audioCacheRef.current.has(nextIndex) || bufferingRef.current.has(nextIndex)) {
           const existingBuffer = audioCacheRef.current.get(nextIndex);
@@ -442,7 +437,6 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
           // Call server for LLM processing
           const result = await generateMutation.mutateAsync({
             id,
-            type,
             useLlmNormalization: settings.useLlmNormalization,
           });
           narration = result.narration;
@@ -522,7 +516,6 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
         // Call server for LLM processing
         const result = await generateMutation.mutateAsync({
           id,
-          type,
           useLlmNormalization: settings.useLlmNormalization,
         });
         narration = result.narration;
@@ -569,7 +562,6 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
     settings.useLlmNormalization,
     generateMutation,
     id,
-    type,
     content,
     speakPiperParagraph,
   ]);

--- a/src/components/saved/SavedArticleContent.tsx
+++ b/src/components/saved/SavedArticleContent.tsx
@@ -152,7 +152,6 @@ export function SavedArticleContent({
       onToggleStar={handleStarToggle}
       showOriginal={showOriginal}
       setShowOriginal={setShowOriginal}
-      narrationArticleType="saved"
       onSwipeNext={onSwipeNext}
       onSwipePrevious={onSwipePrevious}
     />


### PR DESCRIPTION
Since saved articles are now stored in the entries table, the narration API no longer needs to distinguish between entry types. The `type` parameter was only used for returning a slightly different error message.

Removed from:
- Server narration router input schema
- UseNarrationConfig interface
- NarrationControls props
- ArticleContentBody props
- EntryContent and SavedArticleContent components