### PR TITLE
Disable Next.js Link prefetching on sidebar nav links

### DIFF
--- a/src/components/layout/SubscriptionItem.tsx
+++ b/src/components/layout/SubscriptionItem.tsx
@@ -44,6 +44,7 @@ export function SubscriptionItem({
     <li className="group relative">
       <Link
         href={subHref}
+        prefetch={false}
         onClick={onClose}
         className={`ui-text-sm flex min-h-[44px] items-center justify-between rounded-md px-3 py-2 transition-colors ${
           isActive

--- a/src/components/ui/nav-link.tsx
+++ b/src/components/ui/nav-link.tsx
@@ -52,6 +52,7 @@ export function NavLink({
   return (
     <Link
       href={href}
+      prefetch={false}
       onClick={onClick}
       className={`ui-text-sm flex min-h-[44px] items-center justify-between rounded-md px-3 py-2 font-medium transition-colors ${
         isActive
@@ -107,6 +108,7 @@ export function NavLinkWithIcon({
   return (
     <Link
       href={href}
+      prefetch={false}
       onClick={onClick}
       className={`ui-text-sm flex min-h-[44px] flex-1 items-center gap-2 rounded-md px-3 py-2 transition-colors ${
         isActive


### PR DESCRIPTION
## Summary

- Adds `prefetch={false}` to both `NavLink` and `NavLinkWithIcon` components
- Next.js prefetches RSC payloads for all visible `<Link>` components by default. Since the sidebar is always visible with all tag links rendered, this caused an RSC request (`?_rsc=...`) for every tag page on initial load — one per tag. These are wasted requests since tag pages get their data from the already-cached `tags.list` query.

## Test plan

- [ ] Load the app and check the network tab — should no longer see `_rsc` requests for each `/tag/[id]` route on initial load
- [ ] Verify navigating to a tag page still works correctly (the RSC payload will be fetched on-demand when clicked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)