### PR TITLE
Add article full content fetching with readability

### DIFF
--- a/drizzle/0018_full_content.sql
+++ b/drizzle/0018_full_content.sql
@@ -1,0 +1,12 @@
+-- Add full content fetching capability for entries
+-- This allows fetching the full article content from the article URL using Readability
+
+-- Add columns to entries table for storing fetched full content
+ALTER TABLE "entries" ADD COLUMN IF NOT EXISTS "content_full" text;
+ALTER TABLE "entries" ADD COLUMN IF NOT EXISTS "content_full_fetched_at" timestamptz;
+ALTER TABLE "entries" ADD COLUMN IF NOT EXISTS "content_full_error" text;
+
+--> statement-breakpoint
+
+-- Add column to subscriptions table for the per-subscription setting
+ALTER TABLE "subscriptions" ADD COLUMN IF NOT EXISTS "fetch_full_content" boolean NOT NULL DEFAULT false;

--- a/src/components/feeds/EditSubscriptionDialog.tsx
+++ b/src/components/feeds/EditSubscriptionDialog.tsx
@@ -20,6 +20,7 @@ interface EditSubscriptionDialogProps {
   subscriptionId: string;
   currentTitle: string;
   currentCustomTitle: string | null;
+  currentFetchFullContent: boolean;
   currentTagIds: string[];
   onClose: () => void;
 }
@@ -36,6 +37,7 @@ interface EditSubscriptionFormProps {
   subscriptionId: string;
   currentTitle: string;
   currentCustomTitle: string | null;
+  currentFetchFullContent: boolean;
   currentTagIds: string[];
   onClose: () => void;
 }
@@ -53,6 +55,7 @@ export function EditSubscriptionDialog({
   subscriptionId,
   currentTitle,
   currentCustomTitle,
+  currentFetchFullContent,
   currentTagIds,
   onClose,
 }: EditSubscriptionDialogProps) {
@@ -80,6 +83,7 @@ export function EditSubscriptionDialog({
             subscriptionId={subscriptionId}
             currentTitle={currentTitle}
             currentCustomTitle={currentCustomTitle}
+            currentFetchFullContent={currentFetchFullContent}
             currentTagIds={currentTagIds}
             onClose={onClose}
           />
@@ -97,11 +101,13 @@ function EditSubscriptionForm({
   subscriptionId,
   currentTitle,
   currentCustomTitle,
+  currentFetchFullContent,
   currentTagIds,
   onClose,
 }: EditSubscriptionFormProps) {
   // Initialize state with current values
   const [customTitle, setCustomTitle] = useState(currentCustomTitle ?? "");
+  const [fetchFullContent, setFetchFullContent] = useState(currentFetchFullContent);
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>(currentTagIds);
   const [error, setError] = useState<string | null>(null);
 
@@ -117,12 +123,16 @@ function EditSubscriptionForm({
     try {
       setError(null);
 
-      // Update custom title if changed
+      // Update custom title and/or fetchFullContent if changed
       const newCustomTitle = customTitle.trim() || null;
-      if (newCustomTitle !== currentCustomTitle) {
+      const titleChanged = newCustomTitle !== currentCustomTitle;
+      const fetchFullContentChanged = fetchFullContent !== currentFetchFullContent;
+
+      if (titleChanged || fetchFullContentChanged) {
         await updateMutation.mutateAsync({
           id: subscriptionId,
-          customTitle: newCustomTitle,
+          ...(titleChanged && { customTitle: newCustomTitle }),
+          ...(fetchFullContentChanged && { fetchFullContent }),
         });
       }
 
@@ -182,6 +192,27 @@ function EditSubscriptionForm({
           onChange={(e) => setCustomTitle(e.target.value)}
           disabled={isPending}
         />
+      </div>
+
+      {/* Fetch Full Content Toggle */}
+      <div className="mb-4">
+        <label className="flex cursor-pointer items-center gap-3">
+          <input
+            type="checkbox"
+            checked={fetchFullContent}
+            onChange={(e) => setFetchFullContent(e.target.checked)}
+            disabled={isPending}
+            className="h-4 w-4 rounded border-zinc-300 text-zinc-900 focus:ring-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:focus:ring-zinc-400"
+          />
+          <div>
+            <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+              Fetch full content
+            </span>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              Load the full article from the website instead of the feed summary
+            </p>
+          </div>
+        </label>
       </div>
 
       {/* Tags */}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -30,6 +30,7 @@ export function Sidebar({ onClose }: SidebarProps) {
     id: string;
     title: string;
     customTitle: string | null;
+    fetchFullContent: boolean;
     tagIds: string[];
   } | null>(null);
 
@@ -415,6 +416,7 @@ export function Sidebar({ onClose }: SidebarProps) {
                                       id: subscription.id,
                                       title,
                                       customTitle: subscription.customTitle,
+                                      fetchFullContent: subscription.fetchFullContent,
                                       tagIds: subscription.tags.map((t) => t.id),
                                     });
                                   }}
@@ -582,6 +584,7 @@ export function Sidebar({ onClose }: SidebarProps) {
                                     id: subscription.id,
                                     title,
                                     customTitle: subscription.customTitle,
+                                    fetchFullContent: subscription.fetchFullContent,
                                     tagIds: subscription.tags.map((t) => t.id),
                                   });
                                 }}
@@ -663,6 +666,7 @@ export function Sidebar({ onClose }: SidebarProps) {
         subscriptionId={editTarget?.id ?? ""}
         currentTitle={editTarget?.title ?? ""}
         currentCustomTitle={editTarget?.customTitle ?? null}
+        currentFetchFullContent={editTarget?.fetchFullContent ?? false}
         currentTagIds={editTarget?.tagIds ?? []}
         onClose={() => {
           setEditTarget(null);

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -211,6 +211,11 @@ export const entries = pgTable(
     contentCleaned: text("content_cleaned"), // Readability-cleaned HTML
     summary: text("summary"), // truncated for previews
 
+    // Full content fetched from article URL (using Readability)
+    contentFull: text("content_full"), // Full article content fetched from URL
+    contentFullFetchedAt: timestamp("content_full_fetched_at", { withTimezone: true }),
+    contentFullError: text("content_full_error"), // Error message if fetch failed
+
     // Saved article metadata (only for type='saved')
     siteName: text("site_name"),
     imageUrl: text("image_url"),
@@ -327,6 +332,7 @@ export const subscriptions = pgTable(
       .references(() => feeds.id, { onDelete: "cascade" }),
 
     customTitle: text("custom_title"), // user's override for feed title
+    fetchFullContent: boolean("fetch_full_content").notNull().default(false), // fetch full article from URL
 
     subscribedAt: timestamp("subscribed_at", { withTimezone: true }).notNull().defaultNow(), // critical for visibility
     unsubscribedAt: timestamp("unsubscribed_at", { withTimezone: true }), // soft delete

--- a/src/server/trpc/routers/narration.ts
+++ b/src/server/trpc/routers/narration.ts
@@ -119,6 +119,7 @@ export const narrationRouter = createTRPCRouter({
       const entryResult = await ctx.db
         .select({
           id: entries.id,
+          contentFull: entries.contentFull,
           contentCleaned: entries.contentCleaned,
           contentOriginal: entries.contentOriginal,
           contentHash: entries.contentHash,
@@ -133,7 +134,9 @@ export const narrationRouter = createTRPCRouter({
       }
 
       const entry = entryResult[0];
-      const sourceContent = entry.contentCleaned || entry.contentOriginal || "";
+      // Use full content if available, otherwise fall back to cleaned/original
+      const sourceContent =
+        entry.contentFull || entry.contentCleaned || entry.contentOriginal || "";
       const contentHash = entry.contentHash;
 
       // Handle empty content


### PR DESCRIPTION
This adds the ability to fetch full article content from the article URL using Mozilla Readability, rather than relying on the often-truncated content from RSS feeds.

Features:
- Per-subscription setting to enable full content fetching
- On-demand fetching when viewing an entry (with loading indicator)
- Full content is cached in the database to avoid refetching
- Narration automatically uses full content when available
- New fetchFullContent endpoint for entries router

Database changes:
- entries: contentFull, contentFullFetchedAt, contentFullError columns
- subscriptions: fetchFullContent boolean setting

UI changes:
- Toggle in EditSubscriptionDialog for "Fetch full content"
- Loading indicator in EntryContent when fetching full content