### PR TITLE
Add manual file upload feature for reading

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "ioredis": "^5.8.2",
     "linkedom": "^0.18.12",
     "mammoth": "^1.11.0",
+    "marked": "^17.0.1",
     "next": "16.1.1",
     "onnxruntime-web": "1.18.0",
     "pg": "^8.16.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       mammoth:
         specifier: ^1.11.0
         version: 1.11.0
+      marked:
+        specifier: ^17.0.1
+        version: 17.0.1
       next:
         specifier: 16.1.1
         version: 16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4177,6 +4180,11 @@ packages:
   mammoth@1.11.0:
     resolution: {integrity: sha512-BcEqqY/BOwIcI1iR5tqyVlqc3KIaMRa4egSoK83YAVrBf6+yqdAAbtUcFDCWX8Zef8/fgNZ6rl4VUv+vVX8ddQ==}
     engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  marked@17.0.1:
+    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -10031,6 +10039,8 @@ snapshots:
       path-is-absolute: 1.0.1
       underscore: 1.13.7
       xmlbuilder: 10.1.1
+
+  marked@17.0.1: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/src/app/(app)/saved/page.tsx
+++ b/src/app/(app)/saved/page.tsx
@@ -8,6 +8,7 @@
 
 import { Suspense } from "react";
 import { EntryList, EntryContent, UnreadToggle, SortToggle } from "@/components/entries";
+import { FileUploadButton } from "@/components/saved";
 import { useEntryPage } from "@/lib/hooks";
 
 function SavedArticlesContent() {
@@ -26,6 +27,7 @@ function SavedArticlesContent() {
         <div className="mb-4 flex items-center justify-between sm:mb-6">
           <h1 className="text-xl font-bold text-zinc-900 sm:text-2xl dark:text-zinc-50">Saved</h1>
           <div className="flex gap-2">
+            <FileUploadButton />
             <SortToggle sortOrder={page.sortOrder} onToggle={page.toggleSortOrder} />
             <UnreadToggle
               showUnreadOnly={page.showUnreadOnly}

--- a/src/components/saved/FileUploadButton.tsx
+++ b/src/components/saved/FileUploadButton.tsx
@@ -1,0 +1,327 @@
+/**
+ * FileUploadButton Component
+ *
+ * Button and dialog for uploading files to save for later reading.
+ * Supports .docx, .html, and .md files.
+ */
+
+"use client";
+
+import { useState, useRef, useCallback, type ChangeEvent, type DragEvent } from "react";
+import { toast } from "sonner";
+import { trpc } from "@/lib/trpc/client";
+import { Button, Alert } from "@/components/ui";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const SUPPORTED_EXTENSIONS = [".docx", ".html", ".htm", ".md", ".markdown"];
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface FileUploadButtonProps {
+  /** Optional class name for additional styling */
+  className?: string;
+  /** Callback when file is successfully uploaded */
+  onSuccess?: () => void;
+}
+
+// ============================================================================
+// Icons
+// ============================================================================
+
+function UploadIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+      />
+    </svg>
+  );
+}
+
+function DocumentIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+      />
+    </svg>
+  );
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function isValidFileType(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return SUPPORTED_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ============================================================================
+// FileUploadButton Component
+// ============================================================================
+
+export function FileUploadButton({ className = "", onSuccess }: FileUploadButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const utils = trpc.useUtils();
+  const uploadMutation = trpc.saved.uploadFile.useMutation({
+    onSuccess: () => {
+      toast.success("File uploaded successfully");
+      // Invalidate queries to refresh the list
+      utils.entries.list.invalidate();
+      utils.entries.count.invalidate();
+      onSuccess?.();
+      handleClose();
+    },
+    onError: (err) => {
+      setError(err.message);
+      toast.error("Failed to upload file");
+    },
+  });
+
+  const handleOpen = () => {
+    setIsOpen(true);
+    setSelectedFile(null);
+    setError(null);
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setSelectedFile(null);
+    setError(null);
+    setIsDragging(false);
+  };
+
+  const validateFile = useCallback((file: File): string | null => {
+    if (!isValidFileType(file.name)) {
+      return `Unsupported file type. Please upload ${SUPPORTED_EXTENSIONS.join(", ")} files.`;
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      return `File is too large (${formatFileSize(file.size)}). Maximum size is ${formatFileSize(MAX_FILE_SIZE)}.`;
+    }
+    return null;
+  }, []);
+
+  const handleFileSelect = useCallback(
+    (file: File) => {
+      const validationError = validateFile(file);
+      if (validationError) {
+        setError(validationError);
+        setSelectedFile(null);
+        return;
+      }
+      setError(null);
+      setSelectedFile(file);
+    },
+    [validateFile]
+  );
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      handleFileSelect(file);
+    }
+  };
+
+  const handleDragOver = (e: DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+
+    const file = e.dataTransfer.files?.[0];
+    if (file) {
+      handleFileSelect(file);
+    }
+  };
+
+  const handleUpload = async () => {
+    if (!selectedFile) return;
+
+    // Read file as base64
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      // Remove the data URL prefix (e.g., "data:application/...;base64,")
+      const base64Content = result.split(",")[1];
+
+      uploadMutation.mutate({
+        content: base64Content,
+        filename: selectedFile.name,
+      });
+    };
+    reader.onerror = () => {
+      setError("Failed to read file");
+    };
+    reader.readAsDataURL(selectedFile);
+  };
+
+  const handleBrowseClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  return (
+    <>
+      {/* Upload Button */}
+      <button
+        type="button"
+        onClick={handleOpen}
+        className={`inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400 ${className}`}
+        title="Upload file"
+        aria-label="Upload file"
+      >
+        <UploadIcon className="h-5 w-5" />
+        <span className="ml-1.5 hidden text-sm sm:inline">Upload</span>
+      </button>
+
+      {/* Upload Dialog */}
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 z-50 bg-black/50 transition-opacity"
+            onClick={handleClose}
+            aria-hidden="true"
+          />
+
+          {/* Dialog */}
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <div
+              className="w-full max-w-md rounded-lg border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-700 dark:bg-zinc-900"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="upload-dialog-title"
+            >
+              <h2
+                id="upload-dialog-title"
+                className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-50"
+              >
+                Upload File
+              </h2>
+
+              <p className="mb-4 text-sm text-zinc-500 dark:text-zinc-400">
+                Upload a document to save for later reading. Supported formats: Word (.docx), HTML,
+                and Markdown (.md).
+              </p>
+
+              {error && (
+                <Alert variant="error" className="mb-4">
+                  {error}
+                </Alert>
+              )}
+
+              {/* Drop Zone */}
+              <div
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                onClick={handleBrowseClick}
+                className={`mb-4 cursor-pointer rounded-lg border-2 border-dashed p-8 text-center transition-colors ${
+                  isDragging
+                    ? "border-zinc-500 bg-zinc-100 dark:border-zinc-400 dark:bg-zinc-800"
+                    : selectedFile
+                      ? "border-green-500 bg-green-50 dark:border-green-600 dark:bg-green-900/20"
+                      : "border-zinc-300 hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-600 dark:hover:border-zinc-500 dark:hover:bg-zinc-800"
+                }`}
+              >
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept={SUPPORTED_EXTENSIONS.join(",")}
+                  onChange={handleInputChange}
+                  className="hidden"
+                />
+
+                {selectedFile ? (
+                  <div className="flex flex-col items-center">
+                    <DocumentIcon className="h-10 w-10 text-green-600 dark:text-green-500" />
+                    <p className="mt-2 font-medium text-zinc-900 dark:text-zinc-50">
+                      {selectedFile.name}
+                    </p>
+                    <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                      {formatFileSize(selectedFile.size)}
+                    </p>
+                    <p className="mt-2 text-xs text-zinc-400 dark:text-zinc-500">
+                      Click or drop a different file to replace
+                    </p>
+                  </div>
+                ) : (
+                  <div className="flex flex-col items-center">
+                    <UploadIcon className="h-10 w-10 text-zinc-400 dark:text-zinc-500" />
+                    <p className="mt-2 font-medium text-zinc-900 dark:text-zinc-50">
+                      Drop file here or click to browse
+                    </p>
+                    <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                      .docx, .html, .md up to 10MB
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {/* Actions */}
+              <div className="flex justify-end gap-3">
+                <Button
+                  variant="secondary"
+                  onClick={handleClose}
+                  disabled={uploadMutation.isPending}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={handleUpload}
+                  disabled={!selectedFile || uploadMutation.isPending}
+                  loading={uploadMutation.isPending}
+                >
+                  Upload
+                </Button>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/components/saved/index.ts
+++ b/src/components/saved/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Saved article components.
+ */
+
+export { FileUploadButton } from "./FileUploadButton";

--- a/src/server/file/process-upload.ts
+++ b/src/server/file/process-upload.ts
@@ -1,0 +1,245 @@
+/**
+ * File upload processing module.
+ *
+ * Handles conversion of uploaded files to HTML for storage as saved articles.
+ * Supports:
+ * - .docx files → mammoth conversion → Readability cleaning
+ * - .html files → Readability cleaning
+ * - .md files → marked conversion (no cleaning needed)
+ */
+
+import * as mammoth from "mammoth";
+import { marked } from "marked";
+import { cleanContent } from "@/server/feed/content-cleaner";
+import { generateSummary } from "@/server/html/strip-html";
+import { logger } from "@/lib/logger";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Supported file types for upload.
+ */
+export type SupportedFileType = "docx" | "html" | "markdown";
+
+/**
+ * Result from processing an uploaded file.
+ */
+export interface ProcessedFile {
+  /** The cleaned/converted HTML content */
+  contentCleaned: string;
+  /** Plain text excerpt for preview */
+  excerpt: string | null;
+  /** Extracted or derived title (from filename or content) */
+  title: string | null;
+  /** Original file type */
+  fileType: SupportedFileType;
+}
+
+// ============================================================================
+// File Type Detection
+// ============================================================================
+
+/**
+ * Determines file type from filename extension.
+ *
+ * @param filename - The uploaded file's name
+ * @returns The detected file type, or null if unsupported
+ */
+export function detectFileType(filename: string): SupportedFileType | null {
+  const lower = filename.toLowerCase();
+
+  if (lower.endsWith(".docx")) {
+    return "docx";
+  }
+  if (lower.endsWith(".html") || lower.endsWith(".htm")) {
+    return "html";
+  }
+  if (lower.endsWith(".md") || lower.endsWith(".markdown")) {
+    return "markdown";
+  }
+
+  return null;
+}
+
+/**
+ * Extracts a title from a filename by removing the extension.
+ */
+export function titleFromFilename(filename: string): string {
+  // Remove extension
+  let title = filename.replace(/\.(docx|html?|md|markdown)$/i, "");
+
+  // Clean up common patterns
+  title = title
+    // Replace underscores and hyphens with spaces
+    .replace(/[_-]+/g, " ")
+    // Remove multiple spaces
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return title;
+}
+
+// ============================================================================
+// File Processors
+// ============================================================================
+
+/**
+ * Converts a .docx file buffer to HTML using mammoth, then cleans with Readability.
+ */
+async function processDocx(buffer: Buffer, filename: string): Promise<ProcessedFile> {
+  const styleMap = ["p[style-name='Title'] => h1:fresh", "p[style-name='Subtitle'] => h2:fresh"];
+
+  const result = await mammoth.convertToHtml({ buffer }, { styleMap });
+
+  if (result.messages.length > 0) {
+    logger.debug("Mammoth conversion messages", {
+      filename,
+      messages: result.messages.map((m) => m.message),
+    });
+  }
+
+  const rawHtml = result.value;
+
+  // Wrap in HTML structure for Readability
+  const fullHtml = `<!DOCTYPE html><html><body>${rawHtml}</body></html>`;
+
+  // Clean with Readability
+  const cleaned = cleanContent(fullHtml, { minCleanedLength: 10 });
+
+  // Use cleaned content if available, otherwise use raw mammoth output
+  const contentCleaned = cleaned?.content ?? rawHtml;
+  const excerpt = cleaned ? generateSummary(cleaned.content) : generateSummary(rawHtml);
+
+  return {
+    contentCleaned,
+    excerpt: excerpt || null,
+    title: cleaned?.title || titleFromFilename(filename),
+    fileType: "docx",
+  };
+}
+
+/**
+ * Processes an HTML file by cleaning with Readability.
+ */
+function processHtml(content: string, filename: string): ProcessedFile {
+  // Clean with Readability
+  const cleaned = cleanContent(content, { minCleanedLength: 10 });
+
+  if (cleaned) {
+    return {
+      contentCleaned: cleaned.content,
+      excerpt: cleaned.excerpt || generateSummary(cleaned.content) || null,
+      title: cleaned.title || titleFromFilename(filename),
+      fileType: "html",
+    };
+  }
+
+  // If Readability fails, return the raw HTML (sanitization happens on display)
+  return {
+    contentCleaned: content,
+    excerpt: generateSummary(content) || null,
+    title: titleFromFilename(filename),
+    fileType: "html",
+  };
+}
+
+/**
+ * Converts Markdown to HTML using marked.
+ * Markdown content is kept as-is semantically, just rendered to HTML.
+ */
+async function processMarkdown(content: string, filename: string): Promise<ProcessedFile> {
+  // Configure marked for safe rendering
+  marked.setOptions({
+    gfm: true, // GitHub Flavored Markdown
+    breaks: true, // Convert \n to <br>
+  });
+
+  // Convert markdown to HTML
+  const html = await marked.parse(content);
+
+  // Generate excerpt from the HTML
+  const excerpt = generateSummary(html);
+
+  // Try to extract title from first H1 or use filename
+  let title: string | null = null;
+  const h1Match = html.match(/<h1[^>]*>([^<]+)<\/h1>/i);
+  if (h1Match) {
+    title = h1Match[1].trim();
+  }
+
+  return {
+    contentCleaned: html,
+    excerpt: excerpt || null,
+    title: title || titleFromFilename(filename),
+    fileType: "markdown",
+  };
+}
+
+// ============================================================================
+// Main Processing Function
+// ============================================================================
+
+/**
+ * Processes an uploaded file and converts it to HTML for storage.
+ *
+ * @param content - The file content (Buffer for binary files, string for text)
+ * @param filename - The original filename (used for type detection and title)
+ * @returns Processed file with HTML content, or throws if unsupported type
+ *
+ * @example
+ * ```typescript
+ * // For a docx file
+ * const result = await processUploadedFile(buffer, "document.docx");
+ *
+ * // For a markdown file
+ * const result = await processUploadedFile(mdContent, "notes.md");
+ * ```
+ */
+export async function processUploadedFile(
+  content: Buffer | string,
+  filename: string
+): Promise<ProcessedFile> {
+  const fileType = detectFileType(filename);
+
+  if (!fileType) {
+    throw new Error(`Unsupported file type. Supported types: .docx, .html, .htm, .md, .markdown`);
+  }
+
+  logger.info("Processing uploaded file", { filename, fileType });
+
+  switch (fileType) {
+    case "docx": {
+      // docx requires Buffer
+      const buffer = typeof content === "string" ? Buffer.from(content, "base64") : content;
+      return processDocx(buffer, filename);
+    }
+
+    case "html": {
+      // HTML should be string
+      const htmlContent = typeof content === "string" ? content : content.toString("utf-8");
+      return processHtml(htmlContent, filename);
+    }
+
+    case "markdown": {
+      // Markdown should be string
+      const mdContent = typeof content === "string" ? content : content.toString("utf-8");
+      return processMarkdown(mdContent, filename);
+    }
+  }
+}
+
+/**
+ * Gets the list of supported file extensions for display.
+ */
+export function getSupportedExtensions(): string[] {
+  return [".docx", ".html", ".htm", ".md", ".markdown"];
+}
+
+/**
+ * Gets a human-readable description of supported file types.
+ */
+export function getSupportedTypesDescription(): string {
+  return "Word documents (.docx), HTML files (.html), and Markdown files (.md)";
+}


### PR DESCRIPTION
Allow users to upload .docx, .html, and .md files to save for later reading.

- Add marked dependency for Markdown to HTML conversion
- Create file processing utilities that handle each file type:
  - .docx: converted via mammoth, then cleaned with Readability
  - .html: cleaned with Readability
  - .md: rendered to HTML via marked (preserved semantically)
- Add saved.uploadFile tRPC endpoint with base64 file content input
- Create FileUploadButton component with drag-and-drop support
- Add upload button to the Saved articles page header
- Make URL nullable in saved article schema for uploaded files