### PR TITLE
Add SSE event for saved content updates

### DIFF
--- a/src/app/api/v1/events/route.ts
+++ b/src/app/api/v1/events/route.ts
@@ -10,6 +10,7 @@
  * - subscription_created: User subscribed to a new feed
  * - subscription_deleted: User unsubscribed from a feed
  * - saved_article_created: User saved a new article via bookmarklet
+ * - saved_article_updated: A saved article's content was updated (e.g., refetched)
  *
  * Heartbeat: Sent every 30 seconds as a comment (: heartbeat)
  */
@@ -329,6 +330,10 @@ export async function GET(req: Request): Promise<Response> {
               send(formatSSEUserEvent(event));
               trackSSEEventSent(event.type);
             } else if (event.type === "saved_article_created") {
+              // Forward the event to the client
+              send(formatSSEUserEvent(event));
+              trackSSEEventSent(event.type);
+            } else if (event.type === "saved_article_updated") {
               // Forward the event to the client
               send(formatSSEUserEvent(event));
               trackSSEEventSent(event.type);

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -51,7 +51,7 @@ import {
 import { getOAuthAccount, hasGoogleScope, getValidGoogleToken } from "@/server/google/tokens";
 import { GOOGLE_DOCS_READONLY_SCOPE } from "@/server/auth";
 import { logger } from "@/lib/logger";
-import { publishSavedArticleCreated } from "@/server/redis/pubsub";
+import { publishSavedArticleCreated, publishSavedArticleUpdated } from "@/server/redis/pubsub";
 
 // ============================================================================
 // Validation Schemas
@@ -671,6 +671,9 @@ export const savedRouter = createTRPCRouter({
           url: normalizedUrl,
           forced: input.force ?? false,
         });
+
+        // Publish event to notify other browser windows/tabs of the update
+        await publishSavedArticleUpdated(userId, oldEntry.id);
 
         return {
           article: {


### PR DESCRIPTION
When a saved article is refetched and its content is updated, publish a saved_article_updated event to notify other browser windows/tabs. This allows the client to invalidate cached entry data so users see the updated content without manually refreshing.

The event is published via the user's SSE channel after the database update succeeds, following the same pattern as saved_article_created.