### PR TITLE
Add SSE event for new email notifications

### DIFF
--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -561,7 +561,16 @@ export function useRealtimeUpdates(): UseRealtimeUpdatesResult {
           });
         }
 
-        // No invalidation needed - cache is already updated!
+        // For email feeds, also invalidate entries list since new email feeds
+        // always come with an entry. This handles the race condition where the
+        // new_entry event might arrive before we've subscribed to the feed channel.
+        if (data.feed.type === "email") {
+          // Invalidate All Items view (feedId undefined matches all unreadOnly variants)
+          utils.entries.list.invalidate({ feedId: undefined });
+          // Invalidate the specific feed's view (probably not cached yet, but for consistency)
+          utils.entries.list.invalidate({ feedId: data.feedId });
+        }
+        // For non-email feeds, no invalidation needed - cache is already updated!
       } else if (data.type === "subscription_deleted") {
         const existingData = utils.subscriptions.list.getData();
         const stillInCache = existingData?.items.some(


### PR DESCRIPTION
When a new email arrives and creates a new feed/subscription, we now publish a subscription_created event via Redis pub/sub. This ensures:
1. The frontend sidebar updates to show the new email feed
2. The SSE handler subscribes to the feed's channel for future entries
3. The All Items unread count updates correctly

For email feeds specifically, the frontend also invalidates the entries list when receiving subscription_created to handle the race condition where new_entry might arrive before the feed channel subscription.