### PR TITLE
Fix HTML entity decoding in feed titles

### DIFF
--- a/tests/unit/feed-parser-atom.test.ts
+++ b/tests/unit/feed-parser-atom.test.ts
@@ -248,6 +248,44 @@ describe("parseAtomFeed", () => {
 
       expect(feed.items[0].content).toBe("<p>HTML in CDATA</p>");
     });
+
+    it("decodes decimal numeric character references", () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>Flameeyes&#039;s Atom Feed</title>
+          <id>urn:uuid:entity-test</id>
+          <updated>2024-01-01T12:00:00Z</updated>
+          <entry>
+            <title>Entry with &#039;quotes&#039;</title>
+            <id>urn:uuid:entity-entry</id>
+            <updated>2024-01-01T12:00:00Z</updated>
+          </entry>
+        </feed>`;
+
+      const feed = parseAtomFeed(xml);
+
+      expect(feed.title).toBe("Flameeyes's Atom Feed");
+      expect(feed.items[0].title).toBe("Entry with 'quotes'");
+    });
+
+    it("decodes hexadecimal numeric character references", () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>Test &#x27;hex&#x27; entities</title>
+          <id>urn:uuid:hex-test</id>
+          <updated>2024-01-01T12:00:00Z</updated>
+          <entry>
+            <title>Entry with &#x22;quotes&#x22;</title>
+            <id>urn:uuid:hex-entry</id>
+            <updated>2024-01-01T12:00:00Z</updated>
+          </entry>
+        </feed>`;
+
+      const feed = parseAtomFeed(xml);
+
+      expect(feed.title).toBe("Test 'hex' entities");
+      expect(feed.items[0].title).toBe('Entry with "quotes"');
+    });
   });
 
   describe("link relation handling", () => {

--- a/tests/unit/feed-parser-rss.test.ts
+++ b/tests/unit/feed-parser-rss.test.ts
@@ -286,6 +286,65 @@ describe("parseRssFeed", () => {
     });
   });
 
+  describe("numeric character reference decoding", () => {
+    it("decodes decimal numeric character references in titles", () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>Flameeyes&#039;s Weblog</title>
+            <item>
+              <title>Comment by Flameeyes&#039;s Friend</title>
+              <link>https://example.com/post</link>
+            </item>
+          </channel>
+        </rss>`;
+
+      const feed = parseRssFeed(xml);
+
+      expect(feed.title).toBe("Flameeyes's Weblog");
+      expect(feed.items[0].title).toBe("Comment by Flameeyes's Friend");
+    });
+
+    it("decodes hexadecimal numeric character references", () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>Test &#x27;hex&#x27; entities</title>
+            <item>
+              <title>Entry with &#x22;quotes&#x22;</title>
+              <link>https://example.com/post</link>
+            </item>
+          </channel>
+        </rss>`;
+
+      const feed = parseRssFeed(xml);
+
+      expect(feed.title).toBe("Test 'hex' entities");
+      expect(feed.items[0].title).toBe('Entry with "quotes"');
+    });
+
+    it("decodes numeric entities in description and content", () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+          <channel>
+            <title>Entity Feed</title>
+            <description>Feed about Tom&#039;s adventures</description>
+            <item>
+              <title>Post</title>
+              <description>It&#039;s a summary</description>
+              <content:encoded>The full content&#039;s here</content:encoded>
+            </item>
+          </channel>
+        </rss>`;
+
+      const feed = parseRssFeed(xml);
+
+      expect(feed.description).toBe("Feed about Tom's adventures");
+      expect(feed.items[0].summary).toBe("It's a summary");
+      expect(feed.items[0].content).toBe("The full content's here");
+    });
+  });
+
   describe("guid element variations", () => {
     it("parses simple guid string", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
fast-xml-parser decodes standard XML entities (&lt; &gt; &amp; etc.) but not numeric character references like &#039; (apostrophe) or &#x27; (hex). This caused feed titles like "Flameeyes&#039;s Weblog" to display the raw entity instead of the decoded character.

Add decodeNumericEntities() to post-process text after XML parsing, handling both decimal (&#NNN;) and hexadecimal (&#xHH;) forms.