### PR TITLE
Fix HTML entity handling in text display

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "drizzle-orm": "^0.45.1",
     "fast-xml-parser": "^5.3.3",
     "groq-sdk": "^0.37.0",
+    "html-entities": "^2.6.0",
     "ioredis": "^5.8.2",
     "jsdom": "^27.4.0",
     "next": "16.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       groq-sdk:
         specifier: ^0.37.0
         version: 0.37.0
+      html-entities:
+        specifier: ^2.6.0
+        version: 2.6.0
       ioredis:
         specifier: ^5.8.2
         version: 5.8.2
@@ -2975,6 +2978,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -7332,6 +7338,8 @@ snapshots:
       '@exodus/bytes': 1.6.0
     transitivePeerDependencies:
       - '@exodus/crypto'
+
+  html-entities@2.6.0: {}
 
   http-errors@2.0.1:
     dependencies:

--- a/src/lib/narration/html-to-plain-text.ts
+++ b/src/lib/narration/html-to-plain-text.ts
@@ -7,6 +7,8 @@
  * @module narration/html-to-plain-text
  */
 
+import { decode } from "html-entities";
+
 /**
  * Converts HTML to plain text for narration.
  * Uses regex-based conversion that works in any JavaScript environment.
@@ -19,20 +21,17 @@
  * // Returns "Hello\n\nWorld"
  */
 export function htmlToPlainText(html: string): string {
+  const stripped = html
+    // Add paragraph breaks before block elements
+    .replace(/<(p|div|br|h[1-6]|li|tr|blockquote|pre)[^>]*>/gi, "\n\n")
+    // Remove all HTML tags
+    .replace(/<[^>]+>/g, "");
+
+  // Decode all HTML entities (numeric and named like &rsquo; &hellip;)
+  const decoded = decode(stripped);
+
   return (
-    html
-      // Add paragraph breaks before block elements
-      .replace(/<(p|div|br|h[1-6]|li|tr|blockquote|pre)[^>]*>/gi, "\n\n")
-      // Remove all HTML tags
-      .replace(/<[^>]+>/g, "")
-      // Decode common HTML entities
-      .replace(/&nbsp;/g, " ")
-      .replace(/&amp;/g, "&")
-      .replace(/&lt;/g, "<")
-      .replace(/&gt;/g, ">")
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/&apos;/g, "'")
+    decoded
       // Normalize whitespace: collapse multiple spaces to single space
       .replace(/ +/g, " ")
       // Normalize paragraph breaks: collapse multiple newlines to double newline


### PR DESCRIPTION
Replace custom regex-based numeric entity decoding with the html-entities library which handles all HTML5 named entities (like &rsquo; &hellip;) in addition to numeric entities.

This fixes feed entry titles showing raw HTML entities like "Aren&rsquo;t" instead of proper characters.