### PR TITLE
Add play/pause button support for narration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -74,7 +74,20 @@
         <service
             android:name=".service.NarrationService"
             android:exported="false"
-            android:foregroundServiceType="mediaPlayback" />
+            android:foregroundServiceType="mediaPlayback">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </service>
+
+        <!-- Media button receiver for Bluetooth headphone controls -->
+        <receiver
+            android:name="androidx.media.session.MediaButtonReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>


### PR DESCRIPTION
Register MediaButtonReceiver to receive media button events from Bluetooth headphones (like Shokz). Handle MEDIA_BUTTON intents in NarrationService and add play/pause toggle for KEYCODE_MEDIA_PLAY_PAUSE and KEYCODE_HEADSETHOOK.