### PR TITLE
Add upload_article MCP tool for Markdown content

### DIFF
--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -240,6 +240,33 @@ export function registerTools(): Tool[] {
       },
     },
 
+    {
+      name: "upload_article",
+      description:
+        "Upload an article with Markdown content directly, without a URL. Useful for saving content you've written or collected.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          content: {
+            type: "string",
+            description: "Article content in Markdown format (GitHub Flavored Markdown supported)",
+          },
+          title: {
+            type: "string",
+            description: "Article title",
+          },
+        },
+        required: ["content", "title"],
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handler: async (db, args: any) => {
+        return savedService.uploadArticle(db, args.userId, {
+          content: args.content,
+          title: args.title,
+        });
+      },
+    },
+
     // ========================================================================
     // Subscriptions Tools
     // ========================================================================


### PR DESCRIPTION
## Summary

- Adds new `upload_article` MCP tool that accepts Markdown content directly, without requiring a URL
- Useful for AI assistants to save content they've written or collected
- Converts Markdown to HTML using `marked` (GitHub Flavored Markdown)
- Follows the same pattern as the existing file upload endpoint (`saved.uploadFile`)

## Changes

- **`src/server/services/saved.ts`**:
  - Add `uploadArticle` service function
  - Add `UploadArticleParams` interface
  - Export `generateContentHash` (was duplicated)
  - Update `SavedArticle.url` type to `string | null`

- **`src/server/mcp/tools.ts`**:
  - Add `upload_article` tool with `content` (Markdown) and `title` parameters

- **`src/server/trpc/routers/saved.ts`**:
  - Remove duplicated `generateContentHash` function
  - Import from services/saved.ts instead

## Test plan

- [ ] Verify typecheck passes
- [ ] Test MCP tool with Markdown content via Claude Desktop or similar MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)