### PR TITLE
Handle expired sessions in bookmarklet save page

### DIFF
--- a/src/lib/trpc/provider.tsx
+++ b/src/lib/trpc/provider.tsx
@@ -46,6 +46,10 @@ function handleUnauthorizedError() {
   // This prevents login errors from causing a redirect/refresh
   if (!hasSessionCookie()) return;
 
+  // Skip auto-redirect for /save page - it has its own auth error handling
+  // that provides a better UX for the bookmarklet popup
+  if (window.location.pathname === "/save") return;
+
   isLoggingOut = true;
 
   // Clear the session cookie


### PR DESCRIPTION
## Summary

- When the bookmarklet save page encounters an expired/revoked session, show a friendly "Sign In" button instead of a confusing generic error with "Retry"
- Stores the pending URL in sessionStorage so it can be saved after re-authentication
- Prevents TRPCProvider's global error handler from redirecting the /save page, allowing the custom auth error UI to display

## Test plan

- [ ] Use the bookmarklet while logged out or with an expired session
- [ ] Verify the "Your session has expired" message appears with a "Sign In" button
- [ ] Click "Sign In", log in, and verify the article is saved after redirect back to /save

🤖 Generated with [Claude Code](https://claude.ai/code)