### PR TITLE
Refactor stateful UI logic to declarative patterns

### DIFF
--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -66,7 +66,7 @@ export function EntryContent({
   nextEntryId,
   previousEntryId,
 }: EntryContentProps) {
-  const hasMarkedRead = useRef(false);
+  const lastMarkedReadId = useRef<string | null>(null);
   const [showOriginal, setShowOriginal] = useState(false);
 
   // Fetch the entry
@@ -85,14 +85,12 @@ export function EntryContent({
 
   const entry = data?.entry;
 
-  // Mark entry as read when component mounts and entry is loaded (only once)
+  // Mark entry as read when component mounts and entry is loaded
+  // Uses lastMarkedReadId to track which entry was marked, correctly handling navigation between entries
   useEffect(() => {
-    if (entry && !hasMarkedRead.current) {
-      hasMarkedRead.current = true;
-      // Only mark as read if it's currently unread
-      if (!entry.read) {
-        markRead([entryId], true);
-      }
+    if (entry && lastMarkedReadId.current !== entryId && !entry.read) {
+      lastMarkedReadId.current = entryId;
+      markRead([entryId], true);
     }
   }, [entry, entryId, markRead]);
 

--- a/src/components/saved/SavedArticleContent.tsx
+++ b/src/components/saved/SavedArticleContent.tsx
@@ -66,7 +66,7 @@ export function SavedArticleContent({
   nextArticleId,
   previousArticleId,
 }: SavedArticleContentProps) {
-  const hasMarkedRead = useRef(false);
+  const lastMarkedReadId = useRef<string | null>(null);
   const [showOriginal, setShowOriginal] = useState(false);
 
   // Fetch the saved article using unified entries endpoint
@@ -84,14 +84,12 @@ export function SavedArticleContent({
 
   const article = data?.entry;
 
-  // Mark article as read when component mounts and article is loaded (only once)
+  // Mark article as read when component mounts and article is loaded
+  // Uses lastMarkedReadId to track which article was marked, correctly handling navigation between articles
   useEffect(() => {
-    if (article && !hasMarkedRead.current) {
-      hasMarkedRead.current = true;
-      // Only mark as read if it's currently unread
-      if (!article.read) {
-        markRead([articleId], true);
-      }
+    if (article && lastMarkedReadId.current !== articleId && !article.read) {
+      lastMarkedReadId.current = articleId;
+      markRead([articleId], true);
     }
   }, [article, articleId, markRead]);
 

--- a/src/lib/hooks/useKeyboardShortcuts.ts
+++ b/src/lib/hooks/useKeyboardShortcuts.ts
@@ -21,7 +21,7 @@
 
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useRouter } from "next/navigation";
 
@@ -325,21 +325,16 @@ export function useKeyboardShortcuts(
   const isSelectedEntryValid = selectedEntryId === null || entryIds.includes(selectedEntryId);
   const effectiveSelectedEntryId = isSelectedEntryValid ? selectedEntryId : null;
 
-  // Scroll selected entry into view
-  useEffect(() => {
+  // Scroll selected entry into view using useLayoutEffect to ensure DOM is ready
+  useLayoutEffect(() => {
     if (effectiveSelectedEntryId) {
-      // Use a small delay to ensure the DOM has updated
-      const timeoutId = setTimeout(() => {
-        const element = document.querySelector(`[data-entry-id="${effectiveSelectedEntryId}"]`);
-        if (element) {
-          element.scrollIntoView({
-            behavior: "smooth",
-            block: "nearest",
-          });
-        }
-      }, 0);
-
-      return () => clearTimeout(timeoutId);
+      const element = document.querySelector(`[data-entry-id="${effectiveSelectedEntryId}"]`);
+      if (element) {
+        element.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
+      }
     }
   }, [effectiveSelectedEntryId]);
 

--- a/src/lib/hooks/useSavedArticleKeyboardShortcuts.ts
+++ b/src/lib/hooks/useSavedArticleKeyboardShortcuts.ts
@@ -21,7 +21,7 @@
 
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useRouter } from "next/navigation";
 
@@ -296,21 +296,16 @@ export function useSavedArticleKeyboardShortcuts(
     selectedArticleId === null || articleIds.includes(selectedArticleId);
   const effectiveSelectedArticleId = isSelectedArticleValid ? selectedArticleId : null;
 
-  // Scroll selected article into view
-  useEffect(() => {
+  // Scroll selected article into view using useLayoutEffect to ensure DOM is ready
+  useLayoutEffect(() => {
     if (effectiveSelectedArticleId) {
-      // Use a small delay to ensure the DOM has updated
-      const timeoutId = setTimeout(() => {
-        const element = document.querySelector(`[data-entry-id="${effectiveSelectedArticleId}"]`);
-        if (element) {
-          element.scrollIntoView({
-            behavior: "smooth",
-            block: "nearest",
-          });
-        }
-      }, 0);
-
-      return () => clearTimeout(timeoutId);
+      const element = document.querySelector(`[data-entry-id="${effectiveSelectedArticleId}"]`);
+      if (element) {
+        element.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
+      }
     }
   }, [effectiveSelectedArticleId]);
 


### PR DESCRIPTION
- useEnhancedVoices: Add useMemo for derived state (voices array, isStorageLimitExceeded) to avoid unnecessary recalculations
- OfflineBanner: Refactor useOnlineStatus to use useSyncExternalStore pattern for both online status and reconnected state, eliminating useEffect with setState
- useKeyboardShortcuts/useSavedArticleKeyboardShortcuts: Replace useEffect + setTimeout(0) with useLayoutEffect for scroll-into-view
- EntryContent/SavedArticleContent: Track lastMarkedReadId instead of boolean ref to correctly handle navigation between entries