### PR TITLE
Add UI component tests (#368)

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -11,13 +11,13 @@ import { afterEach } from "vitest";
 // This check works because jsdom sets up a window object
 if (typeof window !== "undefined") {
   // Import jest-dom matchers for DOM assertions
-  import("@testing-library/jest-dom/vitest");
+  // Using top-level await to ensure matchers are registered before tests run
+  await import("@testing-library/jest-dom/vitest");
 
   // Import cleanup and set it up
-  import("@testing-library/react").then(({ cleanup }) => {
-    // Cleanup after each test to prevent memory leaks and test pollution
-    afterEach(() => {
-      cleanup();
-    });
+  const { cleanup } = await import("@testing-library/react");
+  // Cleanup after each test to prevent memory leaks and test pollution
+  afterEach(() => {
+    cleanup();
   });
 }

--- a/tests/unit/frontend/components/Alert.test.tsx
+++ b/tests/unit/frontend/components/Alert.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Unit tests for Alert component.
+ *
+ * Tests the presentational component with different variants.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Alert } from "@/components/ui/alert";
+
+describe("Alert", () => {
+  describe("rendering", () => {
+    it("renders children correctly", () => {
+      render(<Alert>Alert message</Alert>);
+      expect(screen.getByRole("alert")).toHaveTextContent("Alert message");
+    });
+
+    it("has role='alert' for accessibility", () => {
+      render(<Alert>Message</Alert>);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("renders with default variant (info)", () => {
+      render(<Alert>Info message</Alert>);
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveClass("bg-blue-50", "text-blue-800");
+    });
+  });
+
+  describe("variants", () => {
+    it("applies error variant styles", () => {
+      render(<Alert variant="error">Error message</Alert>);
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveClass("bg-red-50", "text-red-800");
+    });
+
+    it("applies success variant styles", () => {
+      render(<Alert variant="success">Success message</Alert>);
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveClass("bg-green-50", "text-green-800");
+    });
+
+    it("applies warning variant styles", () => {
+      render(<Alert variant="warning">Warning message</Alert>);
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveClass("bg-yellow-50", "text-yellow-800");
+    });
+
+    it("applies info variant styles", () => {
+      render(<Alert variant="info">Info message</Alert>);
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveClass("bg-blue-50", "text-blue-800");
+    });
+  });
+
+  describe("styling", () => {
+    it("applies base styles", () => {
+      render(<Alert>Styled alert</Alert>);
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveClass("rounded-md", "p-3");
+    });
+
+    it("applies custom className", () => {
+      render(<Alert className="custom-class">Custom</Alert>);
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveClass("custom-class");
+    });
+
+    it("preserves variant styles when custom className is added", () => {
+      render(
+        <Alert variant="error" className="mt-4">
+          Error
+        </Alert>
+      );
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveClass("bg-red-50", "mt-4");
+    });
+  });
+
+  describe("content", () => {
+    it("renders complex children", () => {
+      render(
+        <Alert>
+          <strong>Bold text</strong> and <a href="#">a link</a>
+        </Alert>
+      );
+      expect(screen.getByText("Bold text")).toBeInTheDocument();
+      expect(screen.getByRole("link")).toBeInTheDocument();
+    });
+
+    it("renders multiple elements", () => {
+      render(
+        <Alert>
+          <p>First paragraph</p>
+          <p>Second paragraph</p>
+        </Alert>
+      );
+      expect(screen.getByText("First paragraph")).toBeInTheDocument();
+      expect(screen.getByText("Second paragraph")).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/frontend/components/Button.test.tsx
+++ b/tests/unit/frontend/components/Button.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Unit tests for Button component.
+ *
+ * Tests the presentational component with variants, loading state, and disabled state.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Button } from "@/components/ui/button";
+
+describe("Button", () => {
+  describe("rendering", () => {
+    it("renders children correctly", () => {
+      render(<Button>Click me</Button>);
+      expect(screen.getByRole("button", { name: "Click me" })).toBeInTheDocument();
+    });
+
+    it("renders with default props (primary variant, md size)", () => {
+      render(<Button>Default Button</Button>);
+      const button = screen.getByRole("button");
+      // Primary variant has bg-zinc-900
+      expect(button).toHaveClass("bg-zinc-900");
+      // md size has min-h-[44px]
+      expect(button).toHaveClass("min-h-[44px]");
+    });
+  });
+
+  describe("variants", () => {
+    it("applies primary variant styles", () => {
+      render(<Button variant="primary">Primary</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-zinc-900", "text-white");
+    });
+
+    it("applies secondary variant styles", () => {
+      render(<Button variant="secondary">Secondary</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("border", "bg-white", "text-zinc-900");
+    });
+
+    it("applies ghost variant styles", () => {
+      render(<Button variant="ghost">Ghost</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("text-zinc-900");
+      expect(button).not.toHaveClass("bg-zinc-900", "bg-white");
+    });
+  });
+
+  describe("sizes", () => {
+    it("applies sm size styles", () => {
+      render(<Button size="sm">Small</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("min-h-[36px]", "px-3");
+    });
+
+    it("applies md size styles (default)", () => {
+      render(<Button size="md">Medium</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("min-h-[44px]", "px-4");
+    });
+
+    it("applies lg size styles", () => {
+      render(<Button size="lg">Large</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("min-h-[48px]", "px-6");
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows loading spinner when loading is true", () => {
+      render(<Button loading={true}>Submit</Button>);
+      const button = screen.getByRole("button");
+      // The spinner is an SVG with animate-spin class
+      const spinner = button.querySelector("svg.animate-spin");
+      expect(spinner).toBeInTheDocument();
+    });
+
+    it("does not show spinner when loading is false", () => {
+      render(<Button loading={false}>Submit</Button>);
+      const button = screen.getByRole("button");
+      const spinner = button.querySelector("svg.animate-spin");
+      expect(spinner).not.toBeInTheDocument();
+    });
+
+    it("is disabled when loading", () => {
+      render(<Button loading={true}>Submit</Button>);
+      expect(screen.getByRole("button")).toBeDisabled();
+    });
+
+    it("still shows children text when loading", () => {
+      render(<Button loading={true}>Submit</Button>);
+      expect(screen.getByText("Submit")).toBeInTheDocument();
+    });
+  });
+
+  describe("disabled state", () => {
+    it("is disabled when disabled prop is true", () => {
+      render(<Button disabled={true}>Disabled</Button>);
+      expect(screen.getByRole("button")).toBeDisabled();
+    });
+
+    it("is not disabled when disabled prop is false", () => {
+      render(<Button disabled={false}>Enabled</Button>);
+      expect(screen.getByRole("button")).not.toBeDisabled();
+    });
+
+    it("applies disabled styles", () => {
+      render(<Button disabled={true}>Disabled</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("disabled:cursor-not-allowed", "disabled:opacity-50");
+    });
+  });
+
+  describe("callbacks", () => {
+    it("calls onClick when clicked", () => {
+      const onClick = vi.fn();
+      render(<Button onClick={onClick}>Click me</Button>);
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onClick when disabled", () => {
+      const onClick = vi.fn();
+      render(
+        <Button onClick={onClick} disabled={true}>
+          Click me
+        </Button>
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it("does not call onClick when loading", () => {
+      const onClick = vi.fn();
+      render(
+        <Button onClick={onClick} loading={true}>
+          Click me
+        </Button>
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("additional props", () => {
+    it("applies custom className", () => {
+      render(<Button className="custom-class">Custom</Button>);
+      expect(screen.getByRole("button")).toHaveClass("custom-class");
+    });
+
+    it("passes through type attribute", () => {
+      render(<Button type="submit">Submit</Button>);
+      expect(screen.getByRole("button")).toHaveAttribute("type", "submit");
+    });
+
+    it("passes through aria attributes", () => {
+      render(<Button aria-describedby="description">Accessible</Button>);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-describedby", "description");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("is focusable", () => {
+      render(<Button>Focusable</Button>);
+      const button = screen.getByRole("button");
+      button.focus();
+      expect(document.activeElement).toBe(button);
+    });
+
+    it("has focus ring styles", () => {
+      render(<Button>Focus Ring</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("focus:ring-2", "focus:ring-offset-2");
+    });
+  });
+});

--- a/tests/unit/frontend/components/Card.test.tsx
+++ b/tests/unit/frontend/components/Card.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Unit tests for Card components.
+ *
+ * Tests the Card, CardHeader, CardTitle, CardDescription, CardBody, CardFooter, and StatusCard components.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardBody,
+  CardFooter,
+  StatusCard,
+} from "@/components/ui/card";
+
+describe("Card", () => {
+  describe("rendering", () => {
+    it("renders children correctly", () => {
+      render(<Card>Card content</Card>);
+      expect(screen.getByText("Card content")).toBeInTheDocument();
+    });
+
+    it("applies base styles", () => {
+      render(<Card>Content</Card>);
+      const card = screen.getByText("Content").closest("div");
+      expect(card).toHaveClass("rounded-lg", "border", "bg-white");
+    });
+  });
+
+  describe("padding sizes", () => {
+    it("applies sm padding", () => {
+      render(<Card padding="sm">Small padding</Card>);
+      const card = screen.getByText("Small padding").closest("div");
+      expect(card).toHaveClass("p-3");
+    });
+
+    it("applies md padding", () => {
+      render(<Card padding="md">Medium padding</Card>);
+      const card = screen.getByText("Medium padding").closest("div");
+      expect(card).toHaveClass("p-4");
+    });
+
+    it("applies lg padding (default)", () => {
+      render(<Card padding="lg">Large padding</Card>);
+      const card = screen.getByText("Large padding").closest("div");
+      expect(card).toHaveClass("p-6");
+    });
+
+    it("uses lg padding as default", () => {
+      render(<Card>Default padding</Card>);
+      const card = screen.getByText("Default padding").closest("div");
+      expect(card).toHaveClass("p-6");
+    });
+  });
+
+  describe("custom className", () => {
+    it("applies custom className", () => {
+      render(<Card className="custom-class">Custom</Card>);
+      const card = screen.getByText("Custom").closest("div");
+      expect(card).toHaveClass("custom-class");
+    });
+  });
+});
+
+describe("CardHeader", () => {
+  it("renders children correctly", () => {
+    render(<CardHeader>Header content</CardHeader>);
+    expect(screen.getByText("Header content")).toBeInTheDocument();
+  });
+
+  it("applies margin bottom", () => {
+    render(<CardHeader>Header</CardHeader>);
+    const header = screen.getByText("Header").closest("div");
+    expect(header).toHaveClass("mb-4");
+  });
+
+  it("applies custom className", () => {
+    render(<CardHeader className="custom-header">Header</CardHeader>);
+    const header = screen.getByText("Header").closest("div");
+    expect(header).toHaveClass("custom-header");
+  });
+});
+
+describe("CardTitle", () => {
+  it("renders as h3 element", () => {
+    render(<CardTitle>Title</CardTitle>);
+    expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent("Title");
+  });
+
+  it("applies title styles", () => {
+    render(<CardTitle>Styled Title</CardTitle>);
+    const title = screen.getByRole("heading");
+    expect(title).toHaveClass("font-semibold", "text-zinc-900");
+  });
+
+  it("applies custom className", () => {
+    render(<CardTitle className="custom-title">Title</CardTitle>);
+    expect(screen.getByRole("heading")).toHaveClass("custom-title");
+  });
+});
+
+describe("CardDescription", () => {
+  it("renders as p element", () => {
+    render(<CardDescription>Description text</CardDescription>);
+    const description = screen.getByText("Description text");
+    expect(description.tagName).toBe("P");
+  });
+
+  it("applies description styles", () => {
+    render(<CardDescription>Styled description</CardDescription>);
+    const description = screen.getByText("Styled description");
+    expect(description).toHaveClass("text-zinc-500", "mt-1");
+  });
+
+  it("applies custom className", () => {
+    render(<CardDescription className="custom-desc">Description</CardDescription>);
+    expect(screen.getByText("Description")).toHaveClass("custom-desc");
+  });
+});
+
+describe("CardBody", () => {
+  it("renders children correctly", () => {
+    render(<CardBody>Body content</CardBody>);
+    expect(screen.getByText("Body content")).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    render(<CardBody className="custom-body">Body</CardBody>);
+    const body = screen.getByText("Body").closest("div");
+    expect(body).toHaveClass("custom-body");
+  });
+});
+
+describe("CardFooter", () => {
+  it("renders children correctly", () => {
+    render(<CardFooter>Footer content</CardFooter>);
+    expect(screen.getByText("Footer content")).toBeInTheDocument();
+  });
+
+  it("applies footer styles", () => {
+    render(<CardFooter>Footer</CardFooter>);
+    const footer = screen.getByText("Footer").closest("div");
+    expect(footer).toHaveClass("mt-4", "flex", "items-center", "justify-end", "gap-3");
+  });
+
+  it("applies custom className", () => {
+    render(<CardFooter className="custom-footer">Footer</CardFooter>);
+    const footer = screen.getByText("Footer").closest("div");
+    expect(footer).toHaveClass("custom-footer");
+  });
+});
+
+describe("StatusCard", () => {
+  describe("variants", () => {
+    it("applies info variant styles", () => {
+      render(<StatusCard variant="info">Info</StatusCard>);
+      const card = screen.getByText("Info").closest("div");
+      expect(card).toHaveClass("border-blue-200", "bg-blue-50");
+    });
+
+    it("applies success variant styles", () => {
+      render(<StatusCard variant="success">Success</StatusCard>);
+      const card = screen.getByText("Success").closest("div");
+      expect(card).toHaveClass("border-green-200", "bg-green-50");
+    });
+
+    it("applies warning variant styles", () => {
+      render(<StatusCard variant="warning">Warning</StatusCard>);
+      const card = screen.getByText("Warning").closest("div");
+      expect(card).toHaveClass("border-yellow-200", "bg-yellow-50");
+    });
+
+    it("applies error variant styles", () => {
+      render(<StatusCard variant="error">Error</StatusCard>);
+      const card = screen.getByText("Error").closest("div");
+      expect(card).toHaveClass("border-red-200", "bg-red-50");
+    });
+  });
+
+  describe("padding sizes", () => {
+    it("applies sm padding", () => {
+      render(
+        <StatusCard variant="info" padding="sm">
+          Small
+        </StatusCard>
+      );
+      const card = screen.getByText("Small").closest("div");
+      expect(card).toHaveClass("p-3");
+    });
+
+    it("applies md padding (default)", () => {
+      render(<StatusCard variant="info">Medium</StatusCard>);
+      const card = screen.getByText("Medium").closest("div");
+      expect(card).toHaveClass("p-4");
+    });
+
+    it("applies lg padding", () => {
+      render(
+        <StatusCard variant="info" padding="lg">
+          Large
+        </StatusCard>
+      );
+      const card = screen.getByText("Large").closest("div");
+      expect(card).toHaveClass("p-6");
+    });
+  });
+
+  describe("styling", () => {
+    it("applies base styles", () => {
+      render(<StatusCard variant="info">Base</StatusCard>);
+      const card = screen.getByText("Base").closest("div");
+      expect(card).toHaveClass("rounded-lg", "border");
+    });
+
+    it("applies custom className", () => {
+      render(
+        <StatusCard variant="info" className="custom-status">
+          Custom
+        </StatusCard>
+      );
+      const card = screen.getByText("Custom").closest("div");
+      expect(card).toHaveClass("custom-status");
+    });
+  });
+});
+
+describe("Card composition", () => {
+  it("renders a complete card with all subcomponents", () => {
+    render(
+      <Card>
+        <CardHeader>
+          <CardTitle>Settings</CardTitle>
+          <CardDescription>Manage your account settings</CardDescription>
+        </CardHeader>
+        <CardBody>Main content here</CardBody>
+        <CardFooter>
+          <button>Save</button>
+        </CardFooter>
+      </Card>
+    );
+
+    expect(screen.getByRole("heading", { name: "Settings" })).toBeInTheDocument();
+    expect(screen.getByText("Manage your account settings")).toBeInTheDocument();
+    expect(screen.getByText("Main content here")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+});

--- a/tests/unit/frontend/components/Dialog.test.tsx
+++ b/tests/unit/frontend/components/Dialog.test.tsx
@@ -1,0 +1,335 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Unit tests for Dialog component.
+ *
+ * Tests the dialog behavior including open/close, escape key, backdrop click, and accessibility.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import {
+  Dialog,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogBody,
+  DialogFooter,
+} from "@/components/ui/dialog";
+
+afterEach(() => {
+  cleanup();
+  // Reset body overflow after each test
+  document.body.style.overflow = "";
+});
+
+describe("Dialog", () => {
+  describe("open/close behavior", () => {
+    it("renders when isOpen is true", () => {
+      render(
+        <Dialog isOpen={true} onClose={vi.fn()} title="Test Dialog">
+          Dialog content
+        </Dialog>
+      );
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText("Dialog content")).toBeInTheDocument();
+    });
+
+    it("does not render when isOpen is false", () => {
+      render(
+        <Dialog isOpen={false} onClose={vi.fn()} title="Test Dialog">
+          Dialog content
+        </Dialog>
+      );
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("calls onClose when backdrop is clicked", () => {
+      const onClose = vi.fn();
+      render(
+        <Dialog isOpen={true} onClose={onClose} title="Test Dialog">
+          Content
+        </Dialog>
+      );
+
+      // Find the backdrop (has aria-hidden="true")
+      const backdrop = screen.getByRole("dialog").querySelector('[aria-hidden="true"]');
+      fireEvent.click(backdrop!);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClose when Escape key is pressed", () => {
+      const onClose = vi.fn();
+      render(
+        <Dialog isOpen={true} onClose={onClose} title="Test Dialog">
+          Content
+        </Dialog>
+      );
+
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onClose when other keys are pressed", () => {
+      const onClose = vi.fn();
+      render(
+        <Dialog isOpen={true} onClose={onClose} title="Test Dialog">
+          Content
+        </Dialog>
+      );
+
+      fireEvent.keyDown(document, { key: "Enter" });
+      fireEvent.keyDown(document, { key: "Tab" });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("scroll lock", () => {
+    it("prevents body scroll when open", () => {
+      render(
+        <Dialog isOpen={true} onClose={vi.fn()} title="Test Dialog">
+          Content
+        </Dialog>
+      );
+      expect(document.body.style.overflow).toBe("hidden");
+    });
+
+    it("restores body scroll when closed", () => {
+      const { rerender } = render(
+        <Dialog isOpen={true} onClose={vi.fn()} title="Test Dialog">
+          Content
+        </Dialog>
+      );
+
+      rerender(
+        <Dialog isOpen={false} onClose={vi.fn()} title="Test Dialog">
+          Content
+        </Dialog>
+      );
+
+      expect(document.body.style.overflow).toBe("");
+    });
+
+    it("restores body scroll on unmount", () => {
+      const { unmount } = render(
+        <Dialog isOpen={true} onClose={vi.fn()} title="Test Dialog">
+          Content
+        </Dialog>
+      );
+
+      unmount();
+      expect(document.body.style.overflow).toBe("");
+    });
+  });
+
+  describe("sizes", () => {
+    it("applies sm size", () => {
+      render(
+        <Dialog isOpen={true} onClose={vi.fn()} title="Small Dialog" size="sm">
+          Content
+        </Dialog>
+      );
+      const dialog = screen.getByRole("dialog");
+      const container = dialog.querySelector(".max-w-sm");
+      expect(container).toBeInTheDocument();
+    });
+
+    it("applies md size (default)", () => {
+      render(
+        <Dialog isOpen={true} onClose={vi.fn()} title="Medium Dialog">
+          Content
+        </Dialog>
+      );
+      const dialog = screen.getByRole("dialog");
+      const container = dialog.querySelector(".max-w-md");
+      expect(container).toBeInTheDocument();
+    });
+
+    it("applies lg size", () => {
+      render(
+        <Dialog isOpen={true} onClose={vi.fn()} title="Large Dialog" size="lg">
+          Content
+        </Dialog>
+      );
+      const dialog = screen.getByRole("dialog");
+      const container = dialog.querySelector(".max-w-lg");
+      expect(container).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has role='dialog'", () => {
+      render(
+        <Dialog isOpen={true} onClose={vi.fn()} title="Accessible Dialog">
+          Content
+        </Dialog>
+      );
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    it("has aria-modal='true'", () => {
+      render(
+        <Dialog isOpen={true} onClose={vi.fn()} title="Modal Dialog">
+          Content
+        </Dialog>
+      );
+      expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+    });
+
+    it("generates aria-labelledby from title", () => {
+      render(
+        <Dialog isOpen={true} onClose={vi.fn()} title="My Dialog Title">
+          Content
+        </Dialog>
+      );
+      expect(screen.getByRole("dialog")).toHaveAttribute(
+        "aria-labelledby",
+        "dialog-title-my-dialog-title"
+      );
+    });
+
+    it("uses custom titleId when provided", () => {
+      render(
+        <Dialog isOpen={true} onClose={vi.fn()} title="Dialog" titleId="custom-title-id">
+          Content
+        </Dialog>
+      );
+      expect(screen.getByRole("dialog")).toHaveAttribute("aria-labelledby", "custom-title-id");
+    });
+  });
+
+  describe("custom className", () => {
+    it("applies custom className to dialog container", () => {
+      render(
+        <Dialog isOpen={true} onClose={vi.fn()} title="Custom Dialog" className="custom-class">
+          Content
+        </Dialog>
+      );
+      const dialog = screen.getByRole("dialog");
+      const container = dialog.querySelector(".custom-class");
+      expect(container).toBeInTheDocument();
+    });
+  });
+});
+
+describe("DialogHeader", () => {
+  it("renders children correctly", () => {
+    render(<DialogHeader>Header content</DialogHeader>);
+    expect(screen.getByText("Header content")).toBeInTheDocument();
+  });
+
+  it("applies margin bottom", () => {
+    render(<DialogHeader>Header</DialogHeader>);
+    const header = screen.getByText("Header").closest("div");
+    expect(header).toHaveClass("mb-4");
+  });
+
+  it("applies custom className", () => {
+    render(<DialogHeader className="custom-header">Header</DialogHeader>);
+    const header = screen.getByText("Header").closest("div");
+    expect(header).toHaveClass("custom-header");
+  });
+});
+
+describe("DialogTitle", () => {
+  it("renders as h2 element", () => {
+    render(<DialogTitle>Title</DialogTitle>);
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Title");
+  });
+
+  it("applies title styles", () => {
+    render(<DialogTitle>Styled Title</DialogTitle>);
+    const title = screen.getByRole("heading");
+    expect(title).toHaveClass("font-semibold", "text-zinc-900");
+  });
+
+  it("applies custom id", () => {
+    render(<DialogTitle id="my-title-id">Title</DialogTitle>);
+    expect(screen.getByRole("heading")).toHaveAttribute("id", "my-title-id");
+  });
+
+  it("applies custom className", () => {
+    render(<DialogTitle className="custom-title">Title</DialogTitle>);
+    expect(screen.getByRole("heading")).toHaveClass("custom-title");
+  });
+});
+
+describe("DialogDescription", () => {
+  it("renders as p element", () => {
+    render(<DialogDescription>Description text</DialogDescription>);
+    const description = screen.getByText("Description text");
+    expect(description.tagName).toBe("P");
+  });
+
+  it("applies description styles", () => {
+    render(<DialogDescription>Styled description</DialogDescription>);
+    const description = screen.getByText("Styled description");
+    expect(description).toHaveClass("text-zinc-600", "mt-2");
+  });
+
+  it("applies custom className", () => {
+    render(<DialogDescription className="custom-desc">Description</DialogDescription>);
+    expect(screen.getByText("Description")).toHaveClass("custom-desc");
+  });
+});
+
+describe("DialogBody", () => {
+  it("renders children correctly", () => {
+    render(<DialogBody>Body content</DialogBody>);
+    expect(screen.getByText("Body content")).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    render(<DialogBody className="custom-body">Body</DialogBody>);
+    const body = screen.getByText("Body").closest("div");
+    expect(body).toHaveClass("custom-body");
+  });
+});
+
+describe("DialogFooter", () => {
+  it("renders children correctly", () => {
+    render(<DialogFooter>Footer content</DialogFooter>);
+    expect(screen.getByText("Footer content")).toBeInTheDocument();
+  });
+
+  it("applies footer styles", () => {
+    render(<DialogFooter>Footer</DialogFooter>);
+    const footer = screen.getByText("Footer").closest("div");
+    expect(footer).toHaveClass("mt-6", "flex", "justify-end", "gap-3");
+  });
+
+  it("applies custom className", () => {
+    render(<DialogFooter className="custom-footer">Footer</DialogFooter>);
+    const footer = screen.getByText("Footer").closest("div");
+    expect(footer).toHaveClass("custom-footer");
+  });
+});
+
+describe("Dialog composition", () => {
+  it("renders a complete dialog with all subcomponents", () => {
+    const onClose = vi.fn();
+    render(
+      <Dialog isOpen={true} onClose={onClose} title="Confirm Action">
+        <DialogHeader>
+          <DialogTitle>Confirm Action</DialogTitle>
+          <DialogDescription>Are you sure you want to proceed?</DialogDescription>
+        </DialogHeader>
+        <DialogBody>This action cannot be undone.</DialogBody>
+        <DialogFooter>
+          <button onClick={onClose}>Cancel</button>
+          <button>Confirm</button>
+        </DialogFooter>
+      </Dialog>
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Confirm Action" })).toBeInTheDocument();
+    expect(screen.getByText("Are you sure you want to proceed?")).toBeInTheDocument();
+    expect(screen.getByText("This action cannot be undone.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+  });
+});

--- a/tests/unit/frontend/components/Input.test.tsx
+++ b/tests/unit/frontend/components/Input.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Unit tests for Input component.
+ *
+ * Tests the input with label, error state, and disabled state.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Input } from "@/components/ui/input";
+
+describe("Input", () => {
+  describe("rendering", () => {
+    it("renders an input element", () => {
+      render(<Input />);
+      expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+
+    it("renders with placeholder", () => {
+      render(<Input placeholder="Enter text..." />);
+      expect(screen.getByPlaceholderText("Enter text...")).toBeInTheDocument();
+    });
+
+    it("renders with initial value", () => {
+      render(<Input value="Hello" onChange={vi.fn()} />);
+      expect(screen.getByRole("textbox")).toHaveValue("Hello");
+    });
+  });
+
+  describe("label", () => {
+    it("renders label when provided", () => {
+      render(<Input label="Email" id="email" />);
+      expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    });
+
+    it("does not render label when not provided", () => {
+      render(<Input id="email" />);
+      expect(screen.queryByRole("label")).not.toBeInTheDocument();
+    });
+
+    it("associates label with input via htmlFor", () => {
+      render(<Input label="Email" id="email-field" />);
+      const label = screen.getByText("Email");
+      expect(label).toHaveAttribute("for", "email-field");
+    });
+
+    it("applies label styles", () => {
+      render(<Input label="Styled Label" id="styled" />);
+      const label = screen.getByText("Styled Label");
+      expect(label).toHaveClass("font-medium", "text-zinc-700");
+    });
+  });
+
+  describe("error state", () => {
+    it("renders error message when provided", () => {
+      render(<Input error="This field is required" id="field" />);
+      expect(screen.getByText("This field is required")).toBeInTheDocument();
+    });
+
+    it("does not render error message when not provided", () => {
+      render(<Input id="field" />);
+      expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+    });
+
+    it("applies error border styles", () => {
+      render(<Input error="Error" id="error-field" />);
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveClass("border-red-500");
+    });
+
+    it("applies normal border styles when no error", () => {
+      render(<Input id="normal-field" />);
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveClass("border-zinc-300");
+      expect(input).not.toHaveClass("border-red-500");
+    });
+
+    it("sets aria-invalid when error is present", () => {
+      render(<Input error="Invalid" id="invalid-field" />);
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("does not set aria-invalid when no error", () => {
+      render(<Input id="valid-field" />);
+      const input = screen.getByRole("textbox");
+      expect(input).not.toHaveAttribute("aria-invalid");
+    });
+
+    it("sets aria-describedby to error message id", () => {
+      render(<Input error="Error message" id="my-field" />);
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("aria-describedby", "my-field-error");
+    });
+
+    it("error message has correct id", () => {
+      render(<Input error="Error message" id="my-field" />);
+      const errorMessage = screen.getByText("Error message");
+      expect(errorMessage).toHaveAttribute("id", "my-field-error");
+    });
+
+    it("applies error text styles", () => {
+      render(<Input error="Error text" id="field" />);
+      const errorMessage = screen.getByText("Error text");
+      expect(errorMessage).toHaveClass("text-red-600");
+    });
+  });
+
+  describe("disabled state", () => {
+    it("is disabled when disabled prop is true", () => {
+      render(<Input disabled={true} />);
+      expect(screen.getByRole("textbox")).toBeDisabled();
+    });
+
+    it("is not disabled when disabled prop is false", () => {
+      render(<Input disabled={false} />);
+      expect(screen.getByRole("textbox")).not.toBeDisabled();
+    });
+
+    it("applies disabled styles", () => {
+      render(<Input disabled={true} />);
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveClass("disabled:cursor-not-allowed", "disabled:opacity-50");
+    });
+  });
+
+  describe("callbacks", () => {
+    it("calls onChange when value changes", () => {
+      const onChange = vi.fn();
+      render(<Input onChange={onChange} />);
+
+      fireEvent.change(screen.getByRole("textbox"), { target: { value: "new value" } });
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onFocus when focused", () => {
+      const onFocus = vi.fn();
+      render(<Input onFocus={onFocus} />);
+
+      fireEvent.focus(screen.getByRole("textbox"));
+      expect(onFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onBlur when blurred", () => {
+      const onBlur = vi.fn();
+      render(<Input onBlur={onBlur} />);
+
+      const input = screen.getByRole("textbox");
+      fireEvent.focus(input);
+      fireEvent.blur(input);
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("additional props", () => {
+    it("applies custom className", () => {
+      render(<Input className="custom-class" />);
+      expect(screen.getByRole("textbox")).toHaveClass("custom-class");
+    });
+
+    it("passes through type attribute", () => {
+      render(<Input type="email" />);
+      expect(screen.getByRole("textbox")).toHaveAttribute("type", "email");
+    });
+
+    it("passes through name attribute", () => {
+      render(<Input name="username" />);
+      expect(screen.getByRole("textbox")).toHaveAttribute("name", "username");
+    });
+
+    it("passes through required attribute", () => {
+      render(<Input required />);
+      expect(screen.getByRole("textbox")).toBeRequired();
+    });
+
+    it("passes through maxLength attribute", () => {
+      render(<Input maxLength={100} />);
+      expect(screen.getByRole("textbox")).toHaveAttribute("maxLength", "100");
+    });
+
+    it("passes through autoComplete attribute", () => {
+      render(<Input autoComplete="email" />);
+      expect(screen.getByRole("textbox")).toHaveAttribute("autoComplete", "email");
+    });
+  });
+
+  describe("styling", () => {
+    it("applies base input styles", () => {
+      render(<Input />);
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveClass("rounded-md", "border", "bg-white", "px-3", "py-2");
+    });
+
+    it("applies focus ring styles", () => {
+      render(<Input />);
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveClass("focus:ring-2", "focus:ring-offset-2");
+    });
+
+    it("fills width of container", () => {
+      render(<Input />);
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveClass("w-full");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("is focusable", () => {
+      render(<Input />);
+      const input = screen.getByRole("textbox");
+      input.focus();
+      expect(document.activeElement).toBe(input);
+    });
+
+    it("has proper input id for label association", () => {
+      render(<Input label="Name" id="name-input" />);
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("id", "name-input");
+    });
+  });
+
+  describe("composition with label and error", () => {
+    it("renders complete input with label and error", () => {
+      render(<Input label="Password" id="password" error="Password is too short" />);
+
+      expect(screen.getByLabelText("Password")).toBeInTheDocument();
+      expect(screen.getByRole("textbox")).toHaveAttribute("aria-invalid", "true");
+      expect(screen.getByRole("textbox")).toHaveAttribute("aria-describedby", "password-error");
+      expect(screen.getByText("Password is too short")).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/frontend/components/SortToggle.test.tsx
+++ b/tests/unit/frontend/components/SortToggle.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Unit tests for SortToggle component.
+ *
+ * Tests the toggle button for switching between newest and oldest sorting.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SortToggle } from "@/components/entries/SortToggle";
+
+describe("SortToggle", () => {
+  describe("rendering", () => {
+    it("renders a button element", () => {
+      render(<SortToggle sortOrder="newest" onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+  });
+
+  describe("newest state", () => {
+    it("displays 'Newest' label when sortOrder is newest", () => {
+      render(<SortToggle sortOrder="newest" onToggle={vi.fn()} />);
+      expect(screen.getByText("Newest")).toBeInTheDocument();
+    });
+
+    it("has aria-label 'Sort oldest first' when showing newest", () => {
+      render(<SortToggle sortOrder="newest" onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-label", "Sort oldest first");
+    });
+
+    it("has aria-pressed='false' when sortOrder is newest", () => {
+      render(<SortToggle sortOrder="newest" onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("has title matching aria-label for tooltip", () => {
+      render(<SortToggle sortOrder="newest" onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toHaveAttribute("title", "Sort oldest first");
+    });
+  });
+
+  describe("oldest state", () => {
+    it("displays 'Oldest' label when sortOrder is oldest", () => {
+      render(<SortToggle sortOrder="oldest" onToggle={vi.fn()} />);
+      expect(screen.getByText("Oldest")).toBeInTheDocument();
+    });
+
+    it("has aria-label 'Sort newest first' when showing oldest", () => {
+      render(<SortToggle sortOrder="oldest" onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-label", "Sort newest first");
+    });
+
+    it("has aria-pressed='true' when sortOrder is oldest", () => {
+      render(<SortToggle sortOrder="oldest" onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+    });
+  });
+
+  describe("toggle callback", () => {
+    it("calls onToggle when clicked", () => {
+      const onToggle = vi.fn();
+      render(<SortToggle sortOrder="newest" onToggle={onToggle} />);
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(onToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onToggle with each click", () => {
+      const onToggle = vi.fn();
+      render(<SortToggle sortOrder="newest" onToggle={onToggle} />);
+
+      fireEvent.click(screen.getByRole("button"));
+      fireEvent.click(screen.getByRole("button"));
+      expect(onToggle).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("styling", () => {
+    it("applies custom className", () => {
+      render(<SortToggle sortOrder="newest" onToggle={vi.fn()} className="custom-class" />);
+      expect(screen.getByRole("button")).toHaveClass("custom-class");
+    });
+
+    it("contains icon element", () => {
+      render(<SortToggle sortOrder="newest" onToggle={vi.fn()} />);
+      const button = screen.getByRole("button");
+      const icon = button.querySelector("svg");
+      expect(icon).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has type='button' to prevent form submission", () => {
+      render(<SortToggle sortOrder="newest" onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    });
+
+    it("is focusable", () => {
+      render(<SortToggle sortOrder="newest" onToggle={vi.fn()} />);
+      const button = screen.getByRole("button");
+      button.focus();
+      expect(document.activeElement).toBe(button);
+    });
+
+    it("has focus ring styles", () => {
+      render(<SortToggle sortOrder="newest" onToggle={vi.fn()} />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("focus:ring-2");
+    });
+  });
+});

--- a/tests/unit/frontend/components/UnreadToggle.test.tsx
+++ b/tests/unit/frontend/components/UnreadToggle.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Unit tests for UnreadToggle component.
+ *
+ * Tests the toggle button for showing/hiding read entries.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { UnreadToggle } from "@/components/entries/UnreadToggle";
+
+describe("UnreadToggle", () => {
+  describe("rendering", () => {
+    it("renders a button element", () => {
+      render(<UnreadToggle showUnreadOnly={false} onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+  });
+
+  describe("showUnreadOnly=true state", () => {
+    it("displays 'Unread only' label when showUnreadOnly is true", () => {
+      render(<UnreadToggle showUnreadOnly={true} onToggle={vi.fn()} />);
+      expect(screen.getByText("Unread only")).toBeInTheDocument();
+    });
+
+    it("has aria-label 'Show read items' when showing unread only", () => {
+      render(<UnreadToggle showUnreadOnly={true} onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-label", "Show read items");
+    });
+
+    it("has aria-pressed='false' when showUnreadOnly is true", () => {
+      // isPressed is !showUnreadOnly, so when showUnreadOnly=true, isPressed=false
+      render(<UnreadToggle showUnreadOnly={true} onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("has title matching aria-label for tooltip", () => {
+      render(<UnreadToggle showUnreadOnly={true} onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toHaveAttribute("title", "Show read items");
+    });
+  });
+
+  describe("showUnreadOnly=false state", () => {
+    it("displays 'Show all' label when showUnreadOnly is false", () => {
+      render(<UnreadToggle showUnreadOnly={false} onToggle={vi.fn()} />);
+      expect(screen.getByText("Show all")).toBeInTheDocument();
+    });
+
+    it("has aria-label 'Hide read items' when showing all", () => {
+      render(<UnreadToggle showUnreadOnly={false} onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-label", "Hide read items");
+    });
+
+    it("has aria-pressed='true' when showUnreadOnly is false", () => {
+      // isPressed is !showUnreadOnly, so when showUnreadOnly=false, isPressed=true
+      render(<UnreadToggle showUnreadOnly={false} onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+    });
+  });
+
+  describe("toggle callback", () => {
+    it("calls onToggle when clicked", () => {
+      const onToggle = vi.fn();
+      render(<UnreadToggle showUnreadOnly={false} onToggle={onToggle} />);
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(onToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onToggle with each click", () => {
+      const onToggle = vi.fn();
+      render(<UnreadToggle showUnreadOnly={false} onToggle={onToggle} />);
+
+      fireEvent.click(screen.getByRole("button"));
+      fireEvent.click(screen.getByRole("button"));
+      expect(onToggle).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("styling", () => {
+    it("applies custom className", () => {
+      render(<UnreadToggle showUnreadOnly={false} onToggle={vi.fn()} className="custom-class" />);
+      expect(screen.getByRole("button")).toHaveClass("custom-class");
+    });
+
+    it("contains icon element", () => {
+      render(<UnreadToggle showUnreadOnly={false} onToggle={vi.fn()} />);
+      const button = screen.getByRole("button");
+      const icon = button.querySelector("svg");
+      expect(icon).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has type='button' to prevent form submission", () => {
+      render(<UnreadToggle showUnreadOnly={false} onToggle={vi.fn()} />);
+      expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    });
+
+    it("is focusable", () => {
+      render(<UnreadToggle showUnreadOnly={false} onToggle={vi.fn()} />);
+      const button = screen.getByRole("button");
+      button.focus();
+      expect(document.activeElement).toBe(button);
+    });
+
+    it("has focus ring styles", () => {
+      render(<UnreadToggle showUnreadOnly={false} onToggle={vi.fn()} />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("focus:ring-2");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for UI components: Button, Alert, Card, Dialog, Input, SortToggle, UnreadToggle
- Fix race condition in test setup where jest-dom matchers weren't properly awaited

Closes #368

## Test Coverage Added

| Component | Tests | Coverage |
|-----------|-------|----------|
| Button | 23 | Variants, sizes, loading, disabled, callbacks, accessibility |
| Alert | 12 | All variants (error/success/warning/info), styling |
| Card | 31 | Card, CardHeader, CardTitle, CardDescription, CardBody, CardFooter, StatusCard |
| Dialog | 32 | Open/close, escape key, backdrop click, scroll lock, sizes, accessibility |
| Input | 34 | Label, error state, disabled, callbacks, accessibility |
| SortToggle | 15 | Toggle callback, aria states, styling |
| UnreadToggle | 15 | Toggle callback, aria states, styling |

**Total: 162 new tests** (plus 29 existing in EntryListItem)

## Bug Fix
Fixed a race condition in `tests/setup.ts` where the dynamic imports for `@testing-library/jest-dom/vitest` weren't being awaited, causing intermittent test failures when running multiple test files in parallel.

## Test plan
- [x] All 191 frontend component tests pass
- [x] Typecheck passes
- [x] Tests follow the existing pattern from EntryListItem.test.tsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)