### PR TITLE
Fix Sidebar tags fetching on every page load

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,21 +1,54 @@
 /**
  * App Layout
  *
- * Server component wrapper that provides TRPCProvider and forces dynamic rendering.
+ * Server component wrapper that provides TRPCProvider and prefetches sidebar data.
  * The actual layout UI is in AppLayoutContent.
  */
 
-import { TRPCProvider } from "@/lib/trpc/provider";
+import { dehydrate } from "@tanstack/react-query";
+import { TRPCProvider, HydrationBoundary } from "@/lib/trpc/provider";
+import { createServerQueryClient, createServerCaller } from "@/lib/trpc/server";
 import { AppLayoutContent } from "./AppLayoutContent";
 
 interface AppLayoutProps {
   children: React.ReactNode;
 }
 
-export default function AppLayout({ children }: AppLayoutProps) {
+export default async function AppLayout({ children }: AppLayoutProps) {
+  const queryClient = createServerQueryClient();
+  const { caller, session } = await createServerCaller();
+
+  if (session) {
+    // Prefetch sidebar data to avoid client-side fetches on every navigation
+    await Promise.all([
+      // Tags for sidebar tag list
+      queryClient.prefetchQuery({
+        queryKey: [["tags", "list"], { input: undefined, type: "query" }],
+        queryFn: () => caller.tags.list(),
+      }),
+      // Subscriptions for sidebar feed list and unread counts
+      queryClient.prefetchQuery({
+        queryKey: [["subscriptions", "list"], { input: undefined, type: "query" }],
+        queryFn: () => caller.subscriptions.list(),
+      }),
+      // Saved articles count for sidebar
+      queryClient.prefetchQuery({
+        queryKey: [["entries", "count"], { input: { type: "saved" }, type: "query" }],
+        queryFn: () => caller.entries.count({ type: "saved" }),
+      }),
+      // Starred entries count for sidebar
+      queryClient.prefetchQuery({
+        queryKey: [["entries", "count"], { input: { starredOnly: true }, type: "query" }],
+        queryFn: () => caller.entries.count({ starredOnly: true }),
+      }),
+    ]);
+  }
+
   return (
     <TRPCProvider>
-      <AppLayoutContent>{children}</AppLayoutContent>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <AppLayoutContent>{children}</AppLayoutContent>
+      </HydrationBoundary>
     </TRPCProvider>
   );
 }


### PR DESCRIPTION
The Sidebar component was triggering client-side fetches for tags.list, subscriptions.list, and entries.count on every page load since it wasn't benefiting from page-level SSR prefetching. This adds server-side prefetching in the layout with HydrationBoundary to hydrate the data to the client, eliminating unnecessary XHR requests on navigation.

Fixes #259