### PR TITLE
Ensure husky setup runs automatically

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm install --frozen-lockfile 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This ensures pnpm install runs when Claude Code starts a session, which triggers the prepare script and sets up husky git hooks.