### PR TITLE
Document codebase and create architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ Lion Reader is a self-hosted feed reader that supports RSS and Atom feeds. It's 
 - **Authentication** - Email/password and OAuth (Google, Apple)
 - **OPML import/export** - Migrate from other readers
 - **Keyboard shortcuts** - Vim-style navigation for power users
+- **Full-text search** - Search entries by title and content
+- **Full content fetching** - Optionally fetch complete article content from URLs
 - **REST API** - Public API for third-party clients
+- **MCP Server** - Expose feeds to AI assistants via Model Context Protocol
 - **Android app** - Native Android client in `android/`
 - **Rate limiting** and **error tracking** with Sentry
 
 ### Planned Features
 
-- Full-text search
 - iOS app
 - Offline/PWA support
 
@@ -363,6 +365,28 @@ Lion Reader provides a REST API for third-party clients. Key endpoints:
 | GET    | `/v1/events`            | SSE stream for real-time updates |
 
 See [MVP Specification](docs/MVP.md) for the complete API reference.
+
+## MCP Server
+
+Lion Reader provides an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for AI assistant integration. This allows AI tools like Claude to read and manage your feeds.
+
+### Available Tools
+
+| Tool                 | Description                              |
+| -------------------- | ---------------------------------------- |
+| `list_entries`       | List entries with filters and pagination |
+| `search_entries`     | Full-text search across entries          |
+| `get_entry`          | Get entry with full content              |
+| `mark_entries_read`  | Mark entries read/unread                 |
+| `list_subscriptions` | List all subscriptions                   |
+
+### Running
+
+```bash
+pnpm mcp:serve
+```
+
+Configure your AI assistant to use stdio transport with this command.
 
 ## License
 

--- a/docs/diagrams/backend-api.d2
+++ b/docs/diagrams/backend-api.d2
@@ -1,0 +1,288 @@
+# Backend API Architecture
+# tRPC routers → Services layer → Database
+
+direction: right
+
+title: {
+  label: Backend API Architecture
+  near: top-center
+  shape: text
+  style.font-size: 24
+  style.bold: true
+}
+
+# ==============================================================================
+# Client Layer
+# ==============================================================================
+
+clients: {
+  label: Clients
+  style.fill: "#e3f2fd"
+
+  web: {
+    label: Web App
+    icon: https://icons.terrastruct.com/essentials%2F112-browser.svg
+  }
+
+  android: {
+    label: Android App
+    icon: https://icons.terrastruct.com/tech%2F024-android.svg
+  }
+
+  mcp: {
+    label: MCP Server
+    icon: https://icons.terrastruct.com/essentials%2F123-artificial-intelligence.svg
+    tooltip: "AI assistant integration"
+  }
+}
+
+# ==============================================================================
+# API Layer
+# ==============================================================================
+
+api: {
+  label: API Layer
+  style.fill: "#fff3e0"
+
+  trpc: {
+    label: tRPC Server
+    style.fill: "#ffcc80"
+
+    middleware: {
+      label: Middleware
+
+      auth: {
+        label: Auth
+        tooltip: "Session/API token validation"
+      }
+
+      rate_limit: {
+        label: Rate Limit
+        tooltip: "Token bucket via Redis"
+      }
+    }
+
+    routers: {
+      label: Routers
+      style.fill: "#ffe0b2"
+
+      auth: {
+        label: auth
+        tooltip: "Login, register, OAuth"
+      }
+
+      entries: {
+        label: entries
+        tooltip: "List, get, markRead, star"
+      }
+
+      subscriptions: {
+        label: subscriptions
+        tooltip: "CRUD, import/export"
+      }
+
+      tags: {
+        label: tags
+        tooltip: "Create, update, delete"
+      }
+
+      sync: {
+        label: sync
+        tooltip: "Incremental sync endpoint"
+      }
+
+      narration: {
+        label: narration
+        tooltip: "Text-to-speech"
+      }
+
+      feeds: {
+        label: feeds
+        tooltip: "Preview, discover"
+      }
+
+      saved: {
+        label: saved
+        tooltip: "Read-it-later"
+      }
+
+      admin: {
+        label: admin
+        tooltip: "Invite management"
+      }
+    }
+  }
+
+  rest: {
+    label: REST API
+    style.fill: "#a5d6a7"
+    tooltip: "Generated from tRPC for mobile clients"
+  }
+
+  sse: {
+    label: SSE Endpoint
+    style.fill: "#81d4fa"
+    tooltip: "/api/v1/events"
+  }
+}
+
+# ==============================================================================
+# Services Layer
+# ==============================================================================
+
+services: {
+  label: Services Layer
+  style.fill: "#f3e5f5"
+  tooltip: "Reusable business logic"
+
+  entries_svc: {
+    label: entries
+    shape: hexagon
+
+    methods: |md
+      - listEntries
+      - searchEntries
+      - getEntry
+      - markEntriesRead
+      - countEntries
+    |
+  }
+
+  subscriptions_svc: {
+    label: subscriptions
+    shape: hexagon
+
+    methods: |md
+      - listSubscriptions
+      - searchSubscriptions
+      - getSubscription
+    |
+  }
+
+  narration_svc: {
+    label: narration
+    shape: hexagon
+  }
+
+  full_content_svc: {
+    label: full-content
+    shape: hexagon
+    tooltip: "Fetch article from URL"
+  }
+}
+
+# ==============================================================================
+# Data Layer
+# ==============================================================================
+
+data: {
+  label: Data Layer
+  style.fill: "#e8f5e9"
+
+  postgres: {
+    label: PostgreSQL
+    shape: cylinder
+    style.fill: "#4db6ac"
+
+    tables: |md
+      **Core Tables**
+      - users, sessions
+      - feeds, entries
+      - subscriptions
+      - user_entries
+      - tags
+
+      **Views**
+      - user_feeds
+      - visible_entries
+    |
+  }
+
+  redis: {
+    label: Redis
+    shape: cylinder
+    style.fill: "#ef5350"
+
+    uses: |md
+      - Session cache
+      - Rate limiting
+      - Pub/sub events
+    |
+  }
+}
+
+# ==============================================================================
+# Connections - Client to API
+# ==============================================================================
+
+clients.web -> api.trpc: "tRPC client" {
+  style.stroke: "#1976d2"
+  style.stroke-width: 2
+}
+
+clients.android -> api.rest: "REST API" {
+  style.stroke: "#388e3c"
+  style.stroke-width: 2
+}
+
+clients.mcp -> services: "Direct service calls" {
+  style.stroke: "#7b1fa2"
+  style.stroke-width: 2
+}
+
+clients.web -> api.sse: "SSE stream" {
+  style.stroke: "#0288d1"
+  style.stroke-dash: 3
+}
+
+# ==============================================================================
+# Connections - API to Services
+# ==============================================================================
+
+api.trpc.routers.entries -> services.entries_svc {
+  style.stroke: "#9e9e9e"
+}
+
+api.trpc.routers.subscriptions -> services.subscriptions_svc {
+  style.stroke: "#9e9e9e"
+}
+
+api.trpc.routers.narration -> services.narration_svc {
+  style.stroke: "#9e9e9e"
+}
+
+api.rest -> api.trpc: "Generated from" {
+  style.stroke: "#9e9e9e"
+  style.stroke-dash: 3
+}
+
+# ==============================================================================
+# Connections - Services to Data
+# ==============================================================================
+
+services.entries_svc -> data.postgres {
+  style.stroke: "#4caf50"
+  style.stroke-width: 2
+}
+
+services.subscriptions_svc -> data.postgres {
+  style.stroke: "#4caf50"
+  style.stroke-width: 2
+}
+
+api.sse -> data.redis: "Subscribe to channels" {
+  style.stroke: "#f44336"
+}
+
+api.trpc.middleware.rate_limit -> data.redis: "Check limits" {
+  style.stroke: "#f44336"
+}
+
+api.trpc.middleware.auth -> data.redis: "Session cache" {
+  style.stroke: "#f44336"
+}
+
+api.trpc.middleware.auth -> data.postgres: "Session fallback" {
+  style.stroke: "#4caf50"
+  style.stroke-dash: 3
+}

--- a/docs/diagrams/feed-fetcher.d2
+++ b/docs/diagrams/feed-fetcher.d2
@@ -1,0 +1,353 @@
+# Background Feed Fetcher Architecture
+# Job queue → Worker → Feed processing → Entry storage
+
+direction: down
+
+title: {
+  label: Background Feed Fetcher
+  near: top-center
+  shape: text
+  style.font-size: 24
+  style.bold: true
+}
+
+# ==============================================================================
+# Job Queue System
+# ==============================================================================
+
+queue: {
+  label: Job Queue (Postgres)
+  style.fill: "#e3f2fd"
+
+  jobs_table: {
+    label: jobs table
+    shape: cylinder
+    style.fill: "#64b5f6"
+
+    schema: |md
+      - id: UUID
+      - type: 'fetch_feed' | 'renew_websub'
+      - payload: { feedId }
+      - enabled: boolean
+      - next_run_at: timestamp
+      - running_since: timestamp
+      - consecutive_failures: int
+    |
+  }
+
+  claim_query: {
+    label: Claim Query
+    shape: rectangle
+    style.fill: "#90caf9"
+
+    sql: |sql
+      SELECT * FROM jobs
+      WHERE enabled = true
+        AND next_run_at <= now()
+        AND running_since IS NULL
+      FOR UPDATE SKIP LOCKED
+      LIMIT 1
+    |
+  }
+}
+
+# ==============================================================================
+# Worker Process
+# ==============================================================================
+
+worker: {
+  label: Worker Process
+  style.fill: "#fff3e0"
+
+  main_loop: {
+    label: Main Loop
+    shape: rectangle
+    style.fill: "#ffcc80"
+
+    description: |md
+      **Event-driven execution**
+      - Up to 5 concurrent jobs
+      - Promise.race() for slot filling
+      - 5s poll when queue empty
+      - Graceful shutdown on SIGTERM
+    |
+  }
+
+  handlers: {
+    label: Job Handlers
+    style.fill: "#ffe0b2"
+
+    fetch_feed: {
+      label: fetch_feed
+      shape: rectangle
+      tooltip: "Fetch and process a feed"
+    }
+
+    renew_websub: {
+      label: renew_websub
+      shape: rectangle
+      tooltip: "Renew WebSub subscriptions"
+    }
+
+    process_import: {
+      label: process_opml_import
+      shape: rectangle
+      tooltip: "Import feeds from OPML"
+    }
+  }
+}
+
+# ==============================================================================
+# Feed Fetching Pipeline
+# ==============================================================================
+
+pipeline: {
+  label: Feed Fetching Pipeline
+  style.fill: "#f3e5f5"
+
+  fetch: {
+    label: 1. HTTP Fetch
+    shape: rectangle
+    style.fill: "#ce93d8"
+
+    details: |md
+      - Conditional GET (ETag, Last-Modified)
+      - 30s timeout
+      - User-Agent with feed ID
+      - Handle redirects (301, 302, 307)
+    |
+  }
+
+  parse: {
+    label: 2. Parse Feed
+    shape: rectangle
+    style.fill: "#ba68c8"
+
+    details: |md
+      - Streaming XML parser
+      - RSS, Atom, JSON Feed
+      - Custom parsers (LessWrong, arXiv)
+    |
+  }
+
+  process: {
+    label: 3. Process Entries
+    shape: rectangle
+    style.fill: "#ab47bc"
+
+    details: |md
+      - Detect new vs updated (content hash)
+      - Derive GUIDs
+      - Generate summaries
+      - Absolutize URLs
+    |
+  }
+
+  store: {
+    label: 4. Store Results
+    shape: rectangle
+    style.fill: "#9c27b0"
+    style.font-color: white
+
+    details: |md
+      - Upsert entries
+      - Update feed state
+      - Calculate next_run_at
+    |
+  }
+}
+
+# ==============================================================================
+# Result Handling
+# ==============================================================================
+
+results: {
+  label: Result Handling
+  style.fill: "#e8f5e9"
+
+  success: {
+    label: Success
+    shape: rectangle
+    style.fill: "#81c784"
+
+    action: |md
+      - next_run_at from Cache-Control
+      - Default: 1 hour
+      - Reset consecutive_failures
+    |
+  }
+
+  not_modified: {
+    label: 304 Not Modified
+    shape: rectangle
+    style.fill: "#aed581"
+
+    action: |md
+      - Keep existing entries
+      - Update next_run_at
+    |
+  }
+
+  error: {
+    label: Error
+    shape: rectangle
+    style.fill: "#ef5350"
+    style.font-color: white
+
+    action: |md
+      - Increment consecutive_failures
+      - Exponential backoff
+      - Max: 7 days
+    |
+  }
+}
+
+# ==============================================================================
+# Real-time Notifications
+# ==============================================================================
+
+notifications: {
+  label: Real-time Notifications
+  style.fill: "#e1f5fe"
+
+  redis: {
+    label: Redis Pub/Sub
+    shape: cylinder
+    style.fill: "#29b6f6"
+
+    events: |md
+      - new_entry
+      - entry_updated
+    |
+  }
+
+  sse: {
+    label: SSE to Clients
+    shape: rectangle
+    style.fill: "#4fc3f7"
+  }
+}
+
+# ==============================================================================
+# Connections - Job Claiming
+# ==============================================================================
+
+queue.jobs_table -> queue.claim_query: "Query due jobs" {
+  style.stroke: "#1976d2"
+}
+
+queue.claim_query -> worker.main_loop: "Claim job (row lock)" {
+  style.stroke: "#1976d2"
+  style.stroke-width: 2
+}
+
+# ==============================================================================
+# Connections - Job Dispatch
+# ==============================================================================
+
+worker.main_loop -> worker.handlers.fetch_feed: "Dispatch" {
+  style.stroke: "#f57c00"
+}
+
+worker.main_loop -> worker.handlers.renew_websub {
+  style.stroke: "#f57c00"
+  style.stroke-dash: 3
+}
+
+worker.main_loop -> worker.handlers.process_import {
+  style.stroke: "#f57c00"
+  style.stroke-dash: 3
+}
+
+# ==============================================================================
+# Connections - Pipeline Flow
+# ==============================================================================
+
+worker.handlers.fetch_feed -> pipeline.fetch {
+  style.stroke: "#7b1fa2"
+  style.stroke-width: 2
+}
+
+pipeline.fetch -> pipeline.parse {
+  style.stroke: "#7b1fa2"
+  style.stroke-width: 2
+}
+
+pipeline.parse -> pipeline.process {
+  style.stroke: "#7b1fa2"
+  style.stroke-width: 2
+}
+
+pipeline.process -> pipeline.store {
+  style.stroke: "#7b1fa2"
+  style.stroke-width: 2
+}
+
+# ==============================================================================
+# Connections - Results
+# ==============================================================================
+
+pipeline.store -> results.success: "200 OK" {
+  style.stroke: "#4caf50"
+}
+
+pipeline.fetch -> results.not_modified: "304" {
+  style.stroke: "#8bc34a"
+  style.stroke-dash: 3
+}
+
+pipeline.fetch -> results.error: "4xx/5xx/timeout" {
+  style.stroke: "#f44336"
+  style.stroke-dash: 3
+}
+
+# ==============================================================================
+# Connections - Update Job
+# ==============================================================================
+
+results.success -> queue.jobs_table: "Update next_run_at" {
+  style.stroke: "#4caf50"
+}
+
+results.not_modified -> queue.jobs_table: "Update next_run_at" {
+  style.stroke: "#8bc34a"
+}
+
+results.error -> queue.jobs_table: "Backoff next_run_at" {
+  style.stroke: "#f44336"
+}
+
+# ==============================================================================
+# Connections - Notifications
+# ==============================================================================
+
+pipeline.process -> notifications.redis: "Publish events" {
+  style.stroke: "#0288d1"
+  style.stroke-width: 2
+}
+
+notifications.redis -> notifications.sse: "Forward to clients" {
+  style.stroke: "#0288d1"
+}
+
+# ==============================================================================
+# Flow Sequence Note
+# ==============================================================================
+
+sequence: {
+  label: Typical Flow
+  near: bottom-center
+  style.fill: "#fafafa"
+  style.stroke: "#e0e0e0"
+
+  steps: |md
+    1. Worker polls for due jobs (SELECT FOR UPDATE SKIP LOCKED)
+    2. Claims job by setting running_since
+    3. Fetches feed URL with conditional GET
+    4. Parses XML/JSON (streaming)
+    5. Processes entries (detect new/updated)
+    6. Stores in Postgres, publishes to Redis
+    7. Updates job with next_run_at
+    8. Releases slot, claims next job
+  |
+}

--- a/docs/diagrams/frontend-data-flow.d2
+++ b/docs/diagrams/frontend-data-flow.d2
@@ -1,0 +1,231 @@
+# Frontend Data Flow - Delta-Based State Management
+# Lion Reader uses Zustand for optimistic updates with React Query as the source of truth
+
+direction: down
+
+title: {
+  label: Frontend Data Flow
+  near: top-center
+  shape: text
+  style.font-size: 24
+  style.bold: true
+}
+
+# ==============================================================================
+# Data Sources
+# ==============================================================================
+
+server: {
+  label: Server
+  style.fill: "#e3f2fd"
+
+  api: {
+    label: tRPC API
+    shape: rectangle
+  }
+
+  sse: {
+    label: SSE Endpoint
+    shape: rectangle
+  }
+}
+
+# ==============================================================================
+# Client State Layer
+# ==============================================================================
+
+client: {
+  label: Client State
+  style.fill: "#fff3e0"
+
+  react_query: {
+    label: React Query
+    shape: cylinder
+    style.fill: "#ffcc80"
+
+    description: |md
+      **Canonical server state**
+      - entries.list
+      - subscriptions.list
+      - tags.list
+    |
+  }
+
+  zustand: {
+    label: Zustand Store
+    shape: cylinder
+    style.fill: "#a5d6a7"
+
+    description: |md
+      **Delta layer (changes only)**
+      - readIds / unreadIds
+      - starredIds
+      - subscriptionCountDeltas
+      - tagCountDeltas
+      - pendingEntries
+    |
+  }
+}
+
+# ==============================================================================
+# Hooks Layer
+# ==============================================================================
+
+hooks: {
+  label: Custom Hooks
+  style.fill: "#f3e5f5"
+
+  useRealtimeUpdates: {
+    label: useRealtimeUpdates
+    shape: rectangle
+    tooltip: "Manages SSE connection with polling fallback"
+  }
+
+  useEntryDeltas: {
+    label: useEntryDeltas
+    shape: rectangle
+    tooltip: "Merges server entries with Zustand deltas"
+  }
+
+  useEntryMutations: {
+    label: useEntryMutations
+    shape: rectangle
+    tooltip: "Optimistic mutations (markRead, star)"
+  }
+
+  useEntryPage: {
+    label: useEntryPage
+    shape: rectangle
+    tooltip: "Combines queries, mutations, view state"
+  }
+}
+
+# ==============================================================================
+# UI Layer
+# ==============================================================================
+
+ui: {
+  label: UI Components
+  style.fill: "#e8f5e9"
+
+  sidebar: {
+    label: Sidebar
+    shape: rectangle
+    tooltip: "Subscription list with unread counts"
+  }
+
+  entry_list: {
+    label: EntryList
+    shape: rectangle
+    tooltip: "List of entries with read/starred state"
+  }
+
+  entry_content: {
+    label: EntryContent
+    shape: rectangle
+    tooltip: "Full article view"
+  }
+}
+
+# ==============================================================================
+# Connections - Initial Data Fetch
+# ==============================================================================
+
+server.api -> client.react_query: "Initial fetch" {
+  style.stroke: "#1976d2"
+  style.stroke-width: 2
+}
+
+# ==============================================================================
+# Connections - Real-time Updates
+# ==============================================================================
+
+server.sse -> hooks.useRealtimeUpdates: "SSE events\n(new_entry, entry_updated)" {
+  style.stroke: "#388e3c"
+  style.stroke-width: 2
+}
+
+hooks.useRealtimeUpdates -> client.zustand: "Push deltas" {
+  style.stroke: "#388e3c"
+}
+
+# ==============================================================================
+# Connections - Data Merging
+# ==============================================================================
+
+client.react_query -> hooks.useEntryDeltas: "Server entries" {
+  style.stroke: "#7b1fa2"
+}
+
+client.zustand -> hooks.useEntryDeltas: "Delta state" {
+  style.stroke: "#7b1fa2"
+}
+
+hooks.useEntryDeltas -> ui.entry_list: "Merged entries\n(read/starred applied)" {
+  style.stroke: "#7b1fa2"
+  style.stroke-width: 2
+}
+
+# ==============================================================================
+# Connections - Mutations
+# ==============================================================================
+
+ui.entry_list -> hooks.useEntryMutations: "User action\n(toggle read)" {
+  style.stroke: "#f57c00"
+}
+
+hooks.useEntryMutations -> client.zustand: "1. Optimistic update\n(instant)" {
+  style.stroke: "#f57c00"
+  style.stroke-width: 2
+}
+
+hooks.useEntryMutations -> server.api: "2. Server mutation" {
+  style.stroke: "#f57c00"
+}
+
+# ==============================================================================
+# Connections - Count Updates
+# ==============================================================================
+
+client.zustand -> ui.sidebar: "Count deltas applied" {
+  style.stroke: "#00796b"
+}
+
+client.react_query -> ui.sidebar: "Base counts" {
+  style.stroke: "#00796b"
+}
+
+# ==============================================================================
+# Connections - Page Hook
+# ==============================================================================
+
+hooks.useEntryPage -> hooks.useEntryMutations {
+  style.stroke: "#9e9e9e"
+  style.stroke-dash: 3
+}
+
+hooks.useEntryPage -> hooks.useEntryDeltas {
+  style.stroke: "#9e9e9e"
+  style.stroke-dash: 3
+}
+
+hooks.useEntryPage -> ui.entry_content {
+  style.stroke: "#9e9e9e"
+  style.stroke-dash: 3
+}
+
+# ==============================================================================
+# Legend
+# ==============================================================================
+
+legend: {
+  label: Legend
+  near: bottom-right
+  style.fill: "#fafafa"
+  style.stroke: "#e0e0e0"
+
+  initial: "Blue: Initial data fetch"
+  realtime: "Green: Real-time updates (SSE)"
+  merge: "Purple: Data merging"
+  mutation: "Orange: User mutations"
+}


### PR DESCRIPTION
- Update DESIGN.md with current architecture:
  - Add MCP server section
  - Document services layer pattern
  - Expand frontend architecture with Zustand delta-based state management
  - Document subscriptionId passthrough pattern
  - Add diagram references

- Update README.md:
  - Add full-text search and full content fetching to features
  - Add MCP server feature and usage section
  - Move full-text search from planned to implemented

- Add D2 architecture diagrams:
  - frontend-data-flow.d2: Delta-based state management with Zustand/React Query
  - backend-api.d2: tRPC routers, services layer, and database
  - feed-fetcher.d2: Background job queue and feed processing pipeline