### PR TITLE
Add Uncategorized tag support to Android app

### DIFF
--- a/android/app/src/main/java/com/lionreader/data/api/LionReaderApi.kt
+++ b/android/app/src/main/java/com/lionreader/data/api/LionReaderApi.kt
@@ -94,6 +94,7 @@ interface LionReaderApi {
      *
      * @param feedId Filter by feed ID
      * @param tagId Filter by tag ID
+     * @param uncategorized If true, only return entries from subscriptions with no tags
      * @param unreadOnly Only return unread entries
      * @param starredOnly Only return starred entries
      * @param sortOrder Sort order (newest or oldest)
@@ -106,6 +107,7 @@ interface LionReaderApi {
     suspend fun listEntries(
         feedId: String? = null,
         tagId: String? = null,
+        uncategorized: Boolean? = null,
         unreadOnly: Boolean? = null,
         starredOnly: Boolean? = null,
         sortOrder: SortOrder? = null,
@@ -160,6 +162,7 @@ interface LionReaderApi {
      *
      * @param feedId Filter by feed ID
      * @param tagId Filter by tag ID
+     * @param uncategorized If true, only count entries from subscriptions with no tags
      * @param type Filter to only include entries of this type
      * @param excludeTypes Filter to exclude entries of these types
      * @return EntriesCountResponse with total and unread counts
@@ -167,6 +170,7 @@ interface LionReaderApi {
     suspend fun getEntriesCount(
         feedId: String? = null,
         tagId: String? = null,
+        uncategorized: Boolean? = null,
         type: EntryType? = null,
         excludeTypes: List<EntryType>? = null,
     ): ApiResult<EntriesCountResponse>
@@ -270,6 +274,7 @@ class LionReaderApiImpl
         override suspend fun listEntries(
             feedId: String?,
             tagId: String?,
+            uncategorized: Boolean?,
             unreadOnly: Boolean?,
             starredOnly: Boolean?,
             sortOrder: SortOrder?,
@@ -281,6 +286,7 @@ class LionReaderApiImpl
             apiClient.get(path = "entries") {
                 queryParam("feedId", feedId)
                 queryParam("tagId", tagId)
+                queryParam("uncategorized", uncategorized)
                 queryParam("unreadOnly", unreadOnly)
                 queryParam("starredOnly", starredOnly)
                 queryParam("sortOrder", sortOrder?.value)
@@ -310,12 +316,14 @@ class LionReaderApiImpl
         override suspend fun getEntriesCount(
             feedId: String?,
             tagId: String?,
+            uncategorized: Boolean?,
             type: EntryType?,
             excludeTypes: List<EntryType>?,
         ): ApiResult<EntriesCountResponse> =
             apiClient.get(path = "entries/count") {
                 queryParam("feedId", feedId)
                 queryParam("tagId", tagId)
+                queryParam("uncategorized", uncategorized)
                 type?.let { queryParam("type", it.name.lowercase()) }
                 excludeTypes?.forEach { queryParam("excludeTypes", it.name.lowercase()) }
             }

--- a/android/app/src/main/java/com/lionreader/data/db/dao/EntryDao.kt
+++ b/android/app/src/main/java/com/lionreader/data/db/dao/EntryDao.kt
@@ -20,6 +20,7 @@ interface EntryDao {
      *
      * @param feedId Optional filter by feed ID
      * @param tagId Optional filter by tag ID (entries from feeds with this tag)
+     * @param uncategorized If true, only return entries from feeds with no tags
      * @param unreadOnly If true, only return unread entries
      * @param starredOnly If true, only return starred entries
      * @param sortOrder Sort direction: "newest" or "oldest"
@@ -38,6 +39,12 @@ interface EntryDao {
               JOIN subscription_tags st ON sub.id = st.subscriptionId
               WHERE st.tagId = :tagId
           ))
+          AND (:uncategorized = 0 OR e.feedId IN (
+              SELECT sub.feedId FROM subscriptions sub
+              WHERE sub.id NOT IN (
+                  SELECT st.subscriptionId FROM subscription_tags st
+              )
+          ))
           AND (:unreadOnly = 0 OR COALESCE(s.read, 0) = 0)
           AND (:starredOnly = 0 OR COALESCE(s.starred, 0) = 1)
         ORDER BY
@@ -51,6 +58,7 @@ interface EntryDao {
     fun getEntries(
         feedId: String?,
         tagId: String?,
+        uncategorized: Boolean,
         unreadOnly: Boolean,
         starredOnly: Boolean,
         sortOrder: String,
@@ -130,6 +138,7 @@ interface EntryDao {
      *
      * @param feedId Optional filter by feed ID
      * @param tagId Optional filter by tag ID (entries from feeds with this tag)
+     * @param uncategorized If true, only return entries from feeds with no tags
      * @param unreadOnly If true, only return unread entries
      * @param starredOnly If true, only return starred entries
      * @param sortOrder Sort direction: "newest" or "oldest"
@@ -146,6 +155,12 @@ interface EntryDao {
               JOIN subscription_tags st ON sub.id = st.subscriptionId
               WHERE st.tagId = :tagId
           ))
+          AND (:uncategorized = 0 OR e.feedId IN (
+              SELECT sub.feedId FROM subscriptions sub
+              WHERE sub.id NOT IN (
+                  SELECT st.subscriptionId FROM subscription_tags st
+              )
+          ))
           AND (:unreadOnly = 0 OR COALESCE(s.read, 0) = 0)
           AND (:starredOnly = 0 OR COALESCE(s.starred, 0) = 1)
         ORDER BY
@@ -158,6 +173,7 @@ interface EntryDao {
     suspend fun getEntryIds(
         feedId: String?,
         tagId: String?,
+        uncategorized: Boolean,
         unreadOnly: Boolean,
         starredOnly: Boolean,
         sortOrder: String,

--- a/android/app/src/main/java/com/lionreader/data/repository/EntryRepository.kt
+++ b/android/app/src/main/java/com/lionreader/data/repository/EntryRepository.kt
@@ -35,6 +35,7 @@ import javax.inject.Singleton
 data class EntryFilters(
     val feedId: String? = null,
     val tagId: String? = null,
+    val uncategorized: Boolean = false,
     val unreadOnly: Boolean = false,
     val starredOnly: Boolean = false,
     val sortOrder: SortOrder = SortOrder.NEWEST,
@@ -117,6 +118,7 @@ class EntryRepository
             entryDao.getEntries(
                 feedId = filters.feedId,
                 tagId = filters.tagId,
+                uncategorized = filters.uncategorized,
                 unreadOnly = filters.unreadOnly,
                 starredOnly = filters.starredOnly,
                 sortOrder = filters.sortOrder.value,
@@ -252,6 +254,7 @@ class EntryRepository
                 api.listEntries(
                     feedId = filters.feedId,
                     tagId = filters.tagId,
+                    uncategorized = if (filters.uncategorized) true else null,
                     unreadOnly = if (filters.unreadOnly) true else null,
                     starredOnly = if (filters.starredOnly) true else null,
                     sortOrder = filters.sortOrder,
@@ -893,28 +896,39 @@ class EntryRepository
             // Parse the list context to determine filters
             val feedId: String?
             val tagId: String?
+            val uncategorized: Boolean
             val starredOnly: Boolean
 
             when {
                 listContext == Screen.Starred.route -> {
                     feedId = null
                     tagId = null
+                    uncategorized = false
                     starredOnly = true
+                }
+                listContext == Screen.Uncategorized.route -> {
+                    feedId = null
+                    tagId = null
+                    uncategorized = true
+                    starredOnly = false
                 }
                 listContext.startsWith("tag/") -> {
                     feedId = null
                     tagId = listContext.removePrefix("tag/")
+                    uncategorized = false
                     starredOnly = false
                 }
                 listContext.startsWith("feed/") -> {
                     feedId = listContext.removePrefix("feed/")
                     tagId = null
+                    uncategorized = false
                     starredOnly = false
                 }
                 else -> {
                     // Default to "all"
                     feedId = null
                     tagId = null
+                    uncategorized = false
                     starredOnly = false
                 }
             }
@@ -922,6 +936,7 @@ class EntryRepository
             return entryDao.getEntryIds(
                 feedId = feedId,
                 tagId = tagId,
+                uncategorized = uncategorized,
                 unreadOnly = false, // Don't filter by unread for swipe - user may want to swipe to read entries
                 starredOnly = starredOnly,
                 sortOrder = sortOrder.value,

--- a/android/app/src/main/java/com/lionreader/data/repository/SubscriptionRepository.kt
+++ b/android/app/src/main/java/com/lionreader/data/repository/SubscriptionRepository.kt
@@ -69,6 +69,20 @@ class SubscriptionRepository
         fun getTotalUnreadCount(): Flow<Int> = subscriptionDao.getTotalUnreadCount()
 
         /**
+         * Gets the unread count for uncategorized subscriptions (those with no tags).
+         *
+         * @return Flow of the uncategorized unread count
+         */
+        fun getUncategorizedUnreadCount(): Flow<Int> = subscriptionDao.getUncategorizedUnreadCount()
+
+        /**
+         * Gets subscriptions that have no tags (uncategorized).
+         *
+         * @return Flow of uncategorized subscriptions with feed information
+         */
+        fun getUncategorizedSubscriptions(): Flow<List<SubscriptionWithFeed>> = subscriptionDao.getUncategorizedWithFeeds()
+
+        /**
          * Gets a subscription by its feed ID.
          *
          * @param feedId The feed ID

--- a/android/app/src/main/java/com/lionreader/ui/main/AppDrawer.kt
+++ b/android/app/src/main/java/com/lionreader/ui/main/AppDrawer.kt
@@ -44,6 +44,7 @@ import com.lionreader.ui.navigation.Screen
  * - All entries
  * - Starred entries
  * - Saved Articles
+ * - Uncategorized entries (feeds with no tags)
  * - Tags with colored indicators
  * - Feeds/Subscriptions with unread counts
  * - Sign Out option
@@ -54,6 +55,7 @@ import com.lionreader.ui.navigation.Screen
  * @param totalUnreadCount Total unread count for "All" item badge
  * @param starredUnreadCount Unread count for starred entries badge
  * @param savedUnreadCount Unread count for saved articles badge
+ * @param uncategorizedUnreadCount Unread count for uncategorized entries badge
  * @param onNavigate Callback when a navigation item is selected
  * @param onNavigateToSaved Callback when Saved Articles is clicked
  * @param onSignOut Callback when sign out is clicked
@@ -67,6 +69,7 @@ fun AppDrawer(
     totalUnreadCount: Int,
     starredUnreadCount: Int,
     savedUnreadCount: Int,
+    uncategorizedUnreadCount: Int,
     onNavigate: (String) -> Unit,
     onNavigateToSaved: () -> Unit,
     onSignOut: () -> Unit,
@@ -144,6 +147,33 @@ fun AppDrawer(
                 },
                 selected = currentRoute == Screen.SavedArticles.route,
                 onClick = onNavigateToSaved,
+                modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+            )
+
+            // Uncategorized
+            NavigationDrawerItem(
+                label = { Text("Uncategorized") },
+                icon = {
+                    // Gray color indicator similar to web app
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(12.dp)
+                                .background(
+                                    color = Color(0xFF6B7280),
+                                    shape = CircleShape,
+                                ),
+                    )
+                },
+                badge = {
+                    if (uncategorizedUnreadCount > 0) {
+                        Badge {
+                            Text(formatCount(uncategorizedUnreadCount))
+                        }
+                    }
+                },
+                selected = currentRoute == Screen.Uncategorized.route,
+                onClick = { onNavigate(Screen.Uncategorized.route) },
                 modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
             )
 

--- a/android/app/src/main/java/com/lionreader/ui/main/DrawerViewModel.kt
+++ b/android/app/src/main/java/com/lionreader/ui/main/DrawerViewModel.kt
@@ -80,6 +80,20 @@ class DrawerViewModel
                 )
 
         /**
+         * Unread count for uncategorized subscriptions (those with no tags).
+         *
+         * Used to display badge on "Uncategorized" navigation item.
+         */
+        val uncategorizedUnreadCount: StateFlow<Int> =
+            subscriptionRepository
+                .getUncategorizedUnreadCount()
+                .stateIn(
+                    scope = viewModelScope,
+                    started = SharingStarted.WhileSubscribed(5000),
+                    initialValue = 0,
+                )
+
+        /**
          * Unread count for starred entries.
          *
          * Fetched from the server when refreshData() is called.

--- a/android/app/src/main/java/com/lionreader/ui/main/MainScreen.kt
+++ b/android/app/src/main/java/com/lionreader/ui/main/MainScreen.kt
@@ -42,6 +42,7 @@ fun MainScreen(
     val totalUnreadCount by drawerViewModel.totalUnreadCount.collectAsStateWithLifecycle()
     val starredUnreadCount by drawerViewModel.starredUnreadCount.collectAsStateWithLifecycle()
     val savedUnreadCount by drawerViewModel.savedUnreadCount.collectAsStateWithLifecycle()
+    val uncategorizedUnreadCount by drawerViewModel.uncategorizedUnreadCount.collectAsStateWithLifecycle()
 
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
@@ -68,6 +69,7 @@ fun MainScreen(
                 totalUnreadCount = totalUnreadCount,
                 starredUnreadCount = starredUnreadCount,
                 savedUnreadCount = savedUnreadCount,
+                uncategorizedUnreadCount = uncategorizedUnreadCount,
                 onNavigate = { route ->
                     mainViewModel.navigateTo(route)
                     scope.launch {

--- a/android/app/src/main/java/com/lionreader/ui/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/lionreader/ui/main/MainViewModel.kt
@@ -80,6 +80,7 @@ class MainViewModel
             when {
                 route == Screen.All.route -> Screen.All.TITLE
                 route == Screen.Starred.route -> Screen.Starred.TITLE
+                route == Screen.Uncategorized.route -> Screen.Uncategorized.TITLE
                 route.startsWith("tag/") -> {
                     val tagId = route.removePrefix("tag/")
                     tagRepository.getTag(tagId)?.name ?: "Tag"

--- a/android/app/src/main/java/com/lionreader/ui/navigation/Screen.kt
+++ b/android/app/src/main/java/com/lionreader/ui/navigation/Screen.kt
@@ -95,6 +95,13 @@ sealed class Screen(
     }
 
     /**
+     * Uncategorized entries view - shows entries from subscriptions with no tags.
+     */
+    data object Uncategorized : Screen("uncategorized") {
+        const val TITLE = "Uncategorized"
+    }
+
+    /**
      * Saved article detail screen showing full saved article content.
      * Requires a saved article ID argument.
      */


### PR DESCRIPTION
Add an "Uncategorized" section to the navigation drawer that shows entries from subscriptions with no tags, matching the web app behavior.

Changes:
- Add uncategorized parameter to API endpoints (listEntries, getEntriesCount)
- Add Uncategorized screen to navigation routes
- Update EntryDao and SubscriptionDao with uncategorized queries
- Add uncategorized filter to EntryFilters and EntryRepository
- Add Uncategorized navigation item to AppDrawer with gray color indicator
- Update ViewModels to handle the uncategorized route