### PR TITLE
Audit tests for duplicated logic instead of assertions

### DIFF
--- a/src/lib/narration/html-preprocessing.ts
+++ b/src/lib/narration/html-preprocessing.ts
@@ -28,6 +28,7 @@ export const BLOCK_ELEMENTS = [
   "li",
   "figure",
   "table",
+  "img",
 ] as const;
 
 /**
@@ -44,7 +45,7 @@ export interface PreprocessResult {
  * Preprocesses HTML content for narration by assigning stable IDs to block-level elements.
  *
  * This function parses the HTML, finds all block-level elements (p, h1-h6, blockquote,
- * pre, ul, ol, li, figure, table), and assigns each a unique `data-para-id` attribute
+ * pre, ul, ol, li, figure, table, img), and assigns each a unique `data-para-id` attribute
  * in document order.
  *
  * @param html - The HTML content to preprocess

--- a/tests/unit/client-paragraph-ids.test.ts
+++ b/tests/unit/client-paragraph-ids.test.ts
@@ -12,6 +12,7 @@ import {
   htmlToClientNarration,
   BLOCK_ELEMENTS,
 } from "../../src/lib/narration/client-paragraph-ids";
+import { BLOCK_ELEMENTS as SERVER_BLOCK_ELEMENTS } from "../../src/lib/narration/html-preprocessing";
 
 describe("addParagraphIdsToHtml", () => {
   describe("basic paragraphs", () => {
@@ -372,26 +373,8 @@ console.log(result);</code></pre>
   describe("consistency with server-side processing", () => {
     it("uses the same block elements as server-side", () => {
       // This test ensures client-side processing matches server-side
-      const expectedElements = [
-        "p",
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "h6",
-        "blockquote",
-        "pre",
-        "ul",
-        "ol",
-        "li",
-        "figure",
-        "table",
-        "img",
-      ];
-
-      expect(BLOCK_ELEMENTS).toEqual(expectedElements);
-      expect(BLOCK_ELEMENTS.length).toBe(15);
+      // by importing and comparing against the actual server definition
+      expect(BLOCK_ELEMENTS).toEqual(SERVER_BLOCK_ELEMENTS);
     });
 
     it("produces same ID format as server-side (para-N)", () => {
@@ -498,29 +481,6 @@ describe("createMemoizedAddParagraphIds", () => {
     // Both should still be cached
     expect(memoized(html1)).toBe(result1);
     expect(memoized(html2)).toBe(result2);
-  });
-});
-
-describe("BLOCK_ELEMENTS constant", () => {
-  it("contains expected elements", () => {
-    expect(BLOCK_ELEMENTS).toContain("p");
-    expect(BLOCK_ELEMENTS).toContain("h1");
-    expect(BLOCK_ELEMENTS).toContain("h2");
-    expect(BLOCK_ELEMENTS).toContain("h3");
-    expect(BLOCK_ELEMENTS).toContain("h4");
-    expect(BLOCK_ELEMENTS).toContain("h5");
-    expect(BLOCK_ELEMENTS).toContain("h6");
-    expect(BLOCK_ELEMENTS).toContain("blockquote");
-    expect(BLOCK_ELEMENTS).toContain("pre");
-    expect(BLOCK_ELEMENTS).toContain("ul");
-    expect(BLOCK_ELEMENTS).toContain("ol");
-    expect(BLOCK_ELEMENTS).toContain("li");
-    expect(BLOCK_ELEMENTS).toContain("figure");
-    expect(BLOCK_ELEMENTS).toContain("table");
-  });
-
-  it("has exactly 15 elements", () => {
-    expect(BLOCK_ELEMENTS.length).toBe(15);
   });
 });
 

--- a/tests/unit/html-preprocessing.test.ts
+++ b/tests/unit/html-preprocessing.test.ts
@@ -87,7 +87,7 @@ describe("preprocessHtmlForNarration", () => {
       expect(result.markedHtml).toContain("<blockquote data-para-id");
     });
 
-    it("marks figure and table elements", () => {
+    it("marks figure, img, and table elements", () => {
       const html = `
         <p>Before image</p>
         <figure><img src="test.jpg" alt="Test"><figcaption>Caption</figcaption></figure>
@@ -96,8 +96,10 @@ describe("preprocessHtmlForNarration", () => {
       `;
       const result = preprocessHtmlForNarration(html);
 
-      expect(result.paragraphElements).toEqual(["para-0", "para-1", "para-2", "para-3"]);
+      // p, figure, img (inside figure), table, p = 5 elements
+      expect(result.paragraphElements).toEqual(["para-0", "para-1", "para-2", "para-3", "para-4"]);
       expect(result.markedHtml).toContain("<figure data-para-id");
+      expect(result.markedHtml).toContain("<img src");
       expect(result.markedHtml).toContain("<table data-para-id");
     });
 
@@ -277,7 +279,8 @@ describe("preprocessHtmlForNarration", () => {
       `;
       const result = preprocessHtmlForNarration(html);
 
-      expect(result.paragraphElements).toEqual(["para-0", "para-1", "para-2"]);
+      // p, figure, img (inside figure), p = 4 elements
+      expect(result.paragraphElements).toEqual(["para-0", "para-1", "para-2", "para-3"]);
     });
 
     it("handles HTML entities", () => {
@@ -406,31 +409,7 @@ describe("isBlockElement", () => {
     expect(isBlockElement("div")).toBe(false);
     expect(isBlockElement("span")).toBe(false);
     expect(isBlockElement("a")).toBe(false);
-    expect(isBlockElement("img")).toBe(false);
     expect(isBlockElement("section")).toBe(false);
     expect(isBlockElement("article")).toBe(false);
-  });
-});
-
-describe("BLOCK_ELEMENTS constant", () => {
-  it("contains expected elements", () => {
-    expect(BLOCK_ELEMENTS).toContain("p");
-    expect(BLOCK_ELEMENTS).toContain("h1");
-    expect(BLOCK_ELEMENTS).toContain("h2");
-    expect(BLOCK_ELEMENTS).toContain("h3");
-    expect(BLOCK_ELEMENTS).toContain("h4");
-    expect(BLOCK_ELEMENTS).toContain("h5");
-    expect(BLOCK_ELEMENTS).toContain("h6");
-    expect(BLOCK_ELEMENTS).toContain("blockquote");
-    expect(BLOCK_ELEMENTS).toContain("pre");
-    expect(BLOCK_ELEMENTS).toContain("ul");
-    expect(BLOCK_ELEMENTS).toContain("ol");
-    expect(BLOCK_ELEMENTS).toContain("li");
-    expect(BLOCK_ELEMENTS).toContain("figure");
-    expect(BLOCK_ELEMENTS).toContain("table");
-  });
-
-  it("has exactly 14 elements", () => {
-    expect(BLOCK_ELEMENTS.length).toBe(14);
   });
 });


### PR DESCRIPTION
- Add `img` to server-side BLOCK_ELEMENTS to match client-side
- Fix consistency test to actually import from server module instead of hardcoding expected values (would now catch server/client drift)
- Replace tautological exponential backoff test that duplicated the implementation formula with hardcoded known-good values
- Remove trivial constant tests that just verified definitions match themselves (e.g., testing that 60*60 equals 60*60)