### PR TITLE
Run worker as separate process in dev using concurrently

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -32,8 +32,6 @@ primary_region = "lax"
 
   FETCHER_CONTACT_EMAIL = "self@brendanlong.com"
 
-  # Disable embedded worker since we run a separate niced process
-  DISABLE_EMBEDDED_WORKER = "true"
   WORKER_CONCURRENCY = "1"
 
   # Object storage

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,8 +1,10 @@
 /**
  * Next.js Instrumentation
  *
- * This file is used to initialize server-side instrumentation like Sentry
- * and the background job worker. It runs before any server-side code in Next.js.
+ * This file is used to initialize server-side instrumentation like Sentry.
+ * It runs before any server-side code in Next.js.
+ *
+ * The background job worker runs as a separate process (see scripts/worker.ts).
  *
  * https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
  */
@@ -14,29 +16,7 @@ export async function register() {
 
     const { logger } = await import("./src/lib/logger");
 
-    // Start the background worker for feed fetching
-    // Only start in non-test environments and when not using a separate worker process
-    const useEmbeddedWorker = process.env.DISABLE_EMBEDDED_WORKER !== "true";
-    let worker: Awaited<ReturnType<typeof import("./src/server/jobs/worker").createWorker>> | null =
-      null;
-
-    if (process.env.NODE_ENV !== "test" && useEmbeddedWorker) {
-      const { createWorker } = await import("./src/server/jobs/worker");
-
-      worker = createWorker({
-        pollIntervalMs: 5000, // Poll every 5 seconds
-        concurrency: 3, // Process up to 3 jobs concurrently
-      });
-
-      // Start the worker
-      worker.start().catch((error) => {
-        logger.error("Failed to start background worker", { error });
-      });
-
-      logger.info("Background worker initialized");
-    }
-
-    // Handle graceful shutdown - always register to close DB/Redis connections
+    // Handle graceful shutdown to close DB/Redis connections
     let shuttingDown = false;
     const shutdown = async () => {
       if (shuttingDown) return; // Prevent duplicate shutdown attempts
@@ -44,11 +24,6 @@ export async function register() {
       logger.info("Shutting down Next.js server...");
 
       try {
-        // Stop worker if running
-        if (worker) {
-          await worker.stop();
-        }
-
         // Close Redis connection
         const { redis } = await import("./src/server/redis");
         await redis.quit();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "postinstall": "node scripts/copy-onnx-wasm.mjs",
-    "dev": "next dev --turbopack",
+    "dev": "concurrently --kill-others --names worker,next \"pnpm dev:worker\" \"pnpm dev:next\"",
+    "dev:next": "next dev --turbopack",
+    "dev:worker": "tsx --watch scripts/worker.ts",
     "build": "next build",
     "build:worker": "node scripts/build-worker.mjs",
     "build:migrate": "node scripts/build-migrate.mjs",

--- a/scripts/start-all.sh
+++ b/scripts/start-all.sh
@@ -5,9 +5,6 @@
 
 set -e
 
-# Disable embedded worker since we're running a separate worker process
-export DISABLE_EMBEDDED_WORKER=true
-
 # Use concurrently to manage both processes
 # --kill-others: kill all processes if one exits
 # --kill-others-on-fail: kill all processes if one exits with non-zero


### PR DESCRIPTION
- Add dev:worker script using tsx --watch for hot reloading
- Update pnpm dev to run worker and Next.js in parallel with concurrently
- Remove embedded worker from instrumentation.ts
- Clean up now-unused DISABLE_EMBEDDED_WORKER env var

This makes dev environment match production more closely (worker runs as a separate process) and provides automatic worker restarts when code changes, similar to how Next.js handles the API server.