### PR TITLE
Add YAML frontmatter parsing to markdown processor (#451)

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "superjson": "^2.2.6",
     "trpc-to-openapi": "^3.1.0",
     "tsx": "^4.21.0",
+    "yaml": "^2.8.2",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
       zod:
         specifier: ^4.3.5
         version: 4.3.5

--- a/src/server/file/process-upload.ts
+++ b/src/server/file/process-upload.ts
@@ -150,14 +150,19 @@ function processHtml(content: string, filename: string): ProcessedFile {
 /**
  * Converts Markdown to HTML using marked.
  * Markdown content is kept as-is semantically, just rendered to HTML.
+ * Supports YAML frontmatter for title and description extraction.
  */
 async function processMarkdown(content: string, filename: string): Promise<ProcessedFile> {
-  // Convert markdown to HTML and extract title
-  const { html: contentCleaned, title: extractedTitle } = await convertMarkdown(content);
+  // Convert markdown to HTML and extract title/summary from frontmatter or content
+  const {
+    html: contentCleaned,
+    title: extractedTitle,
+    summary: frontmatterSummary,
+  } = await convertMarkdown(content);
   const title = extractedTitle || titleFromFilename(filename);
 
-  // Generate excerpt from the cleaned content (after title is stripped)
-  const excerpt = generateSummary(contentCleaned);
+  // Prefer frontmatter description, fall back to generated summary from content
+  const excerpt = frontmatterSummary ?? generateSummary(contentCleaned);
 
   return {
     contentCleaned,

--- a/src/server/markdown/index.ts
+++ b/src/server/markdown/index.ts
@@ -1,12 +1,84 @@
 /**
  * Markdown Processing Utilities
  *
- * Centralized Markdown-to-HTML conversion with title extraction.
+ * Centralized Markdown-to-HTML conversion with title extraction and frontmatter parsing.
  * Used by file uploads, URL fetching, and plugins.
  */
 
 import { marked } from "marked";
+import { parse as parseYaml } from "yaml";
 import { extractAndStripTitleHeader } from "@/server/html/strip-title-header";
+
+/**
+ * Result of parsing YAML frontmatter from Markdown.
+ */
+export interface Frontmatter {
+  /** Title from frontmatter */
+  title?: string;
+  /** Description/summary from frontmatter */
+  description?: string;
+  /** Raw frontmatter object for future extensibility */
+  raw: Record<string, unknown>;
+}
+
+/**
+ * Result of stripping frontmatter from Markdown.
+ */
+interface FrontmatterResult {
+  /** Frontmatter data if present, null otherwise */
+  frontmatter: Frontmatter | null;
+  /** Markdown content with frontmatter removed */
+  content: string;
+}
+
+// Regex to match YAML frontmatter at the start of a document
+// Must start with --- on its own line, end with --- on its own line
+const FRONTMATTER_REGEX = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
+
+/**
+ * Extracts and parses YAML frontmatter from Markdown content.
+ *
+ * @param markdown - The Markdown text that may contain frontmatter
+ * @returns Parsed frontmatter and remaining content
+ */
+export function extractFrontmatter(markdown: string): FrontmatterResult {
+  const match = FRONTMATTER_REGEX.exec(markdown);
+
+  if (!match) {
+    return { frontmatter: null, content: markdown };
+  }
+
+  const yamlContent = match[1];
+  const contentWithoutFrontmatter = markdown.slice(match[0].length);
+
+  try {
+    const parsed = parseYaml(yamlContent);
+
+    // Ensure we got an object
+    if (typeof parsed !== "object" || parsed === null) {
+      return { frontmatter: null, content: markdown };
+    }
+
+    const frontmatter: Frontmatter = {
+      raw: parsed as Record<string, unknown>,
+    };
+
+    // Extract title if present and is a string
+    if (typeof parsed.title === "string" && parsed.title.trim()) {
+      frontmatter.title = parsed.title.trim();
+    }
+
+    // Extract description if present and is a string
+    if (typeof parsed.description === "string" && parsed.description.trim()) {
+      frontmatter.description = parsed.description.trim();
+    }
+
+    return { frontmatter, content: contentWithoutFrontmatter };
+  } catch {
+    // YAML parsing failed, treat as no frontmatter
+    return { frontmatter: null, content: markdown };
+  }
+}
 
 /**
  * Converts Markdown to HTML using marked with safe defaults.
@@ -30,28 +102,45 @@ export async function markdownToHtml(markdown: string): Promise<string> {
 export interface ProcessedMarkdown {
   /** HTML content with title header stripped */
   html: string;
-  /** Extracted title from first heading (if any) */
+  /** Extracted title from frontmatter or first heading (if any) */
   title: string | null;
+  /** Summary/description from frontmatter (if any) */
+  summary: string | null;
 }
 
 /**
- * Converts Markdown to HTML and extracts the title from the first heading.
+ * Converts Markdown to HTML and extracts metadata.
  *
- * This is the primary function to use when processing Markdown content,
- * as it handles both conversion and title extraction in one step.
+ * This is the primary function to use when processing Markdown content.
+ * It handles:
+ * 1. YAML frontmatter detection and parsing (title, description)
+ * 2. Markdown to HTML conversion
+ * 3. Title extraction from first heading (if not in frontmatter)
+ *
+ * Priority for title: frontmatter.title > first H1 heading
  *
  * @param markdown - The Markdown text to convert
- * @returns HTML content and extracted title
+ * @returns HTML content, extracted title, and summary
  */
 export async function processMarkdown(markdown: string): Promise<ProcessedMarkdown> {
-  // Convert to HTML
-  const html = await markdownToHtml(markdown);
+  // Extract frontmatter if present
+  const { frontmatter, content: markdownWithoutFrontmatter } = extractFrontmatter(markdown);
 
-  // Extract and strip title header
-  const { title, content } = extractAndStripTitleHeader(html);
+  // Convert remaining markdown to HTML
+  const html = await markdownToHtml(markdownWithoutFrontmatter);
+
+  // Extract and strip title header from HTML
+  const { title: headerTitle, content: htmlWithoutHeader } = extractAndStripTitleHeader(html);
+
+  // Frontmatter title takes priority over header title
+  const title = frontmatter?.title ?? headerTitle;
+
+  // Summary comes from frontmatter description
+  const summary = frontmatter?.description ?? null;
 
   return {
-    html: content,
+    html: htmlWithoutHeader,
     title,
+    summary,
   };
 }

--- a/tests/unit/markdown.test.ts
+++ b/tests/unit/markdown.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for Markdown processing utilities.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractFrontmatter, processMarkdown } from "../../src/server/markdown";
+
+describe("extractFrontmatter", () => {
+  it("extracts title from frontmatter", () => {
+    const markdown = `---
+title: My Article Title
+---
+
+Content here.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.title).toBe("My Article Title");
+    expect(result.content).toBe("\nContent here.");
+  });
+
+  it("extracts description from frontmatter", () => {
+    const markdown = `---
+title: My Article
+description: This is a summary of the article.
+---
+
+Content here.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.title).toBe("My Article");
+    expect(result.frontmatter?.description).toBe("This is a summary of the article.");
+  });
+
+  it("returns null frontmatter when none present", () => {
+    const markdown = `# Regular Heading
+
+Just some content.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter).toBeNull();
+    expect(result.content).toBe(markdown);
+  });
+
+  it("handles frontmatter without title or description", () => {
+    const markdown = `---
+author: John Doe
+date: 2024-01-15
+---
+
+Content.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.title).toBeUndefined();
+    expect(result.frontmatter?.description).toBeUndefined();
+    expect(result.frontmatter?.raw).toEqual({
+      author: "John Doe",
+      date: "2024-01-15",
+    });
+  });
+
+  it("handles Cloudflare docs style frontmatter", () => {
+    const markdown = `---
+title: Overview · Cloudflare Workers docs
+description: "With Cloudflare Workers, you can expect to:"
+lastUpdated: 2026-01-26T13:23:46.000Z
+chatbotDeprioritize: false
+source_url:
+  html: https://developers.cloudflare.com/workers/
+  md: https://developers.cloudflare.com/workers/
+---
+
+A serverless platform for building, deploying, and scaling apps.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.title).toBe("Overview · Cloudflare Workers docs");
+    expect(result.frontmatter?.description).toBe("With Cloudflare Workers, you can expect to:");
+    expect(result.content.trim()).toBe(
+      "A serverless platform for building, deploying, and scaling apps."
+    );
+  });
+
+  it("ignores invalid YAML in frontmatter", () => {
+    const markdown = `---
+title: [invalid yaml
+description: missing closing bracket
+---
+
+Content here.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter).toBeNull();
+    expect(result.content).toBe(markdown);
+  });
+
+  it("ignores non-object YAML frontmatter", () => {
+    const markdown = `---
+just a string value
+---
+
+Content here.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter).toBeNull();
+    expect(result.content).toBe(markdown);
+  });
+
+  it("requires frontmatter at document start", () => {
+    const markdown = `Some text before
+
+---
+title: Not frontmatter
+---
+
+More content.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter).toBeNull();
+    expect(result.content).toBe(markdown);
+  });
+
+  it("handles CRLF line endings", () => {
+    const markdown = "---\r\ntitle: Windows Style\r\n---\r\n\r\nContent.";
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.title).toBe("Windows Style");
+  });
+
+  it("handles empty title or description", () => {
+    const markdown = `---
+title: ""
+description:
+---
+
+Content.`;
+
+    const result = extractFrontmatter(markdown);
+    // Empty strings should not be set as title/description
+    expect(result.frontmatter?.title).toBeUndefined();
+    expect(result.frontmatter?.description).toBeUndefined();
+  });
+
+  it("trims whitespace from title and description", () => {
+    const markdown = `---
+title: "  Padded Title  "
+description: "  Padded Description  "
+---
+
+Content.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.title).toBe("Padded Title");
+    expect(result.frontmatter?.description).toBe("Padded Description");
+  });
+});
+
+describe("processMarkdown", () => {
+  it("extracts title from frontmatter over H1 heading", async () => {
+    const markdown = `---
+title: Frontmatter Title
+---
+
+# Heading Title
+
+Content here.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.title).toBe("Frontmatter Title");
+  });
+
+  it("falls back to H1 heading when no frontmatter title", async () => {
+    const markdown = `---
+author: John Doe
+---
+
+# Heading Title
+
+Content here.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.title).toBe("Heading Title");
+  });
+
+  it("falls back to H1 heading when no frontmatter", async () => {
+    const markdown = `# Heading Title
+
+Content here.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.title).toBe("Heading Title");
+  });
+
+  it("returns summary from frontmatter description", async () => {
+    const markdown = `---
+title: My Article
+description: This is the summary.
+---
+
+Full article content.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.summary).toBe("This is the summary.");
+  });
+
+  it("returns null summary when no description in frontmatter", async () => {
+    const markdown = `---
+title: My Article
+---
+
+Full article content.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.summary).toBeNull();
+  });
+
+  it("returns null summary when no frontmatter", async () => {
+    const markdown = `# My Article
+
+Full article content.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.summary).toBeNull();
+  });
+
+  it("converts markdown to HTML", async () => {
+    const markdown = `# Title
+
+This is **bold** and *italic*.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.html).toContain("<strong>bold</strong>");
+    expect(result.html).toContain("<em>italic</em>");
+  });
+
+  it("strips title header from HTML output", async () => {
+    const markdown = `# Title
+
+Content.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.html).not.toContain("<h1>");
+    expect(result.title).toBe("Title");
+  });
+
+  it("handles Cloudflare docs example", async () => {
+    const markdown = `---
+title: Overview · Cloudflare Workers docs
+description: "With Cloudflare Workers, you can expect to:"
+lastUpdated: 2026-01-26T13:23:46.000Z
+chatbotDeprioritize: false
+source_url:
+  html: https://developers.cloudflare.com/workers/
+  md: https://developers.cloudflare.com/workers/
+---
+
+A serverless platform for building, deploying, and scaling apps across [Cloudflare's global network](https://www.cloudflare.com/network/) with a single command — no infrastructure to manage, no complex configuration`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.title).toBe("Overview · Cloudflare Workers docs");
+    expect(result.summary).toBe("With Cloudflare Workers, you can expect to:");
+    expect(result.html).toContain("serverless platform");
+    expect(result.html).toContain('<a href="https://www.cloudflare.com/network/">');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds YAML frontmatter detection and parsing to the unified markdown processor
- When markdown content starts with `---` frontmatter block, extracts `title` and `description` fields
- Frontmatter title takes priority over H1 heading for article title
- Frontmatter description is used as the article summary

## Details

This fixes issue #451 where saving markdown pages from sites like Cloudflare Docs would show "Untitled" as the title and display raw YAML frontmatter in the content.

**Before:**
- Title: "Untitled"
- Content starts with: `title: Overview · Cloudflare Workers docs description: "With Cloudflare Workers..."`

**After:**
- Title: "Overview · Cloudflare Workers docs"
- Summary: "With Cloudflare Workers, you can expect to:"
- Content starts with the actual article text

## Changes

- `src/server/markdown/index.ts` - Added `extractFrontmatter()` function and updated `processMarkdown()` to use it
- `src/server/services/saved.ts` - Updated to use frontmatter summary for saved articles
- `src/server/file/process-upload.ts` - Updated to use frontmatter summary for file uploads
- `package.json` - Added `yaml` package for robust YAML parsing
- `tests/unit/markdown.test.ts` - Added 20 unit tests covering frontmatter parsing

## Test plan

- [x] Unit tests pass (20 new tests for frontmatter parsing)
- [x] Typecheck passes
- [ ] Manually test saving a URL with frontmatter (e.g., https://developers.cloudflare.com/workers/)

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)