### PR TITLE
Fix quoted names in email feeds

### DIFF
--- a/src/app/api/webhooks/email/mailgun/route.ts
+++ b/src/app/api/webhooks/email/mailgun/route.ts
@@ -52,21 +52,39 @@ function verifySignature(
 }
 
 /**
+ * Strips surrounding double quotes from an email display name.
+ * RFC 2822 uses quotes for names containing special characters like & or commas.
+ *
+ * @param name - The raw display name from an email header
+ * @returns The name with surrounding quotes removed
+ */
+export function stripEmailNameQuotes(name: string): string {
+  // RFC 2822 quoted-string: names with special chars are wrapped in double quotes
+  if (name.startsWith('"') && name.endsWith('"') && name.length >= 2) {
+    return name.slice(1, -1);
+  }
+  return name;
+}
+
+/**
  * Parses a "From" address string into email and name components.
  * Handles formats:
  * - "Name <email@example.com>"
+ * - '"Quoted Name" <email@example.com>' (RFC 2822 quoted names)
  * - "<email@example.com>"
  * - "email@example.com"
  *
  * @param from - The from string to parse
  * @returns Object with address and optional name
  */
-function parseFromAddress(from: string): { address: string; name?: string } {
+export function parseFromAddress(from: string): { address: string; name?: string } {
   // Try to match "Name <email>" format
   const matchWithName = from.match(/^(.+?)\s*<([^>]+)>$/);
   if (matchWithName) {
-    const name = matchWithName[1].trim();
+    const rawName = matchWithName[1].trim();
     const address = matchWithName[2].trim();
+    // Strip surrounding quotes from the name (RFC 2822 quoted-string)
+    const name = stripEmailNameQuotes(rawName);
     return {
       address,
       name: name || undefined,

--- a/tests/unit/email-from-address.test.ts
+++ b/tests/unit/email-from-address.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for email From address parsing utilities.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseFromAddress,
+  stripEmailNameQuotes,
+} from "../../src/app/api/webhooks/email/mailgun/route";
+
+describe("stripEmailNameQuotes", () => {
+  it("strips surrounding double quotes", () => {
+    expect(stripEmailNameQuotes('"Brendan & Corinne Long-Hall"')).toBe(
+      "Brendan & Corinne Long-Hall"
+    );
+  });
+
+  it("returns unquoted name unchanged", () => {
+    expect(stripEmailNameQuotes("John Doe")).toBe("John Doe");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(stripEmailNameQuotes("")).toBe("");
+  });
+
+  it("returns single quote unchanged", () => {
+    expect(stripEmailNameQuotes('"')).toBe('"');
+  });
+
+  it("handles name that starts with quote but does not end with quote", () => {
+    expect(stripEmailNameQuotes('"John Doe')).toBe('"John Doe');
+  });
+
+  it("handles name that ends with quote but does not start with quote", () => {
+    expect(stripEmailNameQuotes('John Doe"')).toBe('John Doe"');
+  });
+
+  it("handles name with internal quotes", () => {
+    expect(stripEmailNameQuotes('"John "The Boss" Doe"')).toBe('John "The Boss" Doe');
+  });
+
+  it("handles just two quotes (empty quoted name)", () => {
+    expect(stripEmailNameQuotes('""')).toBe("");
+  });
+});
+
+describe("parseFromAddress", () => {
+  describe("Name <email> format", () => {
+    it("parses simple name and email", () => {
+      expect(parseFromAddress("John Doe <john@example.com>")).toEqual({
+        name: "John Doe",
+        address: "john@example.com",
+      });
+    });
+
+    it("strips quotes from name with special characters", () => {
+      expect(parseFromAddress('"Brendan & Corinne Long-Hall" <family@example.com>')).toEqual({
+        name: "Brendan & Corinne Long-Hall",
+        address: "family@example.com",
+      });
+    });
+
+    it("strips quotes from name with comma", () => {
+      expect(parseFromAddress('"Doe, John" <john@example.com>')).toEqual({
+        name: "Doe, John",
+        address: "john@example.com",
+      });
+    });
+
+    it("handles unquoted name with simple characters", () => {
+      expect(parseFromAddress("Newsletter <news@example.com>")).toEqual({
+        name: "Newsletter",
+        address: "news@example.com",
+      });
+    });
+
+    it("trims whitespace from name and address", () => {
+      expect(parseFromAddress("  John Doe   <  john@example.com  >")).toEqual({
+        name: "John Doe",
+        address: "john@example.com",
+      });
+    });
+
+    it("returns undefined name when name part is empty", () => {
+      expect(parseFromAddress(" <john@example.com>")).toEqual({
+        name: undefined,
+        address: "john@example.com",
+      });
+    });
+
+    it("returns undefined name when name is just quotes", () => {
+      expect(parseFromAddress('"" <john@example.com>')).toEqual({
+        name: undefined,
+        address: "john@example.com",
+      });
+    });
+  });
+
+  describe("<email> format", () => {
+    it("parses email in angle brackets only", () => {
+      expect(parseFromAddress("<john@example.com>")).toEqual({
+        address: "john@example.com",
+      });
+    });
+
+    it("trims whitespace from email in angle brackets", () => {
+      expect(parseFromAddress("<  john@example.com  >")).toEqual({
+        address: "john@example.com",
+      });
+    });
+  });
+
+  describe("plain email format", () => {
+    it("parses plain email address", () => {
+      expect(parseFromAddress("john@example.com")).toEqual({
+        address: "john@example.com",
+      });
+    });
+
+    it("trims whitespace from plain email", () => {
+      expect(parseFromAddress("  john@example.com  ")).toEqual({
+        address: "john@example.com",
+      });
+    });
+  });
+});


### PR DESCRIPTION
RFC 2822 quotes names containing special characters (like &). When processing inbound emails, we now strip these surrounding quotes so that feed titles and author names display cleanly (e.g., "Brendan & Corinne Long-Hall" becomes Brendan & Corinne Long-Hall).