### PR TITLE
Handle WebSub subscription changes in feeds

### DIFF
--- a/src/server/feed/index.ts
+++ b/src/server/feed/index.ts
@@ -17,4 +17,8 @@ export {
   handleVerificationChallenge,
   verifyHmacSignature,
   renewExpiringSubscriptions,
+  canUseWebSub,
+  subscribeToHub,
+  deactivateWebsub,
+  type SubscribeToHubResult,
 } from "./websub";


### PR DESCRIPTION
When a feed is fetched, we now properly handle WebSub state transitions:

- If a feed discovers a hub URL and WebSub isn't active, initiate subscription
- If a feed had WebSub active but removes the hub URL, deactivate subscription

Also changes the hub URL storage behavior: instead of falling back to the previous hub URL when none is found in feed content, we now clear it. This ensures we correctly detect when a feed removes WebSub support.