### PR TITLE
Review swipe and keyboard navigation logic

### DIFF
--- a/src/lib/hooks/useEntryPage.ts
+++ b/src/lib/hooks/useEntryPage.ts
@@ -219,21 +219,37 @@ export function useEntryPage(options: UseEntryPageOptions): UseEntryPageResult {
     [toggleRead, subscriptionsQuery.data]
   );
 
+  // Navigation callbacks - delegate to useEntryListQuery which owns the list state
+  const goToNextEntry = useCallback(() => {
+    const nextId = entryListQuery.getNextEntryId();
+    if (nextId) {
+      setOpenEntryId(nextId);
+    }
+  }, [entryListQuery, setOpenEntryId]);
+
+  const goToPreviousEntry = useCallback(() => {
+    const prevId = entryListQuery.getPreviousEntryId();
+    if (prevId) {
+      setOpenEntryId(prevId);
+    }
+  }, [entryListQuery, setOpenEntryId]);
+
   // Keyboard shortcuts
-  const { selectedEntryId, setSelectedEntryId, goToNextEntry, goToPreviousEntry } =
-    useKeyboardShortcuts({
-      entries: mergedEntries,
-      onOpenEntry: setOpenEntryId,
-      onClose: closeEntry,
-      isEntryOpen: !!openEntryId,
-      enabled: keyboardShortcutsEnabled,
-      onToggleRead: handleToggleRead,
-      onToggleStar: toggleStar,
-      onRefresh: () => {
-        utils.entries.list.invalidate();
-      },
-      onToggleUnreadOnly: toggleShowUnreadOnly,
-    });
+  const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
+    entries: mergedEntries,
+    onOpenEntry: setOpenEntryId,
+    onClose: closeEntry,
+    isEntryOpen: !!openEntryId,
+    enabled: keyboardShortcutsEnabled,
+    onToggleRead: handleToggleRead,
+    onToggleStar: toggleStar,
+    onRefresh: () => {
+      utils.entries.list.invalidate();
+    },
+    onToggleUnreadOnly: toggleShowUnreadOnly,
+    onNavigateNext: goToNextEntry,
+    onNavigatePrevious: goToPreviousEntry,
+  });
 
   // Entry click handler
   const handleEntryClick = useCallback(


### PR DESCRIPTION
Move navigation logic from useKeyboardShortcuts to useEntryPage, which owns the entry list query. This eliminates duplicate ref tracking and makes data flow clearer.

## Problem
- useKeyboardShortcuts maintained its own refs (lastKnownNextRef, lastKnownPrevRef)
- useEntryListQuery also maintained similar refs
- When the list changed during navigation, these refs could get out of sync
- Navigation would jump to wrong entries when mutations/filtering changed the list

## Solution
- useEntryListQuery owns the list and navigation logic (getNextEntryId, getPreviousEntryId)
- useEntryPage creates callbacks that delegate to useEntryListQuery's methods
- useKeyboardShortcuts simplified to only detect key presses and call callbacks
- Data flow is now: list state -> parent callbacks -> keyboard handler -> entry view

## Changes
- useKeyboardShortcuts: Removed goToNextEntry/goToPreviousEntry, refs, adjacent entry calculation. Added onNavigateNext/onNavigatePrevious callback options.
- useEntryPage: Creates navigation callbacks using useEntryListQuery's methods, passes them to useKeyboardShortcuts and EntryContent
- Reduced useKeyboardShortcuts from 643 to 519 lines