### PR TITLE
Fix targeted invalidation for unread counts

### DIFF
--- a/src/components/saved/FileUploadButton.tsx
+++ b/src/components/saved/FileUploadButton.tsx
@@ -60,9 +60,9 @@ export function FileUploadButton({ className = "", onSuccess }: FileUploadButton
   const uploadMutation = trpc.saved.uploadFile.useMutation({
     onSuccess: () => {
       toast.success("File uploaded successfully");
-      // Invalidate queries to refresh the list
-      utils.entries.list.invalidate();
-      utils.entries.count.invalidate();
+      // Invalidate queries to refresh the saved list and count
+      utils.entries.list.invalidate({ type: "saved" });
+      utils.entries.count.invalidate({ type: "saved" });
       onSuccess?.();
       handleClose();
     },


### PR DESCRIPTION
## Summary

- **markAllRead**: Now invalidates saved count only when saved entries could be affected (`type: "saved"` or no type filter). Previously missing saved count invalidation entirely.
- **FileUploadButton**: Changed from invalidating all `entries.count` caches to only invalidating saved counts (`type: "saved"` filter).

These changes ensure cache invalidation is as targeted as possible while maintaining correctness.

## Test plan

- [ ] Upload a file via FileUploadButton - saved count should update, other counts should remain cached
- [ ] Mark all read on "/all" page - both starred and saved counts should refresh
- [ ] Mark all read on "/saved" page - saved count should refresh
- [ ] Mark all read on a specific subscription - starred count should refresh, saved count should remain cached (since `type` is implicitly `web` or `email`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)