### PR TITLE
Fix subscription event to include full data

### DIFF
--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -198,27 +198,40 @@ async function subscribeToExistingFeed(
     }
   }
 
-  publishSubscriptionCreated(userId, feedId, subscriptionId).catch((err) => {
+  const subscriptionData = {
+    id: subscriptionId,
+    feedId,
+    customTitle: null,
+    subscribedAt,
+    unreadCount,
+    tags: [] as Array<{ id: string; name: string; color: string | null }>,
+  };
+
+  const feedData = {
+    id: feedRecord.id,
+    type: feedRecord.type,
+    url: feedRecord.url,
+    title: feedRecord.title,
+    description: feedRecord.description,
+    siteUrl: feedRecord.siteUrl,
+  };
+
+  publishSubscriptionCreated(
+    userId,
+    feedId,
+    subscriptionId,
+    {
+      ...subscriptionData,
+      subscribedAt: subscribedAt.toISOString(),
+    },
+    feedData
+  ).catch((err) => {
     logger.error("Failed to publish subscription_created event", { err, userId, feedId });
   });
 
   return {
-    subscription: {
-      id: subscriptionId,
-      feedId,
-      customTitle: null,
-      subscribedAt,
-      unreadCount,
-      tags: [],
-    },
-    feed: {
-      id: feedRecord.id,
-      type: feedRecord.type,
-      url: feedRecord.url,
-      title: feedRecord.title,
-      description: feedRecord.description,
-      siteUrl: feedRecord.siteUrl,
-    },
+    subscription: subscriptionData,
+    feed: feedData,
   };
 }
 
@@ -434,27 +447,40 @@ async function subscribeToNewOrUnfetchedFeed(
     }
   }
 
-  publishSubscriptionCreated(userId, feedId, subscriptionId).catch((err) => {
+  const subscriptionData = {
+    id: subscriptionId,
+    feedId,
+    customTitle: null,
+    subscribedAt,
+    unreadCount,
+    tags: [] as Array<{ id: string; name: string; color: string | null }>,
+  };
+
+  const feedData = {
+    id: feedRecord.id,
+    type: feedRecord.type,
+    url: feedRecord.url,
+    title: feedRecord.title,
+    description: feedRecord.description,
+    siteUrl: feedRecord.siteUrl,
+  };
+
+  publishSubscriptionCreated(
+    userId,
+    feedId,
+    subscriptionId,
+    {
+      ...subscriptionData,
+      subscribedAt: subscribedAt.toISOString(),
+    },
+    feedData
+  ).catch((err) => {
     logger.error("Failed to publish subscription_created event", { err, userId, feedId });
   });
 
   return {
-    subscription: {
-      id: subscriptionId,
-      feedId,
-      customTitle: null,
-      subscribedAt,
-      unreadCount,
-      tags: [],
-    },
-    feed: {
-      id: feedRecord.id,
-      type: feedRecord.type,
-      url: feedRecord.url,
-      title: feedRecord.title,
-      description: feedRecord.description,
-      siteUrl: feedRecord.siteUrl,
-    },
+    subscription: subscriptionData,
+    feed: feedData,
   };
 }
 


### PR DESCRIPTION
This enables optimistic cache updates on the client instead of requiring a full refetch of the subscriptions list when a new subscription is added.

Key changes:
- Enhanced SubscriptionCreatedEvent to include complete subscription and feed data (id, title, tags, unreadCount, etc.)
- Updated publishSubscriptionCreated to accept full data in all callers: subscriptions.ts and handlers.ts (OPML import)
- Client now updates subscriptions and tags caches directly via setData instead of invalidating them
- import_completed no longer invalidates subscriptions since individual subscription_created events handle cache updates

For a user with 100+ subscriptions, this reduces data transfer from ~50-100 KB per subscription to 0 KB (no refetch needed). OPML imports now show real-time sidebar updates as each feed is imported.

Fixes #214