### PR TITLE
Add progressive header rendering for entry detail view

### DIFF
--- a/src/lib/cache/entry-cache.ts
+++ b/src/lib/cache/entry-cache.ts
@@ -143,7 +143,7 @@ export function updateEntryStarredStatus(
 /**
  * Entry data from the list (lightweight, no content).
  */
-interface EntryListItem {
+export interface EntryListItem {
   id: string;
   feedId: string;
   subscriptionId: string | null;
@@ -160,35 +160,66 @@ interface EntryListItem {
 }
 
 /**
- * Seeds the entries.get cache with data from a list item for progressive rendering.
- * This allows the entry detail page to render the header immediately while
- * the full content loads.
+ * Finds an entry in the cached entry lists by ID.
+ * Searches through all cached infinite query pages.
  *
- * Only seeds if no data exists yet - won't overwrite existing full data.
- *
- * @param utils - tRPC utils for cache access
- * @param listItem - Entry data from the list
+ * @param queryClient - React Query client for cache access
+ * @param entryId - Entry ID to find
+ * @returns The entry if found, undefined otherwise
  */
-export function seedEntryCacheFromList(utils: TRPCClientUtils, listItem: EntryListItem): void {
-  utils.entries.get.setData({ id: listItem.id }, (existingData) => {
-    // Already have data? Don't overwrite it
-    if (existingData?.entry) {
-      return existingData;
-    }
-    // No data yet - seed with list item (content fields set to null)
-    return {
-      entry: {
-        ...listItem,
-        // Fields not in list item - set to null
-        contentOriginal: null,
-        contentCleaned: null,
-        feedUrl: null,
-        siteName: null,
-        fullContentOriginal: null,
-        fullContentCleaned: null,
-        fullContentFetchedAt: null,
-        fullContentError: null,
-      },
-    };
+export function findEntryInListCache(
+  queryClient: QueryClient,
+  entryId: string
+): EntryListItem | undefined {
+  // Get all cached entry list queries
+  const queries = queryClient.getQueriesData<InfiniteData>({
+    queryKey: [["entries", "list"]],
   });
+
+  for (const [, data] of queries) {
+    if (!data?.pages) continue;
+    for (const page of data.pages) {
+      const entry = page.items.find((e) => e.id === entryId);
+      if (entry) {
+        // The cache contains full EntryListItem data, but TypeScript only sees CachedListEntry
+        return entry as unknown as EntryListItem;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Converts a list item to the full entry response format for use as placeholder data.
+ * Content fields are set to null since they're not available in list data.
+ *
+ * @param listItem - Entry data from the list
+ * @returns Object matching the entries.get response shape
+ */
+export function listItemToPlaceholderEntry(listItem: EntryListItem): {
+  entry: EntryListItem & {
+    contentOriginal: null;
+    contentCleaned: null;
+    feedUrl: null;
+    siteName: null;
+    fullContentOriginal: null;
+    fullContentCleaned: null;
+    fullContentFetchedAt: null;
+    fullContentError: null;
+  };
+} {
+  return {
+    entry: {
+      ...listItem,
+      contentOriginal: null,
+      contentCleaned: null,
+      feedUrl: null,
+      siteName: null,
+      fullContentOriginal: null,
+      fullContentCleaned: null,
+      fullContentFetchedAt: null,
+      fullContentError: null,
+    },
+  };
 }

--- a/src/lib/hooks/useEntryPage.ts
+++ b/src/lib/hooks/useEntryPage.ts
@@ -9,7 +9,6 @@
 
 import { useCallback, useMemo } from "react";
 import { trpc } from "@/lib/trpc/client";
-import { seedEntryCacheFromList } from "@/lib/cache/entry-cache";
 import { useKeyboardShortcutsContext } from "@/components/keyboard";
 import { type ExternalQueryState } from "@/components/entries";
 import { type EntryType } from "./useEntryMutations";
@@ -198,26 +197,16 @@ export function useEntryPage(options: UseEntryPageOptions): UseEntryPageResult {
   const goToNextEntry = useCallback(() => {
     const nextId = entryListQuery.getNextEntryId();
     if (nextId) {
-      // Seed cache for progressive rendering
-      const listItem = entries.find((e) => e.id === nextId);
-      if (listItem) {
-        seedEntryCacheFromList(utils, listItem);
-      }
       setOpenEntryId(nextId);
     }
-  }, [entryListQuery, entries, utils, setOpenEntryId]);
+  }, [entryListQuery, setOpenEntryId]);
 
   const goToPreviousEntry = useCallback(() => {
     const prevId = entryListQuery.getPreviousEntryId();
     if (prevId) {
-      // Seed cache for progressive rendering
-      const listItem = entries.find((e) => e.id === prevId);
-      if (listItem) {
-        seedEntryCacheFromList(utils, listItem);
-      }
       setOpenEntryId(prevId);
     }
-  }, [entryListQuery, entries, utils, setOpenEntryId]);
+  }, [entryListQuery, setOpenEntryId]);
 
   // Keyboard shortcuts
   const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
@@ -236,18 +225,13 @@ export function useEntryPage(options: UseEntryPageOptions): UseEntryPageResult {
     onNavigatePrevious: goToPreviousEntry,
   });
 
-  // Entry click handler - seeds cache for progressive rendering
+  // Entry click handler
   const handleEntryClick = useCallback(
     (entryId: string) => {
-      // Find the entry in the list and seed the cache for progressive rendering
-      const listItem = entries.find((e) => e.id === entryId);
-      if (listItem) {
-        seedEntryCacheFromList(utils, listItem);
-      }
       setSelectedEntryId(entryId);
       setOpenEntryId(entryId);
     },
-    [entries, utils, setSelectedEntryId, setOpenEntryId]
+    [setSelectedEntryId, setOpenEntryId]
   );
 
   // Back handler


### PR DESCRIPTION
When clicking an entry from the list, the entry detail page now renders
the header (title, source, date, read/star buttons) immediately using
data from the list cache, while showing a content skeleton. This provides
a faster perceived load time.

Implementation:
- Add seedEntryCacheFromList() to seed entries.get cache from list data
- Call this function on entry click and next/prev navigation
- EntryContent detects partial data and passes isContentLoading prop
- EntryContentBody shows ContentSkeleton while content loads

The cache seeding only occurs if no data exists yet, preserving any
previously loaded full content.