### PR TITLE
Separate Android documentation into dedicated CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,3 @@ For mutations that update UI state (mark read, star, etc.), use optimistic updat
 - **Prefer `setQueryData`/`setInfiniteData`** for updating specific items in lists
 - **Use `invalidate`** only when you need fresh server data (e.g., computed counts)
 - Targeted updates are faster and avoid unnecessary refetches
-
-## Android App
-
-The Android app lives in `android/`. When adding new API endpoints to `LionReaderApiImpl`, also add them to `clientPaths` in `ApiContractTest` to ensure they're validated against the server's OpenAPI spec.

--- a/android/CLAUDE.md
+++ b/android/CLAUDE.md
@@ -1,0 +1,98 @@
+# Android App Development Guidelines
+
+## Documentation
+
+See [README.md](README.md) for setup, build instructions, and architecture overview.
+
+## Code Quality
+
+Before committing, run:
+
+```bash
+./gradlew check  # Runs ktlint, detekt, and tests
+```
+
+Or run individual checks:
+
+```bash
+./gradlew ktlintCheck     # Code style
+./gradlew ktlintFormat    # Auto-fix style issues
+./gradlew detekt          # Static analysis
+./gradlew test            # Unit tests
+```
+
+## API Contract Testing
+
+When adding new API endpoints to `LionReaderApiImpl`, also add them to `clientPaths` in `ApiContractTest`. This test validates that all client API paths exist in the server's OpenAPI spec, catching mismatches before they cause runtime 404 errors.
+
+Example - if you add a new endpoint in `LionReaderApiImpl.kt`:
+
+```kotlin
+suspend fun getNewThing(): NewThing {
+    return httpClient.get("new-thing").body()
+}
+```
+
+Add the corresponding entry in `ApiContractTest.kt`:
+
+```kotlin
+private val clientPaths = listOf(
+    // ... existing paths ...
+    PathWithMethod("GET", "new-thing"),
+)
+```
+
+Run the contract test:
+
+```bash
+./gradlew testDebugUnitTest --tests "*.ApiContractTest"
+```
+
+## Architecture
+
+The app follows Clean Architecture with MVVM:
+
+- **data/** - API clients, Room database, repositories
+- **di/** - Hilt dependency injection modules
+- **service/** - Background services (sync, etc.)
+- **ui/** - Compose screens, ViewModels, UI state
+
+### Key Patterns
+
+- **Offline-first**: Data flows through Room database; sync via WorkManager
+- **Pending actions**: Offline changes are queued and synced when connectivity returns
+- **Unidirectional data flow**: ViewModels expose StateFlow, UI observes and sends events
+
+## Testing
+
+### Unit Tests (`src/test/`)
+
+- Pure business logic, no Android framework dependencies
+- Run fast, no emulator needed
+- Test ViewModels, repositories, data transformations
+
+### Instrumented Tests (`src/androidTest/`)
+
+- Tests that need Android framework (Room DAOs, UI tests)
+- Require emulator or device
+- Use Hilt testing utilities for DI
+
+## Conventions
+
+### Kotlin
+
+- Use data classes for DTOs and state objects
+- Prefer `sealed class` for representing finite states
+- Use `@Serializable` (kotlinx.serialization) for API models
+
+### Compose
+
+- State hoisting: UI components receive state, emit events
+- Use `remember` and `derivedStateOf` appropriately
+- Preview functions for all reusable components
+
+### Coroutines
+
+- ViewModels use `viewModelScope`
+- Repositories expose `Flow` for reactive data
+- Use `Dispatchers.IO` for blocking operations


### PR DESCRIPTION
Move Android-specific guidelines from the main CLAUDE.md into a new android/CLAUDE.md file. The Android docs now include expanded guidance on code quality checks, API contract testing, architecture patterns, and testing conventions.