### PR TITLE
Add mouse-down preloading for entry lists

### DIFF
--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -38,6 +38,7 @@ export {
 
 export {
   useViewPreferences,
+  getViewPreferences,
   type ViewType,
   type ViewPreferences,
   type UseViewPreferencesResult,

--- a/src/lib/hooks/useViewPreferences.ts
+++ b/src/lib/hooks/useViewPreferences.ts
@@ -174,6 +174,20 @@ function notifyListeners(key: string): void {
 }
 
 /**
+ * Get view preferences synchronously (for use outside of React components).
+ *
+ * This is useful for prefetching in event handlers where hooks can't be called.
+ *
+ * @param viewType - The type of view (all, starred, feed, tag, saved)
+ * @param viewId - Optional ID for feed or tag views
+ * @returns The current view preferences
+ */
+export function getViewPreferences(viewType: ViewType, viewId?: string): ViewPreferences {
+  const key = getStorageKey(viewType, viewId);
+  return getSnapshotCached(key);
+}
+
+/**
  * Hook for managing view preferences with localStorage persistence.
  *
  * Uses useSyncExternalStore for proper React 18 concurrent mode support.


### PR DESCRIPTION
Prefetch entry lists when user presses mouse button on sidebar navigation links (All Items, Starred, Saved, feeds, tags). This gives a 50-150ms head start on data loading before the click completes and navigation occurs.

Uses user's view preferences (unreadOnly, sortOrder) for each view type to ensure prefetched data matches what the page will load.