### PR TITLE
Fix OPML import subscription events and UI

### DIFF
--- a/src/app/api/v1/events/route.ts
+++ b/src/app/api/v1/events/route.ts
@@ -309,7 +309,7 @@ export async function GET(req: Request): Promise<Response> {
 
         // Handle incoming messages
         subscriber.on("message", (channel: string, message: string) => {
-          // Handle user events (subscription_created, subscription_deleted, saved_article_created)
+          // Handle user events (subscription_created, subscription_deleted, saved_article_created, import_progress, import_completed)
           if (channel === userEventsChannel) {
             const event = parseUserEvent(message);
             if (!event) return;
@@ -330,6 +330,10 @@ export async function GET(req: Request): Promise<Response> {
               trackSSEEventSent(event.type);
             } else if (event.type === "saved_article_created") {
               // Forward the event to the client
+              send(formatSSEUserEvent(event));
+              trackSSEEventSent(event.type);
+            } else if (event.type === "import_progress" || event.type === "import_completed") {
+              // Forward import events to the client
               send(formatSSEUserEvent(event));
               trackSSEEventSent(event.type);
             }


### PR DESCRIPTION
The SSE endpoint was only forwarding subscription_created, subscription_deleted, and saved_article_created events. The import_progress and import_completed events were being published during OPML import but silently dropped, preventing the UI from receiving real-time import progress updates.