### PR TITLE
Fix unsubscribe icon overlapping unread count

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -296,7 +296,7 @@ export function Sidebar({ onClose }: SidebarProps) {
                         <span className="truncate">{title}</span>
                       </span>
                       {subscription.unreadCount > 0 && (
-                        <span className="shrink-0 text-xs text-zinc-500 dark:text-zinc-400">
+                        <span className="shrink-0 text-xs text-zinc-500 transition-opacity group-hover:opacity-0 dark:text-zinc-400">
                           ({subscription.unreadCount})
                         </span>
                       )}


### PR DESCRIPTION
The unread count and action buttons (edit/unsubscribe) visually overlapped because the buttons used partial opacity during transitions. Now the unread count fades out when hovering, matching the inverse behavior of the action buttons.