### PR TITLE
Deduplicate constants across narration and feed parsing modules

### DIFF
--- a/src/components/narration/NarrationSettings.tsx
+++ b/src/components/narration/NarrationSettings.tsx
@@ -15,6 +15,7 @@ import { useNarrationSettings } from "@/lib/narration/settings";
 import { getNarrationSupportInfo, isFirefox } from "@/lib/narration/feature-detection";
 import { waitForVoices, rankVoices, findVoiceByUri } from "@/lib/narration/voices";
 import type { TTSProviderId } from "@/lib/narration/types";
+import { PREVIEW_TEXT } from "@/lib/narration/constants";
 import { EnhancedVoicesHelp } from "./EnhancedVoicesHelp";
 import { trpc } from "@/lib/trpc/client";
 
@@ -24,11 +25,6 @@ const EnhancedVoiceList = dynamic(
   () => import("./EnhancedVoiceList").then((mod) => mod.EnhancedVoiceList),
   { ssr: false }
 );
-
-/**
- * Sample text used for voice preview.
- */
-const PREVIEW_TEXT = "This is a preview of how articles will sound with this voice.";
 
 export function NarrationSettings() {
   const [settings, setSettings] = useNarrationSettings();

--- a/src/components/narration/useEnhancedVoices.ts
+++ b/src/components/narration/useEnhancedVoices.ts
@@ -19,6 +19,7 @@ import {
   trackEnhancedVoiceDownloadFailed,
   classifyDownloadError,
 } from "@/lib/telemetry";
+import { PREVIEW_TEXT } from "@/lib/narration/constants";
 
 /**
  * Download status for a voice.
@@ -137,11 +138,6 @@ export interface UseEnhancedVoicesReturn {
    */
   deleteAllVoices: () => Promise<void>;
 }
-
-/**
- * Sample text for voice preview.
- */
-const PREVIEW_TEXT = "This is a preview of how articles will sound with this voice.";
 
 /**
  * Hook for managing enhanced voices.

--- a/src/lib/narration/ArticleNarrator.ts
+++ b/src/lib/narration/ArticleNarrator.ts
@@ -22,6 +22,15 @@
  */
 
 import { isFirefox } from "./feature-detection";
+import {
+  DEFAULT_RATE,
+  DEFAULT_PITCH,
+  MIN_RATE,
+  MAX_RATE,
+  MIN_PITCH,
+  MAX_PITCH,
+  clamp,
+} from "./constants";
 
 /**
  * Possible states for the narration playback.
@@ -46,43 +55,6 @@ export interface NarrationState {
  * Callback type for state change notifications.
  */
 export type StateChangeCallback = (state: NarrationState) => void;
-
-/**
- * Default rate for speech synthesis (1.0 = normal speed).
- */
-const DEFAULT_RATE = 1.0;
-
-/**
- * Default pitch for speech synthesis (1.0 = normal pitch).
- */
-const DEFAULT_PITCH = 1.0;
-
-/**
- * Minimum allowed rate value.
- */
-const MIN_RATE = 0.5;
-
-/**
- * Maximum allowed rate value.
- */
-const MAX_RATE = 2.0;
-
-/**
- * Minimum allowed pitch value.
- */
-const MIN_PITCH = 0.5;
-
-/**
- * Maximum allowed pitch value.
- */
-const MAX_PITCH = 2.0;
-
-/**
- * Clamps a value between a minimum and maximum.
- */
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
 
 /**
  * ArticleNarrator provides paragraph-based narration for articles using the Web Speech API.

--- a/src/lib/narration/block-elements.ts
+++ b/src/lib/narration/block-elements.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared block element definitions for narration.
+ *
+ * This module is isomorphic (works in both browser and server)
+ * and provides the canonical list of block elements for paragraph marking.
+ *
+ * @module narration/block-elements
+ */
+
+/**
+ * Block-level elements that get paragraph markers for narration highlighting.
+ * Used by both server-side preprocessing and client-side highlighting.
+ */
+export const BLOCK_ELEMENTS = [
+  "p",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "blockquote",
+  "pre",
+  "ul",
+  "ol",
+  "li",
+  "figure",
+  "table",
+  "img",
+] as const;
+
+/**
+ * Type for block element tag names.
+ */
+export type BlockElement = (typeof BLOCK_ELEMENTS)[number];

--- a/src/lib/narration/browser-tts-provider.ts
+++ b/src/lib/narration/browser-tts-provider.ts
@@ -10,43 +10,15 @@
 import type { TTSProvider, TTSVoice, SpeakOptions } from "./types";
 import { isFirefox } from "./feature-detection";
 import { waitForVoices as waitForBrowserVoices } from "./voices";
-
-/**
- * Default speech rate (1.0 = normal speed).
- */
-const DEFAULT_RATE = 1.0;
-
-/**
- * Default speech pitch (1.0 = normal pitch).
- */
-const DEFAULT_PITCH = 1.0;
-
-/**
- * Minimum allowed rate value.
- */
-const MIN_RATE = 0.5;
-
-/**
- * Maximum allowed rate value.
- */
-const MAX_RATE = 2.0;
-
-/**
- * Minimum allowed pitch value.
- */
-const MIN_PITCH = 0.5;
-
-/**
- * Maximum allowed pitch value.
- */
-const MAX_PITCH = 2.0;
-
-/**
- * Clamps a value between a minimum and maximum.
- */
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
+import {
+  DEFAULT_RATE,
+  DEFAULT_PITCH,
+  MIN_RATE,
+  MAX_RATE,
+  MIN_PITCH,
+  MAX_PITCH,
+  clamp,
+} from "./constants";
 
 /**
  * BrowserTTSProvider implements TTSProvider using the Web Speech API.

--- a/src/lib/narration/client-paragraph-ids.ts
+++ b/src/lib/narration/client-paragraph-ids.ts
@@ -8,27 +8,10 @@
  * @module narration/client-paragraph-ids
  */
 
-/**
- * Block-level elements that can be highlighted during narration.
- * This matches the server-side BLOCK_ELEMENTS constant.
- */
-export const BLOCK_ELEMENTS = [
-  "p",
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-  "blockquote",
-  "pre",
-  "ul",
-  "ol",
-  "li",
-  "figure",
-  "table",
-  "img",
-] as const;
+import { BLOCK_ELEMENTS } from "./block-elements";
+
+// Re-export for backwards compatibility
+export { BLOCK_ELEMENTS };
 
 /**
  * Result of adding paragraph IDs to HTML content.

--- a/src/lib/narration/constants.ts
+++ b/src/lib/narration/constants.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared constants for narration/TTS functionality.
+ *
+ * @module narration/constants
+ */
+
+/**
+ * Default speech rate (1.0 = normal speed).
+ */
+export const DEFAULT_RATE = 1.0;
+
+/**
+ * Default speech pitch (1.0 = normal pitch).
+ */
+export const DEFAULT_PITCH = 1.0;
+
+/**
+ * Minimum allowed rate value.
+ */
+export const MIN_RATE = 0.5;
+
+/**
+ * Maximum allowed rate value.
+ */
+export const MAX_RATE = 2.0;
+
+/**
+ * Minimum allowed pitch value.
+ */
+export const MIN_PITCH = 0.5;
+
+/**
+ * Maximum allowed pitch value.
+ */
+export const MAX_PITCH = 2.0;
+
+/**
+ * Preview text used for voice demos.
+ */
+export const PREVIEW_TEXT = "This is a preview of how articles will sound with this voice.";
+
+/**
+ * Clamps a value between a minimum and maximum.
+ */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/src/lib/narration/html-to-narration-input.ts
+++ b/src/lib/narration/html-to-narration-input.ts
@@ -9,28 +9,10 @@
  */
 
 import { parseHTML } from "linkedom";
+import { BLOCK_ELEMENTS } from "./block-elements";
 
-/**
- * Block-level elements that get paragraph markers.
- * Must match the client-side BLOCK_ELEMENTS in client-paragraph-ids.ts
- */
-export const BLOCK_ELEMENTS = [
-  "p",
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-  "blockquote",
-  "pre",
-  "ul",
-  "ol",
-  "li",
-  "figure",
-  "table",
-  "img",
-] as const;
+// Re-export for backwards compatibility
+export { BLOCK_ELEMENTS };
 
 /**
  * Set version of BLOCK_ELEMENTS for efficient lookup.

--- a/src/lib/narration/piper-tts-provider.ts
+++ b/src/lib/narration/piper-tts-provider.ts
@@ -12,6 +12,7 @@ import type { TTSProvider, TTSVoice, SpeakOptions } from "./types";
 import { ENHANCED_VOICES, findEnhancedVoice } from "./enhanced-voices";
 import { splitIntoSentences } from "./sentence-splitter";
 import { concatenateAudioBuffers, DEFAULT_SENTENCE_GAP_SECONDS } from "./audio-buffer-utils";
+import { DEFAULT_RATE, MIN_RATE, MAX_RATE, clamp } from "./constants";
 
 /**
  * Dynamically imports the piper-tts-web module.
@@ -64,28 +65,6 @@ const CUSTOM_WASM_PATHS = {
   piperWasm:
     "https://cdn.jsdelivr.net/npm/@diffusionstudio/piper-wasm@1.0.0/build/piper_phonemize.wasm",
 };
-
-/**
- * Default speech rate (1.0 = normal speed).
- */
-const DEFAULT_RATE = 1.0;
-
-/**
- * Minimum allowed rate value.
- */
-const MIN_RATE = 0.5;
-
-/**
- * Maximum allowed rate value.
- */
-const MAX_RATE = 2.0;
-
-/**
- * Clamps a value between a minimum and maximum.
- */
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
 
 /**
  * Error thrown when a voice is not downloaded.

--- a/src/server/feed/streaming/atom-parser.ts
+++ b/src/server/feed/streaming/atom-parser.ts
@@ -7,6 +7,7 @@ import { Parser } from "htmlparser2";
 import { decode } from "html-entities";
 import type { ParsedEntry, SyndicationHints } from "../types";
 import type { FeedParseResult } from "./types";
+import { VALID_UPDATE_PERIODS, type UpdatePeriod } from "./syndication";
 
 type AtomParserState =
   | "initial"
@@ -26,9 +27,6 @@ type AtomParserState =
   | "in_entry_updated"
   | "in_entry_author"
   | "in_entry_author_name";
-
-const VALID_UPDATE_PERIODS = ["hourly", "daily", "weekly", "monthly", "yearly"] as const;
-type UpdatePeriod = (typeof VALID_UPDATE_PERIODS)[number];
 
 /**
  * Parses an Atom feed from a string.

--- a/src/server/feed/streaming/rss-parser.ts
+++ b/src/server/feed/streaming/rss-parser.ts
@@ -7,6 +7,7 @@ import { Parser } from "htmlparser2";
 import { decode } from "html-entities";
 import type { ParsedEntry, SyndicationHints } from "../types";
 import type { FeedParseResult } from "./types";
+import { VALID_UPDATE_PERIODS, type UpdatePeriod } from "./syndication";
 
 /**
  * State machine states for RSS parsing.
@@ -32,9 +33,6 @@ type RssParserState =
   | "in_item_dc_creator"
   | "in_item_pubDate"
   | "in_item_dc_date";
-
-const VALID_UPDATE_PERIODS = ["hourly", "daily", "weekly", "monthly", "yearly"] as const;
-type UpdatePeriod = (typeof VALID_UPDATE_PERIODS)[number];
 
 /**
  * Parses an RSS feed from a string.

--- a/src/server/feed/streaming/syndication.ts
+++ b/src/server/feed/streaming/syndication.ts
@@ -1,0 +1,18 @@
+/**
+ * Syndication constants shared between RSS and Atom parsers.
+ *
+ * @module feed/streaming/syndication
+ */
+
+/**
+ * Valid values for sy:updatePeriod in RSS/Atom feeds.
+ * Part of the RSS 1.0 Syndication Module specification.
+ *
+ * @see http://web.resource.org/rss/1.0/modules/syndication/
+ */
+export const VALID_UPDATE_PERIODS = ["hourly", "daily", "weekly", "monthly", "yearly"] as const;
+
+/**
+ * Type for valid update period values.
+ */
+export type UpdatePeriod = (typeof VALID_UPDATE_PERIODS)[number];


### PR DESCRIPTION
Consolidates several duplicate constant definitions into shared modules:

- TTS constants (DEFAULT_RATE, MIN_RATE, MAX_RATE, etc.) and clamp() function moved to src/lib/narration/constants.ts
- PREVIEW_TEXT for voice demos added to constants.ts
- BLOCK_ELEMENTS extracted to src/lib/narration/block-elements.ts as an isomorphic module usable by both client and server
- VALID_UPDATE_PERIODS for syndication hints moved to src/server/feed/streaming/syndication.ts

This reduces code duplication and ensures these values stay in sync across the codebase.