### PR TITLE
Fix subscription page 404 for users with >50 subscriptions

### DIFF
--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -43,4 +43,5 @@ export {
   addSubscriptionToCache,
   removeSubscriptionFromCache,
   calculateTagDeltasFromSubscriptions,
+  findCachedSubscription,
 } from "./count-cache";


### PR DESCRIPTION
## Summary

- Fixes subscription pages showing "Subscription not found" for users with more than 50 subscriptions
- The subscription page was searching through the first page of `subscriptions.list` results (limited to 50 items alphabetically) to find the current subscription
- Subscriptions not in the first page (e.g. those with titles starting with letters later in the alphabet) would incorrectly show a 404 error
- Fix uses `subscriptions.get` to fetch the specific subscription directly by ID, which always works regardless of pagination

## Test plan

- [ ] Navigate to a subscription page for a subscription that would be beyond the 50th alphabetically — verify it loads correctly
- [ ] Navigate to a subscription page for a subscription in the first 50 — verify it still works
- [ ] Navigate to a nonexistent subscription ID — verify the "not found" error still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)