### PR TITLE
Configure email newsletter feature documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,22 @@ ALLOW_ALL_SIGNUPS=false
 # ALLOWLIST_SECRET=your-secure-secret-here
 
 # =============================================================================
+# Email Newsletters (Optional)
+# =============================================================================
+# Lion Reader can receive email newsletters via custom ingest addresses.
+# Each user gets unique addresses like: {token}@ingest.yourdomain.com
+
+# Domain for ingest email addresses
+# This domain must have MX records pointing to Cloudflare Email Workers
+# Default: ingest.lionreader.com
+# INGEST_EMAIL_DOMAIN=ingest.yourdomain.com
+
+# Webhook secret for authenticating email forwarding from Cloudflare Email Workers
+# Required to enable email newsletter feature
+# Generate a secure random string: openssl rand -base64 32
+# EMAIL_WEBHOOK_SECRET=your-secure-webhook-secret
+
+# =============================================================================
 # AI Features (Optional)
 # =============================================================================
 # Groq API key for AI-powered narration text processing
@@ -121,6 +137,10 @@ ALLOW_ALL_SIGNUPS=false
 #   fly secrets set APPLE_TEAM_ID="..."
 #   fly secrets set APPLE_KEY_ID="..."
 #   fly secrets set APPLE_PRIVATE_KEY="..."
+#
+# Email Newsletters:
+#   fly secrets set INGEST_EMAIL_DOMAIN="ingest.yourdomain.com"
+#   fly secrets set EMAIL_WEBHOOK_SECRET="your-secure-webhook-secret"
 #
 # Observability:
 #   fly secrets set SENTRY_DSN="https://...@sentry.io/..."


### PR DESCRIPTION
Add setup instructions for the email newsletter feature to README.md and .env.example, including:
- Environment variables (INGEST_EMAIL_DOMAIN, EMAIL_WEBHOOK_SECRET)
- DNS/MX record configuration for Cloudflare Email Workers
- Example Cloudflare Worker code for forwarding emails
- Fly.io secrets setup commands