### PR TITLE
Use domain name as fallback feed title

### DIFF
--- a/src/server/feed/atom-parser.ts
+++ b/src/server/feed/atom-parser.ts
@@ -26,7 +26,6 @@ const parserOptions = {
   removeNSPrefix: false,
 };
 
-
 /**
  * Atom link element structure.
  */
@@ -440,11 +439,8 @@ export function parseAtomFeed(xml: string): ParsedFeed {
     throw new Error("Invalid Atom feed: missing feed element");
   }
 
-  // Extract feed title
+  // Extract feed title (may be undefined if feed has no title)
   const title = extractTextConstruct(feed.title);
-  if (!title) {
-    throw new Error("Invalid Atom feed: missing title");
-  }
 
   // Normalize entries to array
   let entries: AtomEntry[] = [];

--- a/src/server/feed/index.ts
+++ b/src/server/feed/index.ts
@@ -4,6 +4,7 @@
  */
 
 export type { ParsedFeed, ParsedEntry, SyndicationHints } from "./types";
+export { getDomainFromUrl } from "./types";
 export { parseRssFeed, parseRssDate } from "./rss-parser";
 export { parseAtomFeed } from "./atom-parser";
 export {

--- a/src/server/feed/json-parser.ts
+++ b/src/server/feed/json-parser.ts
@@ -229,11 +229,6 @@ export function parseJsonFeed(json: string): ParsedFeed {
     throw new Error("Invalid JSON Feed: missing or invalid version");
   }
 
-  // Validate title
-  if (typeof feed.title !== "string" || !feed.title.trim()) {
-    throw new Error("Invalid JSON Feed: missing title");
-  }
-
   // Validate items array
   if (!Array.isArray(feed.items)) {
     throw new Error("Invalid JSON Feed: missing items array");
@@ -242,8 +237,11 @@ export function parseJsonFeed(json: string): ParsedFeed {
   // Prefer favicon over icon (favicon is smaller, like our iconUrl intent)
   const iconUrl = feed.favicon || feed.icon;
 
+  // Extract title (may be undefined if feed has no title)
+  const title = typeof feed.title === "string" ? feed.title.trim() || undefined : undefined;
+
   return {
-    title: feed.title.trim(),
+    title,
     description: feed.description?.trim(),
     siteUrl: feed.home_page_url,
     iconUrl,

--- a/src/server/feed/rss-parser.ts
+++ b/src/server/feed/rss-parser.ts
@@ -26,7 +26,6 @@ const parserOptions = {
   removeNSPrefix: false,
 };
 
-
 /**
  * Parsed RSS channel structure from fast-xml-parser.
  * This represents the raw parsed XML structure before normalization.
@@ -473,11 +472,8 @@ export function parseRssFeed(xml: string): ParsedFeed {
     items = Array.isArray(rawItems) ? rawItems : [rawItems];
   }
 
-  // Extract feed metadata
+  // Extract feed metadata (title may be undefined if feed has no title)
   const title = extractText(channel.title);
-  if (!title) {
-    throw new Error("Invalid RSS feed: missing title");
-  }
 
   return {
     title,

--- a/src/server/feed/types.ts
+++ b/src/server/feed/types.ts
@@ -4,6 +4,22 @@
  */
 
 /**
+ * Extracts the domain from a URL for use as a fallback feed title.
+ * Returns just the hostname (e.g., "danluu.com" from "https://danluu.com/atom.xml").
+ *
+ * @param url - The feed URL
+ * @returns The domain name, or undefined if the URL is invalid
+ */
+export function getDomainFromUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * A parsed entry from any feed format.
  */
 export interface ParsedEntry {
@@ -46,8 +62,8 @@ export interface SyndicationHints {
  * A parsed feed from any format (RSS, Atom, JSON Feed).
  */
 export interface ParsedFeed {
-  /** Feed title */
-  title: string;
+  /** Feed title (may be undefined if feed has no title) */
+  title?: string;
   /** Feed description */
   description?: string;
   /** URL to the feed's website */

--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -22,6 +22,7 @@ import {
   processEntries,
   calculateNextFetch,
   renewExpiringSubscriptions,
+  getDomainFromUrl,
   type FetchFeedResult,
 } from "../feed";
 import { type JobPayloads, createOrEnableFeedJob, enableFeedJob } from "./queue";
@@ -188,10 +189,12 @@ async function processFetchResult(feed: Feed, result: FetchFeedResult): Promise<
       });
 
       // Update feed metadata including WebSub hub discovery
+      // Fall back to domain name if no title is available
+      const fallbackTitle = feed.url ? getDomainFromUrl(feed.url) : undefined;
       await db
         .update(feeds)
         .set({
-          title: parsedFeed.title || feed.title,
+          title: parsedFeed.title || feed.title || fallbackTitle,
           description: parsedFeed.description || feed.description,
           siteUrl: parsedFeed.siteUrl || feed.siteUrl,
           etag: result.cacheHeaders.etag ?? feed.etag,

--- a/src/server/trpc/routers/feeds.ts
+++ b/src/server/trpc/routers/feeds.ts
@@ -15,6 +15,7 @@ import {
   discoverFeeds,
   detectFeedType,
   getCommonFeedUrls,
+  getDomainFromUrl,
   type ParsedEntry,
   type DiscoveredFeed,
 } from "@/server/feed";
@@ -372,10 +373,13 @@ export const feedsRouter = createTRPCRouter({
       // Step 4: Build and return the preview
       const sampleEntries = parsedFeed.items.slice(0, MAX_SAMPLE_ENTRIES).map(toSampleEntry);
 
+      // Use domain as fallback if feed has no title
+      const fallbackTitle = getDomainFromUrl(feedUrl) ?? "Untitled Feed";
+
       return {
         feed: {
           url: feedUrl,
-          title: parsedFeed.title,
+          title: parsedFeed.title ?? fallbackTitle,
           description: parsedFeed.description ?? null,
           siteUrl: parsedFeed.siteUrl ?? null,
           iconUrl: parsedFeed.iconUrl ?? null,

--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -22,7 +22,13 @@ import {
   type OpmlImportFeedData,
 } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
-import { parseFeed, discoverFeeds, detectFeedType, deriveGuid } from "@/server/feed";
+import {
+  parseFeed,
+  discoverFeeds,
+  detectFeedType,
+  deriveGuid,
+  getDomainFromUrl,
+} from "@/server/feed";
 import { parseOpml, generateOpml, type OpmlFeed, type OpmlSubscription } from "@/server/feed/opml";
 import {
   createOrEnableFeedJob,
@@ -386,11 +392,14 @@ async function subscribeToNewOrUnfetchedFeed(
     const feedType = detectFeedType(feedContent) as FeedType;
     const now = new Date();
 
+    // Use domain as fallback if feed has no title
+    const fallbackTitle = getDomainFromUrl(feedUrl);
+
     const newFeed = {
       id: feedId,
       type: feedType === "unknown" ? "rss" : feedType,
       url: feedUrl,
-      title: parsedFeed.title || null,
+      title: parsedFeed.title || fallbackTitle || null,
       description: parsedFeed.description || null,
       siteUrl: parsedFeed.siteUrl || null,
       nextFetchAt: now,

--- a/tests/unit/feed-parser-atom.test.ts
+++ b/tests/unit/feed-parser-atom.test.ts
@@ -127,7 +127,7 @@ describe("parseAtomFeed", () => {
       expect(feed.items[0].pubDate).toEqual(new Date("2024-01-01T12:00:00Z"));
     });
 
-    it("throws error for feed without title", () => {
+    it("returns undefined title for feed without title", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom">
           <subtitle>No title here</subtitle>
@@ -135,7 +135,9 @@ describe("parseAtomFeed", () => {
           <updated>2024-01-01T12:00:00Z</updated>
         </feed>`;
 
-      expect(() => parseAtomFeed(xml)).toThrow("Invalid Atom feed: missing title");
+      const feed = parseAtomFeed(xml);
+      expect(feed.title).toBeUndefined();
+      expect(feed.description).toBe("No title here");
     });
 
     it("throws error for missing feed element", () => {

--- a/tests/unit/feed-parser-json.test.ts
+++ b/tests/unit/feed-parser-json.test.ts
@@ -175,23 +175,25 @@ describe("parseJsonFeed", () => {
       expect(feed.items[0].pubDate).toBeUndefined();
     });
 
-    it("throws error for feed without title", () => {
+    it("returns undefined title for feed without title", () => {
       const json = JSON.stringify({
         version: "https://jsonfeed.org/version/1.1",
         items: [],
       });
 
-      expect(() => parseJsonFeed(json)).toThrow("Invalid JSON Feed: missing title");
+      const feed = parseJsonFeed(json);
+      expect(feed.title).toBeUndefined();
     });
 
-    it("throws error for feed with empty title", () => {
+    it("returns undefined title for feed with empty title", () => {
       const json = JSON.stringify({
         version: "https://jsonfeed.org/version/1.1",
         title: "   ",
         items: [],
       });
 
-      expect(() => parseJsonFeed(json)).toThrow("Invalid JSON Feed: missing title");
+      const feed = parseJsonFeed(json);
+      expect(feed.title).toBeUndefined();
     });
 
     it("throws error for missing version", () => {

--- a/tests/unit/feed-parser-rss.test.ts
+++ b/tests/unit/feed-parser-rss.test.ts
@@ -116,7 +116,7 @@ describe("parseRssFeed", () => {
       expect(feed.items[0].pubDate).toBeUndefined();
     });
 
-    it("throws error for feed without title", () => {
+    it("returns undefined title for feed without title", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <rss version="2.0">
           <channel>
@@ -124,7 +124,9 @@ describe("parseRssFeed", () => {
           </channel>
         </rss>`;
 
-      expect(() => parseRssFeed(xml)).toThrow("Invalid RSS feed: missing title");
+      const feed = parseRssFeed(xml);
+      expect(feed.title).toBeUndefined();
+      expect(feed.description).toBe("No title here");
     });
 
     it("throws error for feed without channel", () => {


### PR DESCRIPTION
Some feeds (like danluu.com/atom.xml) have empty titles which previously caused sync to fail with "Invalid feed: missing title". Now:

- Feed parsers no longer throw errors for missing titles
- ParsedFeed.title is now optional (string | undefined)
- When creating/updating feeds, fall back to domain name from feed URL
- Feed preview also uses domain fallback to always show a title

This allows feeds with missing titles to be synced successfully while still providing a reasonable display name for users.