### PR TITLE
Switch to canary deploy strategy

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -17,8 +17,8 @@ primary_region = "lax"
 [deploy]
   # Run migrations before starting the new app version
   release_command = "node dist/migrate.js"
-  # Rolling deployment: update one machine at a time for zero-downtime deploys
-  strategy = "rolling"
+  # Canary deployment: deploy one Machine first, verify health, then rolling
+  strategy = "canary"
 
 # Single process runs both API and worker (worker is niced for lower CPU priority)
 [processes]


### PR DESCRIPTION
Canary deploys one machine first and verifies its health before continuing with rolling deployment, making it safer to catch issues early before affecting all machines.