### PR TITLE
Update Android app to use new sync API

### DIFF
--- a/android/app/src/main/java/com/lionreader/data/api/LionReaderApi.kt
+++ b/android/app/src/main/java/com/lionreader/data/api/LionReaderApi.kt
@@ -16,6 +16,7 @@ import com.lionreader.data.api.models.SavedArticleResponse
 import com.lionreader.data.api.models.SortOrder
 import com.lionreader.data.api.models.StarredCountResponse
 import com.lionreader.data.api.models.SubscriptionsResponse
+import com.lionreader.data.api.models.SyncChangesResponse
 import com.lionreader.data.api.models.TagsResponse
 import com.lionreader.data.api.models.UserResponse
 import javax.inject.Inject
@@ -225,6 +226,22 @@ interface LionReaderApi {
      * @return NarrationAiAvailableResponse indicating availability
      */
     suspend fun isAiTextProcessingAvailable(): ApiResult<NarrationAiAvailableResponse>
+
+    // ============================================================================
+    // SYNC ENDPOINTS
+    // ============================================================================
+
+    /**
+     * Get changes since a given timestamp for incremental sync.
+     *
+     * Returns all entries, subscriptions, and tags that have changed since
+     * the provided timestamp. If no timestamp is provided, returns a limited
+     * set of recent data for initial sync.
+     *
+     * @param since ISO 8601 timestamp to get changes since (optional for initial sync)
+     * @return SyncChangesResponse with entries, subscriptions, tags, and next syncedAt
+     */
+    suspend fun syncChanges(since: String? = null): ApiResult<SyncChangesResponse>
 }
 
 /**
@@ -359,4 +376,13 @@ class LionReaderApiImpl
 
         override suspend fun isAiTextProcessingAvailable(): ApiResult<NarrationAiAvailableResponse> =
             apiClient.get(path = "narration/ai-available")
+
+        // ============================================================================
+        // SYNC ENDPOINTS
+        // ============================================================================
+
+        override suspend fun syncChanges(since: String?): ApiResult<SyncChangesResponse> =
+            apiClient.get(path = "sync") {
+                queryParam("since", since)
+            }
     }

--- a/android/app/src/main/java/com/lionreader/data/api/models/SyncModels.kt
+++ b/android/app/src/main/java/com/lionreader/data/api/models/SyncModels.kt
@@ -1,0 +1,130 @@
+package com.lionreader.data.api.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Type of feed for sync responses.
+ *
+ * The sync API uses a simplified type enum compared to EntryType.
+ */
+@Serializable
+enum class SyncFeedType {
+    @SerialName("web")
+    WEB,
+
+    @SerialName("email")
+    EMAIL,
+
+    @SerialName("saved")
+    SAVED,
+}
+
+/**
+ * Entry data from the sync API (lightweight, no content).
+ */
+@Serializable
+data class SyncEntryDto(
+    val id: String,
+    @SerialName("feedId")
+    val feedId: String,
+    val type: SyncFeedType,
+    val url: String? = null,
+    val title: String? = null,
+    val author: String? = null,
+    val summary: String? = null,
+    @SerialName("publishedAt")
+    val publishedAt: String? = null, // ISO 8601
+    @SerialName("fetchedAt")
+    val fetchedAt: String,
+    val read: Boolean = false,
+    val starred: Boolean = false,
+    @SerialName("feedTitle")
+    val feedTitle: String? = null,
+    @SerialName("siteName")
+    val siteName: String? = null,
+)
+
+/**
+ * Entry state update from the sync API (read/starred changes only).
+ */
+@Serializable
+data class SyncEntryStateDto(
+    val id: String,
+    val read: Boolean,
+    val starred: Boolean,
+)
+
+/**
+ * Subscription data from the sync API.
+ */
+@Serializable
+data class SyncSubscriptionDto(
+    val id: String,
+    @SerialName("feedId")
+    val feedId: String,
+    @SerialName("feedTitle")
+    val feedTitle: String? = null,
+    @SerialName("feedUrl")
+    val feedUrl: String? = null,
+    @SerialName("feedType")
+    val feedType: SyncFeedType,
+    @SerialName("customTitle")
+    val customTitle: String? = null,
+    @SerialName("subscribedAt")
+    val subscribedAt: String, // ISO 8601
+)
+
+/**
+ * Tag data from the sync API.
+ */
+@Serializable
+data class SyncTagDto(
+    val id: String,
+    val name: String,
+    val color: String? = null,
+)
+
+/**
+ * Changes to entries from the sync API.
+ */
+@Serializable
+data class SyncEntriesChanges(
+    val created: List<SyncEntryDto>,
+    val updated: List<SyncEntryStateDto>,
+    val removed: List<String>,
+)
+
+/**
+ * Changes to subscriptions from the sync API.
+ */
+@Serializable
+data class SyncSubscriptionsChanges(
+    val created: List<SyncSubscriptionDto>,
+    val removed: List<String>,
+)
+
+/**
+ * Changes to tags from the sync API.
+ */
+@Serializable
+data class SyncTagsChanges(
+    val created: List<SyncTagDto>,
+    val removed: List<String>,
+)
+
+/**
+ * Response from the sync.changes endpoint.
+ *
+ * Returns all changes since a given timestamp (or recent data for initial sync).
+ */
+@Serializable
+data class SyncChangesResponse(
+    val entries: SyncEntriesChanges,
+    val subscriptions: SyncSubscriptionsChanges,
+    val tags: SyncTagsChanges,
+    @SerialName("syncedAt")
+    val syncedAt: String, // ISO 8601 - use as next 'since' value
+    @SerialName("hasMore")
+    val hasMore: Boolean,
+)

--- a/android/app/src/main/java/com/lionreader/data/db/dao/EntryDao.kt
+++ b/android/app/src/main/java/com/lionreader/data/db/dao/EntryDao.kt
@@ -178,4 +178,14 @@ interface EntryDao {
         starredOnly: Boolean,
         sortOrder: String,
     ): List<String>
+
+    /**
+     * Deletes entries by a list of IDs.
+     *
+     * Used during incremental sync to remove entries from unsubscribed feeds.
+     *
+     * @param ids The entry IDs to delete
+     */
+    @Query("DELETE FROM entries WHERE id IN (:ids)")
+    suspend fun deleteByIds(ids: List<String>)
 }

--- a/android/app/src/main/java/com/lionreader/data/db/dao/EntryStateDao.kt
+++ b/android/app/src/main/java/com/lionreader/data/db/dao/EntryStateDao.kt
@@ -120,4 +120,38 @@ interface EntryStateDao {
      */
     @Query("SELECT COUNT(*) FROM entry_states WHERE pendingSync = 1")
     suspend fun getPendingSyncCount(): Int
+
+    /**
+     * Updates the read and starred status for an entry without setting pendingSync.
+     *
+     * Used when applying server-side state changes during sync.
+     *
+     * @param entryId The entry ID
+     * @param read The new read status
+     * @param starred The new starred status
+     * @param modifiedAt Timestamp of this modification
+     */
+    @Query(
+        """
+        UPDATE entry_states
+        SET read = :read, starred = :starred, lastModifiedAt = :modifiedAt
+        WHERE entryId = :entryId
+        """,
+    )
+    suspend fun updateReadStarred(
+        entryId: String,
+        read: Boolean,
+        starred: Boolean,
+        modifiedAt: Long,
+    )
+
+    /**
+     * Deletes states for a list of entry IDs.
+     *
+     * Used when removing entries during sync.
+     *
+     * @param entryIds The entry IDs to delete states for
+     */
+    @Query("DELETE FROM entry_states WHERE entryId IN (:entryIds)")
+    suspend fun deleteByEntryIds(entryIds: List<String>)
 }

--- a/android/app/src/main/java/com/lionreader/data/db/dao/SubscriptionDao.kt
+++ b/android/app/src/main/java/com/lionreader/data/db/dao/SubscriptionDao.kt
@@ -187,4 +187,14 @@ interface SubscriptionDao {
         """,
     )
     fun getUncategorizedWithFeeds(): Flow<List<SubscriptionWithFeed>>
+
+    /**
+     * Deletes subscriptions by a list of IDs.
+     *
+     * Used during incremental sync to remove unsubscribed feeds.
+     *
+     * @param ids The subscription IDs to delete
+     */
+    @Query("DELETE FROM subscriptions WHERE id IN (:ids)")
+    suspend fun deleteByIds(ids: List<String>)
 }

--- a/android/app/src/main/java/com/lionreader/data/db/dao/TagDao.kt
+++ b/android/app/src/main/java/com/lionreader/data/db/dao/TagDao.kt
@@ -106,4 +106,14 @@ interface TagDao {
      */
     @Query("DELETE FROM subscription_tags WHERE subscriptionId = :subscriptionId")
     suspend fun deleteTagsForSubscription(subscriptionId: String)
+
+    /**
+     * Deletes tags by a list of IDs.
+     *
+     * Used during incremental sync to remove deleted tags.
+     *
+     * @param ids The tag IDs to delete
+     */
+    @Query("DELETE FROM tags WHERE id IN (:ids)")
+    suspend fun deleteByIds(ids: List<String>)
 }

--- a/android/app/src/main/java/com/lionreader/data/sync/SyncPreferences.kt
+++ b/android/app/src/main/java/com/lionreader/data/sync/SyncPreferences.kt
@@ -1,0 +1,62 @@
+package com.lionreader.data.sync
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Storage for sync-related preferences.
+ *
+ * Stores the last sync timestamp used for incremental sync operations.
+ */
+@Singleton
+class SyncPreferences
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) {
+        private val prefs: SharedPreferences by lazy {
+            context.getSharedPreferences(PREFS_FILE_NAME, Context.MODE_PRIVATE)
+        }
+
+        /**
+         * Gets the last sync timestamp.
+         *
+         * @return ISO 8601 timestamp of the last successful sync, or null for initial sync
+         */
+        fun getLastSyncedAt(): String? = prefs.getString(KEY_LAST_SYNCED_AT, null)
+
+        /**
+         * Saves the last sync timestamp.
+         *
+         * @param syncedAt ISO 8601 timestamp from the server's sync response
+         */
+        fun setLastSyncedAt(syncedAt: String) {
+            prefs.edit().putString(KEY_LAST_SYNCED_AT, syncedAt).apply()
+        }
+
+        /**
+         * Clears the last sync timestamp.
+         *
+         * This forces a full sync on the next sync operation.
+         */
+        fun clearLastSyncedAt() {
+            prefs.edit().remove(KEY_LAST_SYNCED_AT).apply()
+        }
+
+        /**
+         * Clears all sync preferences.
+         *
+         * Called when logging out to reset sync state.
+         */
+        fun clear() {
+            prefs.edit().clear().apply()
+        }
+
+        companion object {
+            private const val PREFS_FILE_NAME = "lion_reader_sync"
+            private const val KEY_LAST_SYNCED_AT = "last_synced_at"
+        }
+    }

--- a/android/app/src/main/java/com/lionreader/di/RepositoryModule.kt
+++ b/android/app/src/main/java/com/lionreader/di/RepositoryModule.kt
@@ -14,6 +14,7 @@ import com.lionreader.data.repository.SyncRepository
 import com.lionreader.data.repository.TagRepository
 import com.lionreader.data.sync.ConnectivityMonitor
 import com.lionreader.data.sync.SyncErrorNotifier
+import com.lionreader.data.sync.SyncPreferences
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -91,6 +92,7 @@ object RepositoryModule {
         tagDao: TagDao,
         connectivityMonitor: ConnectivityMonitor,
         syncRepository: SyncRepository,
+        syncPreferences: SyncPreferences,
     ): EntryRepository =
         EntryRepository(
             api,
@@ -101,6 +103,7 @@ object RepositoryModule {
             tagDao,
             connectivityMonitor,
             syncRepository,
+            syncPreferences,
         )
 
     /**

--- a/android/app/src/test/java/com/lionreader/data/api/ApiContractTest.kt
+++ b/android/app/src/test/java/com/lionreader/data/api/ApiContractTest.kt
@@ -64,6 +64,8 @@ class ApiContractTest {
             // Narration endpoints
             PathWithMethod("POST", "narration/generate"),
             PathWithMethod("GET", "narration/ai-available"),
+            // Sync endpoints
+            PathWithMethod("GET", "sync"),
         )
 
     @BeforeAll


### PR DESCRIPTION
Instead of refetching all data on every sync, the Android app now uses a hybrid approach:

- Initial sync: Full fetch of subscriptions, tags, and all entries using paginated list endpoints to get complete data
- Subsequent syncs: Uses the new sync.changes endpoint for efficient incremental updates (created/updated/removed entries)

Key changes:
- Add SyncModels.kt with Kotlin models for the sync.changes response
- Add syncChanges() to LionReaderApi interface and implementation
- Add SyncPreferences to store last sync timestamp
- Update EntryRepository.syncFromServer() to use hybrid sync approach
- Add deleteByIds() methods to DAOs for handling removals
- Add sync endpoint to ApiContractTest for contract validation