### PR TITLE
Show website name for saved articles

### DIFF
--- a/src/components/saved/SavedArticleContent.tsx
+++ b/src/components/saved/SavedArticleContent.tsx
@@ -124,11 +124,13 @@ export function SavedArticleContent({
   } else if (!article) {
     content = <ArticleContentError message="Article not found" onRetry={() => refetch()} />;
   } else {
+    // For saved articles, prefer siteName (from og:site_name) over feedTitle (which is "Saved Articles")
+    const source = article.siteName ?? getDomain(article.url ?? "");
     content = (
       <ArticleContentBody
         articleId={articleId}
         title={article.title ?? "Untitled"}
-        source={article.feedTitle ?? getDomain(article.url ?? "")}
+        source={source}
         author={article.author}
         url={article.url ?? ""}
         date={article.fetchedAt}

--- a/src/components/saved/SavedArticleListItem.tsx
+++ b/src/components/saved/SavedArticleListItem.tsx
@@ -19,7 +19,8 @@ export interface SavedArticleListItemData {
   id: string;
   url: string | null;
   title: string | null;
-  feedTitle: string | null; // Used as source name
+  feedTitle: string | null;
+  siteName: string | null; // Website name from og:site_name, used as source
   author: string | null;
   summary: string | null; // Excerpt
   read: boolean;
@@ -60,11 +61,13 @@ export const SavedArticleListItem = memo(function SavedArticleListItem({
   onToggleStar,
   onPrefetch,
 }: SavedArticleListItemProps) {
+  // For saved articles, prefer siteName (from og:site_name) over feedTitle (which is "Saved Articles")
+  const source = article.siteName ?? getDomain(article.url ?? "");
   return (
     <ArticleListItem
       id={article.id}
       title={article.title}
-      source={article.feedTitle ?? getDomain(article.url ?? "")}
+      source={source}
       date={article.fetchedAt}
       preview={article.summary}
       read={article.read}

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -100,6 +100,7 @@ const entryListItemSchema = z.object({
   read: z.boolean(),
   starred: z.boolean(),
   feedTitle: z.string().nullable(),
+  siteName: z.string().nullable(),
 });
 
 /**
@@ -121,6 +122,7 @@ const entryFullSchema = z.object({
   starred: z.boolean(),
   feedTitle: z.string().nullable(),
   feedUrl: z.string().nullable(),
+  siteName: z.string().nullable(),
 });
 
 /**
@@ -422,6 +424,7 @@ export const entriesRouter = createTRPCRouter({
         read: userState.read,
         starred: userState.starred,
         feedTitle: feed.title,
+        siteName: entry.siteName,
       }));
 
       // Generate next cursor if there are more results
@@ -518,6 +521,7 @@ export const entriesRouter = createTRPCRouter({
           starred: userState.starred,
           feedTitle: feed.title,
           feedUrl: feed.url,
+          siteName: entry.siteName,
         },
       };
     }),


### PR DESCRIPTION
For saved articles, the feedTitle is always "Saved Articles" which isn't useful. Now we expose the siteName field (from og:site_name metadata) through the entries API and use it as the source in the saved articles UI. Falls back to domain extraction from URL when siteName is not available.