### PR TITLE
Fix entry list refreshing while reading articles (#363)

### DIFF
--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -603,10 +603,12 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
         utils.subscriptions.list.invalidate();
       }
 
-      // Handle subscription changes
+      // Handle subscription changes - only invalidate subscriptions.list, not entries.list
+      // Subscription creates/deletes don't affect which entries are visible in the current view.
+      // New entries from new subscriptions will appear when the user navigates to that feed.
+      // Removed subscriptions won't have their entries shown after navigation away.
       if (hasSubscriptionChanges) {
         utils.subscriptions.list.invalidate();
-        utils.entries.list.invalidate();
       }
 
       if (hasTagChanges) {


### PR DESCRIPTION
## Summary
- Remove unnecessary `entries.list.invalidate()` call when subscription changes are synced
- Subscription creates/deletes don't affect entries visible in the current view
- New entries from new subscriptions appear when user navigates to that feed

Fixes #363

## Root Cause
In `useRealtimeUpdates.ts`, the `performSync()` function was invalidating `entries.list` whenever subscription changes were detected during polling sync. This caused the entry list to refetch and rebuild, which could:
1. Move users to a random entry when swiping through articles
2. Filter out read entries when clicking back (due to refetch with unread-only filter)

## Solution
Only invalidate `subscriptions.list` on subscription changes, not `entries.list`. The entries visible in the current view aren't affected by subscription changes - new entries from new subscriptions will appear when the user navigates to that feed.

## Test plan
- [ ] Open article and swipe through multiple entries
- [ ] In another tab, perform an action that triggers subscription sync (e.g., read an entry from a different subscription)
- [ ] Verify the entry list stays stable and doesn't refresh
- [ ] Click back and verify all entries are still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)