### PR TITLE
Add mark all read button to feeds

### DIFF
--- a/src/app/(app)/all/page.tsx
+++ b/src/app/(app)/all/page.tsx
@@ -15,6 +15,7 @@ import {
   SortToggle,
   type EntryListEntryData,
 } from "@/components/entries";
+import { MarkAllReadDialog } from "@/components/feeds/MarkAllReadDialog";
 import { useKeyboardShortcutsContext } from "@/components/keyboard";
 import {
   useKeyboardShortcuts,
@@ -28,16 +29,28 @@ import { trpc } from "@/lib/trpc/client";
 function AllEntriesContent() {
   const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
   const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
+  const [showMarkAllReadDialog, setShowMarkAllReadDialog] = useState(false);
 
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
   const { showUnreadOnly, toggleShowUnreadOnly, sortOrder, toggleSortOrder } =
     useViewPreferences("all");
   const utils = trpc.useUtils();
 
+  // Get total unread count from subscriptions
+  const subscriptionsQuery = trpc.subscriptions.list.useQuery();
+  const totalUnreadCount =
+    subscriptionsQuery.data?.items.reduce((sum, item) => sum + item.subscription.unreadCount, 0) ??
+    0;
+
   // Entry mutations with optimistic updates
-  const { toggleRead, toggleStar } = useEntryMutations({
+  const { toggleRead, toggleStar, markAllRead, isMarkAllReadPending } = useEntryMutations({
     listFilters: { unreadOnly: showUnreadOnly, sortOrder },
   });
+
+  const handleMarkAllRead = useCallback(() => {
+    markAllRead({});
+    setShowMarkAllReadDialog(false);
+  }, [markAllRead]);
 
   // Keyboard navigation and actions (also provides swipe navigation functions)
   const { selectedEntryId, setSelectedEntryId, goToNextEntry, goToPreviousEntry } =
@@ -106,6 +119,31 @@ function AllEntriesContent() {
       <div className="mb-4 flex items-center justify-between sm:mb-6">
         <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">All Items</h1>
         <div className="flex gap-2">
+          {totalUnreadCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowMarkAllReadDialog(true)}
+              className="inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
+              title="Mark all as read"
+              aria-label="Mark all as read"
+            >
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <span className="ml-1.5 hidden text-sm sm:inline">Mark All Read</span>
+            </button>
+          )}
           <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
           <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
         </div>
@@ -123,6 +161,15 @@ function AllEntriesContent() {
             ? "No unread entries. Toggle to show all items."
             : "No entries yet. Subscribe to some feeds to see entries here."
         }
+      />
+
+      <MarkAllReadDialog
+        isOpen={showMarkAllReadDialog}
+        contextDescription="all feeds"
+        unreadCount={totalUnreadCount}
+        isLoading={isMarkAllReadPending}
+        onConfirm={handleMarkAllRead}
+        onCancel={() => setShowMarkAllReadDialog(false)}
       />
     </div>
   );

--- a/src/components/feeds/MarkAllReadDialog.tsx
+++ b/src/components/feeds/MarkAllReadDialog.tsx
@@ -1,0 +1,116 @@
+/**
+ * MarkAllReadDialog Component
+ *
+ * Confirmation dialog for marking all entries in a feed/tag as read.
+ * Uses a portal to render on top of other content.
+ */
+
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Button } from "@/components/ui";
+
+interface MarkAllReadDialogProps {
+  isOpen: boolean;
+  /** Description of what will be marked as read (e.g., "this feed", "all items", "this tag") */
+  contextDescription: string;
+  /** Number of unread entries that will be marked as read */
+  unreadCount?: number;
+  isLoading: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function MarkAllReadDialog({
+  isOpen,
+  contextDescription,
+  unreadCount,
+  isLoading,
+  onConfirm,
+  onCancel,
+}: MarkAllReadDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Focus trap and escape key handling
+  useEffect(() => {
+    if (!isOpen) return;
+
+    // Focus the cancel button when dialog opens
+    cancelButtonRef.current?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onCancel]);
+
+  // Prevent body scroll when dialog is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mark-all-read-title"
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50" onClick={onCancel} aria-hidden="true" />
+
+      {/* Dialog */}
+      <div
+        ref={dialogRef}
+        className="relative z-10 mx-4 w-full max-w-md rounded-lg border border-zinc-200 bg-white p-6 shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
+      >
+        <h2
+          id="mark-all-read-title"
+          className="text-lg font-semibold text-zinc-900 dark:text-zinc-50"
+        >
+          Mark all as read?
+        </h2>
+
+        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+          {unreadCount !== undefined && unreadCount > 0 ? (
+            <>
+              This will mark{" "}
+              <span className="font-medium text-zinc-900 dark:text-zinc-50">
+                {unreadCount} {unreadCount === 1 ? "entry" : "entries"}
+              </span>{" "}
+              in {contextDescription} as read.
+            </>
+          ) : (
+            <>This will mark all unread entries in {contextDescription} as read.</>
+          )}
+        </p>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <Button ref={cancelButtonRef} variant="secondary" onClick={onCancel} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={onConfirm} loading={isLoading}>
+            Mark All Read
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -47,6 +47,7 @@ export {
 export {
   useEntryMutations,
   type EntryListFilters,
+  type MarkAllReadOptions,
   type UseEntryMutationsOptions,
   type UseEntryMutationsResult,
 } from "./useEntryMutations";


### PR DESCRIPTION
Add a "Mark All Read" button to all feed views (All Items, single feed, tag, and starred) that allows users to mark all unread entries as read with a single action. The button shows only when there are unread entries.

- Create MarkAllReadDialog component for confirmation before action
- Extend markAllRead API to support tagId and starredOnly filters
- Add markAllRead function to useEntryMutations hook
- Add button to All Items, Feed, Tag, and Starred pages