### PR TITLE
Optimize background sync job CPU usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "html-entities": "^2.6.0",
     "ioredis": "^5.8.2",
     "jsdom": "^27.4.0",
+    "linkedom": "^0.18.12",
     "next": "16.1.1",
     "onnxruntime-web": "1.18.0",
     "pg": "^8.16.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0
+      linkedom:
+        specifier: ^0.18.12
+        version: 0.18.12
       next:
         specifier: 16.1.1
         version: 16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2190,6 +2193,9 @@ packages:
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
@@ -2321,14 +2327,24 @@ packages:
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
   cssstyle@5.3.5:
     resolution: {integrity: sha512-GlsEptulso7Jg0VaOZ8BXQi3AkYM5BOJKEO/rjMidSCq70FkIC5y0eawrCXeYzxgt3OCf4Ls+eoxN+/05vN0Ag==}
@@ -2417,8 +2433,21 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.3.1:
     resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv-cli@11.0.0:
     resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
@@ -2554,6 +2583,10 @@ packages:
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -2982,6 +3015,12 @@ packages:
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  htmlparser2@10.0.0:
+    resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -3326,6 +3365,15 @@ packages:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkedom@0.18.12:
+    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   lint-staged@16.2.7:
     resolution: {integrity: sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==}
     engines: {node: '>=20.17'}
@@ -3506,6 +3554,9 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4259,6 +4310,9 @@ packages:
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
+
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -6416,6 +6470,8 @@ snapshots:
 
   bintrees@1.0.2: {}
 
+  boolbase@1.0.0: {}
+
   boundary@2.0.0: {}
 
   brace-expansion@1.1.12:
@@ -6551,12 +6607,24 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
   css-tree@3.1.0:
     dependencies:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
 
+  css-what@6.2.2: {}
+
   cssesc@3.0.0: {}
+
+  cssom@0.5.0: {}
 
   cssstyle@5.3.5:
     dependencies:
@@ -6633,9 +6701,27 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   dompurify@3.3.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv-cli@11.0.0:
     dependencies:
@@ -6687,6 +6773,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -7341,6 +7429,15 @@ snapshots:
 
   html-entities@2.6.0: {}
 
+  html-escaper@3.0.3: {}
+
+  htmlparser2@10.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 6.0.1
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -7704,6 +7801,14 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
 
+  linkedom@0.18.12:
+    dependencies:
+      css-select: 5.2.2
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.0.0
+      uhyphen: 0.2.0
+
   lint-staged@16.2.7:
     dependencies:
       commander: 14.0.2
@@ -7854,6 +7959,10 @@ snapshots:
   node-releases@2.0.27: {}
 
   normalize-path@3.0.0: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   object-assign@4.1.1: {}
 
@@ -8664,6 +8773,8 @@ snapshots:
   typescript@5.9.3: {}
 
   ufo@1.6.1: {}
+
+  uhyphen@0.2.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/src/app/api/webhooks/websub/[feedId]/route.ts
+++ b/src/app/api/webhooks/websub/[feedId]/route.ts
@@ -172,7 +172,7 @@ export async function POST(
   // Process entries from the pushed content
   const now = new Date();
   try {
-    const result = await processEntries(feedId, parsedFeed, { fetchedAt: now });
+    const result = await processEntries(feedId, feed.type, parsedFeed, { fetchedAt: now });
 
     // Update feed timestamps
     await db

--- a/src/server/feed/content-cleaner.ts
+++ b/src/server/feed/content-cleaner.ts
@@ -7,6 +7,7 @@
 
 import { Readability, isProbablyReaderable } from "@mozilla/readability";
 import { JSDOM } from "jsdom";
+import { parseHTML } from "linkedom";
 import { logger } from "@/lib/logger";
 
 /**
@@ -20,14 +21,16 @@ const URL_ATTRIBUTES = ["src", "href", "poster", "srcset"] as const;
  * Converts relative URLs in src, href, poster, and srcset attributes
  * to absolute URLs using the provided base URL.
  *
+ * Uses linkedom for lightweight HTML parsing (much faster than JSDOM).
+ *
  * @param html - The HTML content to process
  * @param baseUrl - The base URL for resolving relative URLs
  * @returns HTML with all relative URLs converted to absolute
  */
 export function absolutizeUrls(html: string, baseUrl: string): string {
   try {
-    const dom = new JSDOM(html);
-    const document = dom.window.document;
+    // Use linkedom for lightweight parsing - much faster than JSDOM
+    const { document } = parseHTML(`<!DOCTYPE html><html><body>${html}</body></html>`);
 
     // Find all elements with URL attributes
     for (const attr of URL_ATTRIBUTES) {

--- a/tests/integration/entry-processor.test.ts
+++ b/tests/integration/entry-processor.test.ts
@@ -434,7 +434,7 @@ describe("Entry Processor", () => {
         ],
       };
 
-      const result = await processEntries(feed.id, parsedFeed);
+      const result = await processEntries(feed.id, feed.type, parsedFeed);
 
       expect(result.newCount).toBe(3);
       expect(result.updatedCount).toBe(0);
@@ -461,7 +461,7 @@ describe("Entry Processor", () => {
         ],
       };
 
-      await processEntries(feed.id, firstFeed);
+      await processEntries(feed.id, feed.type, firstFeed);
 
       // Second fetch: 1 unchanged, 1 updated, 1 new
       const secondFeed: ParsedFeed = {
@@ -473,7 +473,7 @@ describe("Entry Processor", () => {
         ],
       };
 
-      const result = await processEntries(feed.id, secondFeed);
+      const result = await processEntries(feed.id, feed.type, secondFeed);
 
       expect(result.newCount).toBe(1);
       expect(result.updatedCount).toBe(1);
@@ -489,7 +489,7 @@ describe("Entry Processor", () => {
         items: [{ guid: "timestamped-entry", title: "Entry", content: "Content" }],
       };
 
-      await processEntries(feed.id, parsedFeed, { fetchedAt: customFetchedAt });
+      await processEntries(feed.id, feed.type, parsedFeed, { fetchedAt: customFetchedAt });
 
       const entry = await findEntryByGuid(feed.id, "timestamped-entry");
       expect(entry?.fetchedAt.toISOString()).toBe(customFetchedAt.toISOString());
@@ -507,7 +507,7 @@ describe("Entry Processor", () => {
         ],
       };
 
-      const result = await processEntries(feed.id, parsedFeed);
+      const result = await processEntries(feed.id, feed.type, parsedFeed);
 
       // Should process the valid entries
       expect(result.newCount).toBe(2);
@@ -522,7 +522,7 @@ describe("Entry Processor", () => {
         items: [],
       };
 
-      const result = await processEntries(feed.id, parsedFeed);
+      const result = await processEntries(feed.id, feed.type, parsedFeed);
 
       expect(result.newCount).toBe(0);
       expect(result.updatedCount).toBe(0);
@@ -543,7 +543,7 @@ describe("Entry Processor", () => {
       };
 
       // First entry creates, second updates (since content differs)
-      const result = await processEntries(feed.id, parsedFeed);
+      const result = await processEntries(feed.id, feed.type, parsedFeed);
 
       expect(result.newCount).toBe(1);
       expect(result.updatedCount).toBe(1);


### PR DESCRIPTION
- Fix N+1 query pattern in processEntries by batch-loading existing entries for a feed in a single query, then using Map lookup instead of per-entry database queries. This reduces queries from N+1 to 2 for a feed with N entries.

- Remove redundant feed type query by passing feedType as a parameter to processEntries instead of querying the feeds table again.

- Replace jsdom with linkedom for lightweight HTML operations:
  - stripHtml in entry-processor.ts (for summary generation)
  - absolutizeUrls in content-cleaner.ts (for URL resolution) linkedom is significantly faster and uses less memory than jsdom for simple DOM operations.

- Keep jsdom for Readability which requires a more complete DOM implementation.