### PR TITLE
Scroll to top when swiping between articles

### DIFF
--- a/src/lib/hooks/useKeyboardShortcuts.ts
+++ b/src/lib/hooks/useKeyboardShortcuts.ts
@@ -279,11 +279,13 @@ export function useKeyboardShortcuts(
       const nextId = entryIds[0];
       setSelectedEntryId(nextId);
       onOpenEntry(nextId);
+      window.scrollTo(0, 0);
     } else if (currentIndex < entryIds.length - 1) {
       // Go to next entry
       const nextId = entryIds[currentIndex + 1];
       setSelectedEntryId(nextId);
       onOpenEntry(nextId);
+      window.scrollTo(0, 0);
     }
     // If already at the last entry, do nothing
   }, [entryIds, getSelectedIndex, onOpenEntry]);
@@ -299,11 +301,13 @@ export function useKeyboardShortcuts(
       const prevId = entryIds[entryIds.length - 1];
       setSelectedEntryId(prevId);
       onOpenEntry(prevId);
+      window.scrollTo(0, 0);
     } else if (currentIndex > 0) {
       // Go to previous entry
       const prevId = entryIds[currentIndex - 1];
       setSelectedEntryId(prevId);
       onOpenEntry(prevId);
+      window.scrollTo(0, 0);
     }
     // If already at the first entry, do nothing
   }, [entryIds, getSelectedIndex, onOpenEntry]);

--- a/src/lib/hooks/useSavedArticleKeyboardShortcuts.ts
+++ b/src/lib/hooks/useSavedArticleKeyboardShortcuts.ts
@@ -249,11 +249,13 @@ export function useSavedArticleKeyboardShortcuts(
       const nextId = articleIds[0];
       setSelectedArticleId(nextId);
       onOpenArticle(nextId);
+      window.scrollTo(0, 0);
     } else if (currentIndex < articleIds.length - 1) {
       // Go to next article
       const nextId = articleIds[currentIndex + 1];
       setSelectedArticleId(nextId);
       onOpenArticle(nextId);
+      window.scrollTo(0, 0);
     }
     // If already at the last article, do nothing
   }, [articleIds, getSelectedIndex, onOpenArticle]);
@@ -269,11 +271,13 @@ export function useSavedArticleKeyboardShortcuts(
       const prevId = articleIds[articleIds.length - 1];
       setSelectedArticleId(prevId);
       onOpenArticle(prevId);
+      window.scrollTo(0, 0);
     } else if (currentIndex > 0) {
       // Go to previous article
       const prevId = articleIds[currentIndex - 1];
       setSelectedArticleId(prevId);
       onOpenArticle(prevId);
+      window.scrollTo(0, 0);
     }
     // If already at the first article, do nothing
   }, [articleIds, getSelectedIndex, onOpenArticle]);


### PR DESCRIPTION
When swiping left/right or using j/k keys to navigate between articles, the page now scrolls to the top of the new article instead of staying at the previous scroll position.