### PR TITLE
Review and optimize similar code patterns

### DIFF
--- a/src/app/(app)/settings/email/page.tsx
+++ b/src/app/(app)/settings/email/page.tsx
@@ -433,8 +433,11 @@ function SpamPreferenceSection() {
     onSuccess: () => {
       toast.success("Preference updated");
     },
-    onSettled: () => {
-      utils.users["me.preferences"].invalidate();
+    onSettled: (_data, error) => {
+      // Only invalidate on error since optimistic update handles the success case
+      if (error) {
+        utils.users["me.preferences"].invalidate();
+      }
     },
   });
 


### PR DESCRIPTION
The SpamPreferenceSection had optimistic updates but still called invalidate() in onSettled unconditionally. This caused a redundant API fetch after every toggle, even when the optimistic update already had the correct state.

Now only invalidates on error, matching the pattern established in 648a0ef for subscription mutations.