### PR TITLE
Remove deprecated forwardRef usage in UI components (React 19)

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,79 +4,74 @@
  * A styled button with loading state and variants.
  */
 
-import { forwardRef, type ButtonHTMLAttributes } from "react";
+import type { ButtonHTMLAttributes, Ref } from "react";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "ghost";
   size?: "sm" | "md" | "lg";
   loading?: boolean;
+  ref?: Ref<HTMLButtonElement>;
 }
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      variant = "primary",
-      size = "md",
-      loading = false,
-      disabled,
-      className = "",
-      children,
-      ...props
-    },
-    ref
-  ) => {
-    const baseStyles =
-      "inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+export function Button({
+  variant = "primary",
+  size = "md",
+  loading = false,
+  disabled,
+  className = "",
+  children,
+  ref,
+  ...props
+}: ButtonProps) {
+  const baseStyles =
+    "inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
 
-    const variantStyles = {
-      primary:
-        "bg-zinc-900 text-white hover:bg-zinc-800 focus:ring-zinc-900 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200 dark:focus:ring-zinc-400",
-      secondary:
-        "border border-zinc-300 bg-white text-zinc-900 hover:bg-zinc-50 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400",
-      ghost:
-        "text-zinc-900 hover:bg-zinc-100 focus:ring-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400",
-    };
+  const variantStyles = {
+    primary:
+      "bg-zinc-900 text-white hover:bg-zinc-800 focus:ring-zinc-900 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200 dark:focus:ring-zinc-400",
+    secondary:
+      "border border-zinc-300 bg-white text-zinc-900 hover:bg-zinc-50 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400",
+    ghost:
+      "text-zinc-900 hover:bg-zinc-100 focus:ring-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400",
+  };
 
-    // Ensure minimum 44px height for touch targets on mobile (WCAG touch target guidelines)
-    const sizeStyles = {
-      sm: "min-h-[36px] px-3 ui-text-sm sm:min-h-[32px]",
-      md: "min-h-[44px] px-4 ui-text-sm",
-      lg: "min-h-[48px] px-6 ui-text-base",
-    };
+  // Ensure minimum 44px height for touch targets on mobile (WCAG touch target guidelines)
+  const sizeStyles = {
+    sm: "min-h-[36px] px-3 ui-text-sm sm:min-h-[32px]",
+    md: "min-h-[44px] px-4 ui-text-sm",
+    lg: "min-h-[48px] px-6 ui-text-base",
+  };
 
-    return (
-      <button
-        ref={ref}
-        disabled={disabled || loading}
-        className={`${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
-        {...props}
-      >
-        {loading && (
-          <svg
-            className="mr-2 -ml-1 h-4 w-4 animate-spin"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            />
-          </svg>
-        )}
-        {children}
-      </button>
-    );
-  }
-);
-
-Button.displayName = "Button";
+  return (
+    <button
+      ref={ref}
+      disabled={disabled || loading}
+      className={`${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
+      {...props}
+    >
+      {loading && (
+        <svg
+          className="mr-2 -ml-1 h-4 w-4 animate-spin"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+      )}
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/icon-button.tsx
+++ b/src/components/ui/icon-button.tsx
@@ -5,7 +5,7 @@
  * Includes common icon presets for convenience.
  */
 
-import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
+import type { ButtonHTMLAttributes, ReactNode, Ref } from "react";
 
 export interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** Icon content (SVG or component) */
@@ -16,6 +16,7 @@ export interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>
   size?: "sm" | "md";
   /** Visual variant */
   variant?: "ghost" | "subtle";
+  ref?: Ref<HTMLButtonElement>;
 }
 
 /**
@@ -31,35 +32,39 @@ export interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>
  * />
  * ```
  */
-export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-  ({ icon, size = "md", variant = "ghost", className = "", disabled, ...props }, ref) => {
-    const sizeStyles = {
-      sm: "h-7 w-7",
-      md: "h-8 w-8",
-    };
+export function IconButton({
+  icon,
+  size = "md",
+  variant = "ghost",
+  className = "",
+  disabled,
+  ref,
+  ...props
+}: IconButtonProps) {
+  const sizeStyles = {
+    sm: "h-7 w-7",
+    md: "h-8 w-8",
+  };
 
-    const variantStyles = {
-      ghost:
-        "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 active:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 dark:active:bg-zinc-700",
-      subtle:
-        "text-zinc-400 hover:bg-zinc-200 hover:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-300",
-    };
+  const variantStyles = {
+    ghost:
+      "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 active:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 dark:active:bg-zinc-700",
+    subtle:
+      "text-zinc-400 hover:bg-zinc-200 hover:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-300",
+  };
 
-    return (
-      <button
-        ref={ref}
-        type="button"
-        disabled={disabled}
-        className={`flex items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${sizeStyles[size]} ${variantStyles[variant]} ${className}`}
-        {...props}
-      >
-        {icon}
-      </button>
-    );
-  }
-);
-
-IconButton.displayName = "IconButton";
+  return (
+    <button
+      ref={ref}
+      type="button"
+      disabled={disabled}
+      className={`flex items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${sizeStyles[size]} ${variantStyles[variant]} ${className}`}
+      {...props}
+    >
+      {icon}
+    </button>
+  );
+}
 
 // ============================================================================
 // Common Icons

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -4,45 +4,42 @@
  * A styled input field with support for labels, errors, and various states.
  */
 
-import { forwardRef, type InputHTMLAttributes } from "react";
+import type { InputHTMLAttributes, Ref } from "react";
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
+  ref?: Ref<HTMLInputElement>;
 }
 
-export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ label, error, id, className = "", ...props }, ref) => {
-    return (
-      <div className="w-full">
-        {label && (
-          <label
-            htmlFor={id}
-            className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
-          >
-            {label}
-          </label>
-        )}
-        <input
-          ref={ref}
-          id={id}
-          className={`ui-text-sm block w-full rounded-md border bg-white px-3 py-2 text-zinc-900 placeholder:text-zinc-400 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-500 ${
-            error
-              ? "border-red-500 focus:border-red-500 focus:ring-red-500 dark:border-red-500"
-              : "border-zinc-300 focus:border-zinc-900 focus:ring-zinc-900 dark:border-zinc-700 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
-          } ${className}`}
-          aria-invalid={error ? "true" : undefined}
-          aria-describedby={error ? `${id}-error` : undefined}
-          {...props}
-        />
-        {error && (
-          <p id={`${id}-error`} className="ui-text-sm mt-1.5 text-red-600 dark:text-red-400">
-            {error}
-          </p>
-        )}
-      </div>
-    );
-  }
-);
-
-Input.displayName = "Input";
+export function Input({ label, error, id, className = "", ref, ...props }: InputProps) {
+  return (
+    <div className="w-full">
+      {label && (
+        <label
+          htmlFor={id}
+          className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
+        >
+          {label}
+        </label>
+      )}
+      <input
+        ref={ref}
+        id={id}
+        className={`ui-text-sm block w-full rounded-md border bg-white px-3 py-2 text-zinc-900 placeholder:text-zinc-400 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-500 ${
+          error
+            ? "border-red-500 focus:border-red-500 focus:ring-red-500 dark:border-red-500"
+            : "border-zinc-300 focus:border-zinc-900 focus:ring-zinc-900 dark:border-zinc-700 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+        } ${className}`}
+        aria-invalid={error ? "true" : undefined}
+        aria-describedby={error ? `${id}-error` : undefined}
+        {...props}
+      />
+      {error && (
+        <p id={`${id}-error`} className="ui-text-sm mt-1.5 text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Updated `Button`, `Input`, and `IconButton` components to use React 19's ref-as-prop pattern instead of the deprecated `forwardRef`
- Removed unnecessary `displayName` assignments (no longer needed with named function exports)
- Simplified component code structure

## Changes

React 19 deprecates `forwardRef` - components can now accept `ref` as a regular prop. This PR updates the three affected UI components:

**Before (deprecated):**
```tsx
export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
  ({ variant = "primary", ... }, ref) => {
    return <button ref={ref} ... />
  }
);
Button.displayName = "Button";
```

**After (React 19):**
```tsx
interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  ref?: Ref<HTMLButtonElement>;
}

export function Button({ variant = "primary", ref, ...props }: ButtonProps) {
  return <button ref={ref} {...props} />;
}
```

Fixes #374

## Test plan

- [x] TypeScript compilation passes (`pnpm typecheck`)
- [x] Lint and format checks pass (pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)