### PR TITLE
Fix Discord bot ready event deprecation warning

### DIFF
--- a/src/server/discord/bot.ts
+++ b/src/server/discord/bot.ts
@@ -202,7 +202,7 @@ export async function startDiscordBot(): Promise<void> {
     await handleSaveReaction(reaction.message, user);
   });
 
-  client.once("ready", () => {
+  client.once("clientReady", () => {
     logger.info("Discord bot started", {
       tag: client?.user?.tag,
       saveEmoji: DISCORD_SAVE_EMOJI,


### PR DESCRIPTION
The 'ready' event is deprecated in discord.js v14 and will be removed in v15. Using 'clientReady' which is the new name.