### PR TITLE
Remove content cleaning for RSS feeds

### DIFF
--- a/src/server/feed/entry-processor.ts
+++ b/src/server/feed/entry-processor.ts
@@ -14,12 +14,7 @@ import { entries, subscriptions, userEntries, type Entry, type NewEntry } from "
 import { generateUuidv7 } from "../../lib/uuidv7";
 import { publishNewEntry, publishEntryUpdated } from "../redis/pubsub";
 import type { ParsedEntry, ParsedFeed } from "./types";
-import {
-  cleanContent,
-  generateCleanedSummary,
-  absolutizeUrls,
-  type CleanedContent,
-} from "./content-cleaner";
+import { absolutizeUrls } from "./content-cleaner";
 import { logger } from "@/lib/logger";
 
 /**
@@ -136,40 +131,47 @@ function stripHtml(html: string): string {
 
 /**
  * Generates a summary from entry content.
+ *
+ * Prefers the feed-provided summary (from <description> or <summary> elements)
+ * when available, as that's what the publisher intended as the excerpt.
+ * Falls back to generating from full content if no summary is provided.
+ *
  * Strips HTML and truncates to 300 characters.
  *
  * @param entry - The parsed entry
  * @returns Summary string
  */
 export function generateSummary(entry: ParsedEntry): string {
-  const content = entry.content ?? entry.summary ?? "";
-  const stripped = stripHtml(content);
+  // Prefer explicit summary from feed, fall back to content
+  const source = entry.summary ?? entry.content ?? "";
+  const stripped = stripHtml(source);
   return truncate(stripped, 300);
 }
 
 /**
- * Content cleaning result for an entry.
+ * Content processing result for an entry.
  */
-interface EntryCleaningResult {
-  /** The original content (unchanged) */
+interface EntryContentResult {
+  /** The original content with absolutized URLs */
   contentOriginal: string | null;
-  /** The cleaned content (Readability output) or null if cleaning failed */
-  contentCleaned: string | null;
-  /** The summary generated from cleaned content or original */
+  /** Always null for feed entries (cleaning is only for saved articles) */
+  contentCleaned: null;
+  /** The summary generated from original content */
   summary: string;
 }
 
 /**
- * Cleans entry content using Readability and generates a summary.
+ * Processes entry content: absolutizes URLs and generates a summary.
+ *
+ * Note: We don't run Readability on feed entries because RSS/Atom/JSON feeds
+ * already provide clean content. Readability is only used for saved articles
+ * where we're extracting content from full web pages.
  *
  * @param parsedEntry - The parsed entry from the feed
- * @param entryUrl - The URL of the entry (used as base URL for Readability)
- * @returns Cleaning result with original, cleaned content, and summary
+ * @param entryUrl - The URL of the entry (used as base URL for absolutizing)
+ * @returns Content result with original content and summary
  */
-export function cleanEntryContent(
-  parsedEntry: ParsedEntry,
-  entryUrl?: string
-): EntryCleaningResult {
+export function cleanEntryContent(parsedEntry: ParsedEntry, entryUrl?: string): EntryContentResult {
   const originalContent = parsedEntry.content ?? parsedEntry.summary ?? null;
 
   // If no content, return early
@@ -181,37 +183,17 @@ export function cleanEntryContent(
     };
   }
 
-  // Attempt to clean the content with Readability
-  let cleaned: CleanedContent | null = null;
-
-  try {
-    cleaned = cleanContent(originalContent, { url: entryUrl });
-  } catch (error) {
-    // Log but don't fail - we'll use the original content
-    logger.warn("Content cleaning failed", {
-      url: entryUrl,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-
-  // Generate summary from cleaned content if available, otherwise from original
-  let summary: string;
-  if (cleaned) {
-    summary = generateCleanedSummary(cleaned, 300);
-  } else {
-    // Fall back to simple HTML stripping for summary
-    summary = truncate(stripHtml(originalContent), 300);
-  }
-
   // Absolutize relative URLs in original content if we have a base URL
-  // (cleaned content is already absolutized in cleanContent)
   const absolutizedOriginal = entryUrl
     ? absolutizeUrls(originalContent, entryUrl)
     : originalContent;
 
+  // Generate summary by stripping HTML and truncating
+  const summary = generateSummary(parsedEntry);
+
   return {
     contentOriginal: absolutizedOriginal,
-    contentCleaned: cleaned?.content ?? null,
+    contentCleaned: null,
     summary,
   };
 }

--- a/tests/integration/entry-processor.test.ts
+++ b/tests/integration/entry-processor.test.ts
@@ -280,7 +280,8 @@ describe("Entry Processor", () => {
       expect(entry.title).toBe("Article Title");
       expect(entry.author).toBe("John Doe");
       expect(entry.contentOriginal).toBe("<p>Article content here.</p>");
-      expect(entry.summary).toBe("Article content here.");
+      // Summary prefers feed-provided summary over generating from content
+      expect(entry.summary).toBe("Article summary.");
       expect(entry.publishedAt?.toISOString()).toBe(pubDate.toISOString());
       expect(entry.fetchedAt.toISOString()).toBe(fetchedAt.toISOString());
       expect(entry.contentHash).toBe(contentHash);


### PR DESCRIPTION
RSS/Atom/JSON feeds already provide clean content, so running Readability on them is redundant overhead. The cleaning is only valuable for saved articles where we're extracting content from full web pages.

Changes:
- Skip Readability processing for feed entries, store null for contentCleaned
- Prefer feed-provided summary over generating from content
- Keep URL absolutization for relative links in feed content