### PR TITLE
Remove immediate filtering of read articles

### DIFF
--- a/src/lib/cache/entry-cache.ts
+++ b/src/lib/cache/entry-cache.ts
@@ -5,16 +5,78 @@
  *
  * Strategy:
  * - For individual entry views (entries.get): update directly
- * - For entry lists (entries.list): don't invalidate - entries stay visible until navigation
- *   (lists have refetchOnMount: true, so they'll refetch on next navigation)
+ * - For entry lists (entries.list): update in place without invalidation
+ *   (entries stay visible until navigation, lists have refetchOnMount: true)
  * - For counts (subscriptions, tags): update directly via count-cache helpers
  */
 
+import type { QueryClient } from "@tanstack/react-query";
 import type { TRPCClientUtils } from "@/lib/trpc/client";
 
 /**
- * Updates read status for entries in the single entry cache (entries.get).
- * Does NOT invalidate entry lists - entries stay visible until navigation.
+ * Entry data in list cache.
+ */
+interface CachedListEntry {
+  id: string;
+  read: boolean;
+  starred: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * Page structure in infinite query cache.
+ */
+interface CachedPage {
+  items: CachedListEntry[];
+  nextCursor?: string;
+}
+
+/**
+ * Infinite query data structure.
+ */
+interface InfiniteData {
+  pages: CachedPage[];
+  pageParams: unknown[];
+}
+
+/**
+ * Updates entries in all cached entry lists (infinite queries).
+ * Uses QueryClient.setQueriesData to update all cached queries regardless of filters.
+ *
+ * @param queryClient - React Query client for cache access
+ * @param entryIds - Entry IDs to update
+ * @param updates - Fields to update (read, starred)
+ */
+export function updateEntriesInListCache(
+  queryClient: QueryClient,
+  entryIds: string[],
+  updates: Partial<{ read: boolean; starred: boolean }>
+): void {
+  const entryIdSet = new Set(entryIds);
+
+  // Update all cached entry list queries (matches any query starting with ['entries', 'list'])
+  queryClient.setQueriesData<InfiniteData>({ queryKey: [["entries", "list"]] }, (oldData) => {
+    if (!oldData?.pages) return oldData;
+
+    return {
+      ...oldData,
+      pages: oldData.pages.map((page) => ({
+        ...page,
+        items: page.items.map((entry) => {
+          if (entryIdSet.has(entry.id)) {
+            return { ...entry, ...updates };
+          }
+          return entry;
+        }),
+      })),
+    };
+  });
+}
+
+/**
+ * Updates read status for entries in caches.
+ * Updates both entries.get (single entry) and entries.list (all lists) caches.
+ * Does NOT invalidate/refetch - entries stay visible until navigation.
  *
  * Note: Call adjustSubscriptionUnreadCounts and adjustTagUnreadCounts separately
  * for count updates - those update directly without invalidation.
@@ -22,11 +84,13 @@ import type { TRPCClientUtils } from "@/lib/trpc/client";
  * @param utils - tRPC utils for cache access
  * @param entryIds - Entry IDs to update
  * @param read - New read status
+ * @param queryClient - React Query client (optional, needed for list cache updates)
  */
 export function updateEntriesReadStatus(
   utils: TRPCClientUtils,
   entryIds: string[],
-  read: boolean
+  read: boolean,
+  queryClient?: QueryClient
 ): void {
   // Update individual entries.get caches - these are keyed by entry ID
   for (const entryId of entryIds) {
@@ -39,22 +103,27 @@ export function updateEntriesReadStatus(
     });
   }
 
-  // Don't invalidate entry lists - entries stay visible until navigation.
-  // Lists have refetchOnMount: true, so they'll refetch on next navigation.
+  // Update entries in all cached list queries (if queryClient provided)
+  if (queryClient) {
+    updateEntriesInListCache(queryClient, entryIds, { read });
+  }
 }
 
 /**
- * Updates starred status for an entry in the single entry cache.
- * Does NOT invalidate entry lists - entries stay visible until navigation.
+ * Updates starred status for an entry in caches.
+ * Updates both entries.get (single entry) and entries.list (all lists) caches.
+ * Does NOT invalidate/refetch - entries stay visible until navigation.
  *
  * @param utils - tRPC utils for cache access
  * @param entryId - Entry ID to update
  * @param starred - New starred status
+ * @param queryClient - React Query client (optional, needed for list cache updates)
  */
 export function updateEntryStarredStatus(
   utils: TRPCClientUtils,
   entryId: string,
-  starred: boolean
+  starred: boolean,
+  queryClient?: QueryClient
 ): void {
   // Update entries.get cache
   utils.entries.get.setData({ id: entryId }, (oldData) => {
@@ -65,6 +134,8 @@ export function updateEntryStarredStatus(
     };
   });
 
-  // Don't invalidate entry lists - entries stay visible until navigation.
-  // Lists have refetchOnMount: true, so they'll refetch on next navigation.
+  // Update entries in all cached list queries (if queryClient provided)
+  if (queryClient) {
+    updateEntriesInListCache(queryClient, [entryId], { starred });
+  }
 }

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -28,7 +28,11 @@ export {
 } from "./operations";
 
 // Low-level helpers (for special cases)
-export { updateEntriesReadStatus, updateEntryStarredStatus } from "./entry-cache";
+export {
+  updateEntriesReadStatus,
+  updateEntryStarredStatus,
+  updateEntriesInListCache,
+} from "./entry-cache";
 
 export {
   adjustSubscriptionUnreadCounts,

--- a/src/lib/cache/operations.ts
+++ b/src/lib/cache/operations.ts
@@ -10,6 +10,7 @@
  * - Marking a starred entry read affects the starred unread count
  */
 
+import type { QueryClient } from "@tanstack/react-query";
 import type { TRPCClientUtils } from "@/lib/trpc/client";
 import {
   updateEntriesReadStatus,
@@ -60,6 +61,7 @@ export interface SubscriptionData {
  *
  * Updates:
  * - entries.get cache for each entry
+ * - entries.list cache (updates in place, no refetch)
  * - subscriptions.list unread counts
  * - tags.list unread counts
  * - entries.count({ starredOnly: true }) for starred entries
@@ -71,19 +73,22 @@ export interface SubscriptionData {
  * @param utils - tRPC utils for cache access
  * @param entries - Entries with their context (subscriptionId, starred, type)
  * @param read - New read status
+ * @param queryClient - React Query client (optional, for list cache updates)
  */
 export function handleEntriesMarkedRead(
   utils: TRPCClientUtils,
   entries: EntryWithContext[],
-  read: boolean
+  read: boolean,
+  queryClient?: QueryClient
 ): void {
   if (entries.length === 0) return;
 
-  // 1. Update entry read status in entries.get cache + invalidate lists
+  // 1. Update entry read status in entries.get cache and entries.list cache
   updateEntriesReadStatus(
     utils,
     entries.map((e) => e.id),
-    read
+    read,
+    queryClient
   );
 
   // 2. Calculate subscription deltas
@@ -123,6 +128,7 @@ export function handleEntriesMarkedRead(
  *
  * Updates:
  * - entries.get cache
+ * - entries.list cache (updates in place, no refetch)
  * - entries.count({ starredOnly: true }) - total +1, unread +1 if entry is unread
  *
  * Note: Does NOT invalidate entries.list - entries stay visible until navigation.
@@ -130,10 +136,16 @@ export function handleEntriesMarkedRead(
  * @param utils - tRPC utils for cache access
  * @param entryId - Entry ID being starred
  * @param read - Whether the entry is read (from server response)
+ * @param queryClient - React Query client (optional, for list cache updates)
  */
-export function handleEntryStarred(utils: TRPCClientUtils, entryId: string, read: boolean): void {
+export function handleEntryStarred(
+  utils: TRPCClientUtils,
+  entryId: string,
+  read: boolean,
+  queryClient?: QueryClient
+): void {
   // 1. Update entry starred status
-  updateEntryStarredStatus(utils, entryId, true);
+  updateEntryStarredStatus(utils, entryId, true, queryClient);
 
   // 2. Update starred count
   // Total always +1, unread +1 only if entry is unread
@@ -145,6 +157,7 @@ export function handleEntryStarred(utils: TRPCClientUtils, entryId: string, read
  *
  * Updates:
  * - entries.get cache
+ * - entries.list cache (updates in place, no refetch)
  * - entries.count({ starredOnly: true }) - total -1, unread -1 if entry is unread
  *
  * Note: Does NOT invalidate entries.list - entries stay visible until navigation.
@@ -152,10 +165,16 @@ export function handleEntryStarred(utils: TRPCClientUtils, entryId: string, read
  * @param utils - tRPC utils for cache access
  * @param entryId - Entry ID being unstarred
  * @param read - Whether the entry is read (from server response)
+ * @param queryClient - React Query client (optional, for list cache updates)
  */
-export function handleEntryUnstarred(utils: TRPCClientUtils, entryId: string, read: boolean): void {
+export function handleEntryUnstarred(
+  utils: TRPCClientUtils,
+  entryId: string,
+  read: boolean,
+  queryClient?: QueryClient
+): void {
   // 1. Update entry starred status
-  updateEntryStarredStatus(utils, entryId, false);
+  updateEntryStarredStatus(utils, entryId, false, queryClient);
 
   // 2. Update starred count
   // Total always -1, unread -1 only if entry was unread

--- a/src/lib/hooks/useEntryMutations.ts
+++ b/src/lib/hooks/useEntryMutations.ts
@@ -11,6 +11,7 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
 import { handleEntriesMarkedRead, handleEntryStarred, handleEntryUnstarred } from "@/lib/cache";
@@ -104,11 +105,12 @@ export interface UseEntryMutationsResult {
  */
 export function useEntryMutations(): UseEntryMutationsResult {
   const utils = trpc.useUtils();
+  const queryClient = useQueryClient();
 
   // markRead mutation - uses handleEntriesMarkedRead for all cache updates
   const markReadMutation = trpc.entries.markRead.useMutation({
     onSuccess: (data, variables) => {
-      handleEntriesMarkedRead(utils, data.entries, variables.read);
+      handleEntriesMarkedRead(utils, data.entries, variables.read, queryClient);
     },
     onError: () => {
       toast.error("Failed to update read status");
@@ -131,7 +133,7 @@ export function useEntryMutations(): UseEntryMutationsResult {
   // star mutation - uses handleEntryStarred for all cache updates
   const starMutation = trpc.entries.star.useMutation({
     onSuccess: (data) => {
-      handleEntryStarred(utils, data.entry.id, data.entry.read);
+      handleEntryStarred(utils, data.entry.id, data.entry.read, queryClient);
     },
     onError: () => {
       toast.error("Failed to star entry");
@@ -141,7 +143,7 @@ export function useEntryMutations(): UseEntryMutationsResult {
   // unstar mutation - uses handleEntryUnstarred for all cache updates
   const unstarMutation = trpc.entries.unstar.useMutation({
     onSuccess: (data) => {
-      handleEntryUnstarred(utils, data.entry.id, data.entry.read);
+      handleEntryUnstarred(utils, data.entry.id, data.entry.read, queryClient);
     },
     onError: () => {
       toast.error("Failed to unstar entry");


### PR DESCRIPTION
Previously, marking an article as read would immediately invalidate and refetch the entry list, causing read articles to disappear when viewing unread-only lists. This was disorienting for users.

Now entries stay visible until navigation. The entry list has refetchOnMount: true, so it naturally refetches and filters out read entries when the user navigates away and back.

Removes utils.entries.list.invalidate() calls from updateEntriesReadStatus and updateEntryStarredStatus - the fix is removal of code, not addition.