### PR TITLE
Add mousedown prefetching for instant article loading

### DIFF
--- a/src/components/articles/ArticleListItem.tsx
+++ b/src/components/articles/ArticleListItem.tsx
@@ -36,6 +36,8 @@ export interface ArticleListItemProps {
   onToggleRead?: (id: string, currentlyRead: boolean) => void;
   /** Callback when the star indicator is clicked */
   onToggleStar?: (id: string, currentlyStarred: boolean) => void;
+  /** Callback to prefetch article data on mousedown (before click completes) */
+  onPrefetch?: (id: string) => void;
 }
 
 /**
@@ -75,6 +77,7 @@ export const ArticleListItem = memo(function ArticleListItem({
   onClick,
   onToggleRead,
   onToggleStar,
+  onPrefetch,
 }: ArticleListItemProps) {
   const displayTitle = title ?? "Untitled";
 
@@ -87,6 +90,12 @@ export const ArticleListItem = memo(function ArticleListItem({
       e.preventDefault();
       onClick?.(id);
     }
+  };
+
+  const handleMouseDown = () => {
+    // Prefetch article data when user presses mouse button (before click completes)
+    // This gives a 50-150ms head start with near-zero false positives
+    onPrefetch?.(id);
   };
 
   const handleToggleRead = (e: React.MouseEvent) => {
@@ -105,6 +114,7 @@ export const ArticleListItem = memo(function ArticleListItem({
       tabIndex={0}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
+      onMouseDown={handleMouseDown}
       data-entry-id={id}
       className={getItemClasses(read, selected)}
       aria-label={`${read ? "Read" : "Unread"}${selected ? ", selected" : ""} article: ${displayTitle} from ${source}`}

--- a/src/components/entries/EntryList.tsx
+++ b/src/components/entries/EntryList.tsx
@@ -143,6 +143,18 @@ export function EntryList({
     }
   );
 
+  // Get tRPC utils for prefetching on mousedown
+  const utils = trpc.useUtils();
+
+  // Prefetch entry data on mousedown (before click completes)
+  // This gives a 50-150ms head start with near-zero false positives
+  const handlePrefetch = useCallback(
+    (entryId: string) => {
+      utils.entries.get.fetch({ id: entryId });
+    },
+    [utils]
+  );
+
   // Flatten all pages into a single array of entries
   const allEntries = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data?.pages]);
 
@@ -219,6 +231,7 @@ export function EntryList({
           selected={selectedEntryId === entry.id}
           onToggleRead={onToggleRead}
           onToggleStar={onToggleStar}
+          onPrefetch={handlePrefetch}
         />
       ))}
 

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -42,6 +42,10 @@ interface EntryListItemProps {
    * Callback when the star indicator is clicked.
    */
   onToggleStar?: (entryId: string, currentlyStarred: boolean) => void;
+  /**
+   * Callback to prefetch entry data on mousedown (before click completes).
+   */
+  onPrefetch?: (entryId: string) => void;
 }
 
 /**
@@ -54,6 +58,7 @@ export const EntryListItem = memo(function EntryListItem({
   selected = false,
   onToggleRead,
   onToggleStar,
+  onPrefetch,
 }: EntryListItemProps) {
   return (
     <ArticleListItem
@@ -68,6 +73,7 @@ export const EntryListItem = memo(function EntryListItem({
       onClick={onClick}
       onToggleRead={onToggleRead}
       onToggleStar={onToggleStar}
+      onPrefetch={onPrefetch}
     />
   );
 });

--- a/src/components/saved/SavedArticleList.tsx
+++ b/src/components/saved/SavedArticleList.tsx
@@ -134,6 +134,18 @@ export function SavedArticleList({
     }
   );
 
+  // Get tRPC utils for prefetching on mousedown
+  const utils = trpc.useUtils();
+
+  // Prefetch article data on mousedown (before click completes)
+  // This gives a 50-150ms head start with near-zero false positives
+  const handlePrefetch = useCallback(
+    (articleId: string) => {
+      utils.entries.get.fetch({ id: articleId });
+    },
+    [utils]
+  );
+
   // Flatten all pages into a single array of articles
   const allArticles = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data?.pages]);
 
@@ -210,6 +222,7 @@ export function SavedArticleList({
           selected={selectedArticleId === article.id}
           onToggleRead={onToggleRead}
           onToggleStar={onToggleStar}
+          onPrefetch={handlePrefetch}
         />
       ))}
 

--- a/src/components/saved/SavedArticleListItem.tsx
+++ b/src/components/saved/SavedArticleListItem.tsx
@@ -42,6 +42,10 @@ interface SavedArticleListItemProps {
    * Callback when the star indicator is clicked.
    */
   onToggleStar?: (articleId: string, currentlyStarred: boolean) => void;
+  /**
+   * Callback to prefetch article data on mousedown (before click completes).
+   */
+  onPrefetch?: (articleId: string) => void;
 }
 
 /**
@@ -54,6 +58,7 @@ export const SavedArticleListItem = memo(function SavedArticleListItem({
   selected = false,
   onToggleRead,
   onToggleStar,
+  onPrefetch,
 }: SavedArticleListItemProps) {
   return (
     <ArticleListItem
@@ -68,6 +73,7 @@ export const SavedArticleListItem = memo(function SavedArticleListItem({
       onClick={onClick}
       onToggleRead={onToggleRead}
       onToggleStar={onToggleStar}
+      onPrefetch={onPrefetch}
     />
   );
 });


### PR DESCRIPTION
Implements prefetching on mousedown (before click completes) to give a 50-150ms head start with near-zero false positives.

- ArticleListItem now accepts onPrefetch callback triggered on mousedown
- EntryList and SavedArticleList wire up prefetch using trpc.utils.entries.get.fetch
- EntryListItem and SavedArticleListItem pass through onPrefetch prop

This gives users instant article loading when clicking from lists while avoiding the bandwidth waste of hover-based prefetching. The mousedown event fires when the user presses the mouse button, before they release it to complete the click, providing a small but noticeable performance improvement with minimal overhead.