### PR TITLE
Fix unread entries being marked read again

### DIFF
--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -73,7 +73,7 @@ export function EntryContent({
   nextEntryId,
   previousEntryId,
 }: EntryContentProps) {
-  const lastMarkedReadId = useRef<string | null>(null);
+  const hasAutoMarkedRead = useRef(false);
   const [showOriginal, setShowOriginal] = useState(false);
 
   // Fetch the entry
@@ -91,11 +91,13 @@ export function EntryContent({
 
   const entry = data?.entry;
 
-  // Mark entry as read when component mounts and entry is loaded
-  // Uses lastMarkedReadId to track which entry was marked, correctly handling navigation between entries
+  // Mark entry as read once when component mounts and entry data loads
+  // The ref prevents re-marking if user later toggles read status
+  // Component remounts on entry change (via key={openEntryId}), resetting the ref
   useEffect(() => {
-    if (entry && lastMarkedReadId.current !== entryId && !entry.read) {
-      lastMarkedReadId.current = entryId;
+    if (hasAutoMarkedRead.current || !entry) return;
+    hasAutoMarkedRead.current = true;
+    if (!entry.read) {
       markRead([entryId], true);
     }
   }, [entry, entryId, markRead]);


### PR DESCRIPTION
The auto-mark-read effect only set lastMarkedReadId when the entry was unread. If an entry loaded with stale cached read:true, the ref was never set. Then when the user marked it unread, the effect would see an unread entry with an unset ref and re-mark it as read.

Fix by always setting the ref when first processing an entry, regardless of its read state. The auto-mark logic only runs once per entry lifecycle, preventing re-marking after user toggles.