### PR TITLE
Fix paragraph numbering in Android narration UI

### DIFF
--- a/android/app/src/main/java/com/lionreader/ui/narration/NarrationControls.kt
+++ b/android/app/src/main/java/com/lionreader/ui/narration/NarrationControls.kt
@@ -152,9 +152,9 @@ private fun PlayingControls(
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        // Paragraph counter
+        // Paragraph counter (display as 1-indexed for users)
         Text(
-            text = "$currentParagraph of $totalParagraphs",
+            text = "${currentParagraph + 1} of $totalParagraphs",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
@@ -211,9 +211,9 @@ private fun PausedControls(
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        // Paragraph counter
+        // Paragraph counter (display as 1-indexed for users)
         Text(
-            text = "$currentParagraph of $totalParagraphs",
+            text = "${currentParagraph + 1} of $totalParagraphs",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,


### PR DESCRIPTION
The paragraph counter was showing 0-indexed values (e.g., "0 of 10") which is confusing for users. Now displays as 1-indexed (e.g., "1 of 10") to match user expectations and the web app behavior.