### PR TITLE
Fix retry button query error on broken feed

### DIFF
--- a/src/server/trpc/routers/brokenFeeds.ts
+++ b/src/server/trpc/routers/brokenFeeds.ts
@@ -168,7 +168,9 @@ export const brokenFeedsRouter = createTRPCRouter({
           enabled: true,
           updatedAt: now,
         })
-        .where(sql`${jobs.payload}->>'feedId' = ${input.feedId} AND ${jobs.type} = 'fetch_feed'`);
+        .where(
+          sql`${jobs.payload}::json->>'feedId' = ${input.feedId} AND ${jobs.type} = 'fetch_feed'`
+        );
 
       return { success: true };
     }),


### PR DESCRIPTION
The payload column is stored as text, not jsonb. The ->>' operator requires a JSON type, so we need to cast with ::json before extracting the feedId field. Other queries in jobs/queue.ts already do this correctly.