### PR TITLE
Hash raw feed content bytes before conversion

### DIFF
--- a/src/server/feed/fetcher.ts
+++ b/src/server/feed/fetcher.ts
@@ -41,8 +41,8 @@ export interface FetchSuccessResult {
   status: "success";
   /** HTTP status code (200) */
   statusCode: 200;
-  /** Response body content */
-  body: string;
+  /** Response body as raw bytes - allows hashing before expensive text decoding */
+  body: Buffer;
   /** Content-Type header value */
   contentType: string;
   /** Final URL after redirects */
@@ -392,7 +392,9 @@ export async function fetchFeed(
 
       // Handle success (200)
       if (response.status === 200) {
-        const body = await response.text();
+        // Get raw bytes - allows caller to hash before expensive text decoding
+        const arrayBuffer = await response.arrayBuffer();
+        const body = Buffer.from(arrayBuffer);
         const contentType = response.headers.get("content-type") ?? "application/xml";
 
         return {


### PR DESCRIPTION
Optimize feed change detection by hashing raw HTTP response bytes directly instead of first decoding to a string. This avoids the expensive text decoding step when feed content is unchanged (the common case).

Changes:
- fetchFeed() now returns body as Buffer instead of string
- generateBodyHash() hashes raw bytes instead of UTF-8 encoded string
- Add parseFeedFromBuffer() to parse directly from bytes, avoiding the decode-then-reencode cycle that parseFeed(string) requires
- processSuccessfulFetch() now accepts Buffer and uses parseFeedFromBuffer()

The 304 Not Modified handling was already correct - it returns immediately without reading body bytes.