### PR TITLE
Fix scroll position when returning from entry view

### DIFF
--- a/src/app/(app)/all/page.tsx
+++ b/src/app/(app)/all/page.tsx
@@ -102,83 +102,86 @@ function AllEntriesContent() {
     [entryListQuery]
   );
 
-  // If an entry is open, show the full content view
-  // Key forces remount when entryId changes, ensuring fresh refs and mutation state
-  if (openEntryId) {
-    return (
-      <EntryContent
-        key={openEntryId}
-        entryId={openEntryId}
-        listFilters={{ unreadOnly: showUnreadOnly, sortOrder }}
-        onBack={handleBack}
-        onSwipeNext={goToNextEntry}
-        onSwipePrevious={goToPreviousEntry}
-        nextEntryId={entryListQuery.nextEntryId}
-        previousEntryId={entryListQuery.previousEntryId}
-      />
-    );
-  }
-
-  // Otherwise, show the entry list
+  // Render both list and content, hiding the list when viewing an entry.
+  // This preserves scroll position and enables seamless j/k navigation.
   return (
-    <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
-      <div className="mb-4 flex items-center justify-between sm:mb-6">
-        <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">All Items</h1>
-        <div className="flex gap-2">
-          {totalUnreadCount > 0 && (
-            <button
-              type="button"
-              onClick={() => setShowMarkAllReadDialog(true)}
-              className="inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
-              title="Mark all as read"
-              aria-label="Mark all as read"
-            >
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={1.5}
-                aria-hidden="true"
+    <>
+      {/* Entry content - only rendered when an entry is open */}
+      {openEntryId && (
+        <EntryContent
+          key={openEntryId}
+          entryId={openEntryId}
+          listFilters={{ unreadOnly: showUnreadOnly, sortOrder }}
+          onBack={handleBack}
+          onSwipeNext={goToNextEntry}
+          onSwipePrevious={goToPreviousEntry}
+          nextEntryId={entryListQuery.nextEntryId}
+          previousEntryId={entryListQuery.previousEntryId}
+        />
+      )}
+
+      {/* Entry list - always mounted but hidden when viewing an entry */}
+      <div className={`mx-auto max-w-3xl px-4 py-4 sm:p-6 ${openEntryId ? "hidden" : ""}`}>
+        <div className="mb-4 flex items-center justify-between sm:mb-6">
+          <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">
+            All Items
+          </h1>
+          <div className="flex gap-2">
+            {totalUnreadCount > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowMarkAllReadDialog(true)}
+                className="inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
+                title="Mark all as read"
+                aria-label="Mark all as read"
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-              <span className="ml-1.5 hidden text-sm sm:inline">Mark All Read</span>
-            </button>
-          )}
-          <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
-          <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <span className="ml-1.5 hidden text-sm sm:inline">Mark All Read</span>
+              </button>
+            )}
+            <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
+            <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+          </div>
         </div>
+
+        <EntryList
+          filters={{ unreadOnly: showUnreadOnly, sortOrder }}
+          onEntryClick={handleEntryClick}
+          selectedEntryId={selectedEntryId}
+          onToggleRead={toggleRead}
+          onToggleStar={toggleStar}
+          externalEntries={entryListQuery.entries}
+          externalQueryState={externalQueryState}
+          emptyMessage={
+            showUnreadOnly
+              ? "No unread entries. Toggle to show all items."
+              : "No entries yet. Subscribe to some feeds to see entries here."
+          }
+        />
+
+        <MarkAllReadDialog
+          isOpen={showMarkAllReadDialog}
+          contextDescription="all feeds"
+          unreadCount={totalUnreadCount}
+          isLoading={isMarkAllReadPending}
+          onConfirm={handleMarkAllRead}
+          onCancel={() => setShowMarkAllReadDialog(false)}
+        />
       </div>
-
-      <EntryList
-        filters={{ unreadOnly: showUnreadOnly, sortOrder }}
-        onEntryClick={handleEntryClick}
-        selectedEntryId={selectedEntryId}
-        onToggleRead={toggleRead}
-        onToggleStar={toggleStar}
-        externalEntries={entryListQuery.entries}
-        externalQueryState={externalQueryState}
-        emptyMessage={
-          showUnreadOnly
-            ? "No unread entries. Toggle to show all items."
-            : "No entries yet. Subscribe to some feeds to see entries here."
-        }
-      />
-
-      <MarkAllReadDialog
-        isOpen={showMarkAllReadDialog}
-        contextDescription="all feeds"
-        unreadCount={totalUnreadCount}
-        isLoading={isMarkAllReadPending}
-        onConfirm={handleMarkAllRead}
-        onCancel={() => setShowMarkAllReadDialog(false)}
-      />
-    </div>
+    </>
   );
 }
 

--- a/src/app/(app)/feed/[feedId]/page.tsx
+++ b/src/app/(app)/feed/[feedId]/page.tsx
@@ -163,23 +163,6 @@ function SingleFeedContent() {
     [entryListQuery]
   );
 
-  // If an entry is open, show the full content view
-  // Key forces remount when entryId changes, ensuring fresh refs and mutation state
-  if (openEntryId) {
-    return (
-      <EntryContent
-        key={openEntryId}
-        entryId={openEntryId}
-        listFilters={{ feedId, unreadOnly: showUnreadOnly, sortOrder }}
-        onBack={handleBack}
-        onSwipeNext={goToNextEntry}
-        onSwipePrevious={goToPreviousEntry}
-        nextEntryId={entryListQuery.nextEntryId}
-        previousEntryId={entryListQuery.previousEntryId}
-      />
-    );
-  }
-
   // Show loading state while checking subscription
   if (subscriptionsQuery.isLoading) {
     return (
@@ -198,103 +181,122 @@ function SingleFeedContent() {
     subscription.subscription.customTitle ?? subscription.feed.title ?? "Untitled Feed";
   const unreadCount = subscription.subscription.unreadCount;
 
+  // Render both list and content, hiding the list when viewing an entry.
+  // This preserves scroll position and enables seamless j/k navigation.
   return (
-    <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
-      <div className="mb-4 sm:mb-6">
-        {/* Breadcrumb back link */}
-        <Link
-          href="/all"
-          className="mb-2 -ml-2 inline-flex min-h-[36px] items-center rounded-md px-2 text-sm text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 active:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:active:bg-zinc-700"
-        >
-          <svg className="mr-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M10 19l-7-7m0 0l7-7m-7 7h18"
-            />
-          </svg>
-          All Items
-        </Link>
+    <>
+      {/* Entry content - only rendered when an entry is open */}
+      {openEntryId && (
+        <EntryContent
+          key={openEntryId}
+          entryId={openEntryId}
+          listFilters={{ feedId, unreadOnly: showUnreadOnly, sortOrder }}
+          onBack={handleBack}
+          onSwipeNext={goToNextEntry}
+          onSwipePrevious={goToPreviousEntry}
+          nextEntryId={entryListQuery.nextEntryId}
+          previousEntryId={entryListQuery.previousEntryId}
+        />
+      )}
 
-        {/* Feed title and unread count */}
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">
-            {feedTitle}
-          </h1>
-          <div className="flex items-center gap-2">
-            {unreadCount > 0 && (
-              <>
-                <span className="rounded-full bg-zinc-100 px-2.5 py-0.5 text-sm text-zinc-600 sm:px-3 sm:py-1 dark:bg-zinc-800 dark:text-zinc-400">
-                  {unreadCount} unread
-                </span>
-                <button
-                  type="button"
-                  onClick={() => setShowMarkAllReadDialog(true)}
-                  className="inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
-                  title="Mark all as read"
-                  aria-label="Mark all as read"
-                >
-                  <svg
-                    className="h-5 w-5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                    aria-hidden="true"
+      {/* Entry list - always mounted but hidden when viewing an entry */}
+      <div className={`mx-auto max-w-3xl px-4 py-4 sm:p-6 ${openEntryId ? "hidden" : ""}`}>
+        <div className="mb-4 sm:mb-6">
+          {/* Breadcrumb back link */}
+          <Link
+            href="/all"
+            className="mb-2 -ml-2 inline-flex min-h-[36px] items-center rounded-md px-2 text-sm text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 active:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:active:bg-zinc-700"
+          >
+            <svg className="mr-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 19l-7-7m0 0l7-7m-7 7h18"
+              />
+            </svg>
+            All Items
+          </Link>
+
+          {/* Feed title and unread count */}
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">
+              {feedTitle}
+            </h1>
+            <div className="flex items-center gap-2">
+              {unreadCount > 0 && (
+                <>
+                  <span className="rounded-full bg-zinc-100 px-2.5 py-0.5 text-sm text-zinc-600 sm:px-3 sm:py-1 dark:bg-zinc-800 dark:text-zinc-400">
+                    {unreadCount} unread
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setShowMarkAllReadDialog(true)}
+                    className="inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
+                    title="Mark all as read"
+                    aria-label="Mark all as read"
                   >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
-                  </svg>
-                  <span className="ml-1.5 hidden text-sm sm:inline">Mark All Read</span>
-                </button>
-              </>
-            )}
-            <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
-            <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+                    <svg
+                      className="h-5 w-5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={1.5}
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                      />
+                    </svg>
+                    <span className="ml-1.5 hidden text-sm sm:inline">Mark All Read</span>
+                  </button>
+                </>
+              )}
+              <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
+              <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+            </div>
           </div>
+
+          {/* Feed URL if available */}
+          {subscription.feed.siteUrl && (
+            <a
+              href={subscription.feed.siteUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-1 inline-block text-sm text-zinc-500 hover:underline dark:text-zinc-400"
+            >
+              {new URL(subscription.feed.siteUrl).hostname}
+            </a>
+          )}
         </div>
 
-        {/* Feed URL if available */}
-        {subscription.feed.siteUrl && (
-          <a
-            href={subscription.feed.siteUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-1 inline-block text-sm text-zinc-500 hover:underline dark:text-zinc-400"
-          >
-            {new URL(subscription.feed.siteUrl).hostname}
-          </a>
-        )}
+        <EntryList
+          filters={{ feedId, unreadOnly: showUnreadOnly, sortOrder }}
+          onEntryClick={handleEntryClick}
+          selectedEntryId={selectedEntryId}
+          onToggleRead={toggleRead}
+          onToggleStar={toggleStar}
+          externalEntries={entryListQuery.entries}
+          externalQueryState={externalQueryState}
+          emptyMessage={
+            showUnreadOnly
+              ? "No unread entries in this feed. Toggle to show all items."
+              : "No entries in this feed yet. Entries will appear here once the feed is fetched."
+          }
+        />
+
+        <MarkAllReadDialog
+          isOpen={showMarkAllReadDialog}
+          contextDescription="this feed"
+          unreadCount={unreadCount}
+          isLoading={isMarkAllReadPending}
+          onConfirm={handleMarkAllRead}
+          onCancel={() => setShowMarkAllReadDialog(false)}
+        />
       </div>
-
-      <EntryList
-        filters={{ feedId, unreadOnly: showUnreadOnly, sortOrder }}
-        onEntryClick={handleEntryClick}
-        selectedEntryId={selectedEntryId}
-        onToggleRead={toggleRead}
-        onToggleStar={toggleStar}
-        externalEntries={entryListQuery.entries}
-        externalQueryState={externalQueryState}
-        emptyMessage={
-          showUnreadOnly
-            ? "No unread entries in this feed. Toggle to show all items."
-            : "No entries in this feed yet. Entries will appear here once the feed is fetched."
-        }
-      />
-
-      <MarkAllReadDialog
-        isOpen={showMarkAllReadDialog}
-        contextDescription="this feed"
-        unreadCount={unreadCount}
-        isLoading={isMarkAllReadPending}
-        onConfirm={handleMarkAllRead}
-        onCancel={() => setShowMarkAllReadDialog(false)}
-      />
-    </div>
+    </>
   );
 }
 

--- a/src/app/(app)/saved/page.tsx
+++ b/src/app/(app)/saved/page.tsx
@@ -87,47 +87,48 @@ function SavedArticlesContent() {
     };
   }, [openArticleId, articles]);
 
-  // If an article is open, show the full content view
-  // Key forces remount when articleId changes, ensuring fresh refs and mutation state
-  if (openArticleId) {
-    return (
-      <SavedArticleContent
-        key={openArticleId}
-        articleId={openArticleId}
-        onBack={handleBack}
-        onSwipeNext={goToNextArticle}
-        onSwipePrevious={goToPreviousArticle}
-        nextArticleId={nextArticleId}
-        previousArticleId={previousArticleId}
-      />
-    );
-  }
-
-  // Otherwise, show the saved articles list
+  // Render both list and content, hiding the list when viewing an article.
+  // This preserves scroll position and enables seamless j/k navigation.
   return (
-    <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
-      <div className="mb-4 flex items-center justify-between sm:mb-6">
-        <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">Saved</h1>
-        <div className="flex gap-2">
-          <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
-          <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
-        </div>
-      </div>
+    <>
+      {/* Article content - only rendered when an article is open */}
+      {openArticleId && (
+        <SavedArticleContent
+          key={openArticleId}
+          articleId={openArticleId}
+          onBack={handleBack}
+          onSwipeNext={goToNextArticle}
+          onSwipePrevious={goToPreviousArticle}
+          nextArticleId={nextArticleId}
+          previousArticleId={previousArticleId}
+        />
+      )}
 
-      <SavedArticleList
-        filters={{ unreadOnly: showUnreadOnly, sortOrder }}
-        onArticleClick={handleArticleClick}
-        selectedArticleId={selectedArticleId}
-        onArticlesLoaded={handleArticlesLoaded}
-        onToggleRead={toggleRead}
-        onToggleStar={toggleStar}
-        emptyMessage={
-          showUnreadOnly
-            ? "No unread saved articles. Toggle to show all items."
-            : "No saved articles yet. Save articles to read them later."
-        }
-      />
-    </div>
+      {/* Article list - always mounted but hidden when viewing an article */}
+      <div className={`mx-auto max-w-3xl px-4 py-4 sm:p-6 ${openArticleId ? "hidden" : ""}`}>
+        <div className="mb-4 flex items-center justify-between sm:mb-6">
+          <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">Saved</h1>
+          <div className="flex gap-2">
+            <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
+            <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+          </div>
+        </div>
+
+        <SavedArticleList
+          filters={{ unreadOnly: showUnreadOnly, sortOrder }}
+          onArticleClick={handleArticleClick}
+          selectedArticleId={selectedArticleId}
+          onArticlesLoaded={handleArticlesLoaded}
+          onToggleRead={toggleRead}
+          onToggleStar={toggleStar}
+          emptyMessage={
+            showUnreadOnly
+              ? "No unread saved articles. Toggle to show all items."
+              : "No saved articles yet. Save articles to read them later."
+          }
+        />
+      </div>
+    </>
   );
 }
 

--- a/src/app/(app)/starred/page.tsx
+++ b/src/app/(app)/starred/page.tsx
@@ -97,83 +97,84 @@ function StarredEntriesContent() {
     [entryListQuery]
   );
 
-  // If an entry is open, show the full content view
-  // Key forces remount when entryId changes, ensuring fresh refs and mutation state
-  if (openEntryId) {
-    return (
-      <EntryContent
-        key={openEntryId}
-        entryId={openEntryId}
-        listFilters={{ starredOnly: true, unreadOnly: showUnreadOnly, sortOrder }}
-        onBack={handleBack}
-        onSwipeNext={goToNextEntry}
-        onSwipePrevious={goToPreviousEntry}
-        nextEntryId={entryListQuery.nextEntryId}
-        previousEntryId={entryListQuery.previousEntryId}
-      />
-    );
-  }
-
-  // Otherwise, show the starred entries list
+  // Render both list and content, hiding the list when viewing an entry.
+  // This preserves scroll position and enables seamless j/k navigation.
   return (
-    <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
-      <div className="mb-4 flex items-center justify-between sm:mb-6">
-        <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">Starred</h1>
-        <div className="flex gap-2">
-          {unreadStarredCount > 0 && (
-            <button
-              type="button"
-              onClick={() => setShowMarkAllReadDialog(true)}
-              className="inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
-              title="Mark all as read"
-              aria-label="Mark all as read"
-            >
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={1.5}
-                aria-hidden="true"
+    <>
+      {/* Entry content - only rendered when an entry is open */}
+      {openEntryId && (
+        <EntryContent
+          key={openEntryId}
+          entryId={openEntryId}
+          listFilters={{ starredOnly: true, unreadOnly: showUnreadOnly, sortOrder }}
+          onBack={handleBack}
+          onSwipeNext={goToNextEntry}
+          onSwipePrevious={goToPreviousEntry}
+          nextEntryId={entryListQuery.nextEntryId}
+          previousEntryId={entryListQuery.previousEntryId}
+        />
+      )}
+
+      {/* Entry list - always mounted but hidden when viewing an entry */}
+      <div className={`mx-auto max-w-3xl px-4 py-4 sm:p-6 ${openEntryId ? "hidden" : ""}`}>
+        <div className="mb-4 flex items-center justify-between sm:mb-6">
+          <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">Starred</h1>
+          <div className="flex gap-2">
+            {unreadStarredCount > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowMarkAllReadDialog(true)}
+                className="inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
+                title="Mark all as read"
+                aria-label="Mark all as read"
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-              <span className="ml-1.5 hidden text-sm sm:inline">Mark All Read</span>
-            </button>
-          )}
-          <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
-          <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <span className="ml-1.5 hidden text-sm sm:inline">Mark All Read</span>
+              </button>
+            )}
+            <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
+            <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+          </div>
         </div>
+
+        <EntryList
+          filters={{ starredOnly: true, unreadOnly: showUnreadOnly, sortOrder }}
+          onEntryClick={handleEntryClick}
+          selectedEntryId={selectedEntryId}
+          onToggleRead={toggleRead}
+          onToggleStar={toggleStar}
+          externalEntries={entryListQuery.entries}
+          externalQueryState={externalQueryState}
+          emptyMessage={
+            showUnreadOnly
+              ? "No unread starred entries. Toggle to show all starred items."
+              : "No starred entries yet. Star entries to save them for later."
+          }
+        />
+
+        <MarkAllReadDialog
+          isOpen={showMarkAllReadDialog}
+          contextDescription="starred entries"
+          unreadCount={unreadStarredCount}
+          isLoading={isMarkAllReadPending}
+          onConfirm={handleMarkAllRead}
+          onCancel={() => setShowMarkAllReadDialog(false)}
+        />
       </div>
-
-      <EntryList
-        filters={{ starredOnly: true, unreadOnly: showUnreadOnly, sortOrder }}
-        onEntryClick={handleEntryClick}
-        selectedEntryId={selectedEntryId}
-        onToggleRead={toggleRead}
-        onToggleStar={toggleStar}
-        externalEntries={entryListQuery.entries}
-        externalQueryState={externalQueryState}
-        emptyMessage={
-          showUnreadOnly
-            ? "No unread starred entries. Toggle to show all starred items."
-            : "No starred entries yet. Star entries to save them for later."
-        }
-      />
-
-      <MarkAllReadDialog
-        isOpen={showMarkAllReadDialog}
-        contextDescription="starred entries"
-        unreadCount={unreadStarredCount}
-        isLoading={isMarkAllReadPending}
-        onConfirm={handleMarkAllRead}
-        onCancel={() => setShowMarkAllReadDialog(false)}
-      />
-    </div>
+    </>
   );
 }
 

--- a/src/app/(app)/tag/[tagId]/page.tsx
+++ b/src/app/(app)/tag/[tagId]/page.tsx
@@ -163,23 +163,6 @@ function TagEntriesContent() {
     [entryListQuery]
   );
 
-  // If an entry is open, show the full content view
-  // Key forces remount when entryId changes, ensuring fresh refs and mutation state
-  if (openEntryId) {
-    return (
-      <EntryContent
-        key={openEntryId}
-        entryId={openEntryId}
-        listFilters={{ tagId, unreadOnly: showUnreadOnly, sortOrder }}
-        onBack={handleBack}
-        onSwipeNext={goToNextEntry}
-        onSwipePrevious={goToPreviousEntry}
-        nextEntryId={entryListQuery.nextEntryId}
-        previousEntryId={entryListQuery.previousEntryId}
-      />
-    );
-  }
-
   // Show loading state while checking tag
   if (tagsQuery.isLoading) {
     return (
@@ -194,98 +177,117 @@ function TagEntriesContent() {
     return <TagNotFound />;
   }
 
+  // Render both list and content, hiding the list when viewing an entry.
+  // This preserves scroll position and enables seamless j/k navigation.
   return (
-    <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
-      <div className="mb-4 sm:mb-6">
-        {/* Breadcrumb back link */}
-        <Link
-          href="/all"
-          className="mb-2 -ml-2 inline-flex min-h-[36px] items-center rounded-md px-2 text-sm text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 active:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:active:bg-zinc-700"
-        >
-          <svg className="mr-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M10 19l-7-7m0 0l7-7m-7 7h18"
-            />
-          </svg>
-          All Items
-        </Link>
+    <>
+      {/* Entry content - only rendered when an entry is open */}
+      {openEntryId && (
+        <EntryContent
+          key={openEntryId}
+          entryId={openEntryId}
+          listFilters={{ tagId, unreadOnly: showUnreadOnly, sortOrder }}
+          onBack={handleBack}
+          onSwipeNext={goToNextEntry}
+          onSwipePrevious={goToPreviousEntry}
+          nextEntryId={entryListQuery.nextEntryId}
+          previousEntryId={entryListQuery.previousEntryId}
+        />
+      )}
 
-        {/* Tag header with color dot */}
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
-            <span
-              className="inline-block h-4 w-4 rounded-full"
-              style={{ backgroundColor: tag.color || "#6b7280" }}
-              aria-hidden="true"
-            />
-            <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">
-              {tag.name}
-            </h1>
-            {tag.feedCount > 0 && (
-              <span className="rounded-full bg-zinc-100 px-2.5 py-0.5 text-sm text-zinc-600 sm:px-3 sm:py-1 dark:bg-zinc-800 dark:text-zinc-400">
-                {tag.feedCount} feed{tag.feedCount !== 1 ? "s" : ""}
-              </span>
-            )}
-          </div>
-          <div className="flex gap-2">
-            {tag.unreadCount > 0 && (
-              <button
-                type="button"
-                onClick={() => setShowMarkAllReadDialog(true)}
-                className="inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
-                title="Mark all as read"
-                aria-label="Mark all as read"
-              >
-                <svg
-                  className="h-5 w-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={1.5}
-                  aria-hidden="true"
+      {/* Entry list - always mounted but hidden when viewing an entry */}
+      <div className={`mx-auto max-w-3xl px-4 py-4 sm:p-6 ${openEntryId ? "hidden" : ""}`}>
+        <div className="mb-4 sm:mb-6">
+          {/* Breadcrumb back link */}
+          <Link
+            href="/all"
+            className="mb-2 -ml-2 inline-flex min-h-[36px] items-center rounded-md px-2 text-sm text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 active:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:active:bg-zinc-700"
+          >
+            <svg className="mr-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 19l-7-7m0 0l7-7m-7 7h18"
+              />
+            </svg>
+            All Items
+          </Link>
+
+          {/* Tag header with color dot */}
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <span
+                className="inline-block h-4 w-4 rounded-full"
+                style={{ backgroundColor: tag.color || "#6b7280" }}
+                aria-hidden="true"
+              />
+              <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">
+                {tag.name}
+              </h1>
+              {tag.feedCount > 0 && (
+                <span className="rounded-full bg-zinc-100 px-2.5 py-0.5 text-sm text-zinc-600 sm:px-3 sm:py-1 dark:bg-zinc-800 dark:text-zinc-400">
+                  {tag.feedCount} feed{tag.feedCount !== 1 ? "s" : ""}
+                </span>
+              )}
+            </div>
+            <div className="flex gap-2">
+              {tag.unreadCount > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setShowMarkAllReadDialog(true)}
+                  className="inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
+                  title="Mark all as read"
+                  aria-label="Mark all as read"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-                <span className="ml-1.5 hidden text-sm sm:inline">Mark All Read</span>
-              </button>
-            )}
-            <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
-            <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                  <span className="ml-1.5 hidden text-sm sm:inline">Mark All Read</span>
+                </button>
+              )}
+              <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
+              <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+            </div>
           </div>
         </div>
+
+        <EntryList
+          filters={{ tagId, unreadOnly: showUnreadOnly, sortOrder }}
+          onEntryClick={handleEntryClick}
+          selectedEntryId={selectedEntryId}
+          onToggleRead={toggleRead}
+          onToggleStar={toggleStar}
+          externalEntries={entryListQuery.entries}
+          externalQueryState={externalQueryState}
+          emptyMessage={
+            showUnreadOnly
+              ? `No unread entries from feeds tagged with "${tag.name}". Toggle to show all items.`
+              : `No entries from feeds tagged with "${tag.name}" yet.`
+          }
+        />
+
+        <MarkAllReadDialog
+          isOpen={showMarkAllReadDialog}
+          contextDescription={`the "${tag.name}" tag`}
+          unreadCount={tag.unreadCount}
+          isLoading={isMarkAllReadPending}
+          onConfirm={handleMarkAllRead}
+          onCancel={() => setShowMarkAllReadDialog(false)}
+        />
       </div>
-
-      <EntryList
-        filters={{ tagId, unreadOnly: showUnreadOnly, sortOrder }}
-        onEntryClick={handleEntryClick}
-        selectedEntryId={selectedEntryId}
-        onToggleRead={toggleRead}
-        onToggleStar={toggleStar}
-        externalEntries={entryListQuery.entries}
-        externalQueryState={externalQueryState}
-        emptyMessage={
-          showUnreadOnly
-            ? `No unread entries from feeds tagged with "${tag.name}". Toggle to show all items.`
-            : `No entries from feeds tagged with "${tag.name}" yet.`
-        }
-      />
-
-      <MarkAllReadDialog
-        isOpen={showMarkAllReadDialog}
-        contextDescription={`the "${tag.name}" tag`}
-        unreadCount={tag.unreadCount}
-        isLoading={isMarkAllReadPending}
-        onConfirm={handleMarkAllRead}
-        onCancel={() => setShowMarkAllReadDialog(false)}
-      />
-    </div>
+    </>
   );
 }
 

--- a/src/app/(app)/uncategorized/page.tsx
+++ b/src/app/(app)/uncategorized/page.tsx
@@ -108,23 +108,6 @@ function UncategorizedEntriesContent() {
     [entryListQuery]
   );
 
-  // If an entry is open, show the full content view
-  // Key forces remount when entryId changes, ensuring fresh refs and mutation state
-  if (openEntryId) {
-    return (
-      <EntryContent
-        key={openEntryId}
-        entryId={openEntryId}
-        listFilters={{ uncategorized: true, unreadOnly: showUnreadOnly, sortOrder }}
-        onBack={handleBack}
-        onSwipeNext={goToNextEntry}
-        onSwipePrevious={goToPreviousEntry}
-        nextEntryId={entryListQuery.nextEntryId}
-        previousEntryId={entryListQuery.previousEntryId}
-      />
-    );
-  }
-
   // Show loading state while checking subscriptions
   if (subscriptionsQuery.isLoading) {
     return (
@@ -137,98 +120,117 @@ function UncategorizedEntriesContent() {
     );
   }
 
+  // Render both list and content, hiding the list when viewing an entry.
+  // This preserves scroll position and enables seamless j/k navigation.
   return (
-    <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
-      <div className="mb-4 sm:mb-6">
-        {/* Breadcrumb back link */}
-        <Link
-          href="/all"
-          className="mb-2 -ml-2 inline-flex min-h-[36px] items-center rounded-md px-2 text-sm text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 active:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:active:bg-zinc-700"
-        >
-          <svg className="mr-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M10 19l-7-7m0 0l7-7m-7 7h18"
-            />
-          </svg>
-          All Items
-        </Link>
+    <>
+      {/* Entry content - only rendered when an entry is open */}
+      {openEntryId && (
+        <EntryContent
+          key={openEntryId}
+          entryId={openEntryId}
+          listFilters={{ uncategorized: true, unreadOnly: showUnreadOnly, sortOrder }}
+          onBack={handleBack}
+          onSwipeNext={goToNextEntry}
+          onSwipePrevious={goToPreviousEntry}
+          nextEntryId={entryListQuery.nextEntryId}
+          previousEntryId={entryListQuery.previousEntryId}
+        />
+      )}
 
-        {/* Uncategorized header with gray color dot */}
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
-            <span
-              className="inline-block h-4 w-4 rounded-full"
-              style={{ backgroundColor: "#6b7280" }}
-              aria-hidden="true"
-            />
-            <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">
-              Uncategorized
-            </h1>
-            {feedCount > 0 && (
-              <span className="rounded-full bg-zinc-100 px-2.5 py-0.5 text-sm text-zinc-600 sm:px-3 sm:py-1 dark:bg-zinc-800 dark:text-zinc-400">
-                {feedCount} feed{feedCount !== 1 ? "s" : ""}
-              </span>
-            )}
-          </div>
-          <div className="flex gap-2">
-            {unreadCount > 0 && (
-              <button
-                type="button"
-                onClick={() => setShowMarkAllReadDialog(true)}
-                className="inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
-                title="Mark all as read"
-                aria-label="Mark all as read"
-              >
-                <svg
-                  className="h-5 w-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={1.5}
-                  aria-hidden="true"
+      {/* Entry list - always mounted but hidden when viewing an entry */}
+      <div className={`mx-auto max-w-3xl px-4 py-4 sm:p-6 ${openEntryId ? "hidden" : ""}`}>
+        <div className="mb-4 sm:mb-6">
+          {/* Breadcrumb back link */}
+          <Link
+            href="/all"
+            className="mb-2 -ml-2 inline-flex min-h-[36px] items-center rounded-md px-2 text-sm text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 active:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:active:bg-zinc-700"
+          >
+            <svg className="mr-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 19l-7-7m0 0l7-7m-7 7h18"
+              />
+            </svg>
+            All Items
+          </Link>
+
+          {/* Uncategorized header with gray color dot */}
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <span
+                className="inline-block h-4 w-4 rounded-full"
+                style={{ backgroundColor: "#6b7280" }}
+                aria-hidden="true"
+              />
+              <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">
+                Uncategorized
+              </h1>
+              {feedCount > 0 && (
+                <span className="rounded-full bg-zinc-100 px-2.5 py-0.5 text-sm text-zinc-600 sm:px-3 sm:py-1 dark:bg-zinc-800 dark:text-zinc-400">
+                  {feedCount} feed{feedCount !== 1 ? "s" : ""}
+                </span>
+              )}
+            </div>
+            <div className="flex gap-2">
+              {unreadCount > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setShowMarkAllReadDialog(true)}
+                  className="inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
+                  title="Mark all as read"
+                  aria-label="Mark all as read"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-                <span className="ml-1.5 hidden text-sm sm:inline">Mark All Read</span>
-              </button>
-            )}
-            <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
-            <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                  <span className="ml-1.5 hidden text-sm sm:inline">Mark All Read</span>
+                </button>
+              )}
+              <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
+              <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+            </div>
           </div>
         </div>
+
+        <EntryList
+          filters={{ uncategorized: true, unreadOnly: showUnreadOnly, sortOrder }}
+          onEntryClick={handleEntryClick}
+          selectedEntryId={selectedEntryId}
+          onToggleRead={toggleRead}
+          onToggleStar={toggleStar}
+          externalEntries={entryListQuery.entries}
+          externalQueryState={externalQueryState}
+          emptyMessage={
+            showUnreadOnly
+              ? "No unread entries from uncategorized feeds. Toggle to show all items."
+              : "No entries from uncategorized feeds yet."
+          }
+        />
+
+        <MarkAllReadDialog
+          isOpen={showMarkAllReadDialog}
+          contextDescription="uncategorized feeds"
+          unreadCount={unreadCount}
+          isLoading={isMarkAllReadPending}
+          onConfirm={handleMarkAllRead}
+          onCancel={() => setShowMarkAllReadDialog(false)}
+        />
       </div>
-
-      <EntryList
-        filters={{ uncategorized: true, unreadOnly: showUnreadOnly, sortOrder }}
-        onEntryClick={handleEntryClick}
-        selectedEntryId={selectedEntryId}
-        onToggleRead={toggleRead}
-        onToggleStar={toggleStar}
-        externalEntries={entryListQuery.entries}
-        externalQueryState={externalQueryState}
-        emptyMessage={
-          showUnreadOnly
-            ? "No unread entries from uncategorized feeds. Toggle to show all items."
-            : "No entries from uncategorized feeds yet."
-        }
-      />
-
-      <MarkAllReadDialog
-        isOpen={showMarkAllReadDialog}
-        contextDescription="uncategorized feeds"
-        unreadCount={unreadCount}
-        isLoading={isMarkAllReadPending}
-        onConfirm={handleMarkAllRead}
-        onCancel={() => setShowMarkAllReadDialog(false)}
-      />
-    </div>
+    </>
   );
 }
 

--- a/src/lib/hooks/useKeyboardShortcuts.ts
+++ b/src/lib/hooks/useKeyboardShortcuts.ts
@@ -378,8 +378,11 @@ export function useKeyboardShortcuts(
   const effectiveSelectedEntryId = isSelectedEntryValid ? selectedEntryId : null;
 
   // Scroll selected entry into view using useLayoutEffect to ensure DOM is ready
+  // Only scroll when list is visible (not hidden). This handles both:
+  // 1. Selection changes while viewing the list
+  // 2. Returning to list view after viewing an entry
   useLayoutEffect(() => {
-    if (effectiveSelectedEntryId) {
+    if (effectiveSelectedEntryId && !isEntryOpen) {
       const element = document.querySelector(`[data-entry-id="${effectiveSelectedEntryId}"]`);
       if (element) {
         element.scrollIntoView({
@@ -388,7 +391,7 @@ export function useKeyboardShortcuts(
         });
       }
     }
-  }, [effectiveSelectedEntryId]);
+  }, [effectiveSelectedEntryId, isEntryOpen]);
 
   // Keyboard shortcuts
   // j - next entry (select in list, or navigate to next when viewing)

--- a/src/lib/hooks/useSavedArticleKeyboardShortcuts.ts
+++ b/src/lib/hooks/useSavedArticleKeyboardShortcuts.ts
@@ -297,8 +297,11 @@ export function useSavedArticleKeyboardShortcuts(
   const effectiveSelectedArticleId = isSelectedArticleValid ? selectedArticleId : null;
 
   // Scroll selected article into view using useLayoutEffect to ensure DOM is ready
+  // Only scroll when list is visible (not hidden). This handles both:
+  // 1. Selection changes while viewing the list
+  // 2. Returning to list view after viewing an article
   useLayoutEffect(() => {
-    if (effectiveSelectedArticleId) {
+    if (effectiveSelectedArticleId && !isArticleOpen) {
       const element = document.querySelector(`[data-entry-id="${effectiveSelectedArticleId}"]`);
       if (element) {
         element.scrollIntoView({
@@ -307,7 +310,7 @@ export function useSavedArticleKeyboardShortcuts(
         });
       }
     }
-  }, [effectiveSelectedArticleId]);
+  }, [effectiveSelectedArticleId, isArticleOpen]);
 
   // Keyboard shortcuts
   // j - next article (select in list, or navigate to next when viewing)


### PR DESCRIPTION
The entry list was previously unmounted when viewing an entry, causing scroll position to be lost when returning to the list. Now the list stays mounted (hidden via CSS) while viewing entries, which:

- Preserves scroll position automatically
- Enables infinite scroll to work seamlessly with j/k navigation
- Simplifies the scroll-to-selection logic

Also updated the scroll effect to only trigger when the list is visible, handling both selection changes and returning to the list view.