### PR TITLE
Fix feed subscription not appearing in sidebar

### DIFF
--- a/src/app/(app)/subscribe/page.tsx
+++ b/src/app/(app)/subscribe/page.tsx
@@ -65,7 +65,10 @@ export default function SubscribePage() {
       // Add the new subscription directly to the cache instead of invalidating
       // This avoids an extra network request and duplicate SSE-triggered invalidations
       utils.subscriptions.list.setData(undefined, (oldData) => {
-        if (!oldData) return oldData;
+        // Handle case where query hasn't completed yet (race condition)
+        if (!oldData) {
+          return { items: [data] };
+        }
         // Check for duplicates - SSE might have already added this subscription
         if (oldData.items.some((item) => item.subscription.id === data.subscription.id)) {
           return oldData;

--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -506,23 +506,25 @@ export function useRealtimeUpdates(): UseRealtimeUpdatesResult {
             return oldData;
           }
 
-          // Add new subscription to cache
-          return {
-            items: [
-              ...oldData.items,
-              {
-                subscription: {
-                  id: data.subscription.id,
-                  feedId: data.subscription.feedId,
-                  customTitle: data.subscription.customTitle,
-                  subscribedAt: new Date(data.subscription.subscribedAt),
-                  unreadCount: data.subscription.unreadCount,
-                  tags: data.subscription.tags,
-                },
-                feed: data.feed,
-              },
-            ],
+          // Add new subscription to cache and maintain alphabetical order
+          const newItem = {
+            subscription: {
+              id: data.subscription.id,
+              feedId: data.subscription.feedId,
+              customTitle: data.subscription.customTitle,
+              subscribedAt: new Date(data.subscription.subscribedAt),
+              unreadCount: data.subscription.unreadCount,
+              tags: data.subscription.tags,
+            },
+            feed: data.feed,
           };
+          const newItems = [...oldData.items, newItem];
+          newItems.sort((a, b) => {
+            const titleA = (a.subscription.customTitle || a.feed.title || "").toLowerCase();
+            const titleB = (b.subscription.customTitle || b.feed.title || "").toLowerCase();
+            return titleA.localeCompare(titleB);
+          });
+          return { items: newItems };
         });
 
         // Update tags cache with new/updated tag counts


### PR DESCRIPTION
Handle race condition where user subscribes before the subscriptions list query completes. When oldData is undefined, create a new list with the subscription instead of returning undefined (which left the cache unmodified).