### PR TITLE
Check MCP server article saving support

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -451,6 +451,8 @@ Lion Reader exposes functionality to AI assistants via the [Model Context Protoc
 | `mark_entries_read`    | Mark entries as read/unread (bulk)            |
 | `star_entries`         | Star/unstar entries                           |
 | `count_entries`        | Get entry counts with filters                 |
+| `save_article`         | Save a URL for later reading                  |
+| `delete_saved_article` | Delete a saved article                        |
 | `list_subscriptions`   | List all active subscriptions                 |
 | `search_subscriptions` | Search subscriptions by title                 |
 | `get_subscription`     | Get subscription details                      |

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -8,6 +8,7 @@
 import type { db as dbType } from "@/server/db";
 import * as entriesService from "@/server/services/entries";
 import * as subscriptionsService from "@/server/services/subscriptions";
+import * as savedService from "@/server/services/saved";
 
 // ============================================================================
 // Types
@@ -191,6 +192,51 @@ export function registerTools(): Tool[] {
           ...params,
           showSpam: false,
         });
+      },
+    },
+
+    // ========================================================================
+    // Saved Articles Tools
+    // ========================================================================
+
+    {
+      name: "save_article",
+      description:
+        "Save a URL for later reading. Fetches the page, extracts clean content using Readability, and stores it. Returns the saved article if already saved.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          url: { type: "string", description: "The URL to save" },
+          title: {
+            type: "string",
+            description: "Optional title override (useful if page title is poor)",
+          },
+        },
+        required: ["url"],
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handler: async (db, args: any) => {
+        return savedService.saveArticle(db, args.userId, {
+          url: args.url,
+          title: args.title,
+        });
+      },
+    },
+
+    {
+      name: "delete_saved_article",
+      description: "Delete a saved article. Returns success status.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          articleId: { type: "string", description: "The saved article ID to delete" },
+        },
+        required: ["articleId"],
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handler: async (db, args: any) => {
+        const deleted = await savedService.deleteSavedArticle(db, args.userId, args.articleId);
+        return { deleted };
       },
     },
 

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -1,0 +1,403 @@
+/**
+ * Saved Articles Service
+ *
+ * Business logic for saving articles. Used by both tRPC routers and MCP server.
+ * Uses the plugin system for special URL handling (LessWrong, ArXiv, Google Docs, etc.).
+ */
+
+import { eq, and } from "drizzle-orm";
+import { Parser } from "htmlparser2";
+import { createHash } from "crypto";
+import type { db as dbType } from "@/server/db";
+import { entries, userEntries } from "@/server/db/schema";
+import { generateUuidv7 } from "@/lib/uuidv7";
+import { normalizeUrl } from "@/lib/url";
+import { fetchHtmlPage, HttpFetchError } from "@/server/http/fetch";
+import { escapeHtml } from "@/server/http/html";
+import { cleanContent } from "@/server/feed/content-cleaner";
+import { getOrCreateSavedFeed } from "@/server/feed/saved-feed";
+import { generateSummary } from "@/server/html/strip-html";
+import { logger } from "@/lib/logger";
+import { publishSavedArticleCreated } from "@/server/redis/pubsub";
+import { errors } from "@/server/trpc/errors";
+import { pluginRegistry } from "@/server/plugins";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SaveArticleParams {
+  url: string;
+  /** Optional title hint (useful when page title is poor) */
+  title?: string;
+}
+
+export interface SavedArticle {
+  id: string;
+  url: string;
+  title: string | null;
+  siteName: string | null;
+  author: string | null;
+  imageUrl: string | null;
+  contentCleaned: string | null;
+  excerpt: string | null;
+  read: boolean;
+  starred: boolean;
+  savedAt: Date;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+interface PageMetadata {
+  title: string | null;
+  siteName: string | null;
+  author: string | null;
+  imageUrl: string | null;
+}
+
+/**
+ * Extracts metadata from HTML using Open Graph and meta tags.
+ * Uses SAX parsing for efficiency and exits early after </head>.
+ */
+function extractMetadata(html: string, url: string): PageMetadata {
+  const result: PageMetadata = {
+    title: null,
+    siteName: null,
+    author: null,
+    imageUrl: null,
+  };
+
+  let ogTitle: string | null = null;
+  let titleText: string | null = null;
+  let inTitle = false;
+  let titleContent = "";
+
+  const parser = new Parser(
+    {
+      onopentag(name, attribs) {
+        const tagName = name.toLowerCase();
+
+        if (tagName === "title") {
+          inTitle = true;
+          titleContent = "";
+        } else if (tagName === "meta") {
+          const property = attribs.property?.toLowerCase();
+          const metaName = attribs.name?.toLowerCase();
+          const content = attribs.content;
+
+          if (property === "og:title" && content && !ogTitle) {
+            ogTitle = content;
+          } else if (property === "og:site_name" && content && !result.siteName) {
+            result.siteName = content;
+          } else if (property === "og:image" && content && !result.imageUrl) {
+            result.imageUrl = content;
+          } else if (property === "article:author" && content && !result.author) {
+            result.author = content;
+          } else if (metaName === "author" && content && !result.author) {
+            result.author = content;
+          }
+        }
+      },
+      ontext(text) {
+        if (inTitle) {
+          titleContent += text;
+        }
+      },
+      onclosetag(name) {
+        const tagName = name.toLowerCase();
+
+        if (tagName === "title") {
+          inTitle = false;
+          if (titleContent.trim() && !titleText) {
+            titleText = titleContent.trim();
+          }
+        } else if (tagName === "head") {
+          parser.pause();
+        }
+      },
+    },
+    { decodeEntities: true }
+  );
+
+  parser.write(html);
+  parser.end();
+
+  result.title = ogTitle || titleText;
+
+  if (result.imageUrl && !result.imageUrl.startsWith("http")) {
+    try {
+      result.imageUrl = new URL(result.imageUrl, url).href;
+    } catch {
+      result.imageUrl = null;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Generates a SHA-256 content hash for saved article.
+ * Used for narration deduplication.
+ */
+function generateContentHash(title: string | null, content: string | null): string {
+  const titleStr = title ?? "";
+  const contentStr = content ?? "";
+  const hashInput = `${titleStr}\n${contentStr}`;
+  return createHash("sha256").update(hashInput, "utf8").digest("hex");
+}
+
+// ============================================================================
+// Service Functions
+// ============================================================================
+
+/**
+ * Save a URL for later reading.
+ *
+ * Fetches the URL, extracts metadata and clean content via Readability,
+ * and stores it as a saved article. If the URL is already saved, returns
+ * the existing article.
+ *
+ * Uses the plugin system for special URL handling (LessWrong, ArXiv, Google Docs, etc.).
+ */
+export async function saveArticle(
+  db: typeof dbType,
+  userId: string,
+  params: SaveArticleParams
+): Promise<SavedArticle> {
+  const now = new Date();
+  const normalizedUrl = normalizeUrl(params.url);
+
+  // Get or create the user's saved feed
+  const savedFeedId = await getOrCreateSavedFeed(db, userId);
+
+  // Check if URL is already saved
+  const existing = await db
+    .select({
+      entry: entries,
+      userState: userEntries,
+    })
+    .from(entries)
+    .innerJoin(userEntries, eq(userEntries.entryId, entries.id))
+    .where(
+      and(
+        eq(entries.feedId, savedFeedId),
+        eq(entries.guid, normalizedUrl),
+        eq(userEntries.userId, userId)
+      )
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    const { entry, userState } = existing[0];
+    return {
+      id: entry.id,
+      url: entry.url!,
+      title: entry.title,
+      siteName: entry.siteName,
+      author: entry.author,
+      imageUrl: entry.imageUrl,
+      contentCleaned: entry.contentCleaned,
+      excerpt: entry.summary,
+      read: userState.read,
+      starred: userState.starred,
+      savedAt: entry.fetchedAt,
+    };
+  }
+
+  // Try to find a plugin for this URL
+  let urlObj: URL | null = null;
+  try {
+    urlObj = new URL(params.url);
+  } catch {
+    // Invalid URL, continue to normal fetch
+  }
+
+  const plugin = urlObj ? pluginRegistry.findWithCapability(urlObj, "savedArticle") : null;
+
+  let html: string;
+  let pluginContent: {
+    html: string;
+    title?: string | null;
+    author?: string | null;
+    siteName?: string;
+    skipReadability?: boolean;
+  } | null = null;
+
+  if (plugin) {
+    logger.debug("Attempting plugin fetch for saved article", {
+      url: params.url,
+      plugin: plugin.name,
+    });
+
+    try {
+      const content = await plugin.capabilities.savedArticle.fetchContent(urlObj!, {});
+      if (content) {
+        pluginContent = {
+          html: content.html,
+          title: content.title,
+          author: content.author,
+          siteName: plugin.capabilities.savedArticle.siteName,
+          skipReadability: plugin.capabilities.savedArticle.skipReadability,
+        };
+        // Wrap in HTML structure for consistency
+        html = `<!DOCTYPE html><html><head><title>${escapeHtml(content.title ?? "")}</title></head><body>${content.html}</body></html>`;
+        logger.debug("Successfully fetched content via plugin", {
+          url: params.url,
+          plugin: plugin.name,
+          title: content.title,
+        });
+      }
+    } catch (error) {
+      logger.warn("Plugin fetch failed, falling back to normal fetch", {
+        url: params.url,
+        plugin: plugin.name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  // Fall back to normal HTML fetch if no plugin or plugin failed
+  if (!pluginContent) {
+    try {
+      html = await fetchHtmlPage(params.url);
+    } catch (error) {
+      logger.warn("Failed to fetch URL for saved article", {
+        url: params.url,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      if (error instanceof HttpFetchError && error.isBlocked()) {
+        throw errors.siteBlocked(params.url, error.status);
+      }
+      throw errors.savedArticleFetchError(
+        params.url,
+        error instanceof Error ? error.message : "Unknown error"
+      );
+    }
+  }
+
+  // Extract metadata
+  const metadata = extractMetadata(html!, params.url);
+
+  // Run Readability for clean content (unless plugin says to skip)
+  const cleaned = pluginContent?.skipReadability ? null : cleanContent(html!, { url: params.url });
+
+  // Generate excerpt
+  let excerpt: string | null = null;
+  if (pluginContent?.skipReadability) {
+    excerpt = generateSummary(pluginContent.html) || null;
+  } else if (cleaned) {
+    excerpt = cleaned.excerpt || cleaned.textContent.slice(0, 300).trim() || null;
+    if (excerpt && excerpt.length > 300) {
+      excerpt = excerpt.slice(0, 297) + "...";
+    }
+  }
+
+  // Build final values - prefer plugin data, then provided hint, then metadata, then Readability
+  const finalTitle =
+    pluginContent?.title || params.title || metadata.title || cleaned?.title || null;
+  const finalAuthor = pluginContent?.author || metadata.author || cleaned?.byline || null;
+  const finalSiteName = pluginContent?.siteName || metadata.siteName;
+  const finalContentCleaned = pluginContent?.skipReadability
+    ? pluginContent.html
+    : cleaned?.content || null;
+
+  // Compute content hash for narration deduplication
+  const contentHash = generateContentHash(finalTitle, finalContentCleaned || html!);
+
+  // Create new saved article entry
+  const entryId = generateUuidv7();
+  await db.insert(entries).values({
+    id: entryId,
+    feedId: savedFeedId,
+    type: "saved",
+    guid: normalizedUrl,
+    url: normalizedUrl,
+    title: finalTitle,
+    author: finalAuthor,
+    contentOriginal: html!,
+    contentCleaned: finalContentCleaned,
+    summary: excerpt,
+    siteName: finalSiteName,
+    imageUrl: metadata.imageUrl,
+    publishedAt: null,
+    fetchedAt: now,
+    contentHash,
+    spamScore: null,
+    isSpam: false,
+    listUnsubscribeMailto: null,
+    listUnsubscribeHttps: null,
+    listUnsubscribePost: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  // Create user_entries row
+  await db.insert(userEntries).values({
+    userId,
+    entryId,
+    read: false,
+    starred: false,
+  });
+
+  // Publish event to notify other browser windows/tabs
+  await publishSavedArticleCreated(userId, entryId);
+
+  logger.info("Saved article via service", {
+    entryId,
+    url: normalizedUrl,
+    title: finalTitle,
+    plugin: plugin?.name,
+  });
+
+  return {
+    id: entryId,
+    url: normalizedUrl,
+    title: finalTitle,
+    siteName: finalSiteName ?? null,
+    author: finalAuthor,
+    imageUrl: metadata.imageUrl,
+    contentCleaned: finalContentCleaned,
+    excerpt,
+    read: false,
+    starred: false,
+    savedAt: now,
+  };
+}
+
+/**
+ * Delete a saved article.
+ *
+ * @returns true if deleted, false if not found
+ */
+export async function deleteSavedArticle(
+  db: typeof dbType,
+  userId: string,
+  articleId: string
+): Promise<boolean> {
+  const savedFeedId = await getOrCreateSavedFeed(db, userId);
+
+  // Verify the article exists and belongs to the user's saved feed
+  const existing = await db
+    .select({ id: entries.id })
+    .from(entries)
+    .innerJoin(userEntries, eq(userEntries.entryId, entries.id))
+    .where(
+      and(
+        eq(entries.id, articleId),
+        eq(entries.feedId, savedFeedId),
+        eq(userEntries.userId, userId)
+      )
+    )
+    .limit(1);
+
+  if (existing.length === 0) {
+    return false;
+  }
+
+  // Delete the entry (will cascade to user_entries)
+  await db.delete(entries).where(eq(entries.id, articleId));
+
+  return true;
+}


### PR DESCRIPTION
Adds a new MCP tool for saving articles for later reading:
- save_article: Save a URL with automatic content extraction
- delete_saved_article: Remove a saved article

Supports special URL handlers:
- LessWrong: Uses GraphQL API for better content extraction
- ArXiv: Transforms to HTML version when available
- Google Docs: Uses public API (private docs require OAuth via web UI)
- Plugins: Uses registered plugins for site-specific handling

Creates a new saved article service that can be shared between tRPC routers and MCP server.