### PR TITLE
Fix missing titles for arXiv papers

### DIFF
--- a/src/server/http/html.ts
+++ b/src/server/http/html.ts
@@ -60,3 +60,18 @@ export function escapeHtml(text: string): string {
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#039;");
 }
+
+/**
+ * Wraps an HTML fragment in a full document structure.
+ *
+ * Used by plugins that return content fragments (e.g., from APIs) to ensure
+ * consistent document structure for metadata extraction and Readability.
+ *
+ * @param html - The HTML fragment to wrap
+ * @param title - Optional title for the document
+ * @returns A complete HTML document
+ */
+export function wrapHtmlFragment(html: string, title?: string | null): string {
+  const titleTag = title ? `<title>${escapeHtml(title)}</title>` : "";
+  return `<!DOCTYPE html><html><head>${titleTag}</head><body>${html}</body></html>`;
+}

--- a/src/server/plugins/google-docs.ts
+++ b/src/server/plugins/google-docs.ts
@@ -5,6 +5,7 @@ import {
   normalizeGoogleDocsUrl,
   fetchGoogleDocsFromUrl,
 } from "@/server/google/docs";
+import { wrapHtmlFragment } from "@/server/http/html";
 import { logger } from "@/lib/logger";
 
 /**
@@ -48,10 +49,11 @@ export const googleDocsPlugin: UrlPlugin = {
 
           // Normalize the URL to use as canonical
           const canonical = normalizeGoogleDocsUrl(url.href);
+          const title = content.title || null;
 
           return {
-            html: content.html,
-            title: content.title || null,
+            html: wrapHtmlFragment(content.html, title),
+            title,
             author: content.author || null,
             publishedAt: content.modifiedAt || null,
             canonicalUrl: canonical,

--- a/src/server/plugins/lesswrong.ts
+++ b/src/server/plugins/lesswrong.ts
@@ -6,6 +6,7 @@ import {
   buildLessWrongUserFeedUrl,
 } from "@/server/feed/lesswrong";
 import { cleanLessWrongContent } from "@/server/feed/content-cleaner";
+import { wrapHtmlFragment } from "@/server/http/html";
 import { logger } from "@/lib/logger";
 
 /**
@@ -86,7 +87,7 @@ export const lessWrongPlugin: UrlPlugin = {
                 : null;
 
           return {
-            html: content.html,
+            html: wrapHtmlFragment(content.html, title),
             title: title || null,
             author: content.author || null,
             publishedAt: content.publishedAt || null,

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -14,7 +14,7 @@ import { generateUuidv7 } from "@/lib/uuidv7";
 import { normalizeUrl } from "@/lib/url";
 import { fetchHtmlPage, HttpFetchError } from "@/server/http/fetch";
 import { processMarkdown } from "@/server/markdown";
-import { escapeHtml } from "@/server/http/html";
+import { wrapHtmlFragment } from "@/server/http/html";
 import { cleanContent } from "@/server/feed/content-cleaner";
 import { getOrCreateSavedFeed } from "@/server/feed/saved-feed";
 import { generateSummary } from "@/server/html/strip-html";
@@ -261,8 +261,7 @@ export async function saveArticle(
           siteName: plugin.capabilities.savedArticle.siteName,
           skipReadability: plugin.capabilities.savedArticle.skipReadability,
         };
-        // Wrap in HTML structure for consistency
-        html = `<!DOCTYPE html><html><head><title>${escapeHtml(content.title ?? "")}</title></head><body>${content.html}</body></html>`;
+        html = content.html;
         logger.debug("Successfully fetched content via plugin", {
           url: params.url,
           plugin: plugin.name,
@@ -292,7 +291,7 @@ export async function saveArticle(
           url: params.url,
         });
         markdownResult = await processMarkdown(result.content);
-        html = markdownResult.html;
+        html = wrapHtmlFragment(markdownResult.html, markdownResult.title);
       } else {
         html = result.content;
       }

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -478,8 +478,7 @@ export const savedRouter = createTRPCRouter({
                 siteName: plugin.capabilities.savedArticle.siteName,
                 publishedAt: content.publishedAt,
               };
-              // Wrap the content in a basic HTML structure for consistency
-              html = `<!DOCTYPE html><html><head><title>${escapeHtml(content.title ?? "")}</title></head><body>${content.html}</body></html>`;
+              html = content.html;
               logger.debug("Successfully fetched content via plugin", {
                 url: input.url,
                 plugin: plugin.name,


### PR DESCRIPTION
## Summary

Fixes #455 - arXiv papers were showing "Untitled" even though they have valid HTML `<title>` tags.

**Root cause:** The saved article service was wrapping all plugin content in a new HTML structure with an empty `<title>` tag. For plugins like ArXiv that return full HTML documents (not fragments), this buried the real `<title>` inside `<body>`, so metadata extraction never found it.

**Fix:** Move HTML wrapping responsibility to each plugin:
- Plugins returning **fragments** (LessWrong, Google Docs, GitHub) now wrap their output in a full HTML document structure with proper `<title>`
- Plugins returning **full documents** (ArXiv) pass them through unchanged
- The saved article service no longer wraps plugin content

## Test plan

- [ ] Save an arXiv paper URL and verify the title is extracted correctly
- [ ] Save a LessWrong post and verify title still works
- [ ] Save a GitHub gist/README and verify title still works
- [ ] Save a Google Doc and verify title still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)