### PR TITLE
Make entry links open in new tab

### DIFF
--- a/src/components/articles/ArticleContentBody.tsx
+++ b/src/components/articles/ArticleContentBody.tsx
@@ -10,6 +10,22 @@
 import { useEffect, useRef, useMemo, useCallback } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import DOMPurify from "dompurify";
+
+// Configure DOMPurify to open all external links in new tabs
+// This hook runs after each element is sanitized
+if (typeof window !== "undefined") {
+  DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+    // Only process anchor elements with href attributes
+    if (node.tagName === "A" && node.hasAttribute("href")) {
+      const href = node.getAttribute("href") ?? "";
+      // Only add target="_blank" for http/https links (external links)
+      if (href.startsWith("http://") || href.startsWith("https://")) {
+        node.setAttribute("target", "_blank");
+        node.setAttribute("rel", "noopener noreferrer");
+      }
+    }
+  });
+}
 import { Button } from "@/components/ui/button";
 import {
   NarrationControls,


### PR DESCRIPTION
Use DOMPurify's afterSanitizeAttributes hook to add target="_blank" and rel="noopener noreferrer" to all anchor elements with http/https URLs in article content. This ensures links in feed entries open in new browser tabs instead of navigating away from the reader.