### PR TITLE
Add Discord bot invite link generator

### DIFF
--- a/src/app/(app)/settings/integrations/page.tsx
+++ b/src/app/(app)/settings/integrations/page.tsx
@@ -1,16 +1,23 @@
 /**
  * Integrations Settings Page
  *
- * Page for browser extensions, bookmarklets, and AI integrations.
+ * Page for browser extensions, bookmarklets, Discord bot, and AI integrations.
  */
 
-import { BookmarkletSettings, IntegrationsSettings } from "@/components/settings";
+import {
+  BookmarkletSettings,
+  DiscordBotSettings,
+  IntegrationsSettings,
+} from "@/components/settings";
 
 export default function IntegrationsPage() {
   return (
     <div className="space-y-8">
       {/* Save to Lion Reader (Firefox extension + bookmarklet) */}
       <BookmarkletSettings />
+
+      {/* Discord Bot */}
+      <DiscordBotSettings />
 
       {/* AI Integrations (MCP) */}
       <IntegrationsSettings />

--- a/src/components/settings/DiscordBotSettings.tsx
+++ b/src/components/settings/DiscordBotSettings.tsx
@@ -1,0 +1,154 @@
+/**
+ * DiscordBotSettings Component
+ *
+ * Settings section for the Discord bot integration.
+ * Shows the bot invite link and usage instructions.
+ */
+
+"use client";
+
+import { useState } from "react";
+import { trpc } from "@/lib/trpc/client";
+import { DiscordIcon, ExternalLinkIcon } from "@/components/ui";
+
+/**
+ * Check if a string is a custom Discord emoji name (word) vs a unicode emoji.
+ * Custom emojis are alphanumeric with underscores, like "savetolionreader".
+ */
+function isCustomEmoji(emoji: string): boolean {
+  return /^[a-zA-Z0-9_]+$/.test(emoji);
+}
+
+/**
+ * Format an emoji for display. Custom emojis get wrapped in colons.
+ */
+function formatEmoji(emoji: string): { text: string; isCustom: boolean } {
+  const isCustom = isCustomEmoji(emoji);
+  return {
+    text: isCustom ? `:${emoji}:` : emoji,
+    isCustom,
+  };
+}
+
+export function DiscordBotSettings() {
+  const [copied, setCopied] = useState(false);
+
+  const { data: botConfig, isLoading } = trpc.auth.discordBotConfig.useQuery();
+
+  const copyInviteUrl = () => {
+    if (botConfig?.inviteUrl) {
+      navigator.clipboard.writeText(botConfig.inviteUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  // Don't render if bot is not enabled
+  if (isLoading) {
+    return null;
+  }
+
+  if (!botConfig?.enabled) {
+    return null;
+  }
+
+  const emoji = botConfig.saveEmoji ? formatEmoji(botConfig.saveEmoji) : null;
+
+  return (
+    <section>
+      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">Discord Bot</h2>
+      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+        {/* Description */}
+        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+          Save articles to Lion Reader by reacting to Discord messages. When you react to a message
+          containing a URL, the article will be saved to your account.
+        </p>
+
+        {/* Invite Button */}
+        <div className="mt-6">
+          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
+            Add Bot to Server
+          </h3>
+          <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+            Invite the Lion Reader bot to your Discord server to enable saving articles.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-3">
+            <a
+              href={botConfig.inviteUrl ?? "#"}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-indigo-300 bg-indigo-50 px-4 py-2.5 font-medium text-indigo-800 shadow-sm transition-all hover:border-indigo-400 hover:bg-indigo-100 hover:shadow dark:border-indigo-700 dark:bg-indigo-950 dark:text-indigo-200 dark:hover:border-indigo-600 dark:hover:bg-indigo-900"
+            >
+              <DiscordIcon className="h-4 w-4" />
+              Invite Bot
+              <ExternalLinkIcon className="h-3.5 w-3.5" />
+            </a>
+            <button
+              type="button"
+              onClick={copyInviteUrl}
+              className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 font-medium text-zinc-700 shadow-sm transition-all hover:border-zinc-400 hover:bg-zinc-50 hover:shadow dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:bg-zinc-700"
+            >
+              {copied ? "Copied!" : "Copy Link"}
+            </button>
+          </div>
+        </div>
+
+        {/* Usage Instructions */}
+        <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
+          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">How to Use</h3>
+          <ol className="ui-text-sm mt-2 list-inside list-decimal space-y-2 text-zinc-600 dark:text-zinc-400">
+            <li>
+              <strong className="text-zinc-900 dark:text-zinc-200">Link your account</strong> - Sign
+              in to Lion Reader with Discord, or use{" "}
+              <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
+                /link
+              </code>{" "}
+              with an API token
+            </li>
+            <li>
+              <strong className="text-zinc-900 dark:text-zinc-200">React to messages</strong> -{" "}
+              {emoji ? (
+                <>
+                  React with{" "}
+                  {emoji.isCustom ? (
+                    <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
+                      {emoji.text}
+                    </code>
+                  ) : (
+                    <span className="text-base">{emoji.text}</span>
+                  )}{" "}
+                  to any message containing a URL
+                </>
+              ) : (
+                "Add the configured emoji reaction to any message containing a URL"
+              )}
+            </li>
+            <li>
+              <strong className="text-zinc-900 dark:text-zinc-200">Check your Saved</strong> - The
+              article will appear in your Saved section
+            </li>
+          </ol>
+        </div>
+
+        {/* Bot Commands */}
+        <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Bot Commands</h3>
+          <dl className="ui-text-sm mt-2 space-y-2 text-zinc-600 dark:text-zinc-400">
+            <div>
+              <dt className="inline font-mono text-zinc-800 dark:text-zinc-200">/status</dt>
+              <dd className="ml-2 inline">- Check if your Discord account is linked</dd>
+            </div>
+            <div>
+              <dt className="inline font-mono text-zinc-800 dark:text-zinc-200">/link [token]</dt>
+              <dd className="ml-2 inline">- Link your account using an API token</dd>
+            </div>
+            <div>
+              <dt className="inline font-mono text-zinc-800 dark:text-zinc-200">/unlink</dt>
+              <dd className="ml-2 inline">- Remove your linked API token</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -10,6 +10,7 @@ export { KeyboardShortcutsSettings } from "./KeyboardShortcutsSettings";
 export { TagManagement } from "./TagManagement";
 export { BookmarkletSettings } from "./BookmarkletSettings";
 export { IntegrationsSettings } from "./IntegrationsSettings";
+export { DiscordBotSettings } from "./DiscordBotSettings";
 export { AboutSection } from "./AboutSection";
 // Import directly from file to avoid barrel export pulling in piper-tts-web
 // which has Node.js-only code that breaks the client bundle

--- a/src/server/discord/config.ts
+++ b/src/server/discord/config.ts
@@ -1,0 +1,33 @@
+/**
+ * Discord Bot Configuration
+ *
+ * Shared configuration for the Discord bot, used by both the bot itself
+ * and the API endpoint that exposes bot settings to the frontend.
+ */
+
+// ============================================================================
+// Environment Variables
+// ============================================================================
+
+export const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
+export const DISCORD_CLIENT_ID = process.env.DISCORD_CLIENT_ID;
+export const DISCORD_SAVE_EMOJI = process.env.DISCORD_SAVE_EMOJI || "🦁";
+
+// ============================================================================
+// Derived Configuration
+// ============================================================================
+
+/**
+ * Whether the Discord bot is enabled.
+ * Requires both bot token and client ID to be set.
+ */
+export const DISCORD_BOT_ENABLED = !!(DISCORD_BOT_TOKEN && DISCORD_CLIENT_ID);
+
+/**
+ * Bot invite URL with required permissions.
+ * Permissions: VIEW_CHANNEL (1024) + SEND_MESSAGES (2048) + ADD_REACTIONS (64)
+ *            + READ_MESSAGE_HISTORY (65536) + USE_EXTERNAL_EMOJIS (262144) = 330816
+ */
+export const DISCORD_BOT_INVITE_URL = DISCORD_BOT_ENABLED
+  ? `https://discord.com/oauth2/authorize?client_id=${DISCORD_CLIENT_ID}&permissions=330816&integration_type=0&scope=bot+applications.commands`
+  : null;

--- a/src/server/trpc/routers/auth.ts
+++ b/src/server/trpc/routers/auth.ts
@@ -38,6 +38,11 @@ import {
   processOAuthCallback,
 } from "@/server/auth";
 import { GOOGLE_DRIVE_SCOPE } from "@/server/google/docs";
+import {
+  DISCORD_BOT_ENABLED,
+  DISCORD_BOT_INVITE_URL,
+  DISCORD_SAVE_EMOJI,
+} from "@/server/discord/config";
 
 // ============================================================================
 // Validation Schemas
@@ -756,6 +761,37 @@ export const authRouter = createTRPCRouter({
         },
         sessionToken: token,
         isNewUser: oauthResult.isNewUser,
+      };
+    }),
+
+  /**
+   * Get Discord bot configuration.
+   *
+   * Returns whether the Discord bot is enabled and the invite URL.
+   * Used by the settings page to show the bot invite link.
+   */
+  discordBotConfig: publicProcedure
+    .meta({
+      openapi: {
+        method: "GET",
+        path: "/auth/discord-bot-config",
+        tags: ["Auth"],
+        summary: "Get Discord bot configuration",
+      },
+    })
+    .input(z.object({}).optional())
+    .output(
+      z.object({
+        enabled: z.boolean(),
+        inviteUrl: z.string().nullable(),
+        saveEmoji: z.string().nullable(),
+      })
+    )
+    .query(() => {
+      return {
+        enabled: DISCORD_BOT_ENABLED,
+        inviteUrl: DISCORD_BOT_INVITE_URL,
+        saveEmoji: DISCORD_BOT_ENABLED ? DISCORD_SAVE_EMOJI : null,
       };
     }),
 


### PR DESCRIPTION
Adds a new section to the Integrations settings page that shows the Discord bot invite link. The section includes:
- Invite button that opens the Discord authorization page
- Copy link button for easy sharing
- Usage instructions and bot commands reference

Only displays when the Discord bot is enabled (DISCORD_BOT_TOKEN set).