### PR TITLE
Prevent auto-update of cached summaries on model change

### DIFF
--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -218,7 +218,7 @@ export function EntryContent({
   // Handle summary regenerate
   const handleSummaryRegenerate = useCallback(() => {
     setSummaryError(null);
-    summarizationMutation.mutate({ entryId });
+    summarizationMutation.mutate({ entryId, forceRegenerate: true });
   }, [summarizationMutation, entryId]);
 
   // Auto-fetch full content when entry loads and setting is enabled

--- a/src/server/trpc/routers/summarization.ts
+++ b/src/server/trpc/routers/summarization.ts
@@ -43,6 +43,8 @@ const uuidSchema = z.string().uuid("Invalid ID");
  */
 const generateInputSchema = z.object({
   entryId: uuidSchema,
+  /** Force regeneration even if a cached summary exists */
+  forceRegenerate: z.boolean().optional().default(false),
 });
 
 // ============================================================================
@@ -148,11 +150,10 @@ export const summarizationRouter = createTRPCRouter({
 
       const summaryRecord = summary[0];
 
-      // Check if summary is stale (different prompt version)
-      const isStale = summaryRecord.promptVersion !== CURRENT_PROMPT_VERSION;
-
-      // Return cached summary if available and not stale
-      if (summaryRecord.summaryText && !isStale) {
+      // Return cached summary if available and not forcing regeneration
+      // Note: We preserve cached summaries even when the model/prompt version changes,
+      // allowing users to manually regenerate via the "Regenerate" button if desired.
+      if (summaryRecord.summaryText && !input.forceRegenerate) {
         return {
           summary: summaryRecord.summaryText,
           cached: true,


### PR DESCRIPTION
Instead of automatically regenerating summaries when the prompt version changes, preserve cached summaries and let users manually regenerate via the "Regenerate" button if they want a newer summary.

- Add forceRegenerate parameter to summarization.generate mutation
- Remove automatic isStale check that invalidated old summaries
- Pass forceRegenerate: true when user clicks Regenerate button