### PR TITLE
Reduce Fly.io health check interval from 15s to 5s

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -76,7 +76,7 @@ primary_region = "lax"
 
 [[http_service.checks]]
   grace_period = "30s"
-  interval = "15s"
+  interval = "5s"
   timeout = "5s"
   method = "GET"
   path = "/api/health"


### PR DESCRIPTION
Faster health checks enable quicker detection of healthy instances
during deploys, making rolling deployments more seamless. The health
endpoint is lightweight (SELECT 1 + Redis PING), so this adds
negligible load.