### PR TITLE
Sync unread toggle with query string parameter

### DIFF
--- a/src/components/entries/UnreadToggle.tsx
+++ b/src/components/entries/UnreadToggle.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { type MouseEvent } from "react";
+import { EyeIcon, EyeSlashIcon } from "@/components/ui";
 
 interface UnreadToggleProps {
   /**
@@ -24,64 +25,6 @@ interface UnreadToggleProps {
    * Optional class name for additional styling.
    */
   className?: string;
-}
-
-/**
- * Eye icon (open) - shown when viewing all items (read items visible).
- * suppressHydrationWarning because the icon may differ between server (defaults)
- * and client (localStorage) on initial render.
- */
-function EyeIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      aria-hidden="true"
-      suppressHydrationWarning
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
-        suppressHydrationWarning
-      />
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-        suppressHydrationWarning
-      />
-    </svg>
-  );
-}
-
-/**
- * Eye slash icon - shown when hiding read items (unread only).
- * suppressHydrationWarning because the icon may differ between server (defaults)
- * and client (localStorage) on initial render.
- */
-function EyeSlashIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      aria-hidden="true"
-      suppressHydrationWarning
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
-        suppressHydrationWarning
-      />
-    </svg>
-  );
 }
 
 /**
@@ -110,7 +53,6 @@ export function UnreadToggle({ showUnreadOnly, onToggle, className = "" }: Unrea
       title={label}
       aria-label={label}
       aria-pressed={showUnreadOnly ? false : true}
-      suppressHydrationWarning
     >
       <Icon className="h-5 w-5" />
       <span className="ui-text-sm ml-1.5 hidden sm:inline">

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -6,7 +6,7 @@
 
 export { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 
-export { getViewPreferences, type ViewType } from "./viewPreferences";
+export { DEFAULT_PREFERENCES, type ViewType, type ViewPreferences } from "./viewPreferences";
 
 export { useUrlViewPreferences, parseViewPreferencesFromParams } from "./useUrlViewPreferences";
 

--- a/src/lib/hooks/useEntryPage.ts
+++ b/src/lib/hooks/useEntryPage.ts
@@ -156,7 +156,7 @@ export interface UseEntryPageResult {
  * ```
  */
 export function useEntryPage(options: UseEntryPageOptions): UseEntryPageResult {
-  const { viewId, viewScopeId, filters = {} } = options;
+  const { filters = {} } = options;
 
   const utils = trpc.useUtils();
 
@@ -166,9 +166,9 @@ export function useEntryPage(options: UseEntryPageOptions): UseEntryPageResult {
   // Keyboard shortcuts context
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
 
-  // View preferences (unread only, sort order)
+  // View preferences (unread only, sort order) - synced to URL query params
   const { showUnreadOnly, toggleShowUnreadOnly, sortOrder, toggleSortOrder } =
-    useUrlViewPreferences(viewId, viewScopeId);
+    useUrlViewPreferences();
 
   // Combined filters including view preferences
   const combinedFilters = useMemo(

--- a/src/lib/hooks/viewPreferences.ts
+++ b/src/lib/hooks/viewPreferences.ts
@@ -1,12 +1,12 @@
 /**
- * View Preferences Shared Module
+ * View Preferences Types and Constants
  *
- * Contains shared types, constants, and utilities for view preferences
- * that can be used by both server and client code.
+ * Contains types and default values for view preferences.
+ * Preferences are synced to URL query params (see useUrlViewPreferences).
  */
 
 /**
- * View types for storing separate preferences.
+ * View types for different entry list pages.
  */
 export type ViewType = "all" | "starred" | "subscription" | "tag" | "saved" | "uncategorized";
 
@@ -26,58 +26,9 @@ export interface ViewPreferences {
 }
 
 /**
- * Default preferences for new views.
+ * Default preferences for all views.
  */
 export const DEFAULT_PREFERENCES: ViewPreferences = {
   showUnreadOnly: true,
   sortOrder: "newest",
 };
-
-/**
- * Generate localStorage key for a view.
- */
-export function getStorageKey(viewType: ViewType, viewId?: string): string {
-  if (viewId) {
-    return `lion-reader:view-prefs:${viewType}:${viewId}`;
-  }
-  return `lion-reader:view-prefs:${viewType}`;
-}
-
-/**
- * Load preferences from localStorage.
- */
-export function loadPreferences(key: string): ViewPreferences {
-  if (typeof window === "undefined") {
-    return DEFAULT_PREFERENCES;
-  }
-
-  try {
-    const stored = localStorage.getItem(key);
-    if (stored) {
-      const parsed = JSON.parse(stored) as Partial<ViewPreferences>;
-      return {
-        ...DEFAULT_PREFERENCES,
-        ...parsed,
-      };
-    }
-  } catch {
-    // Invalid JSON, use defaults
-  }
-
-  return DEFAULT_PREFERENCES;
-}
-
-/**
- * Get view preferences synchronously.
- *
- * On the server, this returns DEFAULT_PREFERENCES.
- * On the client, this reads from localStorage (with caching).
- *
- * @param viewType - The type of view (all, starred, feed, tag, saved, uncategorized)
- * @param viewId - Optional ID for feed or tag views
- * @returns The current view preferences
- */
-export function getViewPreferences(viewType: ViewType, viewId?: string): ViewPreferences {
-  const key = getStorageKey(viewType, viewId);
-  return loadPreferences(key);
-}


### PR DESCRIPTION
Use URL query params as the source of truth for view preferences instead of falling back to localStorage. This ensures server and client render the same state, eliminating hydration mismatches and removing the need for suppressHydrationWarning on the UnreadToggle.