### PR TITLE
Add subscriber count to feed reader user agent

### DIFF
--- a/src/server/feed/fetcher.ts
+++ b/src/server/feed/fetcher.ts
@@ -22,6 +22,8 @@ export interface FetchFeedOptions {
   maxRedirects?: number;
   /** Feed ID for debugging (included in User-Agent) */
   feedId?: string;
+  /** Number of active subscribers (included in User-Agent for publishers) */
+  subscriberCount?: number;
 }
 
 /**
@@ -313,11 +315,17 @@ export async function fetchFeed(
     userAgent,
     maxRedirects = DEFAULT_MAX_REDIRECTS,
     feedId,
+    subscriberCount,
   } = options;
 
   // Build request headers
   const headers: Record<string, string> = {
-    "User-Agent": userAgent ?? buildUserAgent(feedId ? { context: `feed:${feedId}` } : undefined),
+    "User-Agent":
+      userAgent ??
+      buildUserAgent({
+        context: feedId ? `feed:${feedId}` : undefined,
+        subscriberCount,
+      }),
     Accept: "application/rss+xml, application/atom+xml, application/xml, text/xml, */*",
   };
 

--- a/src/server/http/user-agent.ts
+++ b/src/server/http/user-agent.ts
@@ -9,8 +9,9 @@
  * - App URL (primary contact)
  * - GitHub repository URL
  * - Contact email (if configured)
+ * - Subscriber count (if provided, for feed fetching)
  *
- * Format: LionReader/1.0[-COMMIT] [context] (+APP_URL; GITHUB_URL; EMAIL)
+ * Format: LionReader/1.0[-COMMIT] [context] (+APP_URL; GITHUB_URL; EMAIL; SUBSCRIBERS)
  */
 
 import { fetcherConfig } from "../config/env";
@@ -43,17 +44,26 @@ export interface UserAgentOptions {
    * Example: "feed:abc123"
    */
   context?: string;
+
+  /**
+   * Optional subscriber count to include in the User-Agent.
+   * This is useful for feed publishers to know how many subscribers
+   * are receiving their content through this reader.
+   * Example: 42 -> "42 subscribers"
+   */
+  subscriberCount?: number;
 }
 
 /**
  * Builds a standardized User-Agent string for outgoing HTTP requests.
  *
- * Format: LionReader/1.0-COMMIT context (+APP_URL; GITHUB_URL; EMAIL)
+ * Format: LionReader/1.0-COMMIT context (+APP_URL; GITHUB_URL; EMAIL; SUBSCRIBERS)
  * - COMMIT: Git commit SHA if available
  * - context: Optional context string (e.g., "feed:abc123")
  * - APP_URL: NEXT_PUBLIC_APP_URL with + prefix (primary contact)
  * - GITHUB_URL: Always included for reference
  * - EMAIL: Contact email if configured
+ * - SUBSCRIBERS: Subscriber count if provided (e.g., "42 subscribers")
  *
  * @param options - Optional configuration for the User-Agent
  * @returns The formatted User-Agent string
@@ -64,9 +74,9 @@ export interface UserAgentOptions {
  * // => "LionReader/1.0-abc1234 (+https://lionreader.com; https://github.com/brendanlong/lion-reader; admin@example.com)"
  *
  * @example
- * // With feed context
- * buildUserAgent({ context: "feed:abc123" })
- * // => "LionReader/1.0-abc1234 feed:abc123 (+https://lionreader.com; ...)"
+ * // With feed context and subscriber count
+ * buildUserAgent({ context: "feed:abc123", subscriberCount: 42 })
+ * // => "LionReader/1.0-abc1234 feed:abc123 (+https://lionreader.com; ...; 42 subscribers)"
  */
 export function buildUserAgent(options?: UserAgentOptions): string {
   // Version with optional commit hash
@@ -93,6 +103,13 @@ export function buildUserAgent(options?: UserAgentOptions): string {
 
   if (fetcherConfig.contactEmail) {
     parts.push(fetcherConfig.contactEmail);
+  }
+
+  // Include subscriber count if provided (useful for publishers)
+  if (options?.subscriberCount !== undefined && options.subscriberCount >= 0) {
+    const subscriberText =
+      options.subscriberCount === 1 ? "1 subscriber" : `${options.subscriberCount} subscribers`;
+    parts.push(subscriberText);
   }
 
   ua += ` (${parts.join("; ")})`;


### PR DESCRIPTION
Include the number of active subscribers in the User-Agent header when fetching feeds in the background. This helps publishers understand their audience reach through Lion Reader.

The format is "N subscribers" (or "1 subscriber" for singular) appended to the comment section of the user agent string.