### PR TITLE
Fix login redirects and logout button

### DIFF
--- a/src/server/trpc/routers/auth.ts
+++ b/src/server/trpc/routers/auth.ts
@@ -871,8 +871,12 @@ export const authRouter = createTRPCRouter({
    *
    * Revokes the current session token, invalidating it for future requests.
    * Also clears the session from Redis cache.
+   *
+   * This is a public procedure so that logout works even if the session is
+   * already expired or invalid. If there's no valid session, this just
+   * returns success (the user is already logged out from the server's perspective).
    */
-  logout: protectedProcedure
+  logout: publicProcedure
     .meta({
       openapi: {
         method: "POST",
@@ -885,6 +889,7 @@ export const authRouter = createTRPCRouter({
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx }) => {
       // Revoke the current session using the token from context
+      // If there's no valid session token, we're already logged out
       if (ctx.sessionToken) {
         await revokeSessionByToken(ctx.sessionToken);
       }


### PR DESCRIPTION
- Add server-side redirect to /login in app layout when not authenticated (prevents showing error page before client-side redirect kicks in)
- Change logout endpoint from protectedProcedure to publicProcedure (allows logout to succeed even if session is already expired/invalid)