### PR TITLE
Add tag support for OPML imports and exports

### DIFF
--- a/src/server/feed/opml.ts
+++ b/src/server/feed/opml.ts
@@ -35,8 +35,10 @@ export interface OpmlSubscription {
   xmlUrl: string;
   /** URL to the feed's website */
   htmlUrl?: string;
-  /** Category/folder name (optional) */
+  /** Category/folder name (optional, single folder) */
   folder?: string;
+  /** Tags/folders the feed belongs to (optional, multiple tags) */
+  tags?: string[];
 }
 
 /**
@@ -233,7 +235,7 @@ export function parseOpml(xml: string): OpmlFeed[] {
 }
 
 /**
- * Groups subscriptions by folder.
+ * Groups subscriptions by folder (legacy single-folder support).
  */
 function groupByFolder(
   subscriptions: OpmlSubscription[]
@@ -247,6 +249,29 @@ function groupByFolder(
       existing.push(sub);
     } else {
       groups.set(folder, [sub]);
+    }
+  }
+
+  return groups;
+}
+
+/**
+ * Groups subscriptions by tags for multi-tag export.
+ * Returns a map where keys are tag names and values are subscriptions with that tag.
+ */
+function groupByTags(subscriptions: OpmlSubscription[]): Map<string, OpmlSubscription[]> {
+  const groups = new Map<string, OpmlSubscription[]>();
+
+  for (const sub of subscriptions) {
+    if (sub.tags && sub.tags.length > 0) {
+      for (const tag of sub.tags) {
+        const existing = groups.get(tag);
+        if (existing) {
+          existing.push(sub);
+        } else {
+          groups.set(tag, [sub]);
+        }
+      }
     }
   }
 
@@ -268,6 +293,14 @@ function escapeXml(text: string): string {
 /**
  * Generates OPML XML from a list of subscriptions.
  *
+ * When subscriptions have `tags`, the export format is:
+ * - All feeds listed at top level (no folder)
+ * - Feeds re-listed inside each tag folder they belong to
+ *
+ * When subscriptions use `folder` (legacy), the format is:
+ * - Feeds without folder at top level
+ * - Feeds with folder inside their respective folder
+ *
  * @param subscriptions - Array of subscriptions to export
  * @param metadata - Optional document metadata
  * @returns OPML XML string
@@ -275,7 +308,7 @@ function escapeXml(text: string): string {
  * @example
  * ```ts
  * const xml = generateOpml([
- *   { title: "Blog", xmlUrl: "https://blog.example.com/feed", folder: "Tech" },
+ *   { title: "Blog", xmlUrl: "https://blog.example.com/feed", tags: ["Tech", "Favorites"] },
  *   { title: "News", xmlUrl: "https://news.example.com/rss" }
  * ], { title: "My Subscriptions" });
  * ```
@@ -284,28 +317,53 @@ export function generateOpml(
   subscriptions: OpmlSubscription[],
   metadata: OpmlMetadata = {}
 ): string {
-  const grouped = groupByFolder(subscriptions);
   const dateCreated = new Date().toISOString();
+
+  // Check if any subscriptions use the new tags format
+  const hasTagsFormat = subscriptions.some((sub) => sub.tags !== undefined);
 
   // Build outline elements
   const outlines: string[] = [];
 
-  // First, add subscriptions without folders
-  const noFolder = grouped.get(undefined);
-  if (noFolder) {
-    for (const sub of noFolder) {
+  if (hasTagsFormat) {
+    // New format: all feeds at top level + re-listed in tag folders
+    // First, add ALL subscriptions at top level
+    for (const sub of subscriptions) {
       outlines.push(buildOutlineElement(sub));
     }
-  }
 
-  // Then, add folders with their subscriptions
-  for (const [folder, subs] of grouped) {
-    if (folder === undefined) continue;
-
-    const folderOutlines = subs.map((sub) => buildOutlineElement(sub)).join("\n        ");
-    outlines.push(`      <outline text="${escapeXml(folder)}">
+    // Then, add tag folders with their subscriptions
+    const tagGroups = groupByTags(subscriptions);
+    // Sort tag folders alphabetically for consistent output
+    const sortedTags = Array.from(tagGroups.keys()).sort();
+    for (const tag of sortedTags) {
+      const subs = tagGroups.get(tag)!;
+      const folderOutlines = subs.map((sub) => buildOutlineElement(sub)).join("\n        ");
+      outlines.push(`      <outline text="${escapeXml(tag)}">
         ${folderOutlines}
       </outline>`);
+    }
+  } else {
+    // Legacy format: group by single folder
+    const grouped = groupByFolder(subscriptions);
+
+    // First, add subscriptions without folders
+    const noFolder = grouped.get(undefined);
+    if (noFolder) {
+      for (const sub of noFolder) {
+        outlines.push(buildOutlineElement(sub));
+      }
+    }
+
+    // Then, add folders with their subscriptions
+    for (const [folder, subs] of grouped) {
+      if (folder === undefined) continue;
+
+      const folderOutlines = subs.map((sub) => buildOutlineElement(sub)).join("\n        ");
+      outlines.push(`      <outline text="${escapeXml(folder)}">
+        ${folderOutlines}
+      </outline>`);
+    }
   }
 
   const title = metadata.title || "Lion Reader Subscriptions";

--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -14,6 +14,8 @@ import {
   feeds,
   subscriptions,
   opmlImports,
+  tags,
+  subscriptionTags,
   type Feed,
   type OpmlImportFeedResult,
 } from "../db/schema";
@@ -827,6 +829,48 @@ export async function handleProcessOpmlImport(
 
     const existingUrls = new Set(existingSubscriptions.map((s) => s.feedUrl));
 
+    // Collect all unique tag names from categories in the import
+    const tagNames = new Set<string>();
+    for (const feed of importRecord.feedsData) {
+      if (feed.category) {
+        for (const categoryName of feed.category) {
+          tagNames.add(categoryName);
+        }
+      }
+    }
+
+    // Get or create tags for each unique category name
+    const tagNameToId = new Map<string, string>();
+    if (tagNames.size > 0) {
+      // Get existing tags for this user
+      const existingTags = await db
+        .select({ id: tags.id, name: tags.name })
+        .from(tags)
+        .where(eq(tags.userId, userId));
+
+      for (const existingTag of existingTags) {
+        if (tagNames.has(existingTag.name)) {
+          tagNameToId.set(existingTag.name, existingTag.id);
+        }
+      }
+
+      // Create tags that don't exist
+      const now = new Date();
+      for (const tagName of tagNames) {
+        if (!tagNameToId.has(tagName)) {
+          const tagId = generateUuidv7();
+          await db.insert(tags).values({
+            id: tagId,
+            userId,
+            name: tagName,
+            createdAt: now,
+          });
+          tagNameToId.set(tagName, tagId);
+          logger.debug("OPML import: created tag", { tagName, tagId, userId });
+        }
+      }
+    }
+
     // Process each feed
     const results: OpmlImportFeedResult[] = [];
     let imported = 0;
@@ -948,6 +992,36 @@ export async function handleProcessOpmlImport(
             createdAt: now,
             updatedAt: now,
           });
+        }
+
+        // Associate subscription with tags from categories
+        if (opmlFeed.category && opmlFeed.category.length > 0) {
+          const tagIds = opmlFeed.category
+            .map((categoryName) => tagNameToId.get(categoryName))
+            .filter((id): id is string => id !== undefined);
+
+          if (tagIds.length > 0) {
+            // Delete any existing subscription_tags (in case of reactivation)
+            await db
+              .delete(subscriptionTags)
+              .where(eq(subscriptionTags.subscriptionId, actualSubscriptionId));
+
+            // Insert new subscription_tags entries
+            const tagNow = new Date();
+            await db.insert(subscriptionTags).values(
+              tagIds.map((tagId) => ({
+                subscriptionId: actualSubscriptionId,
+                tagId,
+                createdAt: tagNow,
+              }))
+            );
+
+            logger.debug("OPML import: associated subscription with tags", {
+              subscriptionId: actualSubscriptionId,
+              tagIds,
+              feedUrl,
+            });
+          }
         }
 
         // Publish subscription_created event (fire and forget)

--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -1099,23 +1099,44 @@ export const subscriptionsRouter = createTRPCRouter({
         };
       }
 
-      // Step 2: Create import record
+      // Step 2: Deduplicate feeds by URL, merging categories
+      // This ensures a feed in 5 tags counts as 1 import, not 5
+      const feedsByUrl = new Map<string, OpmlImportFeedData>();
+      for (const feed of opmlFeeds) {
+        const existing = feedsByUrl.get(feed.xmlUrl);
+        if (existing) {
+          // Merge categories (use first level of category path as tag)
+          if (feed.category && feed.category.length > 0) {
+            const tagName = feed.category[0]; // Use first level as tag
+            if (!existing.category) {
+              existing.category = [tagName];
+            } else if (!existing.category.includes(tagName)) {
+              existing.category.push(tagName);
+            }
+          }
+          // Use title from first occurrence (don't overwrite)
+        } else {
+          feedsByUrl.set(feed.xmlUrl, {
+            xmlUrl: feed.xmlUrl,
+            title: feed.title,
+            htmlUrl: feed.htmlUrl,
+            // Use first level of category path as tag name
+            category: feed.category && feed.category.length > 0 ? [feed.category[0]] : undefined,
+          });
+        }
+      }
+
+      const feedsData = Array.from(feedsByUrl.values());
+
+      // Step 3: Create import record
       const importId = generateUuidv7();
       const now = new Date();
-
-      // Convert OpmlFeed[] to OpmlImportFeedData[]
-      const feedsData: OpmlImportFeedData[] = opmlFeeds.map((feed) => ({
-        xmlUrl: feed.xmlUrl,
-        title: feed.title,
-        htmlUrl: feed.htmlUrl,
-        category: feed.category,
-      }));
 
       await ctx.db.insert(opmlImports).values({
         id: importId,
         userId,
         status: "pending",
-        totalFeeds: opmlFeeds.length,
+        totalFeeds: feedsData.length, // Use deduplicated count
         importedCount: 0,
         skippedCount: 0,
         failedCount: 0,
@@ -1125,7 +1146,7 @@ export const subscriptionsRouter = createTRPCRouter({
         updatedAt: now,
       });
 
-      // Step 3: Queue background job to process the import
+      // Step 4: Queue background job to process the import
       await createJob({
         type: "process_opml_import",
         payload: { importId },
@@ -1135,12 +1156,13 @@ export const subscriptionsRouter = createTRPCRouter({
       logger.info("OPML import queued", {
         importId,
         userId,
-        totalFeeds: opmlFeeds.length,
+        totalFeeds: feedsData.length,
+        originalCount: opmlFeeds.length, // Log original for debugging
       });
 
       return {
         importId,
-        totalFeeds: opmlFeeds.length,
+        totalFeeds: feedsData.length, // Return deduplicated count
       };
     }),
 
@@ -1148,7 +1170,8 @@ export const subscriptionsRouter = createTRPCRouter({
    * Export subscriptions as OPML.
    *
    * Generates an OPML XML file containing all active subscriptions
-   * for the current user.
+   * for the current user. Feeds are listed at the top level and
+   * re-listed inside their tag folders.
    *
    * @returns OPML XML content
    */
@@ -1171,25 +1194,38 @@ export const subscriptionsRouter = createTRPCRouter({
     .query(async ({ ctx }) => {
       const userId = ctx.session.user.id;
 
-      // Get all active subscriptions with feed info
+      // Get all active subscriptions with feed info and tags
       const userSubscriptions = await ctx.db
         .select({
-          subscription: subscriptions,
-          feed: feeds,
+          subscriptionId: subscriptions.id,
+          subscriptionCustomTitle: subscriptions.customTitle,
+          feedUrl: feeds.url,
+          feedTitle: feeds.title,
+          feedSiteUrl: feeds.siteUrl,
+          // Tags aggregated as JSON array
+          tagNames: sql<string[]>`
+            COALESCE(
+              array_agg(${tags.name}) FILTER (WHERE ${tags.id} IS NOT NULL),
+              '{}'::text[]
+            )
+          `,
         })
         .from(subscriptions)
         .innerJoin(feeds, eq(subscriptions.feedId, feeds.id))
+        .leftJoin(subscriptionTags, eq(subscriptionTags.subscriptionId, subscriptions.id))
+        .leftJoin(tags, eq(tags.id, subscriptionTags.tagId))
         .where(and(eq(subscriptions.userId, userId), isNull(subscriptions.unsubscribedAt)))
+        .groupBy(subscriptions.id, feeds.id)
         .orderBy(feeds.title);
 
       // Convert to OPML subscription format
       const opmlSubscriptions: OpmlSubscription[] = userSubscriptions
-        .filter(({ feed }) => feed.url !== null)
-        .map(({ subscription, feed }) => ({
-          title: subscription.customTitle || feed.title || feed.url || "Untitled Feed",
-          xmlUrl: feed.url!,
-          htmlUrl: feed.siteUrl ?? undefined,
-          // folder: undefined, // TODO: Add when tags are implemented
+        .filter((row) => row.feedUrl !== null)
+        .map((row) => ({
+          title: row.subscriptionCustomTitle || row.feedTitle || row.feedUrl || "Untitled Feed",
+          xmlUrl: row.feedUrl!,
+          htmlUrl: row.feedSiteUrl ?? undefined,
+          tags: row.tagNames.length > 0 ? row.tagNames : undefined,
         }));
 
       // Generate OPML


### PR DESCRIPTION
- Export: Lists feeds at top level + re-lists them in each tag folder
- Import: Deduplicates feeds by URL (1 feed in 5 tags = 1 import)
- Import: Creates tags from OPML categories (first level of path)
- Import: Associates imported subscriptions with their tags

This follows the standard OPML folder structure where feeds can appear in multiple folders/categories.