### PR TITLE
Add shared debug keystore support for CI builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -114,6 +114,14 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
 
+      - name: Setup debug keystore
+        if: ${{ env.DEBUG_KEYSTORE_BASE64 != '' }}
+        env:
+          DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+        run: |
+          echo "$DEBUG_KEYSTORE_BASE64" | base64 -d > ${{ runner.temp }}/debug.keystore
+          echo "DEBUG_KEYSTORE_PATH=${{ runner.temp }}/debug.keystore" >> $GITHUB_ENV
+
       - name: Build debug APK
         run: ./gradlew assembleDebug
 
@@ -154,6 +162,14 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
+
+      - name: Setup debug keystore
+        if: ${{ env.DEBUG_KEYSTORE_BASE64 != '' }}
+        env:
+          DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+        run: |
+          echo "$DEBUG_KEYSTORE_BASE64" | base64 -d > ${{ runner.temp }}/debug.keystore
+          echo "DEBUG_KEYSTORE_PATH=${{ runner.temp }}/debug.keystore" >> $GITHUB_ENV
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -51,9 +51,16 @@ android {
     }
 
     signingConfigs {
-        // Debug signing config - uses default debug keystore
+        // Debug signing config - uses custom keystore if DEBUG_KEYSTORE_PATH is set, otherwise default
         getByName("debug") {
-            // Uses default debug keystore automatically
+            val debugKeystorePath = System.getenv("DEBUG_KEYSTORE_PATH")
+            if (debugKeystorePath != null) {
+                storeFile = file(debugKeystorePath)
+                storePassword = "android"
+                keyAlias = "androiddebugkey"
+                keyPassword = "android"
+            }
+            // If DEBUG_KEYSTORE_PATH is not set, uses default debug keystore automatically
         }
 
         // Release signing config - reads from environment variables or local.properties


### PR DESCRIPTION
Configure Android build to use a custom debug keystore from DEBUG_KEYSTORE_PATH environment variable when available. This allows CI to use a consistent keystore for debug builds, enabling easier updates to installed debug APKs.

The workflow decodes the keystore from DEBUG_KEYSTORE_BASE64 secret and sets the path for both build and instrumented-test jobs.