### PR TITLE
Fix article publish date display bug

### DIFF
--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -24,7 +24,7 @@ export function formatRelativeTime(date: Date): string {
     return `${diffHours} ${diffHours === 1 ? "hour" : "hours"} ago`;
   } else if (diffDays < 7) {
     return `${diffDays} ${diffDays === 1 ? "day" : "days"} ago`;
-  } else if (diffWeeks < 4) {
+  } else if (diffDays < 30) {
     return `${diffWeeks} ${diffWeeks === 1 ? "week" : "weeks"} ago`;
   } else if (diffMonths < 12) {
     return `${diffMonths} ${diffMonths === 1 ? "month" : "months"} ago`;


### PR DESCRIPTION
The relative time formatting had a gap where entries between 28-29 days old would show "0 months ago". This happened because:
- The weeks condition was `diffWeeks < 4` (i.e., < 28 days)
- For 28-29 day old entries, diffWeeks = 4, falling through to months
- But diffMonths = floor(29/30) = 0, resulting in "0 months ago"

Changed the weeks threshold from `diffWeeks < 4` to `diffDays < 30` so we show "4 weeks ago" for entries 28-29 days old, and only switch to months when diffDays >= 30 (guaranteeing diffMonths >= 1).