### PR TITLE
Fix Android back gesture to return to previous list

### DIFF
--- a/android/app/src/main/java/com/lionreader/ui/entries/EntryDetailScreen.kt
+++ b/android/app/src/main/java/com/lionreader/ui/entries/EntryDetailScreen.kt
@@ -2,6 +2,7 @@ package com.lionreader.ui.entries
 
 import android.content.Intent
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -128,6 +129,9 @@ fun EntryDetailScreen(
             }
         }
     }
+
+    // Handle system back gesture to ensure proper navigation back to the originating list
+    BackHandler(onBack = onBack)
 
     Scaffold(
         modifier = modifier,

--- a/android/app/src/main/java/com/lionreader/ui/saved/SavedArticleDetailScreen.kt
+++ b/android/app/src/main/java/com/lionreader/ui/saved/SavedArticleDetailScreen.kt
@@ -2,6 +2,7 @@ package com.lionreader.ui.saved
 
 import android.content.Intent
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -120,6 +121,9 @@ fun SavedArticleDetailScreen(
             }
         }
     }
+
+    // Handle system back gesture to ensure proper navigation
+    BackHandler(onBack = onBack)
 
     Scaffold(
         modifier = modifier,

--- a/android/app/src/main/java/com/lionreader/ui/saved/SavedArticlesListScreen.kt
+++ b/android/app/src/main/java/com/lionreader/ui/saved/SavedArticlesListScreen.kt
@@ -1,5 +1,6 @@
 package com.lionreader.ui.saved
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -77,6 +78,9 @@ fun SavedArticlesListScreen(
             }
         }
     }
+
+    // Handle system back gesture to ensure proper navigation
+    BackHandler(onBack = onBack)
 
     Scaffold(
         modifier = modifier,


### PR DESCRIPTION
Add explicit BackHandler to detail screens so the system back gesture uses the same navigation path as the in-app back button. This ensures users return to their original list (e.g., Starred, a specific feed) rather than defaulting to All Items.