### PR TITLE
Add LessWrong GraphQL API support for saved articles

### DIFF
--- a/src/server/feed/lesswrong.ts
+++ b/src/server/feed/lesswrong.ts
@@ -1,0 +1,542 @@
+/**
+ * LessWrong content fetcher using the GraphQL API.
+ *
+ * LessWrong pages are JavaScript-heavy and don't render well with server-side fetching.
+ * This module provides direct access to post and comment content via their GraphQL API.
+ *
+ * Reference: https://www.lesswrong.com/posts/LJiGhpq8w4Badr5KJ/graphql-tutorial-for-lesswrong-and-effective-altruism-forum
+ */
+
+import { z } from "zod";
+import { logger } from "@/lib/logger";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * LessWrong GraphQL API endpoint.
+ */
+const LESSWRONG_GRAPHQL_ENDPOINT = "https://www.lesswrong.com/graphql";
+
+/**
+ * Timeout for GraphQL requests in milliseconds.
+ */
+const GRAPHQL_TIMEOUT_MS = 15000;
+
+/**
+ * User-Agent for requests.
+ */
+const USER_AGENT = "LionReader/1.0 (+https://lionreader.com)";
+
+// ============================================================================
+// URL Parsing
+// ============================================================================
+
+/**
+ * Pattern for matching LessWrong post URLs.
+ * Matches: https://www.lesswrong.com/posts/{postId}/{slug}
+ *          https://lesswrong.com/posts/{postId}/{slug}
+ *
+ * The postId is a 17-character alphanumeric ID.
+ * Uses a negative lookahead to ensure the ID is exactly 17 characters
+ * (not followed by more alphanumeric characters).
+ */
+const LESSWRONG_POST_URL_PATTERN =
+  /^https?:\/\/(?:www\.)?lesswrong\.com\/posts\/([a-zA-Z0-9]{17})(?![a-zA-Z0-9])/;
+
+/**
+ * Checks if a URL is a LessWrong post URL.
+ */
+export function isLessWrongUrl(url: string): boolean {
+  return LESSWRONG_POST_URL_PATTERN.test(url);
+}
+
+/**
+ * Extracts the post ID from a LessWrong URL.
+ * Returns null if the URL is not a valid LessWrong post URL.
+ */
+export function extractPostId(url: string): string | null {
+  const match = url.match(LESSWRONG_POST_URL_PATTERN);
+  return match ? match[1] : null;
+}
+
+/**
+ * Extracts the comment ID from a LessWrong URL.
+ * Comment URLs have a ?commentId= query parameter.
+ * Returns null if there's no comment ID in the URL.
+ */
+export function extractCommentId(url: string): string | null {
+  try {
+    const urlObj = new URL(url);
+    return urlObj.searchParams.get("commentId");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Checks if a LessWrong URL points to a specific comment.
+ */
+export function isLessWrongCommentUrl(url: string): boolean {
+  return isLessWrongUrl(url) && extractCommentId(url) !== null;
+}
+
+// ============================================================================
+// GraphQL Types
+// ============================================================================
+
+/**
+ * Zod schema for the GraphQL response.
+ */
+const graphqlResponseSchema = z.object({
+  data: z
+    .object({
+      post: z
+        .object({
+          result: z
+            .object({
+              _id: z.string(),
+              title: z.string().nullable(),
+              slug: z.string().nullable(),
+              pageUrl: z.string().nullable(),
+              postedAt: z.string().nullable(),
+              user: z
+                .object({
+                  displayName: z.string().nullable(),
+                  username: z.string().nullable(),
+                })
+                .nullable(),
+              coauthors: z
+                .array(
+                  z.object({
+                    displayName: z.string().nullable(),
+                    username: z.string().nullable(),
+                  })
+                )
+                .nullable(),
+              contents: z
+                .object({
+                  html: z.string().nullable(),
+                })
+                .nullable(),
+            })
+            .nullable(),
+        })
+        .nullable(),
+    })
+    .nullable(),
+  errors: z
+    .array(
+      z.object({
+        message: z.string(),
+      })
+    )
+    .optional(),
+});
+
+/**
+ * Result from fetching LessWrong post content.
+ */
+export interface LessWrongPostContent {
+  /** Post ID */
+  postId: string;
+  /** Post title */
+  title: string | null;
+  /** HTML content of the post */
+  html: string;
+  /** Author display name */
+  author: string | null;
+  /** Post publication date */
+  publishedAt: Date | null;
+  /** Canonical URL */
+  url: string | null;
+}
+
+/**
+ * Zod schema for the comment GraphQL response.
+ */
+const commentGraphqlResponseSchema = z.object({
+  data: z
+    .object({
+      comment: z
+        .object({
+          result: z
+            .object({
+              _id: z.string(),
+              postId: z.string().nullable(),
+              pageUrl: z.string().nullable(),
+              postedAt: z.string().nullable(),
+              user: z
+                .object({
+                  displayName: z.string().nullable(),
+                  username: z.string().nullable(),
+                })
+                .nullable(),
+              post: z
+                .object({
+                  title: z.string().nullable(),
+                })
+                .nullable(),
+              contents: z
+                .object({
+                  html: z.string().nullable(),
+                })
+                .nullable(),
+            })
+            .nullable(),
+        })
+        .nullable(),
+    })
+    .nullable(),
+  errors: z
+    .array(
+      z.object({
+        message: z.string(),
+      })
+    )
+    .optional(),
+});
+
+/**
+ * Result from fetching LessWrong comment content.
+ */
+export interface LessWrongCommentContent {
+  /** Comment ID */
+  commentId: string;
+  /** Parent post title (for context) */
+  postTitle: string | null;
+  /** HTML content of the comment */
+  html: string;
+  /** Author display name */
+  author: string | null;
+  /** Comment post date */
+  publishedAt: Date | null;
+  /** Canonical URL */
+  url: string | null;
+}
+
+// ============================================================================
+// GraphQL Fetching
+// ============================================================================
+
+/**
+ * GraphQL query to fetch post content.
+ * We request the full HTML content via contents.html.
+ */
+const POST_QUERY = `
+  query GetPost($postId: String!) {
+    post(input: { selector: { _id: $postId } }) {
+      result {
+        _id
+        title
+        slug
+        pageUrl
+        postedAt
+        user {
+          displayName
+          username
+        }
+        coauthors {
+          displayName
+          username
+        }
+        contents {
+          html
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Fetches post content from LessWrong using their GraphQL API.
+ *
+ * @param postId - The LessWrong post ID (17-character alphanumeric)
+ * @returns Post content including HTML, or null if fetch fails
+ */
+export async function fetchLessWrongPost(postId: string): Promise<LessWrongPostContent | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), GRAPHQL_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(LESSWRONG_GRAPHQL_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        query: POST_QUERY,
+        variables: { postId },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      logger.warn("LessWrong GraphQL request failed", {
+        postId,
+        status: response.status,
+        statusText: response.statusText,
+      });
+      return null;
+    }
+
+    const json = await response.json();
+    const parsed = graphqlResponseSchema.safeParse(json);
+
+    if (!parsed.success) {
+      logger.warn("LessWrong GraphQL response validation failed", {
+        postId,
+        error: parsed.error.message,
+      });
+      return null;
+    }
+
+    // Check for GraphQL errors
+    if (parsed.data.errors && parsed.data.errors.length > 0) {
+      logger.warn("LessWrong GraphQL returned errors", {
+        postId,
+        errors: parsed.data.errors.map((e) => e.message),
+      });
+      return null;
+    }
+
+    const post = parsed.data.data?.post?.result;
+    if (!post) {
+      logger.debug("LessWrong post not found", { postId });
+      return null;
+    }
+
+    const html = post.contents?.html;
+    if (!html) {
+      logger.debug("LessWrong post has no content", { postId });
+      return null;
+    }
+
+    // Build author string from user and coauthors
+    const authors: string[] = [];
+    if (post.user?.displayName) {
+      authors.push(post.user.displayName);
+    } else if (post.user?.username) {
+      authors.push(post.user.username);
+    }
+    if (post.coauthors) {
+      for (const coauthor of post.coauthors) {
+        if (coauthor.displayName) {
+          authors.push(coauthor.displayName);
+        } else if (coauthor.username) {
+          authors.push(coauthor.username);
+        }
+      }
+    }
+
+    return {
+      postId: post._id,
+      title: post.title,
+      html,
+      author: authors.length > 0 ? authors.join(", ") : null,
+      publishedAt: post.postedAt ? new Date(post.postedAt) : null,
+      url: post.pageUrl,
+    };
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      logger.warn("LessWrong GraphQL request timed out", { postId });
+    } else {
+      logger.warn("LessWrong GraphQL request error", {
+        postId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Fetches LessWrong post content from a URL.
+ *
+ * This is a convenience function that extracts the post ID from the URL
+ * and fetches the content.
+ *
+ * @param url - The LessWrong post URL
+ * @returns Post content including HTML, or null if URL is invalid or fetch fails
+ */
+export async function fetchLessWrongPostFromUrl(url: string): Promise<LessWrongPostContent | null> {
+  const postId = extractPostId(url);
+  if (!postId) {
+    logger.debug("Not a valid LessWrong post URL", { url });
+    return null;
+  }
+
+  return fetchLessWrongPost(postId);
+}
+
+/**
+ * GraphQL query to fetch comment content.
+ * We request the full HTML content via contents.html.
+ */
+const COMMENT_QUERY = `
+  query GetComment($commentId: String!) {
+    comment(input: { selector: { _id: $commentId } }) {
+      result {
+        _id
+        postId
+        pageUrl
+        postedAt
+        user {
+          displayName
+          username
+        }
+        post {
+          title
+        }
+        contents {
+          html
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Fetches comment content from LessWrong using their GraphQL API.
+ *
+ * @param commentId - The LessWrong comment ID
+ * @returns Comment content including HTML, or null if fetch fails
+ */
+export async function fetchLessWrongComment(
+  commentId: string
+): Promise<LessWrongCommentContent | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), GRAPHQL_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(LESSWRONG_GRAPHQL_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        query: COMMENT_QUERY,
+        variables: { commentId },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      logger.warn("LessWrong GraphQL comment request failed", {
+        commentId,
+        status: response.status,
+        statusText: response.statusText,
+      });
+      return null;
+    }
+
+    const json = await response.json();
+    const parsed = commentGraphqlResponseSchema.safeParse(json);
+
+    if (!parsed.success) {
+      logger.warn("LessWrong GraphQL comment response validation failed", {
+        commentId,
+        error: parsed.error.message,
+      });
+      return null;
+    }
+
+    // Check for GraphQL errors
+    if (parsed.data.errors && parsed.data.errors.length > 0) {
+      logger.warn("LessWrong GraphQL comment returned errors", {
+        commentId,
+        errors: parsed.data.errors.map((e) => e.message),
+      });
+      return null;
+    }
+
+    const comment = parsed.data.data?.comment?.result;
+    if (!comment) {
+      logger.debug("LessWrong comment not found", { commentId });
+      return null;
+    }
+
+    const html = comment.contents?.html;
+    if (!html) {
+      logger.debug("LessWrong comment has no content", { commentId });
+      return null;
+    }
+
+    // Get author name
+    const author = comment.user?.displayName || comment.user?.username || null;
+
+    return {
+      commentId: comment._id,
+      postTitle: comment.post?.title ?? null,
+      html,
+      author,
+      publishedAt: comment.postedAt ? new Date(comment.postedAt) : null,
+      url: comment.pageUrl,
+    };
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      logger.warn("LessWrong GraphQL comment request timed out", { commentId });
+    } else {
+      logger.warn("LessWrong GraphQL comment request error", {
+        commentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Union type for content fetched from LessWrong.
+ */
+export type LessWrongContent =
+  | (LessWrongPostContent & { type: "post" })
+  | (LessWrongCommentContent & { type: "comment" });
+
+/**
+ * Fetches LessWrong content from a URL, detecting whether it's a post or comment.
+ *
+ * This is the main entry point for fetching LessWrong content. It automatically
+ * detects whether the URL points to a post or a comment and fetches accordingly.
+ *
+ * @param url - The LessWrong URL (post or comment)
+ * @returns Content including HTML, or null if URL is invalid or fetch fails
+ */
+export async function fetchLessWrongContentFromUrl(url: string): Promise<LessWrongContent | null> {
+  if (!isLessWrongUrl(url)) {
+    logger.debug("Not a valid LessWrong URL", { url });
+    return null;
+  }
+
+  // Check if this is a comment URL
+  const commentId = extractCommentId(url);
+  if (commentId) {
+    logger.debug("Fetching LessWrong comment", { url, commentId });
+    const comment = await fetchLessWrongComment(commentId);
+    if (comment) {
+      return { ...comment, type: "comment" };
+    }
+    return null;
+  }
+
+  // Otherwise, fetch as a post
+  const postId = extractPostId(url);
+  if (postId) {
+    logger.debug("Fetching LessWrong post", { url, postId });
+    const post = await fetchLessWrongPost(postId);
+    if (post) {
+      return { ...post, type: "post" };
+    }
+  }
+
+  return null;
+}

--- a/tests/unit/lesswrong.test.ts
+++ b/tests/unit/lesswrong.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for LessWrong URL detection and post ID extraction.
+ *
+ * These test the pure functions that determine if a URL is from LessWrong
+ * and extract the post ID for GraphQL API calls.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  isLessWrongUrl,
+  extractPostId,
+  extractCommentId,
+  isLessWrongCommentUrl,
+} from "../../src/server/feed/lesswrong";
+
+describe("LessWrong URL detection", () => {
+  describe("isLessWrongUrl", () => {
+    it("returns true for standard LessWrong post URLs", () => {
+      expect(
+        isLessWrongUrl(
+          "https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm/local-validity-as-a-key-to-sanity-and-civilization"
+        )
+      ).toBe(true);
+      expect(
+        isLessWrongUrl(
+          "https://lesswrong.com/posts/WQFioaudEH8R7fyhm/local-validity-as-a-key-to-sanity-and-civilization"
+        )
+      ).toBe(true);
+    });
+
+    it("returns true for LessWrong post URLs without slug", () => {
+      expect(isLessWrongUrl("https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm")).toBe(true);
+      expect(isLessWrongUrl("https://lesswrong.com/posts/WQFioaudEH8R7fyhm")).toBe(true);
+    });
+
+    it("returns true for LessWrong post URLs with query params", () => {
+      expect(
+        isLessWrongUrl(
+          "https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm/some-slug?commentId=abc123"
+        )
+      ).toBe(true);
+      expect(isLessWrongUrl("https://lesswrong.com/posts/WQFioaudEH8R7fyhm?ref=foo")).toBe(true);
+    });
+
+    it("returns true for LessWrong post URLs with hash fragments", () => {
+      expect(
+        isLessWrongUrl("https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm/slug#comments")
+      ).toBe(true);
+    });
+
+    it("returns true for HTTP URLs (not just HTTPS)", () => {
+      expect(isLessWrongUrl("http://www.lesswrong.com/posts/WQFioaudEH8R7fyhm/slug")).toBe(true);
+      expect(isLessWrongUrl("http://lesswrong.com/posts/WQFioaudEH8R7fyhm/slug")).toBe(true);
+    });
+
+    it("returns false for non-LessWrong URLs", () => {
+      expect(isLessWrongUrl("https://example.com/article")).toBe(false);
+      expect(isLessWrongUrl("https://google.com")).toBe(false);
+      expect(isLessWrongUrl("https://greaterwrong.com/posts/WQFioaudEH8R7fyhm/slug")).toBe(false);
+    });
+
+    it("returns false for LessWrong non-post URLs", () => {
+      expect(isLessWrongUrl("https://www.lesswrong.com")).toBe(false);
+      expect(isLessWrongUrl("https://www.lesswrong.com/users/eliezer_yudkowsky")).toBe(false);
+      expect(isLessWrongUrl("https://www.lesswrong.com/tags/rationality")).toBe(false);
+      expect(isLessWrongUrl("https://www.lesswrong.com/sequences/abc")).toBe(false);
+    });
+
+    it("returns false for invalid URLs", () => {
+      expect(isLessWrongUrl("not a url")).toBe(false);
+      expect(isLessWrongUrl("")).toBe(false);
+      expect(isLessWrongUrl("lesswrong.com/posts/WQFioaudEH8R7fyhm")).toBe(false);
+    });
+  });
+
+  describe("extractPostId", () => {
+    it("extracts post ID from standard LessWrong URLs", () => {
+      expect(
+        extractPostId(
+          "https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm/local-validity-as-a-key-to-sanity-and-civilization"
+        )
+      ).toBe("WQFioaudEH8R7fyhm");
+      expect(extractPostId("https://lesswrong.com/posts/LJiGhpq8w4Badr5KJ/graphql-tutorial")).toBe(
+        "LJiGhpq8w4Badr5KJ"
+      );
+    });
+
+    it("extracts post ID from URLs without slug", () => {
+      expect(extractPostId("https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm")).toBe(
+        "WQFioaudEH8R7fyhm"
+      );
+    });
+
+    it("extracts post ID from URLs with query params", () => {
+      expect(
+        extractPostId("https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm/slug?commentId=abc")
+      ).toBe("WQFioaudEH8R7fyhm");
+    });
+
+    it("extracts post ID from URLs with hash fragments", () => {
+      expect(extractPostId("https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm/slug#section")).toBe(
+        "WQFioaudEH8R7fyhm"
+      );
+    });
+
+    it("returns null for non-LessWrong URLs", () => {
+      expect(extractPostId("https://example.com/article")).toBe(null);
+      expect(extractPostId("https://greaterwrong.com/posts/WQFioaudEH8R7fyhm/slug")).toBe(null);
+    });
+
+    it("returns null for LessWrong non-post URLs", () => {
+      expect(extractPostId("https://www.lesswrong.com")).toBe(null);
+      expect(extractPostId("https://www.lesswrong.com/users/eliezer")).toBe(null);
+    });
+
+    it("returns null for posts with invalid ID length", () => {
+      // Post IDs should be exactly 17 characters
+      expect(extractPostId("https://www.lesswrong.com/posts/short/slug")).toBe(null);
+      expect(extractPostId("https://www.lesswrong.com/posts/waytoolongtobeavalidpostid/slug")).toBe(
+        null
+      );
+    });
+
+    it("returns null for invalid URLs", () => {
+      expect(extractPostId("not a url")).toBe(null);
+      expect(extractPostId("")).toBe(null);
+    });
+  });
+
+  describe("extractCommentId", () => {
+    it("extracts comment ID from URLs with commentId query param", () => {
+      expect(
+        extractCommentId(
+          "https://www.lesswrong.com/posts/ZnNeKw2Be8BR7bmeN/adamzerner-s-shortform?commentId=F2mFKsTHbt24KeLNT"
+        )
+      ).toBe("F2mFKsTHbt24KeLNT");
+    });
+
+    it("extracts comment ID when there are other query params", () => {
+      expect(
+        extractCommentId(
+          "https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm/slug?ref=foo&commentId=abc123&other=bar"
+        )
+      ).toBe("abc123");
+    });
+
+    it("returns null for URLs without commentId", () => {
+      expect(extractCommentId("https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm/slug")).toBe(null);
+      expect(
+        extractCommentId("https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm/slug?ref=foo")
+      ).toBe(null);
+    });
+
+    it("returns null for invalid URLs", () => {
+      expect(extractCommentId("not a url")).toBe(null);
+      expect(extractCommentId("")).toBe(null);
+    });
+  });
+
+  describe("isLessWrongCommentUrl", () => {
+    it("returns true for LessWrong post URLs with commentId", () => {
+      expect(
+        isLessWrongCommentUrl(
+          "https://www.lesswrong.com/posts/ZnNeKw2Be8BR7bmeN/adamzerner-s-shortform?commentId=F2mFKsTHbt24KeLNT"
+        )
+      ).toBe(true);
+    });
+
+    it("returns false for LessWrong post URLs without commentId", () => {
+      expect(isLessWrongCommentUrl("https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm/slug")).toBe(
+        false
+      );
+    });
+
+    it("returns false for non-LessWrong URLs even with commentId", () => {
+      expect(isLessWrongCommentUrl("https://example.com/posts/abc?commentId=123")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
LessWrong pages require JavaScript to render, so normal HTTP fetching doesn't work well. This adds special handling to fetch post and comment content directly via the LessWrong GraphQL API, with fallback to normal fetching if the API fails.

Features:
- Detect LessWrong post URLs (lesswrong.com/posts/{id}/...)
- Detect comment URLs via ?commentId= query parameter
- Fetch full HTML content, author, title, and publication date via GraphQL
- For comments, generate descriptive titles like "Author's comment on Post"
- Set siteName to "LessWrong" for API-fetched content
- Graceful fallback to normal HTTP fetch if GraphQL fails