### PR TITLE
Deduplicate default domain configuration

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -92,8 +92,7 @@ android {
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
 
-            // Debug-specific configuration
-            buildConfigField("String", "API_BASE_URL", "\"https://lionreader.com\"")
+            // Debug-specific configuration (API_BASE_URL inherited from defaultConfig)
             buildConfigField("boolean", "LOGGING_ENABLED", "true")
 
             // Debug uses default debug signing
@@ -108,8 +107,7 @@ android {
                 "proguard-rules.pro",
             )
 
-            // Release-specific configuration
-            buildConfigField("String", "API_BASE_URL", "\"https://lionreader.com\"")
+            // Release-specific configuration (API_BASE_URL inherited from defaultConfig)
             buildConfigField("boolean", "LOGGING_ENABLED", "false")
 
             // Release signing - only applied if keystore is configured

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -9,7 +9,7 @@
  * - Badge updates
  */
 
-const DEFAULT_SERVER_URL = "https://lionreader.com";
+import { DEFAULT_SERVER_URL } from "./constants.js";
 
 /**
  * Get the configured server URL from storage.

--- a/extension/src/constants.js
+++ b/extension/src/constants.js
@@ -1,0 +1,8 @@
+/**
+ * Shared constants for the Lion Reader browser extension.
+ */
+
+/**
+ * Default server URL used when no custom URL is configured.
+ */
+export const DEFAULT_SERVER_URL = "https://lionreader.com";

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -236,6 +236,6 @@
     </div>
   </div>
 
-  <script src="options.js"></script>
+  <script type="module" src="options.js"></script>
 </body>
 </html>

--- a/extension/src/options.js
+++ b/extension/src/options.js
@@ -2,7 +2,7 @@
  * Options page script for Lion Reader browser extension.
  */
 
-const DEFAULT_SERVER_URL = "https://lionreader.com";
+import { DEFAULT_SERVER_URL } from "./constants.js";
 
 // DOM Elements
 const serverUrlInput = document.getElementById("server-url");

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -266,6 +266,6 @@
     </div>
   </div>
 
-  <script src="popup.js"></script>
+  <script type="module" src="popup.js"></script>
 </body>
 </html>

--- a/extension/src/popup.js
+++ b/extension/src/popup.js
@@ -5,6 +5,8 @@
  * If no token exists, opens the web auth flow to get one.
  */
 
+import { DEFAULT_SERVER_URL } from "./constants.js";
+
 // DOM Elements
 const loadingEl = document.getElementById("loading");
 const loadingUrlEl = document.getElementById("loading-url");
@@ -26,9 +28,6 @@ const openLionReaderBtn = document.getElementById("open-lionreader-btn");
 let currentUrl = null;
 let currentTitle = null;
 let countdownInterval = null;
-
-// Default server URL
-const DEFAULT_SERVER_URL = "https://lionreader.com";
 
 /**
  * Get the configured server URL from storage.


### PR DESCRIPTION
- Create shared constants.js for browser extension with DEFAULT_SERVER_URL
- Update popup.js, options.js, and background.js to import from constants
- Convert popup and options HTML to use ES modules
- Remove redundant API_BASE_URL overrides from Android build types (debug and release were duplicating the same value from defaultConfig)