### PR TITLE
Optimize Dockerfile layer caching strategy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,10 +13,16 @@ dist/
 # Tests - not needed in production
 tests/
 
-# Documentation
+# Non-web apps
+android/
+extension/
+
+# Source assets (originals, not public/)
+assets/
+
+# Documentation and notes
 docs/
 *.md
-!README.md
 
 # Docker files (prevent recursive context)
 Dockerfile
@@ -54,6 +60,11 @@ fly.toml
 .prettierrc
 .prettierignore
 eslint.config.mjs
+
+# Dev-only configs
+knip.json
+vitest.config.ts
+package-lock.json
 
 # Coverage and test reports
 coverage/


### PR DESCRIPTION
Exclude additional files/directories that don't affect the web build:
- android/, extension/ - Non-web apps
- assets/ - Source design files
- knip.json, vitest.config.ts - Dev-only configs
- package-lock.json - npm lockfile (we use pnpm)
- Remove README.md exception (not needed in build)

This prevents unnecessary cache invalidation when these files change.