### PR TITLE
Fix hydration mismatch between server and client

### DIFF
--- a/src/components/settings/BookmarkletSettings.tsx
+++ b/src/components/settings/BookmarkletSettings.tsx
@@ -14,12 +14,11 @@ export function BookmarkletSettings() {
   const bookmarkletRef = useRef<HTMLAnchorElement>(null);
 
   // Generate the bookmarklet URL using the app's base URL
+  // Check env var first (available on both server and client), then fall back to window.location.origin
   const { bookmarkletHref, appUrl } = useMemo(() => {
-    // Use NEXT_PUBLIC_APP_URL if available, otherwise use window.location.origin
     const baseUrl =
-      typeof window !== "undefined"
-        ? process.env.NEXT_PUBLIC_APP_URL || window.location.origin
-        : "";
+      process.env.NEXT_PUBLIC_APP_URL ||
+      (typeof window !== "undefined" ? window.location.origin : "");
 
     // The bookmarklet JavaScript - opens the save page in a popup window
     const bookmarkletCode = `javascript:(function(){window.open('${baseUrl}/save?url='+encodeURIComponent(location.href),'save','width=400,height=300')})();`;

--- a/src/components/settings/IntegrationsSettings.tsx
+++ b/src/components/settings/IntegrationsSettings.tsx
@@ -13,9 +13,12 @@ import Link from "next/link";
 export function IntegrationsSettings() {
   const [copiedSection, setCopiedSection] = useState<string | null>(null);
 
+  // Check env var first (available on both server and client), then fall back to window.location.origin
   const baseUrl = useMemo(() => {
-    if (typeof window === "undefined") return "";
-    return process.env.NEXT_PUBLIC_APP_URL || window.location.origin;
+    return (
+      process.env.NEXT_PUBLIC_APP_URL ||
+      (typeof window !== "undefined" ? window.location.origin : "")
+    );
   }, []);
 
   const mcpUrl = `${baseUrl}/mcp`;


### PR DESCRIPTION
The original code checked `typeof window !== "undefined"` before checking the env var, causing the server to always use "" even when NEXT_PUBLIC_APP_URL was properly configured. This caused hydration mismatches.

Fixed by checking the env var first - since NEXT_PUBLIC_* vars are inlined at build time, they're available on both server and client. Now falls back to window.location.origin only when the env var is not set.

Applied the same fix to IntegrationsSettings.tsx which had the same bug.