### PR TITLE
Fix unnecessary cache invalidation for entries list

### DIFF
--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -382,7 +382,14 @@ export function useRealtimeUpdates(): UseRealtimeUpdatesResult {
       if (!data) return;
 
       if (data.type === "new_entry") {
-        utils.entries.list.invalidate();
+        // Use targeted invalidation to avoid refetching entries for feeds the user isn't viewing.
+        // Invalidate "all entries" view (no feedId filter)
+        utils.entries.list.invalidate({ feedId: undefined });
+        // Invalidate the specific feed's view
+        utils.entries.list.invalidate({ feedId: data.feedId });
+        // Invalidate unread-only views since new entries are unread by default
+        utils.entries.list.invalidate({ unreadOnly: true });
+
         // Increment the unread count for the specific subscription instead of invalidating all
         utils.subscriptions.list.setData(undefined, (oldData) => {
           if (!oldData) return oldData;


### PR DESCRIPTION
Previously, the new_entry SSE event would invalidate the entire entries.list cache, causing unnecessary refetches even when the user was viewing a different feed.

Now we use filter-aware invalidation to only invalidate:
- "All entries" view (feedId undefined)
- The specific feed's view that received the new entry
- Unread-only views (since new entries are unread by default)

This reduces network traffic proportionally to the number of subscribed feeds by avoiding refetches for feeds the user isn't currently viewing.

Fixes #215