### PR TITLE
Optimize feed subscription API calls

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -69,9 +69,14 @@ export function Sidebar({ onClose }: SidebarProps) {
       }
       toast.error("Failed to unsubscribe from feed");
     },
-    onSettled: () => {
-      // Invalidate related caches that need fresh server data
-      utils.subscriptions.list.invalidate();
+    onSettled: (_data, error) => {
+      // Only invalidate on error since optimistic update handles the success case
+      // The SSE handler will also skip invalidation since the subscription is already removed
+      if (error) {
+        utils.subscriptions.list.invalidate();
+      }
+      // Invalidate entries and tags to update counts (entries from unsubscribed feed
+      // are filtered out by the query, tags need updated unread counts)
       utils.entries.list.invalidate();
       utils.tags.list.invalidate();
     },


### PR DESCRIPTION
When subscribing to a new feed, the app was triggering multiple redundant API fetches because:

1. The subscribe mutation called invalidate() on subscriptions.list, which triggered a refetch
2. The SSE handler for subscription_created also invalidated subscriptions.list AND entries.list (blanket invalidation)
3. The unsubscribe mutation's onSettled always invalidated subscriptions.list even though optimistic updates already handled the success case

This change:
- Uses setQueryData to add new subscriptions directly to the cache instead of invalidating and refetching
- Makes SSE handlers smart enough to skip invalidation if the mutation already updated the cache (for same-tab operations)
- Only invalidates subscriptions.list on unsubscribe error (optimistic update handles success)

Cross-tab sync still works because SSE events from other tabs will trigger invalidations when the subscription isn't already in the local cache.