### PR TITLE
Stream HTTP responses directly into feed parsers

### DIFF
--- a/src/server/feed/index.ts
+++ b/src/server/feed/index.ts
@@ -41,6 +41,8 @@ export {
   fetchFeed,
   shouldRetry,
   getRetryDelay,
+  streamToChunks,
+  chunksToStream,
   type FetchFeedOptions,
   type FetchFeedResult,
   type FetchSuccessResult,


### PR DESCRIPTION
Instead of buffering the entire HTTP response as a string and then converting it back to a stream for parsing, we now:

1. Return response.body (ReadableStream<Uint8Array>) from fetchFeed
2. Collect chunks for hashing (still needed for change detection)
3. Pass chunks directly to the streaming parser

This eliminates the string encoding/decoding overhead and uses the streaming parser API consistently throughout the feed processing pipeline. While we still need to buffer for the hash check (to avoid re-parsing unchanged feeds), the data stays as binary throughout.