### PR TITLE
Fix filter design inconsistency across endpoints

### DIFF
--- a/android/app/src/main/java/com/lionreader/data/api/LionReaderApi.kt
+++ b/android/app/src/main/java/com/lionreader/data/api/LionReaderApi.kt
@@ -14,7 +14,6 @@ import com.lionreader.data.api.models.ProvidersResponse
 import com.lionreader.data.api.models.SaveArticleRequest
 import com.lionreader.data.api.models.SavedArticleResponse
 import com.lionreader.data.api.models.SortOrder
-import com.lionreader.data.api.models.StarredCountResponse
 import com.lionreader.data.api.models.SubscriptionsResponse
 import com.lionreader.data.api.models.SyncChangesResponse
 import com.lionreader.data.api.models.TagsResponse
@@ -152,13 +151,6 @@ interface LionReaderApi {
     suspend fun unstar(id: String): ApiResult<Unit>
 
     /**
-     * Get the count of starred entries.
-     *
-     * @return StarredCountResponse with total and unread counts
-     */
-    suspend fun getStarredCount(): ApiResult<StarredCountResponse>
-
-    /**
      * Get the count of entries with optional filters.
      *
      * @param feedId Filter by feed ID
@@ -166,6 +158,8 @@ interface LionReaderApi {
      * @param uncategorized If true, only count entries from subscriptions with no tags
      * @param type Filter to only include entries of this type
      * @param excludeTypes Filter to exclude entries of these types
+     * @param unreadOnly If true, only count unread entries
+     * @param starredOnly If true, only count starred entries
      * @return EntriesCountResponse with total and unread counts
      */
     suspend fun getEntriesCount(
@@ -174,6 +168,8 @@ interface LionReaderApi {
         uncategorized: Boolean? = null,
         type: EntryType? = null,
         excludeTypes: List<EntryType>? = null,
+        unreadOnly: Boolean? = null,
+        starredOnly: Boolean? = null,
     ): ApiResult<EntriesCountResponse>
 
     // ============================================================================
@@ -328,14 +324,14 @@ class LionReaderApiImpl
 
         override suspend fun unstar(id: String): ApiResult<Unit> = apiClient.deleteNoContent(path = "entries/$id/star")
 
-        override suspend fun getStarredCount(): ApiResult<StarredCountResponse> = apiClient.get(path = "entries/starred/count")
-
         override suspend fun getEntriesCount(
             feedId: String?,
             tagId: String?,
             uncategorized: Boolean?,
             type: EntryType?,
             excludeTypes: List<EntryType>?,
+            unreadOnly: Boolean?,
+            starredOnly: Boolean?,
         ): ApiResult<EntriesCountResponse> =
             apiClient.get(path = "entries/count") {
                 queryParam("feedId", feedId)
@@ -343,6 +339,8 @@ class LionReaderApiImpl
                 queryParam("uncategorized", uncategorized)
                 type?.let { queryParam("type", it.name.lowercase()) }
                 excludeTypes?.forEach { queryParam("excludeTypes", it.name.lowercase()) }
+                queryParam("unreadOnly", unreadOnly)
+                queryParam("starredOnly", starredOnly)
             }
 
         // ============================================================================

--- a/android/app/src/main/java/com/lionreader/data/api/models/EntryModels.kt
+++ b/android/app/src/main/java/com/lionreader/data/api/models/EntryModels.kt
@@ -91,15 +91,6 @@ enum class SortOrder(
 }
 
 /**
- * Response from starred entries count endpoint.
- */
-@Serializable
-data class StarredCountResponse(
-    val total: Int,
-    val unread: Int,
-)
-
-/**
  * Response from entries count endpoint.
  */
 @Serializable

--- a/android/app/src/main/java/com/lionreader/data/repository/EntryRepository.kt
+++ b/android/app/src/main/java/com/lionreader/data/repository/EntryRepository.kt
@@ -3,9 +3,9 @@ package com.lionreader.data.repository
 import android.util.Log
 import com.lionreader.data.api.ApiResult
 import com.lionreader.data.api.LionReaderApi
+import com.lionreader.data.api.models.EntriesCountResponse
 import com.lionreader.data.api.models.EntryDto
 import com.lionreader.data.api.models.SortOrder
-import com.lionreader.data.api.models.StarredCountResponse
 import com.lionreader.data.api.models.SubscriptionWithFeedDto
 import com.lionreader.data.api.models.SyncChangesResponse
 import com.lionreader.data.api.models.SyncEntryDto
@@ -142,10 +142,10 @@ class EntryRepository
         /**
          * Fetches the starred entries count from the server.
          *
-         * @return StarredCountResponse with total and unread counts, or null on failure
+         * @return EntriesCountResponse with total and unread counts, or null on failure
          */
-        suspend fun fetchStarredCount(): StarredCountResponse? =
-            when (val result = api.getStarredCount()) {
+        suspend fun fetchStarredCount(): EntriesCountResponse? =
+            when (val result = api.getEntriesCount(starredOnly = true)) {
                 is ApiResult.Success -> result.data
                 else -> null
             }

--- a/android/app/src/test/java/com/lionreader/data/api/ApiContractTest.kt
+++ b/android/app/src/test/java/com/lionreader/data/api/ApiContractTest.kt
@@ -56,7 +56,6 @@ class ApiContractTest {
             PathWithMethod("POST", "entries/mark-read"),
             PathWithMethod("POST", "entries/{id}/star"),
             PathWithMethod("DELETE", "entries/{id}/star"),
-            PathWithMethod("GET", "entries/starred/count"),
             PathWithMethod("GET", "entries/count"),
             // Saved articles endpoints (only save and delete - other operations use entries)
             PathWithMethod("POST", "saved"),

--- a/src/app/(app)/starred/page.tsx
+++ b/src/app/(app)/starred/page.tsx
@@ -41,7 +41,7 @@ function StarredEntriesContent() {
   });
 
   // Get starred entries count (total and unread)
-  const starredCountQuery = trpc.entries.starredCount.useQuery();
+  const starredCountQuery = trpc.entries.count.useQuery({ starredOnly: true });
   const unreadStarredCount = starredCountQuery.data?.unread ?? 0;
 
   // Entry mutations with optimistic updates

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -37,7 +37,8 @@ export function Sidebar({ onClose }: SidebarProps) {
   const tagsQuery = trpc.tags.list.useQuery();
   // Use unified entries.count with type='saved' filter
   const savedCountQuery = trpc.entries.count.useQuery({ type: "saved" });
-  const starredCountQuery = trpc.entries.starredCount.useQuery();
+  // Use unified entries.count with starredOnly filter
+  const starredCountQuery = trpc.entries.count.useQuery({ starredOnly: true });
   const utils = trpc.useUtils();
 
   const unsubscribeMutation = trpc.subscriptions.delete.useMutation({

--- a/src/lib/hooks/useEntryMutations.ts
+++ b/src/lib/hooks/useEntryMutations.ts
@@ -254,7 +254,7 @@ export function useEntryMutations(options?: UseEntryMutationsOptions): UseEntryM
       // Only the unread count changes - total stays the same since starred status isn't changing
       const starredEntries = data.entries.filter((e) => e.starred);
       if (starredEntries.length > 0) {
-        utils.entries.starredCount.setData(undefined, (old) => {
+        utils.entries.count.setData({ starredOnly: true }, (old) => {
           if (!old) return old;
           // When marking read, decrease unread count; when marking unread, increase it
           const delta = variables.read ? -starredEntries.length : starredEntries.length;
@@ -288,7 +288,7 @@ export function useEntryMutations(options?: UseEntryMutationsOptions): UseEntryM
       // Invalidate tag unread counts
       utils.tags.list.invalidate();
       // Invalidate starred count as it may have changed
-      utils.entries.starredCount.invalidate();
+      utils.entries.count.invalidate({ starredOnly: true });
     },
     onError: () => {
       toast.error("Failed to mark all as read");
@@ -325,7 +325,7 @@ export function useEntryMutations(options?: UseEntryMutationsOptions): UseEntryM
     },
     onSuccess: (data) => {
       // Update starred count directly - total increases by 1, unread increases if entry is unread
-      utils.entries.starredCount.setData(undefined, (old) => {
+      utils.entries.count.setData({ starredOnly: true }, (old) => {
         if (!old) return old;
         return {
           total: old.total + 1,
@@ -382,7 +382,7 @@ export function useEntryMutations(options?: UseEntryMutationsOptions): UseEntryM
     },
     onSuccess: (data) => {
       // Update starred count directly - total decreases by 1, unread decreases if entry is unread
-      utils.entries.starredCount.setData(undefined, (old) => {
+      utils.entries.count.setData({ starredOnly: true }, (old) => {
         if (!old) return old;
         return {
           total: Math.max(0, old.total - 1),

--- a/src/lib/hooks/useSavedArticleMutations.ts
+++ b/src/lib/hooks/useSavedArticleMutations.ts
@@ -150,7 +150,7 @@ export function useSavedArticleMutations(
       // Only the unread count changes - total stays the same since starred status isn't changing
       const starredEntries = data.entries.filter((e) => e.starred);
       if (starredEntries.length > 0) {
-        utils.entries.starredCount.setData(undefined, (old) => {
+        utils.entries.count.setData({ starredOnly: true }, (old) => {
           if (!old) return old;
           // When marking read, decrease unread count; when marking unread, increase it
           const delta = variables.read ? -starredEntries.length : starredEntries.length;
@@ -205,7 +205,7 @@ export function useSavedArticleMutations(
     },
     onSuccess: (data) => {
       // Update starred count directly - total increases by 1, unread increases if entry is unread
-      utils.entries.starredCount.setData(undefined, (old) => {
+      utils.entries.count.setData({ starredOnly: true }, (old) => {
         if (!old) return old;
         return {
           total: old.total + 1,
@@ -253,7 +253,7 @@ export function useSavedArticleMutations(
     },
     onSuccess: (data) => {
       // Update starred count directly - total decreases by 1, unread decreases if entry is unread
-      utils.entries.starredCount.setData(undefined, (old) => {
+      utils.entries.count.setData({ starredOnly: true }, (old) => {
         if (!old) return old;
         return {
           total: Math.max(0, old.total - 1),


### PR DESCRIPTION
Add unreadOnly and starredOnly filters to the entries.count endpoint for consistency with entries.list. This eliminates the need for a separate entries.starredCount endpoint.

Changes:
- Add unreadOnly and starredOnly parameters to entries.count
- Remove entries.starredCount endpoint
- Update web app to use entries.count({ starredOnly: true })
- Update Android app to use getEntriesCount(starredOnly = true)
- Remove StarredCountResponse from Android (use EntriesCountResponse)

This resolves the filter inconsistency between entries/count and entries/list endpoints, making the API more uniform and easier to use.