### PR TITLE
Fix article swiping pagination issue

### DIFF
--- a/src/app/(app)/feed/[feedId]/page.tsx
+++ b/src/app/(app)/feed/[feedId]/page.tsx
@@ -15,7 +15,7 @@ import {
   EntryContent,
   UnreadToggle,
   SortToggle,
-  type EntryListEntryData,
+  type ExternalQueryState,
 } from "@/components/entries";
 import { MarkAllReadDialog } from "@/components/feeds/MarkAllReadDialog";
 import { useKeyboardShortcutsContext } from "@/components/keyboard";
@@ -24,7 +24,7 @@ import {
   useViewPreferences,
   useEntryMutations,
   useEntryUrlState,
-  type KeyboardEntryData,
+  useEntryListQuery,
 } from "@/lib/hooks";
 
 /**
@@ -89,7 +89,6 @@ function SingleFeedContent() {
   const feedId = params.feedId;
 
   const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
-  const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
   const [showMarkAllReadDialog, setShowMarkAllReadDialog] = useState(false);
 
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
@@ -98,6 +97,12 @@ function SingleFeedContent() {
     feedId
   );
   const utils = trpc.useUtils();
+
+  // Use entry list query that stays mounted while viewing entries
+  const entryListQuery = useEntryListQuery({
+    filters: { feedId, unreadOnly: showUnreadOnly, sortOrder },
+    openEntryId,
+  });
 
   // Entry mutations with optimistic updates
   const { toggleRead, toggleStar, markAllRead, isMarkAllReadPending } = useEntryMutations({
@@ -112,7 +117,7 @@ function SingleFeedContent() {
   // Keyboard navigation and actions (also provides swipe navigation functions)
   const { selectedEntryId, setSelectedEntryId, goToNextEntry, goToPreviousEntry } =
     useKeyboardShortcuts({
-      entries,
+      entries: entryListQuery.entries,
       onOpenEntry: setOpenEntryId,
       onClose: closeEntry,
       isEntryOpen: !!openEntryId,
@@ -143,22 +148,20 @@ function SingleFeedContent() {
     closeEntry();
   }, [closeEntry]);
 
-  const handleEntriesLoaded = useCallback((loadedEntries: EntryListEntryData[]) => {
-    setEntries(loadedEntries);
-  }, []);
-
-  // Calculate next and previous entry IDs for prefetching
-  const { nextEntryId, previousEntryId } = useMemo(() => {
-    if (!openEntryId) return { nextEntryId: undefined, previousEntryId: undefined };
-
-    const currentIndex = entries.findIndex((e) => e.id === openEntryId);
-    if (currentIndex === -1) return { nextEntryId: undefined, previousEntryId: undefined };
-
-    return {
-      nextEntryId: currentIndex < entries.length - 1 ? entries[currentIndex + 1].id : undefined,
-      previousEntryId: currentIndex > 0 ? entries[currentIndex - 1].id : undefined,
-    };
-  }, [openEntryId, entries]);
+  // Build external query state for EntryList
+  const externalQueryState: ExternalQueryState = useMemo(
+    () => ({
+      isLoading: entryListQuery.isLoading,
+      isError: entryListQuery.isError,
+      errorMessage: entryListQuery.errorMessage,
+      isFetchingNextPage: entryListQuery.isFetchingNextPage,
+      hasNextPage: entryListQuery.hasNextPage,
+      fetchNextPage: entryListQuery.fetchNextPage,
+      refetch: entryListQuery.refetch,
+      prefetchEntry: entryListQuery.prefetchEntry,
+    }),
+    [entryListQuery]
+  );
 
   // If an entry is open, show the full content view
   // Key forces remount when entryId changes, ensuring fresh refs and mutation state
@@ -170,8 +173,8 @@ function SingleFeedContent() {
         onBack={handleBack}
         onSwipeNext={goToNextEntry}
         onSwipePrevious={goToPreviousEntry}
-        nextEntryId={nextEntryId}
-        previousEntryId={previousEntryId}
+        nextEntryId={entryListQuery.nextEntryId}
+        previousEntryId={entryListQuery.previousEntryId}
       />
     );
   }
@@ -271,9 +274,10 @@ function SingleFeedContent() {
         filters={{ feedId, unreadOnly: showUnreadOnly, sortOrder }}
         onEntryClick={handleEntryClick}
         selectedEntryId={selectedEntryId}
-        onEntriesLoaded={handleEntriesLoaded}
         onToggleRead={toggleRead}
         onToggleStar={toggleStar}
+        externalEntries={entryListQuery.entries}
+        externalQueryState={externalQueryState}
         emptyMessage={
           showUnreadOnly
             ? "No unread entries in this feed. Toggle to show all items."

--- a/src/app/(app)/tag/[tagId]/page.tsx
+++ b/src/app/(app)/tag/[tagId]/page.tsx
@@ -15,7 +15,7 @@ import {
   EntryContent,
   UnreadToggle,
   SortToggle,
-  type EntryListEntryData,
+  type ExternalQueryState,
 } from "@/components/entries";
 import { MarkAllReadDialog } from "@/components/feeds/MarkAllReadDialog";
 import { useKeyboardShortcutsContext } from "@/components/keyboard";
@@ -24,7 +24,7 @@ import {
   useViewPreferences,
   useEntryMutations,
   useEntryUrlState,
-  type KeyboardEntryData,
+  useEntryListQuery,
 } from "@/lib/hooks";
 
 /**
@@ -89,7 +89,6 @@ function TagEntriesContent() {
   const tagId = params.tagId;
 
   const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
-  const [entries, setEntries] = useState<KeyboardEntryData[]>([]);
   const [showMarkAllReadDialog, setShowMarkAllReadDialog] = useState(false);
 
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
@@ -98,6 +97,12 @@ function TagEntriesContent() {
     tagId
   );
   const utils = trpc.useUtils();
+
+  // Use entry list query that stays mounted while viewing entries
+  const entryListQuery = useEntryListQuery({
+    filters: { tagId, unreadOnly: showUnreadOnly, sortOrder },
+    openEntryId,
+  });
 
   // Entry mutations with optimistic updates
   const { toggleRead, toggleStar, markAllRead, isMarkAllReadPending } = useEntryMutations({
@@ -112,7 +117,7 @@ function TagEntriesContent() {
   // Keyboard navigation and actions (also provides swipe navigation functions)
   const { selectedEntryId, setSelectedEntryId, goToNextEntry, goToPreviousEntry } =
     useKeyboardShortcuts({
-      entries,
+      entries: entryListQuery.entries,
       onOpenEntry: setOpenEntryId,
       onClose: closeEntry,
       isEntryOpen: !!openEntryId,
@@ -143,22 +148,20 @@ function TagEntriesContent() {
     closeEntry();
   }, [closeEntry]);
 
-  const handleEntriesLoaded = useCallback((loadedEntries: EntryListEntryData[]) => {
-    setEntries(loadedEntries);
-  }, []);
-
-  // Calculate next and previous entry IDs for prefetching
-  const { nextEntryId, previousEntryId } = useMemo(() => {
-    if (!openEntryId) return { nextEntryId: undefined, previousEntryId: undefined };
-
-    const currentIndex = entries.findIndex((e) => e.id === openEntryId);
-    if (currentIndex === -1) return { nextEntryId: undefined, previousEntryId: undefined };
-
-    return {
-      nextEntryId: currentIndex < entries.length - 1 ? entries[currentIndex + 1].id : undefined,
-      previousEntryId: currentIndex > 0 ? entries[currentIndex - 1].id : undefined,
-    };
-  }, [openEntryId, entries]);
+  // Build external query state for EntryList
+  const externalQueryState: ExternalQueryState = useMemo(
+    () => ({
+      isLoading: entryListQuery.isLoading,
+      isError: entryListQuery.isError,
+      errorMessage: entryListQuery.errorMessage,
+      isFetchingNextPage: entryListQuery.isFetchingNextPage,
+      hasNextPage: entryListQuery.hasNextPage,
+      fetchNextPage: entryListQuery.fetchNextPage,
+      refetch: entryListQuery.refetch,
+      prefetchEntry: entryListQuery.prefetchEntry,
+    }),
+    [entryListQuery]
+  );
 
   // If an entry is open, show the full content view
   // Key forces remount when entryId changes, ensuring fresh refs and mutation state
@@ -170,8 +173,8 @@ function TagEntriesContent() {
         onBack={handleBack}
         onSwipeNext={goToNextEntry}
         onSwipePrevious={goToPreviousEntry}
-        nextEntryId={nextEntryId}
-        previousEntryId={previousEntryId}
+        nextEntryId={entryListQuery.nextEntryId}
+        previousEntryId={entryListQuery.previousEntryId}
       />
     );
   }
@@ -262,9 +265,10 @@ function TagEntriesContent() {
         filters={{ tagId, unreadOnly: showUnreadOnly, sortOrder }}
         onEntryClick={handleEntryClick}
         selectedEntryId={selectedEntryId}
-        onEntriesLoaded={handleEntriesLoaded}
         onToggleRead={toggleRead}
         onToggleStar={toggleStar}
+        externalEntries={entryListQuery.entries}
+        externalQueryState={externalQueryState}
         emptyMessage={
           showUnreadOnly
             ? `No unread entries from feeds tagged with "${tag.name}". Toggle to show all items.`

--- a/src/components/entries/index.ts
+++ b/src/components/entries/index.ts
@@ -6,7 +6,12 @@
 
 export { EntryListItem, type EntryListItemData } from "./EntryListItem";
 export { EntryListSkeleton } from "./EntryListSkeleton";
-export { EntryList, type EntryListFilters, type EntryListEntryData } from "./EntryList";
+export {
+  EntryList,
+  type EntryListFilters,
+  type EntryListEntryData,
+  type ExternalQueryState,
+} from "./EntryList";
 export { EntryContent } from "./EntryContent";
 export { UnreadToggle } from "./UnreadToggle";
 export { SortToggle } from "./SortToggle";

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -68,3 +68,11 @@ export {
 } from "./useSwipeGestures";
 
 export { useExpandedTags, type UseExpandedTagsResult } from "./useExpandedTags";
+
+export {
+  useEntryListQuery,
+  type EntryListQueryFilters,
+  type EntryNavigationData,
+  type UseEntryListQueryOptions,
+  type UseEntryListQueryResult,
+} from "./useEntryListQuery";

--- a/src/lib/hooks/useEntryListQuery.ts
+++ b/src/lib/hooks/useEntryListQuery.ts
@@ -1,0 +1,302 @@
+/**
+ * useEntryListQuery Hook
+ *
+ * Manages the infinite query for entry lists and provides navigation
+ * that automatically loads more entries when approaching list boundaries.
+ *
+ * This hook keeps the query mounted even when viewing an entry, enabling
+ * seamless swiping/navigation beyond the initially loaded entries.
+ */
+
+"use client";
+
+import { useMemo, useCallback, useRef, useEffect } from "react";
+import { trpc } from "@/lib/trpc/client";
+
+/**
+ * Filter options for the entry list query.
+ */
+export interface EntryListQueryFilters {
+  feedId?: string;
+  tagId?: string;
+  uncategorized?: boolean;
+  unreadOnly?: boolean;
+  starredOnly?: boolean;
+  sortOrder?: "newest" | "oldest";
+}
+
+/**
+ * Entry data needed for keyboard/swipe navigation.
+ */
+export interface EntryNavigationData {
+  id: string;
+  url: string | null;
+  read: boolean;
+  starred: boolean;
+}
+
+/**
+ * Options for the useEntryListQuery hook.
+ */
+export interface UseEntryListQueryOptions {
+  /**
+   * Filter options for the query.
+   */
+  filters: EntryListQueryFilters;
+
+  /**
+   * Number of entries per page.
+   * @default 20
+   */
+  pageSize?: number;
+
+  /**
+   * Currently open entry ID (for navigation context).
+   */
+  openEntryId?: string | null;
+
+  /**
+   * Number of entries from the end at which to prefetch the next page.
+   * @default 3
+   */
+  prefetchThreshold?: number;
+}
+
+/**
+ * Result returned by the useEntryListQuery hook.
+ */
+export interface UseEntryListQueryResult {
+  /**
+   * All entries loaded so far (flattened from all pages).
+   */
+  entries: EntryNavigationData[];
+
+  /**
+   * Whether the initial load is in progress.
+   */
+  isLoading: boolean;
+
+  /**
+   * Whether there was an error loading entries.
+   */
+  isError: boolean;
+
+  /**
+   * Error message if isError is true.
+   */
+  errorMessage?: string;
+
+  /**
+   * Whether more entries are being fetched.
+   */
+  isFetchingNextPage: boolean;
+
+  /**
+   * Whether there are more entries to load.
+   */
+  hasNextPage: boolean;
+
+  /**
+   * Fetch the next page of entries.
+   */
+  fetchNextPage: () => void;
+
+  /**
+   * Refetch all entries.
+   */
+  refetch: () => void;
+
+  /**
+   * The next entry ID relative to the open entry (for prefetching).
+   */
+  nextEntryId?: string;
+
+  /**
+   * The previous entry ID relative to the open entry (for prefetching).
+   */
+  previousEntryId?: string;
+
+  /**
+   * Navigate to the next entry, loading more if needed.
+   * Returns the entry ID to navigate to, or undefined if at the end.
+   */
+  getNextEntryId: () => string | undefined;
+
+  /**
+   * Navigate to the previous entry.
+   * Returns the entry ID to navigate to, or undefined if at the start.
+   */
+  getPreviousEntryId: () => string | undefined;
+
+  /**
+   * Prefetch entry data on mousedown (before click completes).
+   */
+  prefetchEntry: (entryId: string) => void;
+}
+
+/**
+ * Hook for managing entry list queries with navigation support.
+ *
+ * Unlike using the infinite query directly in EntryList, this hook
+ * stays mounted even when viewing an entry, enabling seamless
+ * navigation beyond initially loaded entries.
+ */
+export function useEntryListQuery(options: UseEntryListQueryOptions): UseEntryListQueryResult {
+  const { filters, pageSize = 20, openEntryId, prefetchThreshold = 3 } = options;
+
+  const utils = trpc.useUtils();
+
+  // Track if we've triggered a fetch to avoid duplicate calls
+  const fetchingRef = useRef(false);
+
+  // Use infinite query for cursor-based pagination
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+  } = trpc.entries.list.useInfiniteQuery(
+    {
+      feedId: filters.feedId,
+      tagId: filters.tagId,
+      uncategorized: filters.uncategorized,
+      unreadOnly: filters.unreadOnly,
+      starredOnly: filters.starredOnly,
+      sortOrder: filters.sortOrder,
+      limit: pageSize,
+    },
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+      refetchOnMount: true,
+    }
+  );
+
+  // Flatten all pages into a single array of entries
+  const entries: EntryNavigationData[] = useMemo(() => {
+    return (
+      data?.pages.flatMap((page) =>
+        page.items.map((entry) => ({
+          id: entry.id,
+          url: entry.url,
+          read: entry.read,
+          starred: entry.starred,
+        }))
+      ) ?? []
+    );
+  }, [data?.pages]);
+
+  // Calculate next and previous entry IDs for prefetching
+  const { nextEntryId, previousEntryId, currentIndex } = useMemo(() => {
+    if (!openEntryId) {
+      return { nextEntryId: undefined, previousEntryId: undefined, currentIndex: -1 };
+    }
+
+    const idx = entries.findIndex((e) => e.id === openEntryId);
+    if (idx === -1) {
+      return { nextEntryId: undefined, previousEntryId: undefined, currentIndex: -1 };
+    }
+
+    return {
+      nextEntryId: idx < entries.length - 1 ? entries[idx + 1].id : undefined,
+      previousEntryId: idx > 0 ? entries[idx - 1].id : undefined,
+      currentIndex: idx,
+    };
+  }, [openEntryId, entries]);
+
+  // Proactively load more entries when approaching the end of the list
+  useEffect(() => {
+    if (
+      currentIndex >= 0 &&
+      entries.length > 0 &&
+      entries.length - currentIndex <= prefetchThreshold &&
+      hasNextPage &&
+      !isFetchingNextPage &&
+      !fetchingRef.current
+    ) {
+      fetchingRef.current = true;
+      fetchNextPage().finally(() => {
+        fetchingRef.current = false;
+      });
+    }
+  }, [
+    currentIndex,
+    entries.length,
+    prefetchThreshold,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  ]);
+
+  // Get next entry ID, triggering a fetch if near the end
+  const getNextEntryId = useCallback((): string | undefined => {
+    if (entries.length === 0) return undefined;
+
+    const idx = openEntryId ? entries.findIndex((e) => e.id === openEntryId) : -1;
+
+    if (idx === -1) {
+      // Nothing selected, return the first entry
+      return entries[0]?.id;
+    }
+
+    if (idx < entries.length - 1) {
+      // Return next entry
+      return entries[idx + 1].id;
+    }
+
+    // At the last entry - return undefined (we already prefetch proactively)
+    return undefined;
+  }, [entries, openEntryId]);
+
+  // Get previous entry ID
+  const getPreviousEntryId = useCallback((): string | undefined => {
+    if (entries.length === 0) return undefined;
+
+    const idx = openEntryId ? entries.findIndex((e) => e.id === openEntryId) : -1;
+
+    if (idx === -1) {
+      // Nothing selected, return the last entry
+      return entries[entries.length - 1]?.id;
+    }
+
+    if (idx > 0) {
+      // Return previous entry
+      return entries[idx - 1].id;
+    }
+
+    // At the first entry
+    return undefined;
+  }, [entries, openEntryId]);
+
+  // Prefetch entry data on mousedown
+  const prefetchEntry = useCallback(
+    (entryId: string) => {
+      utils.entries.get.fetch({ id: entryId });
+    },
+    [utils]
+  );
+
+  // Wrap fetchNextPage to reset the fetching ref
+  const wrappedFetchNextPage = useCallback(() => {
+    fetchNextPage();
+  }, [fetchNextPage]);
+
+  return {
+    entries,
+    isLoading,
+    isError,
+    errorMessage: error?.message,
+    isFetchingNextPage,
+    hasNextPage: hasNextPage ?? false,
+    fetchNextPage: wrappedFetchNextPage,
+    refetch,
+    nextEntryId,
+    previousEntryId,
+    getNextEntryId,
+    getPreviousEntryId,
+    prefetchEntry,
+  };
+}


### PR DESCRIPTION
When swiping through articles in the web app, navigation would stop at the boundaries of the initially loaded entries. This happened because:

1. The EntryList component (with its infinite query) unmounts when viewing an article, so no new pages could be fetched
2. Navigation functions only worked within the already-loaded entries
3. There was no mechanism to load more entries while swiping

This fix:

- Creates useEntryListQuery hook that keeps the infinite query mounted at the page level, even while viewing an article
- Adds proactive prefetching when approaching the end of loaded entries (within 3 entries of the end)
- Updates EntryList to optionally accept external query state, avoiding duplicate queries while sharing pagination state
- Updates all entry list pages (all, starred, feed, tag, uncategorized) to use the new pattern