### PR TITLE
Add configurable summary word limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,10 +80,24 @@ ALLOW_ALL_SIGNUPS=false
 # =============================================================================
 # AI Features (Optional)
 # =============================================================================
+
+# --- Narration (Text Processing) ---
 # Groq API key for AI-powered narration text processing
 # Get from: https://console.groq.com/keys
 # If not set, narration falls back to simple HTML-to-text conversion
 # GROQ_API_KEY=gsk_...
+
+# --- Article Summarization ---
+# Anthropic API key for AI-powered article summaries
+# Get from: https://console.anthropic.com/settings/keys
+# If not set, summarization feature will be disabled
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# Model to use for summarization (default: claude-sonnet-4-5)
+# SUMMARIZATION_MODEL=claude-sonnet-4-5
+
+# Maximum words for generated summaries (default: 300)
+# SUMMARIZATION_MAX_WORDS=300
 
 # =============================================================================
 # Google Integration (Optional)
@@ -201,6 +215,9 @@ ALLOW_ALL_SIGNUPS=false
 #
 # AI Features:
 #   fly secrets set GROQ_API_KEY="gsk_..."
+#   fly secrets set ANTHROPIC_API_KEY="sk-ant-..."
+#   fly secrets set SUMMARIZATION_MODEL="claude-sonnet-4-5"
+#   fly secrets set SUMMARIZATION_MAX_WORDS="300"
 #
 # Google Integration:
 #   fly secrets set GOOGLE_SERVICE_ACCOUNT_JSON="eyJ0eXBlIjoi..."  # For public Google Docs (base64 encoded)


### PR DESCRIPTION
- Add SUMMARIZATION_MAX_WORDS config (default 300)
- Update prompt to use Anthropic Console best practices format
- Parse <summary> tags from LLM response for cleaner extraction
- Document ANTHROPIC_API_KEY and summarization configs in .env.example
- Increment prompt version to invalidate cached summaries