### PR TITLE
Memoize context value in KeyboardShortcutsProvider

### DIFF
--- a/src/components/keyboard/KeyboardShortcutsProvider.tsx
+++ b/src/components/keyboard/KeyboardShortcutsProvider.tsx
@@ -7,7 +7,7 @@
 
 "use client";
 
-import { createContext, useContext, useState, useCallback } from "react";
+import { createContext, useContext, useState, useCallback, useMemo } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { KeyboardShortcutsModal } from "./KeyboardShortcutsModal";
 import { useKeyboardShortcutsEnabled } from "@/lib/hooks/useKeyboardShortcutsEnabled";
@@ -72,13 +72,16 @@ export function KeyboardShortcutsProvider({ children }: KeyboardShortcutsProvide
     [enabled, isLoading, isModalOpen, openShortcutsModal]
   );
 
-  const contextValue: KeyboardShortcutsContextValue = {
-    enabled,
-    setEnabled,
-    openShortcutsModal,
-    closeShortcutsModal,
-    isModalOpen,
-  };
+  const contextValue = useMemo<KeyboardShortcutsContextValue>(
+    () => ({
+      enabled,
+      setEnabled,
+      openShortcutsModal,
+      closeShortcutsModal,
+      isModalOpen,
+    }),
+    [enabled, setEnabled, openShortcutsModal, closeShortcutsModal, isModalOpen]
+  );
 
   return (
     <KeyboardShortcutsContext.Provider value={contextValue}>


### PR DESCRIPTION
## Summary

- Fixes #375 by wrapping the context value object in `useMemo`
- Prevents unnecessary re-renders of all context consumers when the provider re-renders
- Context consumers now only re-render when actual context values change

## Test plan

- [ ] Verify the app builds and runs without errors
- [ ] Test keyboard shortcuts functionality (press `?` to open shortcuts modal)
- [ ] Verify shortcuts can be enabled/disabled in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)