### PR TITLE
Fix read articles not disappearing in unread mode

### DIFF
--- a/src/lib/hooks/useEntryMutations.ts
+++ b/src/lib/hooks/useEntryMutations.ts
@@ -208,9 +208,17 @@ export function useEntryMutations(options?: UseEntryMutationsOptions): UseEntryM
           ...oldData,
           pages: oldData.pages.map((page) => ({
             ...page,
-            items: page.items.map((item) =>
-              variables.ids.includes(item.id) ? { ...item, read: variables.read } : item
-            ),
+            items: page.items
+              .map((item) =>
+                variables.ids.includes(item.id) ? { ...item, read: variables.read } : item
+              )
+              // Filter out entries that no longer match the unreadOnly filter
+              .filter((item) => {
+                if (listFilters?.unreadOnly && item.read) {
+                  return false;
+                }
+                return true;
+              }),
           })),
         };
       });
@@ -315,9 +323,15 @@ export function useEntryMutations(options?: UseEntryMutationsOptions): UseEntryM
           ...oldData,
           pages: oldData.pages.map((page) => ({
             ...page,
-            items: page.items.map((item) =>
-              item.id === variables.id ? { ...item, starred: false } : item
-            ),
+            items: page.items
+              .map((item) => (item.id === variables.id ? { ...item, starred: false } : item))
+              // Filter out entries that no longer match the starredOnly filter
+              .filter((item) => {
+                if (listFilters?.starredOnly && !item.starred) {
+                  return false;
+                }
+                return true;
+              }),
           })),
         };
       });


### PR DESCRIPTION
The optimistic update handlers for markRead and unstar mutations were updating the item properties but not removing entries from the list when they no longer matched the current filter conditions.

When marking an entry as read while viewing "unread only" mode, the entry now immediately disappears from the list instead of staying visible until the next refetch.

Similarly, when unstarring an entry while viewing "starred only" mode, the entry is now removed from the list immediately.