### PR TITLE
Fix: full content fetch not triggering when previous attempt failed

### DIFF
--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -159,8 +159,10 @@ export function EntryContent({
       fetchFullContent: newValue,
     });
 
-    // If enabling full content and it hasn't been fetched yet, trigger fetch
-    if (newValue && !entry.fullContentFetchedAt) {
+    // If enabling full content and it hasn't been fetched successfully, trigger fetch
+    // This includes retrying after a previous error
+    const needsFetch = !entry.fullContentFetchedAt || entry.fullContentError;
+    if (newValue && needsFetch) {
       fetchFullContentMutation.mutate({ id: entryId });
     }
   }, [entry, fetchFullContent, entryId, updateSubscriptionMutation, fetchFullContentMutation]);
@@ -255,7 +257,8 @@ export function EntryContent({
   useEffect(() => {
     if (hasAutoFetchedFullContent.current || !entry) return;
     if (!fetchFullContent) return;
-    if (entry.fullContentFetchedAt) return; // Already fetched
+    // Skip if already fetched successfully (has timestamp but no error)
+    if (entry.fullContentFetchedAt && !entry.fullContentError) return;
     if (fetchFullContentMutation.isPending) return; // Already fetching
 
     hasAutoFetchedFullContent.current = true;

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -43,6 +43,7 @@ import {
   ArrowLeftIcon,
   SpinnerIcon,
   SparklesIcon,
+  AlertIcon,
 } from "@/components/ui";
 import { SummaryCard } from "@/components/summarization";
 import {
@@ -485,25 +486,35 @@ export function EntryContentBody({
           {/* Full content toggle - shows when URL exists */}
           {url && onToggleFetchFullContent && (
             <Button
-              variant={fetchFullContent ? "primary" : "secondary"}
+              variant={fullContentError ? "secondary" : fetchFullContent ? "primary" : "secondary"}
               size="sm"
               onClick={onToggleFetchFullContent}
               disabled={isFullContentFetching}
               className={
-                fetchFullContent
-                  ? "bg-blue-500 text-white hover:bg-blue-600 dark:bg-blue-500 dark:text-white dark:hover:bg-blue-600"
-                  : ""
+                fullContentError
+                  ? "border-red-300 text-red-600 hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950"
+                  : fetchFullContent
+                    ? "bg-blue-500 text-white hover:bg-blue-600 dark:bg-blue-500 dark:text-white dark:hover:bg-blue-600"
+                    : ""
               }
               aria-label={
-                fetchFullContent
-                  ? "Switch to feed content"
-                  : "Fetch and display full article content"
+                fullContentError
+                  ? `Retry fetching full content (previous error: ${fullContentError})`
+                  : fetchFullContent
+                    ? "Switch to feed content"
+                    : "Fetch and display full article content"
               }
+              title={fullContentError ? `Error: ${fullContentError}` : undefined}
             >
               {isFullContentFetching ? (
                 <>
                   <SpinnerIcon className="h-4 w-4" />
                   <span className="ml-2">Fetching...</span>
+                </>
+              ) : fullContentError ? (
+                <>
+                  <AlertIcon className="h-4 w-4" />
+                  <span className="ml-2">Retry Fetch</span>
                 </>
               ) : fetchFullContent ? (
                 <span>Full Content</span>


### PR DESCRIPTION
## Summary
- Fixes #445: Fetching full content doesn't work for some feeds
- The "Fetch Full Content" button was silently failing for entries that had a previous fetch attempt that errored
- Now clicking the button properly triggers a retry when there was a previous error

## Changes
- **EntryContent.tsx**: Updated `handleToggleFetchFullContent` to check for `fullContentError` in addition to `fullContentFetchedAt`
- **EntryContent.tsx**: Updated auto-fetch `useEffect` to retry when there was a previous error
- **EntryContentBody.tsx**: Added "Retry Fetch" button state with error styling (red border/text) when there's a `fullContentError`
- Added tooltip showing the error message on hover

## Root Cause
The code was checking `!entry.fullContentFetchedAt` to decide whether to trigger a fetch, but `fullContentFetchedAt` is set even when the fetch fails. So entries with previous failed fetches would never retry.

## Test plan
- [ ] Open an entry from a feed where full content fetch previously failed
- [ ] Verify the button shows "Retry Fetch" with red styling
- [ ] Hover over button to see error tooltip
- [ ] Click the button and verify fetch is triggered
- [ ] Verify auto-fetch also retries when entering an entry with a previous error

🤖 Generated with [Claude Code](https://claude.com/claude-code)