### PR TITLE
Fix OAuth flow in Firefox Android home screen app

### DIFF
--- a/src/app/(auth)/auth/oauth/callback/page.tsx
+++ b/src/app/(auth)/auth/oauth/callback/page.tsx
@@ -16,6 +16,7 @@
 import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc/client";
+import { broadcastOAuthComplete } from "@/lib/oauth-channel";
 
 /**
  * Validation result for OAuth callback parameters
@@ -143,6 +144,8 @@ function OAuthCallbackContent() {
       // Store the session token in a cookie
       document.cookie = `session=${data.sessionToken}; path=/; max-age=${30 * 24 * 60 * 60}; samesite=lax`;
       cleanupOAuthState();
+      // Broadcast completion for PWAs that may be listening in another window
+      broadcastOAuthComplete("/all");
       router.push("/all");
       router.refresh();
     },
@@ -157,6 +160,8 @@ function OAuthCallbackContent() {
     onSuccess: (data) => {
       document.cookie = `session=${data.sessionToken}; path=/; max-age=${30 * 24 * 60 * 60}; samesite=lax`;
       cleanupOAuthState();
+      // Broadcast completion for PWAs that may be listening in another window
+      broadcastOAuthComplete("/all");
       router.push("/all");
       router.refresh();
     },

--- a/src/app/(auth)/auth/oauth/complete/page.tsx
+++ b/src/app/(auth)/auth/oauth/complete/page.tsx
@@ -1,0 +1,83 @@
+/**
+ * OAuth Complete Page
+ *
+ * This page serves as an intermediate step after OAuth authentication completes.
+ * Its purpose is to broadcast the OAuth completion event so that PWAs running
+ * in a separate context (common on Firefox Android) can detect that auth finished.
+ *
+ * Flow:
+ * 1. OAuth callback sets the session cookie
+ * 2. Callback redirects here with ?redirect=<target>
+ * 3. This page broadcasts completion via BroadcastChannel and localStorage
+ * 4. Then redirects to the target page
+ *
+ * For PWAs: The original PWA window listens for the broadcast and refreshes
+ * to pick up the session cookie, even if OAuth happened in a separate browser window.
+ */
+
+"use client";
+
+import { Suspense, useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { broadcastOAuthComplete } from "@/lib/oauth-channel";
+
+export default function OAuthCompletePage() {
+  return (
+    <Suspense>
+      <OAuthCompleteContent />
+    </Suspense>
+  );
+}
+
+function OAuthCompleteContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const hasProcessed = useRef(false);
+
+  useEffect(() => {
+    if (hasProcessed.current) return;
+    hasProcessed.current = true;
+
+    const redirectTo = searchParams.get("redirect") ?? "/all";
+
+    // Broadcast OAuth completion for PWAs listening in other windows/tabs
+    broadcastOAuthComplete(redirectTo);
+
+    // Small delay to ensure broadcast is sent before redirecting
+    // This helps ensure the message is received by listeners
+    setTimeout(() => {
+      router.replace(redirectTo);
+    }, 100);
+  }, [router, searchParams]);
+
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <h2 className="mb-6 text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+        Sign-in successful
+      </h2>
+      <div className="flex flex-col items-center gap-4">
+        <svg
+          className="h-8 w-8 animate-spin text-zinc-900 dark:text-zinc-100"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400">Redirecting...</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/v1/auth/oauth/apple/callback/route.ts
+++ b/src/app/api/v1/auth/oauth/apple/callback/route.ts
@@ -121,9 +121,9 @@ export async function POST(request: NextRequest) {
       lastActiveAt: now,
     });
 
-    // Redirect to app with session cookie
+    // Redirect through OAuth completion page to broadcast success for PWAs
     // Use 303 to convert POST to GET for the redirect
-    const response = NextResponse.redirect(`${appUrl}/all`, 303);
+    const response = NextResponse.redirect(`${appUrl}/auth/oauth/complete?redirect=/all`, 303);
 
     // Set session cookie (30 days)
     response.cookies.set("session", token, {

--- a/src/app/api/v1/auth/oauth/google/callback/route.ts
+++ b/src/app/api/v1/auth/oauth/google/callback/route.ts
@@ -165,8 +165,8 @@ export async function GET(request: NextRequest) {
       lastActiveAt: now,
     });
 
-    // Redirect to app with session cookie
-    const response = NextResponse.redirect(`${appUrl}/all`);
+    // Redirect through OAuth completion page to broadcast success for PWAs
+    const response = NextResponse.redirect(`${appUrl}/auth/oauth/complete?redirect=/all`);
 
     // Set session cookie (30 days)
     response.cookies.set("session", token, {

--- a/src/lib/oauth-channel.ts
+++ b/src/lib/oauth-channel.ts
@@ -1,0 +1,172 @@
+/**
+ * OAuth Channel Utility
+ *
+ * Provides cross-tab communication for OAuth flows, particularly important for
+ * PWAs on mobile browsers (like Firefox Android) where OAuth may open in a
+ * separate browser window rather than within the PWA.
+ *
+ * Uses BroadcastChannel as the primary method, with localStorage events as fallback.
+ */
+
+const OAUTH_CHANNEL_NAME = "lion-reader-oauth";
+const OAUTH_COMPLETION_KEY = "oauth_completion";
+
+export interface OAuthCompletionMessage {
+  type: "oauth_complete";
+  success: boolean;
+  /** Where to redirect after OAuth completes */
+  redirectTo: string;
+  /** Timestamp to prevent stale messages */
+  timestamp: number;
+}
+
+/**
+ * Broadcast that OAuth has completed successfully.
+ * Called from the OAuth callback page after setting the session cookie.
+ */
+export function broadcastOAuthComplete(redirectTo: string): void {
+  const message: OAuthCompletionMessage = {
+    type: "oauth_complete",
+    success: true,
+    redirectTo,
+    timestamp: Date.now(),
+  };
+
+  // Primary method: BroadcastChannel (works cross-tab in same origin)
+  try {
+    const channel = new BroadcastChannel(OAUTH_CHANNEL_NAME);
+    channel.postMessage(message);
+    channel.close();
+  } catch {
+    // BroadcastChannel not supported, fall through to localStorage
+  }
+
+  // Secondary method: localStorage event (triggers storage event in other tabs)
+  // This serves as a fallback and also allows detection via visibility change
+  try {
+    localStorage.setItem(OAUTH_COMPLETION_KEY, JSON.stringify(message));
+  } catch {
+    // localStorage not available
+  }
+}
+
+/**
+ * Check if OAuth has recently completed (for visibility change detection).
+ * Returns the completion message if found and recent (within 5 minutes).
+ */
+export function checkOAuthCompletion(): OAuthCompletionMessage | null {
+  try {
+    const stored = localStorage.getItem(OAUTH_COMPLETION_KEY);
+    if (!stored) return null;
+
+    const message: OAuthCompletionMessage = JSON.parse(stored);
+
+    // Check if the completion is recent (within 5 minutes)
+    const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
+    if (message.timestamp < fiveMinutesAgo) {
+      // Stale completion, clean it up
+      clearOAuthCompletion();
+      return null;
+    }
+
+    return message;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Clear the OAuth completion marker from localStorage.
+ * Should be called after handling the completion.
+ */
+export function clearOAuthCompletion(): void {
+  try {
+    localStorage.removeItem(OAUTH_COMPLETION_KEY);
+  } catch {
+    // localStorage not available
+  }
+}
+
+/**
+ * Subscribe to OAuth completion events.
+ * Returns a cleanup function to unsubscribe.
+ *
+ * @param callback - Called when OAuth completes in another tab/window
+ */
+export function subscribeToOAuthCompletion(
+  callback: (message: OAuthCompletionMessage) => void
+): () => void {
+  const cleanupFns: (() => void)[] = [];
+
+  // Primary method: BroadcastChannel
+  try {
+    const channel = new BroadcastChannel(OAUTH_CHANNEL_NAME);
+    const handleMessage = (event: MessageEvent<OAuthCompletionMessage>) => {
+      if (event.data?.type === "oauth_complete") {
+        callback(event.data);
+      }
+    };
+    channel.addEventListener("message", handleMessage);
+    cleanupFns.push(() => {
+      channel.removeEventListener("message", handleMessage);
+      channel.close();
+    });
+  } catch {
+    // BroadcastChannel not supported
+  }
+
+  // Secondary method: storage event (fires when localStorage changes in another tab)
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === OAUTH_COMPLETION_KEY && event.newValue) {
+      try {
+        const message: OAuthCompletionMessage = JSON.parse(event.newValue);
+        if (message.type === "oauth_complete") {
+          callback(message);
+        }
+      } catch {
+        // Invalid JSON
+      }
+    }
+  };
+  window.addEventListener("storage", handleStorage);
+  cleanupFns.push(() => window.removeEventListener("storage", handleStorage));
+
+  // Return cleanup function
+  return () => {
+    for (const cleanup of cleanupFns) {
+      cleanup();
+    }
+  };
+}
+
+/**
+ * Check for OAuth completion when the page becomes visible.
+ * This handles the case where the PWA is backgrounded during OAuth.
+ *
+ * @param callback - Called if OAuth has completed while the page was hidden
+ */
+export function checkOAuthOnVisibilityChange(
+  callback: (message: OAuthCompletionMessage) => void
+): () => void {
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      const completion = checkOAuthCompletion();
+      if (completion) {
+        callback(completion);
+      }
+    }
+  };
+
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+
+  // Also check immediately in case we're already visible and OAuth completed
+  if (document.visibilityState === "visible") {
+    const completion = checkOAuthCompletion();
+    if (completion) {
+      // Use setTimeout to avoid calling callback synchronously during setup
+      setTimeout(() => callback(completion), 0);
+    }
+  }
+
+  return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+}


### PR DESCRIPTION
When using the web app added to home screen on Firefox Android, OAuth opens in a separate browser window. After OAuth completes, the browser redirects to the app but the PWA doesn't know OAuth finished.

This adds cross-tab communication using BroadcastChannel and localStorage so the PWA can detect when OAuth completes in another window:

- Add oauth-channel utility for BroadcastChannel/localStorage messaging
- Create OAuth completion page that broadcasts success before redirect
- Update login page to listen for OAuth completion events
- Handle visibility change to detect OAuth completion when app is resumed