### PR TITLE
Remove tag subscriptions when user unsubscribes

### DIFF
--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -943,6 +943,9 @@ export const subscriptionsRouter = createTRPCRouter({
         });
       }
 
+      // Remove all tag associations so resubscribing starts fresh
+      await ctx.db.delete(subscriptionTags).where(eq(subscriptionTags.subscriptionId, input.id));
+
       // Soft delete by setting unsubscribedAt
       await ctx.db
         .update(subscriptions)


### PR DESCRIPTION
When unsubscribing from a feed, delete all subscription_tags records so the user won't be placed back into the same tags if they resubscribe.