### PR TITLE
Set pool idle timeout to 30s to reduce connection crash errors

### DIFF
--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -13,6 +13,8 @@ if (!connectionString) {
 
 export const pool = new Pool({
   connectionString,
+  // Close idle connections before Fly.io's 60s proxy timeout to avoid "server conn crashed?" errors
+  idleTimeoutMillis: 30000,
 });
 
 // Handle unexpected errors on idle clients in the pool.


### PR DESCRIPTION
Fly.io's proxy times out idle connections after 60 seconds. When the proxy kills a connection but the pool still thinks it's valid, we get "server conn crashed?" errors on next use. Setting idleTimeoutMillis to 30s proactively closes connections before this happens.