### PR TITLE
Audit database queries for upsert pattern

### DIFF
--- a/src/server/feed/saved-feed.ts
+++ b/src/server/feed/saved-feed.ts
@@ -14,55 +14,53 @@ import { generateUuidv7 } from "@/lib/uuidv7";
  * Gets or creates the user's saved articles feed.
  *
  * This is idempotent - safe to call multiple times.
- * If the saved feed doesn't exist, it will be created.
- * If it already exists, its ID is returned.
+ * Uses INSERT ON CONFLICT to handle race conditions atomically.
  *
  * @param db - Database instance
  * @param userId - User ID
  * @returns The feed ID of the user's saved articles feed
  */
 export async function getOrCreateSavedFeed(db: Database, userId: string): Promise<string> {
-  // Try to find existing saved feed
-  const existing = await db
+  // Attempt to create the saved feed - ON CONFLICT handles the case where it already exists
+  const feedId = generateUuidv7();
+  const now = new Date();
+
+  await db
+    .insert(feeds)
+    .values({
+      id: feedId,
+      type: "saved",
+      userId,
+      title: "Saved Articles",
+      // URL-based fields are NULL for saved feeds
+      url: null,
+      emailSenderPattern: null,
+      // Metadata fields
+      description: null,
+      siteUrl: null,
+      // Fetch state fields are NULL for saved feeds (not polled)
+      etag: null,
+      lastModifiedHeader: null,
+      lastFetchedAt: null,
+      nextFetchAt: null,
+      // Error tracking
+      consecutiveFailures: 0,
+      lastError: null,
+      // WebSub fields are NULL for saved feeds
+      hubUrl: null,
+      selfUrl: null,
+      websubActive: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing();
+
+  // Fetch the feed ID (either just inserted or already existed)
+  const result = await db
     .select({ id: feeds.id })
     .from(feeds)
     .where(and(eq(feeds.type, "saved"), eq(feeds.userId, userId)))
     .limit(1);
 
-  if (existing.length > 0) {
-    return existing[0].id;
-  }
-
-  // Create new saved feed
-  const feedId = generateUuidv7();
-  const now = new Date();
-
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "saved",
-    userId,
-    title: "Saved Articles",
-    // URL-based fields are NULL for saved feeds
-    url: null,
-    emailSenderPattern: null,
-    // Metadata fields
-    description: null,
-    siteUrl: null,
-    // Fetch state fields are NULL for saved feeds (not polled)
-    etag: null,
-    lastModifiedHeader: null,
-    lastFetchedAt: null,
-    nextFetchAt: null,
-    // Error tracking
-    consecutiveFailures: 0,
-    lastError: null,
-    // WebSub fields are NULL for saved feeds
-    hubUrl: null,
-    selfUrl: null,
-    websubActive: false,
-    createdAt: now,
-    updatedAt: now,
-  });
-
-  return feedId;
+  return result[0].id;
 }


### PR DESCRIPTION
Apply the "just do it" pattern to avoid check-then-act race conditions:

- tags.ts: Use INSERT ON CONFLICT for tag creation, DELETE RETURNING for deletion
- saved-feed.ts: INSERT first with ON CONFLICT, then SELECT to get ID
- blockedSenders.ts: Use DELETE RETURNING to verify existence

Document the pattern in CLAUDE.md with clear examples of when to use it and when to skip it (e.g., soft-delete reactivation logic).