### PR TITLE
Fix sidebar showing incomplete subscriptions and incorrect unread counts

### DIFF
--- a/src/FRONTEND_STATE.md
+++ b/src/FRONTEND_STATE.md
@@ -50,19 +50,20 @@ Centralized helpers in `src/lib/cache/` ensure consistent updates across the cod
 | ------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ------------------------------ |
 | `entries.list` (infinite) | `EntryList`, `useEntryListQuery`, `useEntryPage` | `subscriptionId`, `tagId`, `uncategorized`, `unreadOnly`, `starredOnly`, `sortOrder`, `type`, `limit` | Paginated entry list           |
 | `entries.get`             | `EntryContent`                                   | `{ id }`                                                                                              | Single entry with full content |
-| `entries.count`           | `Sidebar`                                        | `{ type: "saved" }` or `{ starredOnly: true }`                                                        | Unread count for badges        |
+| `entries.count`           | `Sidebar`                                        | `{}`, `{ type: "saved" }`, or `{ starredOnly: true }`                                                 | Unread count for badges        |
 
 ### Subscription Queries
 
-| Query                | Used In                                                | Filters | Description                               |
-| -------------------- | ------------------------------------------------------ | ------- | ----------------------------------------- |
-| `subscriptions.list` | `Sidebar`, `EntryContent`, `useEntryPage`, entry pages | None    | All user subscriptions with unread counts |
+| Query                           | Used In                         | Filters                            | Description                                      |
+| ------------------------------- | ------------------------------- | ---------------------------------- | ------------------------------------------------ |
+| `subscriptions.list`            | `EntryContent`, `useEntryPage`  | None                               | First page of subscriptions for placeholder data |
+| `subscriptions.list` (infinite) | `TagSubscriptionList` (sidebar) | `{ tagId }` or `{ uncategorized }` | Per-tag paginated subscriptions                  |
 
 ### Tag Queries
 
-| Query       | Used In                                              | Filters | Description                      |
-| ----------- | ---------------------------------------------------- | ------- | -------------------------------- |
-| `tags.list` | `Sidebar`, `EditSubscriptionDialog`, `TagManagement` | None    | All user tags with unread counts |
+| Query       | Used In                                              | Filters | Description                                             |
+| ----------- | ---------------------------------------------------- | ------- | ------------------------------------------------------- |
+| `tags.list` | `Sidebar`, `EditSubscriptionDialog`, `TagManagement` | None    | All user tags with unread counts + uncategorized counts |
 
 ### Feed Queries
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -6,9 +6,8 @@
  *
  * Prefetches data used across all pages (sidebar, header):
  * - auth.me (user info for header)
- * - subscriptions.list (sidebar feed list)
- * - tags.list (sidebar tag list)
- * - entries.count (starred/saved counts)
+ * - tags.list (sidebar tag structure and unread counts)
+ * - entries.count (all/starred/saved counts for sidebar)
  *
  * Initial sync uses null cursors to get all recent data, which then establishes
  * the baseline cursors for subsequent incremental syncs.
@@ -53,15 +52,15 @@ export default async function AppLayout({ children }: AppLayoutProps) {
       queryKey: [["auth", "me"], { type: "query" }],
       queryFn: () => trpc.auth.me(),
     }),
-    // Subscriptions for sidebar
-    queryClient.prefetchQuery({
-      queryKey: [["subscriptions", "list"], { type: "query" }],
-      queryFn: () => trpc.subscriptions.list(),
-    }),
-    // Tags for sidebar
+    // Tags for sidebar (includes uncategorized counts)
     queryClient.prefetchQuery({
       queryKey: [["tags", "list"], { type: "query" }],
       queryFn: () => trpc.tags.list(),
+    }),
+    // All Articles count for sidebar
+    queryClient.prefetchQuery({
+      queryKey: [["entries", "count"], { input: {}, type: "query" }],
+      queryFn: () => trpc.entries.count({}),
     }),
     // Saved count for sidebar
     queryClient.prefetchQuery({

--- a/src/app/(app)/settings/broken-feeds/page.tsx
+++ b/src/app/(app)/settings/broken-feeds/page.tsx
@@ -126,6 +126,8 @@ export default function BrokenFeedsPage() {
       utils.brokenFeeds.list.invalidate();
       utils.subscriptions.list.invalidate();
       utils.entries.list.invalidate();
+      utils.entries.count.invalidate();
+      utils.tags.list.invalidate();
       setUnsubscribeTarget(null);
       toast.success("Unsubscribed from feed");
     },

--- a/src/components/layout/TagSubscriptionList.tsx
+++ b/src/components/layout/TagSubscriptionList.tsx
@@ -1,0 +1,122 @@
+/**
+ * TagSubscriptionList Component
+ *
+ * Renders subscriptions within a tag section using infinite scrolling.
+ * Subscriptions are fetched per-tag (or uncategorized) when the section is expanded,
+ * with more pages loaded automatically as the user scrolls.
+ */
+
+"use client";
+
+import { useEffect, useRef } from "react";
+import { trpc } from "@/lib/trpc/client";
+import { SubscriptionItem } from "./SubscriptionItem";
+
+interface TagSubscriptionListProps {
+  /** Tag ID to filter by, or undefined for uncategorized */
+  tagId?: string;
+  /** Whether to show uncategorized subscriptions (no tags) */
+  uncategorized?: boolean;
+  /** Current pathname for active state */
+  pathname: string;
+  /** Callback when sidebar should close (mobile) */
+  onClose: () => void;
+  /** Callback to edit a subscription */
+  onEdit: (sub: {
+    id: string;
+    title: string;
+    customTitle: string | null;
+    tagIds: string[];
+  }) => void;
+  /** Callback to unsubscribe */
+  onUnsubscribe: (sub: { id: string; title: string }) => void;
+}
+
+export function TagSubscriptionList({
+  tagId,
+  uncategorized,
+  pathname,
+  onClose,
+  onEdit,
+  onUnsubscribe,
+}: TagSubscriptionListProps) {
+  const sentinelRef = useRef<HTMLLIElement>(null);
+
+  const subscriptionsQuery = trpc.subscriptions.list.useInfiniteQuery(
+    { tagId, uncategorized, limit: 50 },
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    }
+  );
+
+  const allSubscriptions = subscriptionsQuery.data?.pages.flatMap((p) => p.items) ?? [];
+
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = subscriptionsQuery;
+
+  // Infinite scroll: observe sentinel element to load more
+  useEffect(() => {
+    if (!hasNextPage || isFetchingNextPage) return;
+
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  if (subscriptionsQuery.isLoading) {
+    return (
+      <ul className="mt-1 ml-6 space-y-1">
+        {[1, 2].map((i) => (
+          <li key={i}>
+            <div className="h-9 animate-pulse rounded-md bg-zinc-100 dark:bg-zinc-800" />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (allSubscriptions.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="mt-1 ml-6 space-y-1">
+      {allSubscriptions.map((sub) => (
+        <SubscriptionItem
+          key={sub.id}
+          subscription={sub}
+          isActive={pathname === `/subscription/${sub.id}`}
+          onClose={onClose}
+          onEdit={() =>
+            onEdit({
+              id: sub.id,
+              title: sub.title || "Untitled Feed",
+              customTitle: sub.title !== sub.originalTitle ? sub.title : null,
+              tagIds: sub.tags.map((t) => t.id),
+            })
+          }
+          onUnsubscribe={() =>
+            onUnsubscribe({
+              id: sub.id,
+              title: sub.title || "Untitled Feed",
+            })
+          }
+        />
+      ))}
+      {/* Sentinel for infinite scroll */}
+      {subscriptionsQuery.hasNextPage && (
+        <li ref={sentinelRef} className="h-1" aria-hidden="true" />
+      )}
+    </ul>
+  );
+}

--- a/src/components/settings/OpmlImportExport.tsx
+++ b/src/components/settings/OpmlImportExport.tsx
@@ -127,10 +127,18 @@ function ImportSection() {
     if (isCompleted && !prevCompleted.current) {
       prevCompleted.current = true;
       utils.subscriptions.list.invalidate();
+      utils.tags.list.invalidate();
+      utils.entries.count.invalidate();
     } else if (baseState.type !== "importing") {
       prevCompleted.current = false;
     }
-  }, [importState.type, baseState.type, utils.subscriptions.list]);
+  }, [
+    importState.type,
+    baseState.type,
+    utils.subscriptions.list,
+    utils.tags.list,
+    utils.entries.count,
+  ]);
 
   const importMutation = trpc.subscriptions.import.useMutation({
     onSuccess: (data) => {

--- a/src/lib/hooks/useEntryMutations.ts
+++ b/src/lib/hooks/useEntryMutations.ts
@@ -125,6 +125,9 @@ export function useEntryMutations(): UseEntryMutationsResult {
       utils.subscriptions.list.invalidate();
       utils.tags.list.invalidate();
 
+      // All Articles count is always affected
+      utils.entries.count.invalidate({});
+
       // Starred count is always affected since starred entries can exist in any view
       utils.entries.count.invalidate({ starredOnly: true });
 

--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -496,7 +496,7 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
         // This allows smooth scrolling while keeping counts fresh
         // New entries appear when user navigates to that feed/view
         if (data.feedType) {
-          handleNewEntry(utils, data.subscriptionId, data.feedType);
+          handleNewEntry(utils, data.subscriptionId, data.feedType, queryClient);
         }
       } else if (data.type === "entry_updated") {
         // Invalidate the specific entry to refresh content
@@ -546,7 +546,7 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
         utils.entries.list.invalidate();
       }
     },
-    [utils]
+    [utils, queryClient]
   );
 
   /**

--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -683,6 +683,7 @@ export const subscriptionsRouter = createTRPCRouter({
    * Supports optional filtering and pagination:
    * - query: Case-insensitive title search (substring matching)
    * - tagId: Filter by tag
+   * - uncategorized: Only show subscriptions with no tags
    * - unreadOnly: Only show feeds with unread items
    * - cursor/limit: Cursor-based pagination (max 100 per page)
    *
@@ -702,6 +703,7 @@ export const subscriptionsRouter = createTRPCRouter({
         .object({
           query: z.string().optional(),
           tagId: z.string().uuid().optional(),
+          uncategorized: z.boolean().optional(),
           unreadOnly: z.boolean().optional(),
           cursor: z.string().optional(),
           limit: z.number().min(1).max(100).optional(),

--- a/tests/unit/frontend/cache/operations.test.ts
+++ b/tests/unit/frontend/cache/operations.test.ts
@@ -213,24 +213,26 @@ describe("handleNewEntry", () => {
     expect(countOps.length).toBeGreaterThan(0);
   });
 
-  it("does not increment saved count for web entries", () => {
+  it("increments All Articles count but not saved count for web entries", () => {
     handleNewEntry(mockUtils.utils, "sub-1", "web");
 
-    // For web entries, we don't update the saved count
+    // For web entries, we update All Articles count but not saved count
     const countOps = mockUtils.operations.filter(
       (op) => op.type === "setData" && op.router === "entries" && op.procedure === "count"
     );
-    expect(countOps.length).toBe(0);
+    // Only 1 operation: All Articles count (no saved count for web entries)
+    expect(countOps.length).toBe(1);
   });
 
-  it("increments saved unread count for email entries", () => {
+  it("increments All Articles count but not saved count for email entries", () => {
     handleNewEntry(mockUtils.utils, "sub-1", "email");
 
-    // Email entries don't affect saved count
+    // Email entries update All Articles count but don't affect saved count
     const countOps = mockUtils.operations.filter(
       (op) => op.type === "setData" && op.router === "entries" && op.procedure === "count"
     );
-    expect(countOps.length).toBe(0);
+    // Only 1 operation: All Articles count (no saved count for email entries)
+    expect(countOps.length).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #434

- **All Articles unread count**: Now uses server-side `entries.count({})` instead of summing paginated subscription counts client-side
- **Tag structure**: Sidebar uses `tags.list` response (which already returns all tags with correct counts) instead of client-side grouping of paginated subscriptions
- **Uncategorized section**: Always shown when uncategorized subscriptions exist — `tags.list` now includes `uncategorized` counts, and `subscriptions.list` supports `uncategorized` filter
- **Per-tag subscription lists**: New `TagSubscriptionList` component uses infinite scrolling per-tag, loading subscriptions on-demand when a tag is expanded
- **Cache consistency**: Updated cache operations to maintain `entries.count({})` for All Articles, and added proper invalidation across unsubscribe, import, and broken feeds flows

## Test plan

- [ ] Verify all subscriptions appear in the sidebar (not just the first page)
- [ ] Verify the Uncategorized category appears when there are uncategorized subscriptions
- [ ] Verify the All Articles unread count is correct
- [ ] Verify tag unread counts are correct
- [ ] Verify expanding a tag loads its subscriptions with infinite scroll
- [ ] Verify marking entries read/unread updates All Articles count
- [ ] Verify unsubscribing updates sidebar correctly
- [ ] Verify subscribing to a new feed updates sidebar correctly
- [ ] Run `pnpm typecheck` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)