### PR TITLE
Remove prefetch on mouse-down for entries

### DIFF
--- a/src/app/(app)/all/client.tsx
+++ b/src/app/(app)/all/client.tsx
@@ -102,7 +102,6 @@ function AllEntriesContent() {
       hasNextPage: entryListQuery.hasNextPage,
       fetchNextPage: entryListQuery.fetchNextPage,
       refetch: entryListQuery.refetch,
-      prefetchEntry: entryListQuery.prefetchEntry,
     }),
     [entryListQuery]
   );

--- a/src/app/(app)/starred/client.tsx
+++ b/src/app/(app)/starred/client.tsx
@@ -93,7 +93,6 @@ function StarredEntriesContent() {
       hasNextPage: entryListQuery.hasNextPage,
       fetchNextPage: entryListQuery.fetchNextPage,
       refetch: entryListQuery.refetch,
-      prefetchEntry: entryListQuery.prefetchEntry,
     }),
     [entryListQuery]
   );

--- a/src/app/(app)/subscription/[id]/client.tsx
+++ b/src/app/(app)/subscription/[id]/client.tsx
@@ -160,7 +160,6 @@ function SingleSubscriptionContent() {
       hasNextPage: entryListQuery.hasNextPage,
       fetchNextPage: entryListQuery.fetchNextPage,
       refetch: entryListQuery.refetch,
-      prefetchEntry: entryListQuery.prefetchEntry,
     }),
     [entryListQuery]
   );

--- a/src/app/(app)/tag/[tagId]/client.tsx
+++ b/src/app/(app)/tag/[tagId]/client.tsx
@@ -163,7 +163,6 @@ function UncategorizedContent() {
       hasNextPage: entryListQuery.hasNextPage,
       fetchNextPage: entryListQuery.fetchNextPage,
       refetch: entryListQuery.refetch,
-      prefetchEntry: entryListQuery.prefetchEntry,
     }),
     [entryListQuery]
   );
@@ -363,7 +362,6 @@ function TagContent({ tagId }: { tagId: string }) {
       hasNextPage: entryListQuery.hasNextPage,
       fetchNextPage: entryListQuery.fetchNextPage,
       refetch: entryListQuery.refetch,
-      prefetchEntry: entryListQuery.prefetchEntry,
     }),
     [entryListQuery]
   );

--- a/src/app/(app)/uncategorized/client.tsx
+++ b/src/app/(app)/uncategorized/client.tsx
@@ -102,7 +102,6 @@ function UncategorizedEntriesContent() {
       hasNextPage: entryListQuery.hasNextPage,
       fetchNextPage: entryListQuery.fetchNextPage,
       refetch: entryListQuery.refetch,
-      prefetchEntry: entryListQuery.prefetchEntry,
     }),
     [entryListQuery]
   );

--- a/src/components/articles/ArticleListItem.tsx
+++ b/src/components/articles/ArticleListItem.tsx
@@ -36,8 +36,6 @@ interface ArticleListItemProps {
   onToggleRead?: (id: string, currentlyRead: boolean) => void;
   /** Callback when the star indicator is clicked */
   onToggleStar?: (id: string, currentlyStarred: boolean) => void;
-  /** Callback to prefetch article data on mousedown (before click completes) */
-  onPrefetch?: (id: string) => void;
 }
 
 /**
@@ -77,7 +75,6 @@ export const ArticleListItem = memo(function ArticleListItem({
   onClick,
   onToggleRead,
   onToggleStar,
-  onPrefetch,
 }: ArticleListItemProps) {
   const displayTitle = title ?? "Untitled";
 
@@ -90,12 +87,6 @@ export const ArticleListItem = memo(function ArticleListItem({
       e.preventDefault();
       onClick?.(id);
     }
-  };
-
-  const handleMouseDown = () => {
-    // Prefetch article data when user presses mouse button (before click completes)
-    // This gives a 50-150ms head start with near-zero false positives
-    onPrefetch?.(id);
   };
 
   const handleToggleRead = (e: React.MouseEvent) => {
@@ -114,7 +105,6 @@ export const ArticleListItem = memo(function ArticleListItem({
       tabIndex={0}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
-      onMouseDown={handleMouseDown}
       data-entry-id={id}
       className={getItemClasses(read, selected)}
       aria-label={`${read ? "Read" : "Unread"}${selected ? ", selected" : ""} article: ${displayTitle} from ${source}`}

--- a/src/components/entries/EntryList.tsx
+++ b/src/components/entries/EntryList.tsx
@@ -103,11 +103,6 @@ export interface ExternalQueryState {
    * Refetch all entries.
    */
   refetch: () => void;
-
-  /**
-   * Prefetch entry data on mousedown.
-   */
-  prefetchEntry: (entryId: string) => void;
 }
 
 interface EntryListProps {
@@ -203,22 +198,6 @@ export function EntryList({
       // Disable when using external data
       enabled: !useExternalData,
     }
-  );
-
-  // Get tRPC utils for prefetching on mousedown
-  const utils = trpc.useUtils();
-
-  // Prefetch entry data on mousedown (before click completes)
-  // This gives a 50-150ms head start with near-zero false positives
-  const handlePrefetch = useCallback(
-    (entryId: string) => {
-      if (useExternalData && externalQueryState?.prefetchEntry) {
-        externalQueryState.prefetchEntry(entryId);
-      } else {
-        utils.entries.get.fetch({ id: entryId });
-      }
-    },
-    [useExternalData, externalQueryState, utils]
   );
 
   // Flatten all pages into a single array of entries (from internal query)
@@ -321,7 +300,6 @@ export function EntryList({
           selected={selectedEntryId === entry.id}
           onToggleRead={onToggleRead}
           onToggleStar={onToggleStar}
-          onPrefetch={handlePrefetch}
         />
       ))}
 

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -42,10 +42,6 @@ interface EntryListItemProps {
    * Callback when the star indicator is clicked.
    */
   onToggleStar?: (entryId: string, currentlyStarred: boolean) => void;
-  /**
-   * Callback to prefetch entry data on mousedown (before click completes).
-   */
-  onPrefetch?: (entryId: string) => void;
 }
 
 /**
@@ -58,7 +54,6 @@ export const EntryListItem = memo(function EntryListItem({
   selected = false,
   onToggleRead,
   onToggleStar,
-  onPrefetch,
 }: EntryListItemProps) {
   return (
     <ArticleListItem
@@ -73,7 +68,6 @@ export const EntryListItem = memo(function EntryListItem({
       onClick={onClick}
       onToggleRead={onToggleRead}
       onToggleStar={onToggleStar}
-      onPrefetch={onPrefetch}
     />
   );
 });

--- a/src/components/saved/SavedArticleList.tsx
+++ b/src/components/saved/SavedArticleList.tsx
@@ -134,18 +134,6 @@ export function SavedArticleList({
     }
   );
 
-  // Get tRPC utils for prefetching on mousedown
-  const utils = trpc.useUtils();
-
-  // Prefetch article data on mousedown (before click completes)
-  // This gives a 50-150ms head start with near-zero false positives
-  const handlePrefetch = useCallback(
-    (articleId: string) => {
-      utils.entries.get.fetch({ id: articleId });
-    },
-    [utils]
-  );
-
   // Flatten all pages into a single array of articles
   const allArticles = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data?.pages]);
 
@@ -222,7 +210,6 @@ export function SavedArticleList({
           selected={selectedArticleId === article.id}
           onToggleRead={onToggleRead}
           onToggleStar={onToggleStar}
-          onPrefetch={handlePrefetch}
         />
       ))}
 

--- a/src/components/saved/SavedArticleListItem.tsx
+++ b/src/components/saved/SavedArticleListItem.tsx
@@ -43,10 +43,6 @@ interface SavedArticleListItemProps {
    * Callback when the star indicator is clicked.
    */
   onToggleStar?: (articleId: string, currentlyStarred: boolean) => void;
-  /**
-   * Callback to prefetch article data on mousedown (before click completes).
-   */
-  onPrefetch?: (articleId: string) => void;
 }
 
 /**
@@ -59,7 +55,6 @@ export const SavedArticleListItem = memo(function SavedArticleListItem({
   selected = false,
   onToggleRead,
   onToggleStar,
-  onPrefetch,
 }: SavedArticleListItemProps) {
   // For saved articles, prefer siteName (from og:site_name) over feedTitle (which is "Saved Articles")
   const source = article.siteName ?? getDomain(article.url ?? "");
@@ -76,7 +71,6 @@ export const SavedArticleListItem = memo(function SavedArticleListItem({
       onClick={onClick}
       onToggleRead={onToggleRead}
       onToggleStar={onToggleStar}
-      onPrefetch={onPrefetch}
     />
   );
 });

--- a/src/lib/hooks/useEntryListQuery.ts
+++ b/src/lib/hooks/useEntryListQuery.ts
@@ -135,11 +135,6 @@ export interface UseEntryListQueryResult {
    * Returns the entry ID to navigate to, or undefined if at the start.
    */
   getPreviousEntryId: () => string | undefined;
-
-  /**
-   * Prefetch entry data on mousedown (before click completes).
-   */
-  prefetchEntry: (entryId: string) => void;
 }
 
 /**
@@ -151,8 +146,6 @@ export interface UseEntryListQueryResult {
  */
 export function useEntryListQuery(options: UseEntryListQueryOptions): UseEntryListQueryResult {
   const { filters, pageSize = 20, openEntryId, prefetchThreshold = 3 } = options;
-
-  const utils = trpc.useUtils();
 
   // Track if we've triggered a fetch to avoid duplicate calls
   const fetchingRef = useRef(false);
@@ -320,14 +313,6 @@ export function useEntryListQuery(options: UseEntryListQueryOptions): UseEntryLi
     return undefined;
   }, [entries, openEntryId]);
 
-  // Prefetch entry data on mousedown
-  const prefetchEntry = useCallback(
-    (entryId: string) => {
-      utils.entries.get.fetch({ id: entryId });
-    },
-    [utils]
-  );
-
   // Wrap fetchNextPage to reset the fetching ref
   const wrappedFetchNextPage = useCallback(() => {
     fetchNextPage();
@@ -346,6 +331,5 @@ export function useEntryListQuery(options: UseEntryListQueryOptions): UseEntryLi
     previousEntryId,
     getNextEntryId,
     getPreviousEntryId,
-    prefetchEntry,
   };
 }


### PR DESCRIPTION
The mousedown prefetch on entry clicks was conflicting with RSC prefetching, causing double-fetches. Entry content is now prefetched server-side, making this client-side prefetch redundant.

Removes:
- onPrefetch prop from ArticleListItem, EntryListItem, SavedArticleListItem
- handleMouseDown/onMouseDown from ArticleListItem
- prefetchEntry from useEntryListQuery hook
- prefetchEntry from ExternalQueryState interface
- handlePrefetch callbacks from EntryList and SavedArticleList