### PR TITLE
Fix summary generation timing in content cleaners

### DIFF
--- a/src/server/email/process-inbound.ts
+++ b/src/server/email/process-inbound.ts
@@ -396,7 +396,10 @@ export async function processInboundEmail(email: InboundEmail): Promise<ProcessE
     }
   }
 
-  const summary = generateSummary(contentOriginal);
+  // Generate summary from cleaned content if available, otherwise from original.
+  // This ensures summaries are based on the main content and not email boilerplate.
+  const contentForSummary = contentCleaned ?? contentOriginal;
+  const summary = generateSummary(contentForSummary);
 
   // Parse List-Unsubscribe headers
   const listUnsubscribeMailto = parseListUnsubscribeMailto(email.headers.listUnsubscribe);


### PR DESCRIPTION
Email processing was generating summaries from the original HTML content, including boilerplate headers, footers, and unsubscribe links. This is inconsistent with feed processing, which generates summaries from cleaned content via Readability.

Now email summaries use cleaned content (if available) or fall back to original, matching the pattern used in feed and file upload processing.