### PR TITLE
Use savedArticle plugin capability for full content fetching

### DIFF
--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -300,6 +300,7 @@ export function EntryContent({
         onSwipeNext={onSwipeNext}
         onSwipePrevious={onSwipePrevious}
         // Full content props - only available if entry has a subscription
+        fullContentOriginal={entry.fullContentOriginal}
         fullContentCleaned={entry.fullContentCleaned}
         fullContentFetchedAt={entry.fullContentFetchedAt}
         fullContentError={entry.fullContentError}

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -109,7 +109,9 @@ export interface EntryContentBodyProps {
   /** Callback when swiping to previous article */
   onSwipePrevious?: () => void;
   // Full content fields
-  /** Full content cleaned HTML (fetched from URL) */
+  /** Full content original HTML (fetched from URL) */
+  fullContentOriginal?: string | null;
+  /** Full content cleaned HTML (fetched from URL), null if Readability was skipped */
   fullContentCleaned?: string | null;
   /** Whether full content has been fetched */
   fullContentFetchedAt?: Date | null;
@@ -173,6 +175,7 @@ export function EntryContentBody({
   onSwipeNext,
   onSwipePrevious,
   // Full content props
+  fullContentOriginal,
   fullContentCleaned,
   fullContentFetchedAt,
   fullContentError,
@@ -198,7 +201,9 @@ export function EntryContentBody({
   // Full content is shown if:
   // 1. User has fetchFullContent enabled for the subscription
   // 2. Full content has been fetched successfully (no error, has content)
-  const hasFullContent = Boolean(fullContentCleaned && fullContentFetchedAt && !fullContentError);
+  const hasFullContent = Boolean(
+    (fullContentCleaned || fullContentOriginal) && fullContentFetchedAt && !fullContentError
+  );
   const showFullContent = fetchFullContent && hasFullContent;
 
   // Check if both feed content versions are available for toggle
@@ -209,7 +214,7 @@ export function EntryContentBody({
   // Priority: full content (if enabled and available) > cleaned feed content > original feed content
   let contentToDisplay: string | null;
   if (showFullContent) {
-    contentToDisplay = fullContentCleaned ?? null;
+    contentToDisplay = fullContentCleaned ?? fullContentOriginal ?? null;
   } else if (showOriginal) {
     contentToDisplay = contentOriginal;
   } else {

--- a/src/server/plugins/lesswrong.ts
+++ b/src/server/plugins/lesswrong.ts
@@ -1,4 +1,4 @@
-import type { UrlPlugin, EntryContent, SavedArticleContent } from "./types";
+import type { UrlPlugin, SavedArticleContent } from "./types";
 import {
   fetchLessWrongContentFromUrl,
   fetchLessWrongUserBySlug,
@@ -13,8 +13,7 @@ import { logger } from "@/lib/logger";
  *
  * Provides capabilities for:
  * - Feed: Transform user profiles to RSS feeds, clean entry content
- * - Entry: Fetch full post/comment content from URLs
- * - SavedArticle: Fetch full post/comment content (same as entry)
+ * - SavedArticle: Fetch full post/comment content via GraphQL API
  */
 export const lessWrongPlugin: UrlPlugin = {
   name: "lesswrong",
@@ -70,36 +69,6 @@ export const lessWrongPlugin: UrlPlugin = {
       },
 
       siteName: "LessWrong",
-    },
-
-    entry: {
-      async fetchFullContent(url: URL): Promise<EntryContent | null> {
-        try {
-          const content = await fetchLessWrongContentFromUrl(url.href);
-          if (!content) return null;
-
-          // Handle both posts and comments (which have different title fields)
-          const title =
-            content.type === "post"
-              ? content.title
-              : content.type === "comment"
-                ? content.postTitle
-                : null;
-
-          return {
-            html: content.html,
-            title: title || undefined,
-            author: content.author || undefined,
-            publishedAt: content.publishedAt || undefined,
-          };
-        } catch (error) {
-          logger.warn("Failed to fetch LessWrong full content", {
-            url: url.href,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          return null;
-        }
-      },
     },
 
     savedArticle: {

--- a/src/server/plugins/types.ts
+++ b/src/server/plugins/types.ts
@@ -25,7 +25,6 @@ export interface UrlPlugin {
 
 export interface PluginCapabilities {
   feed?: FeedCapability;
-  entry?: EntryCapability;
   savedArticle?: SavedArticleCapability;
 }
 
@@ -57,24 +56,6 @@ export interface FeedCapability {
    * Falls back to feed's own site name if not provided.
    */
   siteName?: string;
-}
-
-// ============ Entry Capability ============
-
-export interface EntryCapability {
-  /**
-   * Fetch full content for an entry URL.
-   * Used when RSS provides only excerpts.
-   * Return null to fall back to normal fetching.
-   */
-  fetchFullContent?(url: URL): Promise<EntryContent | null>;
-}
-
-export interface EntryContent {
-  html: string;
-  title?: string;
-  author?: string;
-  publishedAt?: Date;
 }
 
 // ============ Saved Article Capability ============


### PR DESCRIPTION
## Summary

- Full content fetching for RSS entries now uses the `savedArticle` plugin capability instead of the removed `entry` capability
- This fixes ArXiv full content fetching — the ArXiv plugin already had `savedArticle` but `fetchFullContent` was looking for `entry`, so the plugin was never used
- Removed the redundant `EntryCapability`/`EntryContent` types and the duplicate `entry` capability from the LessWrong plugin
- Plugin content now respects `skipReadability` and runs Readability when appropriate, matching the saved articles flow

## Test plan

- [x] Typecheck passes
- [x] All 1454 unit tests pass
- [ ] Verify ArXiv full content fetch works (e.g. https://arxiv.org/abs/2601.16032 should fetch HTML version)
- [ ] Verify LessWrong full content fetch still works via savedArticle capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)