### PR TITLE
Fix sync token to use granular cursors for each query type (#339)

### DIFF
--- a/drizzle/0039_user_feeds_created_at.sql
+++ b/drizzle/0039_user_feeds_created_at.sql
@@ -1,0 +1,72 @@
+-- Migration: Add created_at to user_feeds view for sync cursor tracking
+-- This enables correct incremental sync by tracking the actual creation time of subscriptions
+
+-- Drop dependent view first
+DROP VIEW IF EXISTS visible_entries;
+
+-- Drop and recreate user_feeds view with created_at
+DROP VIEW IF EXISTS user_feeds;
+
+CREATE VIEW user_feeds AS
+SELECT
+  s.id,
+  s.user_id,
+  s.subscribed_at,
+  s.created_at,                                   -- added for sync cursor tracking
+  s.feed_id,                                      -- internal use only
+  s.feed_ids,                                     -- for entry visibility queries
+  s.custom_title,
+  s.fetch_full_content,
+  f.type,
+  COALESCE(s.custom_title, f.title) AS title,    -- resolved title
+  f.title AS original_title,                      -- for "rename" UI
+  f.url,
+  f.site_url,
+  f.description
+FROM subscriptions s
+JOIN feeds f ON f.id = s.feed_id
+WHERE s.unsubscribed_at IS NULL;
+
+-- Recreate visible_entries view (depends on user_feeds indirectly through subscriptions)
+CREATE VIEW visible_entries AS
+SELECT
+  ue.user_id,
+  e.id,
+  e.feed_id,
+  e.type,
+  e.guid,
+  e.url,
+  e.title,
+  e.author,
+  e.content_original,
+  e.content_cleaned,
+  e.summary,
+  e.site_name,
+  e.image_url,
+  e.published_at,
+  e.fetched_at,
+  e.last_seen_at,
+  e.content_hash,
+  e.spam_score,
+  e.is_spam,
+  e.list_unsubscribe_mailto,
+  e.list_unsubscribe_https,
+  e.list_unsubscribe_post,
+  e.created_at,
+  e.updated_at,
+  e.full_content_original,
+  e.full_content_cleaned,
+  e.full_content_fetched_at,
+  e.full_content_error,
+  ue.read,
+  ue.starred,
+  s.id AS subscription_id
+FROM user_entries ue
+JOIN entries e ON e.id = ue.entry_id
+LEFT JOIN subscriptions s ON (
+  s.user_id = ue.user_id
+  AND e.feed_id = ANY(s.feed_ids)
+)
+WHERE
+  s.unsubscribed_at IS NULL
+  OR ue.starred = true;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1767460000000,
       "tag": "0038_entry_summaries",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1767470000000,
+      "tag": "0039_user_feeds_created_at",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/AppLayoutContent.tsx
+++ b/src/app/(app)/AppLayoutContent.tsx
@@ -18,13 +18,14 @@ import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { KeyboardShortcutsProvider } from "@/components/keyboard";
 import { trpc } from "@/lib/trpc/client";
 import { AppearanceProvider } from "@/lib/appearance";
+import { type SyncCursors } from "@/lib/hooks/useRealtimeUpdates";
 
 interface AppLayoutContentProps {
   children: React.ReactNode;
-  initialSyncCursor: string;
+  initialCursors: SyncCursors;
 }
 
-export function AppLayoutContent({ children, initialSyncCursor }: AppLayoutContentProps) {
+export function AppLayoutContent({ children, initialCursors }: AppLayoutContentProps) {
   const router = useRouter();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
@@ -48,7 +49,7 @@ export function AppLayoutContent({ children, initialSyncCursor }: AppLayoutConte
 
   return (
     <AppearanceProvider>
-      <RealtimeProvider initialSyncCursor={initialSyncCursor}>
+      <RealtimeProvider initialCursors={initialCursors}>
         <KeyboardShortcutsProvider>
           <Toaster position="bottom-right" richColors closeButton />
           <div className="flex h-screen bg-zinc-50 dark:bg-zinc-950">

--- a/src/components/layout/RealtimeProvider.tsx
+++ b/src/components/layout/RealtimeProvider.tsx
@@ -11,7 +11,7 @@
 "use client";
 
 import { type ReactNode } from "react";
-import { useRealtimeUpdates } from "@/lib/hooks/useRealtimeUpdates";
+import { useRealtimeUpdates, type SyncCursors } from "@/lib/hooks/useRealtimeUpdates";
 import { ConnectionStatusIndicator } from "./ConnectionStatusIndicator";
 
 interface RealtimeProviderProps {
@@ -21,10 +21,10 @@ interface RealtimeProviderProps {
   children: ReactNode;
 
   /**
-   * Initial sync cursor from server (ISO8601 timestamp).
+   * Initial sync cursors from server (one per entity type).
    * Used for SSE reconnection and polling mode to avoid missing events.
    */
-  initialSyncCursor: string;
+  initialCursors: SyncCursors;
 
   /**
    * Whether to show the connection status indicator.
@@ -45,9 +45,13 @@ interface RealtimeProviderProps {
  * ```tsx
  * // In your app layout:
  * export default function AppLayout({ children }) {
- *   const initialSyncCursor = new Date().toISOString();
+ *   // Initial cursors - null values for fresh sync
+ *   const initialCursors: SyncCursors = {
+ *     entries: null, entryStates: null, subscriptions: null,
+ *     removedSubscriptions: null, tags: null
+ *   };
  *   return (
- *     <RealtimeProvider initialSyncCursor={initialSyncCursor}>
+ *     <RealtimeProvider initialCursors={initialCursors}>
  *       {children}
  *     </RealtimeProvider>
  *   );
@@ -56,10 +60,10 @@ interface RealtimeProviderProps {
  */
 export function RealtimeProvider({
   children,
-  initialSyncCursor,
+  initialCursors,
   showStatusIndicator = true,
 }: RealtimeProviderProps) {
-  const { status, reconnect } = useRealtimeUpdates(initialSyncCursor);
+  const { status, reconnect } = useRealtimeUpdates(initialCursors);
 
   return (
     <>

--- a/src/lib/trpc/server.ts
+++ b/src/lib/trpc/server.ts
@@ -100,11 +100,17 @@ export function createServerQueryClient(): QueryClient {
 export interface PrefetchResult {
   queryClient: QueryClient;
   /**
-   * Server timestamp for SSE sync cursor.
-   * Should be captured after all prefetches complete to ensure
-   * no events are missed between prefetch and SSE connection.
+   * Initial sync cursors for each entity type.
+   * Null values indicate an initial sync that will fetch all recent data
+   * and establish baseline cursors for subsequent incremental syncs.
    */
-  initialSyncCursor: string;
+  initialCursors: {
+    entries: string | null;
+    entryStates: string | null;
+    subscriptions: string | null;
+    removedSubscriptions: string | null;
+    tags: string | null;
+  };
 }
 
 /**

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -607,6 +607,7 @@ export const userFeeds = pgView("user_feeds", {
   id: uuid("id").notNull(),
   userId: uuid("user_id").notNull(),
   subscribedAt: timestamp("subscribed_at", { withTimezone: true }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull(), // for sync cursor tracking
   feedId: uuid("feed_id").notNull(), // internal use only
   feedIds: uuid("feed_ids").array().notNull(), // for entry visibility queries
   customTitle: text("custom_title"),


### PR DESCRIPTION
The previous sync implementation used a single server timestamp as the sync cursor, but this could miss changes because different queries use different columns for ordering (entries.createdAt, userEntries.updatedAt, subscriptions.createdAt, etc.).

This change introduces granular cursors for each entity type:
- entries: based on entries.createdAt
- entryStates: based on userEntries.updatedAt
- subscriptions: based on subscriptions.createdAt
- removedSubscriptions: based on subscriptions.unsubscribedAt
- tags: based on tags.createdAt

Each cursor is derived from the actual last item returned by its query, ensuring no data is missed between syncs. The deprecated `since` parameter is still supported for backward compatibility.

Also adds created_at to the user_feeds view via migration.