### PR TITLE
Fix tag unread counts not updating when marking entries read/unread

### DIFF
--- a/src/lib/cache/operations.ts
+++ b/src/lib/cache/operations.ts
@@ -76,7 +76,8 @@ function updateSubscriptionAndTagCounts(
   adjustSubscriptionUnreadCounts(utils, subscriptionDeltas, queryClient);
   const { tagDeltas, uncategorizedDelta } = calculateTagDeltasFromSubscriptions(
     utils,
-    subscriptionDeltas
+    subscriptionDeltas,
+    queryClient
   );
   adjustTagUnreadCounts(utils, tagDeltas, uncategorizedDelta);
 }


### PR DESCRIPTION
## Summary

- `calculateTagDeltasFromSubscriptions` only searched the unparameterized `subscriptions.list` cache for subscription tag data, but in the sidebar the subscription data lives in per-tag infinite query caches
- This caused tag unread counts to never update when marking entries read/unread (Uncategorized worked because it uses a separate delta that doesn't require subscription tag lookups)
- Now searches both the unparameterized cache and all per-tag infinite query caches, matching the pattern already used by `adjustSubscriptionUnreadCounts`

## Test plan

- [ ] Subscribe to a feed that has a tag assigned
- [ ] Navigate to the tag view in the sidebar
- [ ] Mark an entry as read — verify the tag's unread count decreases
- [ ] Mark an entry as unread — verify the tag's unread count increases
- [ ] Verify the Uncategorized tag still updates correctly
- [ ] Verify subscription-level unread counts still update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)