### PR TITLE
Show regenerate button only when settings change

### DIFF
--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -173,6 +173,7 @@ export function EntryContent({
     text: string;
     modelId: string;
     generatedAt: Date | null;
+    settingsChanged: boolean;
   } | null>(null);
   const [showSummary, setShowSummary] = useState(false);
   const [summaryError, setSummaryError] = useState<string | null>(null);
@@ -188,6 +189,7 @@ export function EntryContent({
         text: result.summary,
         modelId: result.modelId,
         generatedAt: result.generatedAt,
+        settingsChanged: result.settingsChanged,
       });
       setSummaryError(null);
       setShowSummary(true);

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -297,6 +297,7 @@ export interface EntryContentBodyProps {
     text: string;
     modelId: string;
     generatedAt: Date | null;
+    settingsChanged: boolean;
   } | null;
   /** Whether to show the summary card */
   showSummary?: boolean;
@@ -829,6 +830,7 @@ export function EntryContentBody({
       <hr className="mb-6 border-zinc-200 sm:mb-8 dark:border-zinc-700" />
 
       {/* Summary card - shown above content when available */}
+      {/* Show regenerate button on error (to retry) or when settings have changed */}
       {showSummary && (summary || summaryError || isSummarizing) && (
         <SummaryCard
           summary={summary?.text ?? ""}
@@ -837,7 +839,7 @@ export function EntryContentBody({
           isLoading={isSummarizing}
           error={summaryError}
           onClose={onSummaryClose}
-          onRegenerate={onSummaryRegenerate}
+          onRegenerate={summaryError || summary?.settingsChanged ? onSummaryRegenerate : undefined}
         />
       )}
 


### PR DESCRIPTION
The regenerate button now only appears when regenerating would produce different results - either because the model has changed or the prompt version has been incremented. The button still shows on errors to allow retrying failed generation.

Changes:
- Add settingsChanged field to summarization API response
- Compare cached summary's modelId/promptVersion with current settings
- Conditionally pass onRegenerate to SummaryCard based on settingsChanged