### PR TITLE
Add configurable emoji reactions for Discord bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -217,6 +217,8 @@ ALLOW_ALL_SIGNUPS=false
 #
 # DISCORD_BOT_TOKEN=your-bot-token
 # DISCORD_SAVE_EMOJI=🦁
+# DISCORD_SUCCESS_EMOJI=salutinglionreader
+# DISCORD_ERROR_EMOJI=😿
 
 # =============================================================================
 # Observability (Optional)

--- a/src/components/settings/DiscordBotSettings.tsx
+++ b/src/components/settings/DiscordBotSettings.tsx
@@ -53,6 +53,8 @@ export function DiscordBotSettings() {
   }
 
   const emoji = botConfig.saveEmoji ? formatEmoji(botConfig.saveEmoji) : null;
+  const successEmoji = botConfig.successEmoji ? formatEmoji(botConfig.successEmoji) : null;
+  const errorEmoji = botConfig.errorEmoji ? formatEmoji(botConfig.errorEmoji) : null;
 
   return (
     <section>
@@ -121,6 +123,38 @@ export function DiscordBotSettings() {
                 </>
               ) : (
                 "Add the configured emoji reaction to any message containing a URL"
+              )}
+            </li>
+            <li>
+              <strong className="text-zinc-900 dark:text-zinc-200">Look for the reaction</strong> -{" "}
+              {successEmoji ? (
+                <>
+                  The bot will react with{" "}
+                  {successEmoji.isCustom ? (
+                    <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
+                      {successEmoji.text}
+                    </code>
+                  ) : (
+                    <span className="text-base">{successEmoji.text}</span>
+                  )}{" "}
+                  on success
+                  {errorEmoji && (
+                    <>
+                      {" "}
+                      or{" "}
+                      {errorEmoji.isCustom ? (
+                        <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
+                          {errorEmoji.text}
+                        </code>
+                      ) : (
+                        <span className="text-base">{errorEmoji.text}</span>
+                      )}{" "}
+                      on failure
+                    </>
+                  )}
+                </>
+              ) : (
+                "The bot will react to confirm the save succeeded or failed"
               )}
             </li>
             <li>

--- a/src/server/discord/config.ts
+++ b/src/server/discord/config.ts
@@ -12,6 +12,8 @@
 export const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
 export const DISCORD_CLIENT_ID = process.env.DISCORD_CLIENT_ID;
 export const DISCORD_SAVE_EMOJI = process.env.DISCORD_SAVE_EMOJI || "🦁";
+export const DISCORD_SUCCESS_EMOJI = process.env.DISCORD_SUCCESS_EMOJI || "salutinglionreader";
+export const DISCORD_ERROR_EMOJI = process.env.DISCORD_ERROR_EMOJI || "😿";
 
 // ============================================================================
 // Derived Configuration

--- a/src/server/trpc/routers/auth.ts
+++ b/src/server/trpc/routers/auth.ts
@@ -42,6 +42,8 @@ import {
   DISCORD_BOT_ENABLED,
   DISCORD_BOT_INVITE_URL,
   DISCORD_SAVE_EMOJI,
+  DISCORD_SUCCESS_EMOJI,
+  DISCORD_ERROR_EMOJI,
 } from "@/server/discord/config";
 
 // ============================================================================
@@ -785,6 +787,8 @@ export const authRouter = createTRPCRouter({
         enabled: z.boolean(),
         inviteUrl: z.string().nullable(),
         saveEmoji: z.string().nullable(),
+        successEmoji: z.string().nullable(),
+        errorEmoji: z.string().nullable(),
       })
     )
     .query(() => {
@@ -792,6 +796,8 @@ export const authRouter = createTRPCRouter({
         enabled: DISCORD_BOT_ENABLED,
         inviteUrl: DISCORD_BOT_INVITE_URL,
         saveEmoji: DISCORD_BOT_ENABLED ? DISCORD_SAVE_EMOJI : null,
+        successEmoji: DISCORD_BOT_ENABLED ? DISCORD_SUCCESS_EMOJI : null,
+        errorEmoji: DISCORD_BOT_ENABLED ? DISCORD_ERROR_EMOJI : null,
       };
     }),
 


### PR DESCRIPTION
- Add configurable DISCORD_SUCCESS_EMOJI (default: salutinglionreader) and DISCORD_ERROR_EMOJI (default: crying_cat_face) environment variables
- Bot now reacts to messages with success/error emoji instead of DMing
- Update settings UI to show the emoji feedback behavior
- Remove sendResultsDM function as DMs were considered too spammy