### PR TITLE
Fix PWA service worker not being generated in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:next": "next dev --turbopack",
     "dev:worker": "tsx watch --clear-screen=false scripts/worker.ts",
     "dev:discord-bot": "tsx watch --clear-screen=false scripts/discord-bot.ts",
-    "build": "next build",
+    "build": "next build --webpack",
     "build:worker": "node scripts/build-worker.mjs",
     "build:discord-bot": "node scripts/build-discord-bot.mjs",
     "build:migrate": "node scripts/build-migrate.mjs",


### PR DESCRIPTION
Next.js 16 defaults to Turbopack for builds, but next-pwa is a Webpack plugin that doesn't run under Turbopack. This caused sw.js to silently not be generated, breaking the Share Target API (which showed localhost:3000 errors when sharing to the installed PWA).

Adding --webpack flag ensures the production build uses Webpack, allowing next-pwa to generate the service worker properly.