### PR TITLE
Fix saved articles sorting to use fetched time instead of published time

### DIFF
--- a/drizzle/0032_clear_saved_articles_published_at.sql
+++ b/drizzle/0032_clear_saved_articles_published_at.sql
@@ -1,0 +1,7 @@
+-- Clear published_at for saved articles so they sort by fetched_at (save time)
+-- Saved articles should use fetchedAt for sorting, not the original article's publish date
+-- COALESCE(published_at, fetched_at) will now return fetched_at for all saved articles
+
+UPDATE entries
+SET published_at = NULL, updated_at = NOW()
+WHERE type = 'saved' AND published_at IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1767390000000,
       "tag": "0031_feed_redirect_tracking",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1767400000000,
+      "tag": "0032_clear_saved_articles_published_at",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -363,13 +363,9 @@ export const entriesRouter = createTRPCRouter({
         conditions.push(eq(entries.isSpam, false));
       }
 
-      // For saved articles, sort by fetchedAt (when saved) since that's what users care about
-      // For feed entries, sort by publishedAt (when published), falling back to fetchedAt if null
+      // Sort by publishedAt, falling back to fetchedAt if null
       // Use entry.id as tiebreaker for stable ordering
-      const sortColumn =
-        input.type === "saved"
-          ? entries.fetchedAt
-          : sql`COALESCE(${entries.publishedAt}, ${entries.fetchedAt})`;
+      const sortColumn = sql`COALESCE(${entries.publishedAt}, ${entries.fetchedAt})`;
 
       // Add cursor condition if present
       // Uses compound comparison: (sortColumn, id) for stable pagination
@@ -433,14 +429,10 @@ export const entriesRouter = createTRPCRouter({
       }));
 
       // Generate next cursor if there are more results
-      // Cursor timestamp must match the sort column used above
       let nextCursor: string | undefined;
       if (hasMore && resultEntries.length > 0) {
         const lastEntry = resultEntries[resultEntries.length - 1].entry;
-        const lastTs =
-          input.type === "saved"
-            ? lastEntry.fetchedAt
-            : (lastEntry.publishedAt ?? lastEntry.fetchedAt);
+        const lastTs = lastEntry.publishedAt ?? lastEntry.fetchedAt;
         nextCursor = encodeCursor(lastTs, lastEntry.id);
       }
 

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -554,9 +554,8 @@ export const savedRouter = createTRPCRouter({
         : lessWrongContent
           ? "LessWrong"
           : metadata.siteName;
-      // For publishedAt, prefer API data when available
-      const finalPublishedAt =
-        googleDocsContent?.modifiedAt || lessWrongContent?.publishedAt || now;
+      // Saved articles don't have a publishedAt - they use fetchedAt (when saved)
+      // This ensures consistent sorting by save time in all views
 
       // For Google Docs API content, use the HTML directly (already clean and structured)
       const finalContentCleaned = googleDocsContent?.html || cleaned?.content || null;
@@ -579,7 +578,7 @@ export const savedRouter = createTRPCRouter({
         summary: excerpt,
         siteName: finalSiteName,
         imageUrl: metadata.imageUrl,
-        publishedAt: finalPublishedAt,
+        publishedAt: null,
         fetchedAt: now, // When saved
         contentHash,
         // Email-specific fields are NULL for saved entries
@@ -616,7 +615,7 @@ export const savedRouter = createTRPCRouter({
           excerpt,
           read: false,
           starred: false,
-          savedAt: finalPublishedAt,
+          savedAt: now,
         },
       };
     }),


### PR DESCRIPTION
Saved articles were being sorted by COALESCE(published_at, fetched_at) but displaying fetched_at in the UI, causing a confusing mismatch. For example, saving a LessWrong article from 2020 would sort it to the bottom of the list even though it was just saved, while the UI would show "just now".

Now saved articles (type='saved') sort by fetched_at, which matches what the UI displays and what users expect - articles sorted by when they were saved.

Feed entries continue to use COALESCE(published_at, fetched_at) since users want to see articles in publication order.