### PR TITLE
Fix RSS feed entry sorting in preview

### DIFF
--- a/src/server/trpc/routers/feeds.ts
+++ b/src/server/trpc/routers/feeds.ts
@@ -324,7 +324,16 @@ export const feedsRouter = createTRPCRouter({
       }
 
       // Step 4: Build and return the preview
-      const sampleEntries = parsedFeed.items
+      // Sort entries by publication date (newest first) before taking sample
+      // Entries without dates are placed last
+      const sortedItems = [...parsedFeed.items].sort((a, b) => {
+        if (!a.pubDate && !b.pubDate) return 0;
+        if (!a.pubDate) return 1;
+        if (!b.pubDate) return -1;
+        return b.pubDate.getTime() - a.pubDate.getTime();
+      });
+
+      const sampleEntries = sortedItems
         .slice(0, MAX_SAMPLE_ENTRIES)
         .map((entry) => toSampleEntry(entry, finalFeedUrl));
 


### PR DESCRIPTION
Feed preview was displaying entries in feed document order rather than by publication date, causing old articles to appear at the top of the "Recent Entries" preview. Sort entries by pubDate descending before taking the sample, with entries missing dates placed last.