### PR TITLE
Remove async from feed parsers, simplify to strings

### DIFF
--- a/src/server/feed/index.ts
+++ b/src/server/feed/index.ts
@@ -13,16 +13,16 @@ export {
   UnknownFeedFormatError,
   type FeedType,
 } from "./parser";
-// Re-export streaming parsers for direct stream access
+// Re-export SAX-based parsers for direct access
 export {
-  parseFeedStream,
-  parseFeedStreamWithFormat,
-  parseRssStream,
-  parseAtomStream,
-  parseJsonStream,
-  parseOpmlStream,
-  type StreamingFeedResult,
-  type StreamingOpmlResult,
+  parseFeed as parseFeedSax,
+  parseFeedWithFormat as parseFeedWithFormatSax,
+  parseRss,
+  parseAtom,
+  parseJson,
+  parseOpml as parseOpmlSax,
+  type FeedParseResult,
+  type OpmlParseResult,
 } from "./streaming";
 export {
   discoverFeeds,

--- a/src/server/feed/streaming/index.ts
+++ b/src/server/feed/streaming/index.ts
@@ -1,23 +1,17 @@
 /**
- * Streaming feed and OPML parsers.
- * These parsers work with ReadableStream<Uint8Array> and yield entries/feeds
- * via async generators as they're parsed.
+ * Feed and OPML parsers using SAX-style parsing.
+ * These parsers work with strings and return parsed results synchronously.
  */
 
 // Types
-export type { StreamingFeedResult, StreamingOpmlResult, OpmlFeed } from "./types";
+export type { FeedParseResult, OpmlParseResult, OpmlFeed } from "./types";
 
 // Unified parser with auto-detection
-export {
-  parseFeedStream,
-  parseFeedStreamWithFormat,
-  detectFeedType,
-  UnknownFeedFormatError,
-} from "./parser";
+export { parseFeed, parseFeedWithFormat, detectFeedType, UnknownFeedFormatError } from "./parser";
 export type { FeedType } from "./parser";
 
 // Individual parsers
-export { parseRssStream } from "./rss-parser";
-export { parseAtomStream } from "./atom-parser";
-export { parseJsonStream } from "./json-parser";
-export { parseOpmlStream, OpmlStreamParseError } from "./opml-parser";
+export { parseRss } from "./rss-parser";
+export { parseAtom } from "./atom-parser";
+export { parseJson } from "./json-parser";
+export { parseOpml, OpmlParseError } from "./opml-parser";

--- a/src/server/feed/streaming/types.ts
+++ b/src/server/feed/streaming/types.ts
@@ -1,14 +1,14 @@
 /**
- * Streaming feed parser result types.
+ * Feed parser result types.
  */
 
 import type { ParsedEntry, SyndicationHints } from "../types";
 
 /**
- * Result of streaming feed parsing.
- * Metadata is available immediately; entries are yielded as they're parsed.
+ * Result of feed parsing.
+ * Contains feed metadata and parsed entries.
  */
-export interface StreamingFeedResult {
+export interface FeedParseResult {
   title?: string;
   description?: string;
   siteUrl?: string;
@@ -17,15 +17,15 @@ export interface StreamingFeedResult {
   selfUrl?: string;
   ttlMinutes?: number;
   syndication?: SyndicationHints;
-  entries: AsyncGenerator<ParsedEntry, void, undefined>;
+  entries: ParsedEntry[];
 }
 
 /**
- * Result of streaming OPML parsing.
- * Feeds are yielded as they're parsed from the OPML file.
+ * Result of OPML parsing.
+ * Contains the list of feeds parsed from the OPML file.
  */
-export interface StreamingOpmlResult {
-  feeds: AsyncGenerator<OpmlFeed, void, undefined>;
+export interface OpmlParseResult {
+  feeds: OpmlFeed[];
 }
 
 /**

--- a/tests/unit/feed-parser.test.ts
+++ b/tests/unit/feed-parser.test.ts
@@ -189,7 +189,7 @@ describe("detectFeedType", () => {
 
 describe("parseFeed", () => {
   describe("auto-detection and parsing", () => {
-    it("parses RSS 2.0 feed automatically", async () => {
+    it("parses RSS 2.0 feed automatically", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <rss version="2.0">
           <channel>
@@ -203,7 +203,7 @@ describe("parseFeed", () => {
           </channel>
         </rss>`;
 
-      const feed = await parseFeed(xml);
+      const feed = parseFeed(xml);
 
       expect(feed.title).toBe("RSS Feed");
       expect(feed.siteUrl).toBe("https://example.com");
@@ -212,7 +212,7 @@ describe("parseFeed", () => {
       expect(feed.items[0].title).toBe("RSS Post");
     });
 
-    it("parses Atom 1.0 feed automatically", async () => {
+    it("parses Atom 1.0 feed automatically", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom">
           <title>Atom Feed</title>
@@ -228,7 +228,7 @@ describe("parseFeed", () => {
           </entry>
         </feed>`;
 
-      const feed = await parseFeed(xml);
+      const feed = parseFeed(xml);
 
       expect(feed.title).toBe("Atom Feed");
       expect(feed.siteUrl).toBe("https://example.com");
@@ -237,7 +237,7 @@ describe("parseFeed", () => {
       expect(feed.items[0].title).toBe("Atom Post");
     });
 
-    it("parses JSON Feed 1.1 automatically", async () => {
+    it("parses JSON Feed 1.1 automatically", () => {
       const json = JSON.stringify({
         version: "https://jsonfeed.org/version/1.1",
         title: "JSON Feed",
@@ -252,7 +252,7 @@ describe("parseFeed", () => {
         ],
       });
 
-      const feed = await parseFeed(json);
+      const feed = parseFeed(json);
 
       expect(feed.title).toBe("JSON Feed");
       expect(feed.siteUrl).toBe("https://example.com");
@@ -261,20 +261,20 @@ describe("parseFeed", () => {
       expect(feed.items[0].title).toBe("JSON Post");
     });
 
-    it("throws UnknownFeedFormatError for unknown format", async () => {
+    it("throws UnknownFeedFormatError for unknown format", () => {
       const html = `<!DOCTYPE html>
         <html>
           <head><title>Not a feed</title></head>
           <body></body>
         </html>`;
 
-      await expect(parseFeed(html)).rejects.toThrow(UnknownFeedFormatError);
-      await expect(parseFeed(html)).rejects.toThrow("Unknown feed format");
+      expect(() => parseFeed(html)).toThrow(UnknownFeedFormatError);
+      expect(() => parseFeed(html)).toThrow("Unknown feed format");
     });
   });
 
   describe("unified output format", () => {
-    it("produces consistent output for RSS, Atom, and JSON feeds", async () => {
+    it("produces consistent output for RSS, Atom, and JSON feeds", () => {
       const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
         <rss version="2.0">
           <channel>
@@ -321,9 +321,9 @@ describe("parseFeed", () => {
         ],
       });
 
-      const rssFeed = await parseFeed(rssXml);
-      const atomFeed = await parseFeed(atomXml);
-      const jsonParsed = await parseFeed(jsonFeed);
+      const rssFeed = parseFeed(rssXml);
+      const atomFeed = parseFeed(atomXml);
+      const jsonParsed = parseFeed(jsonFeed);
 
       // All should have same structure
       expect(rssFeed.title).toBe(atomFeed.title);
@@ -347,7 +347,7 @@ describe("parseFeed", () => {
 });
 
 describe("parseFeedWithFormat", () => {
-  it("parses RSS feed with explicit format", async () => {
+  it("parses RSS feed with explicit format", () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
       <rss version="2.0">
         <channel>
@@ -355,12 +355,12 @@ describe("parseFeedWithFormat", () => {
         </channel>
       </rss>`;
 
-    const feed = await parseFeedWithFormat(xml, "rss");
+    const feed = parseFeedWithFormat(xml, "rss");
 
     expect(feed.title).toBe("RSS Feed");
   });
 
-  it("parses Atom feed with explicit format", async () => {
+  it("parses Atom feed with explicit format", () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
       <feed xmlns="http://www.w3.org/2005/Atom">
         <title>Atom Feed</title>
@@ -368,35 +368,35 @@ describe("parseFeedWithFormat", () => {
         <updated>2024-01-01T00:00:00Z</updated>
       </feed>`;
 
-    const feed = await parseFeedWithFormat(xml, "atom");
+    const feed = parseFeedWithFormat(xml, "atom");
 
     expect(feed.title).toBe("Atom Feed");
   });
 
-  it("parses JSON Feed with explicit format", async () => {
+  it("parses JSON Feed with explicit format", () => {
     const json = JSON.stringify({
       version: "https://jsonfeed.org/version/1.1",
       title: "JSON Feed",
       items: [],
     });
 
-    const feed = await parseFeedWithFormat(json, "json");
+    const feed = parseFeedWithFormat(json, "json");
 
     expect(feed.title).toBe("JSON Feed");
   });
 
-  it("returns empty result when parsing Atom as RSS", async () => {
+  it("returns empty result when parsing Atom as RSS", () => {
     const atomXml = `<?xml version="1.0" encoding="UTF-8"?>
       <feed xmlns="http://www.w3.org/2005/Atom">
         <title>Atom Feed</title>
       </feed>`;
 
     // Streaming parser is lenient and returns empty result for mismatched format
-    const feed = await parseFeedWithFormat(atomXml, "rss");
+    const feed = parseFeedWithFormat(atomXml, "rss");
     expect(feed.items).toHaveLength(0);
   });
 
-  it("returns empty result when parsing RSS as Atom", async () => {
+  it("returns empty result when parsing RSS as Atom", () => {
     const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
       <rss version="2.0">
         <channel>
@@ -405,11 +405,11 @@ describe("parseFeedWithFormat", () => {
       </rss>`;
 
     // Streaming parser is lenient and returns empty result for mismatched format
-    const feed = await parseFeedWithFormat(rssXml, "atom");
+    const feed = parseFeedWithFormat(rssXml, "atom");
     expect(feed.items).toHaveLength(0);
   });
 
-  it("throws when format doesn't match content (JSON)", async () => {
+  it("throws when format doesn't match content (JSON)", () => {
     const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
       <rss version="2.0">
         <channel>
@@ -418,7 +418,7 @@ describe("parseFeedWithFormat", () => {
       </rss>`;
 
     // Trying to parse RSS as JSON should fail
-    await expect(parseFeedWithFormat(rssXml, "json")).rejects.toThrow();
+    expect(() => parseFeedWithFormat(rssXml, "json")).toThrow();
   });
 });
 

--- a/tests/unit/opml.test.ts
+++ b/tests/unit/opml.test.ts
@@ -13,7 +13,7 @@ import {
 
 describe("parseOpml", () => {
   describe("basic OPML parsing", () => {
-    it("parses a simple OPML with flat feeds", async () => {
+    it("parses a simple OPML with flat feeds", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head>
@@ -25,7 +25,7 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(2);
       expect(feeds[0]).toEqual({
@@ -39,7 +39,7 @@ describe("parseOpml", () => {
       });
     });
 
-    it("parses OPML with title attribute instead of text", async () => {
+    it("parses OPML with title attribute instead of text", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="1.0">
           <head><title>Feeds</title></head>
@@ -48,13 +48,13 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(1);
       expect(feeds[0].title).toBe("Blog Title");
     });
 
-    it("prefers text attribute over title when both present", async () => {
+    it("prefers text attribute over title when both present", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>Feeds</title></head>
@@ -63,12 +63,12 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds[0].title).toBe("Text Value");
     });
 
-    it("handles feeds without type attribute", async () => {
+    it("handles feeds without type attribute", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>Feeds</title></head>
@@ -77,7 +77,7 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(1);
       expect(feeds[0].xmlUrl).toBe("https://example.com/feed");
@@ -85,7 +85,7 @@ describe("parseOpml", () => {
   });
 
   describe("nested folders/categories", () => {
-    it("parses single-level nested folders", async () => {
+    it("parses single-level nested folders", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>Feeds</title></head>
@@ -98,7 +98,7 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(3);
       expect(feeds[0]).toEqual({
@@ -117,7 +117,7 @@ describe("parseOpml", () => {
       });
     });
 
-    it("parses deeply nested folders", async () => {
+    it("parses deeply nested folders", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>Feeds</title></head>
@@ -132,13 +132,13 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(1);
       expect(feeds[0].category).toEqual(["Technology", "Programming", "JavaScript"]);
     });
 
-    it("handles multiple folders at the same level", async () => {
+    it("handles multiple folders at the same level", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>Feeds</title></head>
@@ -152,14 +152,14 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(2);
       expect(feeds[0].category).toEqual(["News"]);
       expect(feeds[1].category).toEqual(["Sports"]);
     });
 
-    it("handles category attribute on feed outline", async () => {
+    it("handles category attribute on feed outline", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>Feeds</title></head>
@@ -168,12 +168,12 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds[0].category).toEqual(["Tech"]);
     });
 
-    it("handles slash-separated category paths in attribute", async () => {
+    it("handles slash-separated category paths in attribute", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>Feeds</title></head>
@@ -182,12 +182,12 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds[0].category).toEqual(["Tech", "Programming"]);
     });
 
-    it("prefers folder nesting over category attribute", async () => {
+    it("prefers folder nesting over category attribute", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>Feeds</title></head>
@@ -198,26 +198,26 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds[0].category).toEqual(["Folder"]);
     });
   });
 
   describe("edge cases", () => {
-    it("returns empty array for OPML with no feeds", async () => {
+    it("returns empty array for OPML with no feeds", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>Empty</title></head>
           <body></body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(0);
     });
 
-    it("returns empty array for OPML with only empty folders", async () => {
+    it("returns empty array for OPML with only empty folders", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>Empty Folders</title></head>
@@ -226,12 +226,12 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(0);
     });
 
-    it("handles OPML with single outline (not array)", async () => {
+    it("handles OPML with single outline (not array)", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>Single</title></head>
@@ -240,12 +240,12 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(1);
     });
 
-    it("ignores outlines without xmlUrl that are not folders", async () => {
+    it("ignores outlines without xmlUrl that are not folders", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>Mixed</title></head>
@@ -256,13 +256,13 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(1);
       expect(feeds[0].title).toBe("Valid Feed");
     });
 
-    it("handles feeds with missing title", async () => {
+    it("handles feeds with missing title", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>No Title</title></head>
@@ -271,14 +271,14 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(1);
       expect(feeds[0].title).toBeUndefined();
       expect(feeds[0].xmlUrl).toBe("https://example.com/feed");
     });
 
-    it("handles CDATA in text content", async () => {
+    it("handles CDATA in text content", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title><![CDATA[My Feeds]]></title></head>
@@ -287,40 +287,40 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds[0].title).toBe("Blog & News");
     });
   });
 
   describe("error handling", () => {
-    it("throws OpmlParseError for invalid XML", async () => {
+    it("throws OpmlParseError for invalid XML", () => {
       const xml = "not valid xml at all <>";
 
-      await expect(parseOpml(xml)).rejects.toThrow(OpmlParseError);
+      expect(() => parseOpml(xml)).toThrow(OpmlParseError);
     });
 
-    it("throws OpmlParseError for missing opml element", async () => {
+    it("throws OpmlParseError for missing opml element", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <rss version="2.0">
           <channel><title>Not OPML</title></channel>
         </rss>`;
 
-      await expect(parseOpml(xml)).rejects.toThrow("Invalid OPML: missing opml element");
+      expect(() => parseOpml(xml)).toThrow("Invalid OPML: missing opml element");
     });
 
-    it("throws OpmlParseError for missing body element", async () => {
+    it("throws OpmlParseError for missing body element", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="2.0">
           <head><title>No Body</title></head>
         </opml>`;
 
-      await expect(parseOpml(xml)).rejects.toThrow("Invalid OPML: missing body element");
+      expect(() => parseOpml(xml)).toThrow("Invalid OPML: missing body element");
     });
   });
 
   describe("real-world OPML examples", () => {
-    it("parses Feedly-style OPML export", async () => {
+    it("parses Feedly-style OPML export", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="1.0">
           <head>
@@ -335,7 +335,7 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(3);
       expect(feeds[0].category).toEqual(["tech"]);
@@ -343,7 +343,7 @@ describe("parseOpml", () => {
       expect(feeds[2].category).toBeUndefined();
     });
 
-    it("parses Inoreader-style OPML export", async () => {
+    it("parses Inoreader-style OPML export", () => {
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
         <opml version="1.0">
           <head>
@@ -359,7 +359,7 @@ describe("parseOpml", () => {
           </body>
         </opml>`;
 
-      const feeds = await parseOpml(xml);
+      const feeds = parseOpml(xml);
 
       expect(feeds).toHaveLength(1);
       expect(feeds[0].category).toEqual(["Blogs", "Personal"]);
@@ -483,7 +483,7 @@ describe("generateOpml", () => {
   });
 
   describe("round-trip", () => {
-    it("generated OPML can be parsed back", async () => {
+    it("generated OPML can be parsed back", () => {
       const subscriptions: OpmlSubscription[] = [
         {
           title: "Blog One",
@@ -494,7 +494,7 @@ describe("generateOpml", () => {
       ];
 
       const xml = generateOpml(subscriptions, { title: "Test Export" });
-      const parsed = await parseOpml(xml);
+      const parsed = parseOpml(xml);
 
       expect(parsed).toHaveLength(2);
       expect(parsed[0].title).toBe("Blog One");
@@ -504,7 +504,7 @@ describe("generateOpml", () => {
       expect(parsed[1].category).toEqual(["Tech"]);
     });
 
-    it("preserves folder structure in round-trip", async () => {
+    it("preserves folder structure in round-trip", () => {
       const subscriptions: OpmlSubscription[] = [
         { title: "Blog 1", xmlUrl: "https://blog1.example.com/feed", folder: "Category A" },
         { title: "Blog 2", xmlUrl: "https://blog2.example.com/feed", folder: "Category A" },
@@ -513,7 +513,7 @@ describe("generateOpml", () => {
       ];
 
       const xml = generateOpml(subscriptions);
-      const parsed = await parseOpml(xml);
+      const parsed = parseOpml(xml);
 
       expect(parsed).toHaveLength(4);
 
@@ -530,27 +530,27 @@ describe("generateOpml", () => {
 });
 
 describe("isValidOpml", () => {
-  it("returns true for valid OPML", async () => {
+  it("returns true for valid OPML", () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
       <opml version="2.0">
         <head><title>Valid</title></head>
         <body></body>
       </opml>`;
 
-    expect(await isValidOpml(xml)).toBe(true);
+    expect(isValidOpml(xml)).toBe(true);
   });
 
-  it("returns false for invalid XML", async () => {
-    expect(await isValidOpml("not xml")).toBe(false);
+  it("returns false for invalid XML", () => {
+    expect(isValidOpml("not xml")).toBe(false);
   });
 
-  it("returns false for non-OPML XML", async () => {
+  it("returns false for non-OPML XML", () => {
     const xml = `<?xml version="1.0"?><rss><channel></channel></rss>`;
-    expect(await isValidOpml(xml)).toBe(false);
+    expect(isValidOpml(xml)).toBe(false);
   });
 
-  it("returns false for OPML without body", async () => {
+  it("returns false for OPML without body", () => {
     const xml = `<?xml version="1.0"?><opml version="2.0"><head></head></opml>`;
-    expect(await isValidOpml(xml)).toBe(false);
+    expect(isValidOpml(xml)).toBe(false);
   });
 });


### PR DESCRIPTION
The async streaming approach added complexity without significant benefit since feeds are typically small enough to buffer in memory. This change simplifies the parsers while keeping the SAX-style parsing for memory efficiency during parsing.

Changes:
- Convert parseRssStream/parseAtomStream/parseJsonStream/parseOpmlStream to parseRss/parseAtom/parseJson/parseOpml that take string input
- Replace AsyncGenerator<ParsedEntry> with synchronous ParsedEntry[]
- Remove ReadableStream conversion helpers
- Update all tests to use sync API
- Keep SAX-style parsing (htmlparser2) for efficient parsing

The parsers still use SAX-style parsing internally, which processes the XML incrementally rather than building a full DOM tree. This provides memory efficiency during parsing while avoiding the complexity of async stream handling.