### PR TITLE
Use site name and author metadata for saved articles

### DIFF
--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -325,7 +325,9 @@ export function EntryContent({
       <EntryContentBody
         articleId={entryId}
         title={entry.title ?? "Untitled"}
-        source={entry.feedTitle ?? "Unknown Feed"}
+        source={
+          (entry.type === "saved" ? entry.siteName : null) ?? entry.feedTitle ?? "Unknown Feed"
+        }
         author={entry.author}
         url={entry.url}
         date={entry.publishedAt ?? entry.fetchedAt}

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -29,6 +29,8 @@ export interface EntryListItemData {
   read: boolean;
   starred: boolean;
   feedTitle: string | null;
+  /** Site name for saved articles (e.g., "arXiv", "LessWrong", extracted from og:site_name) */
+  siteName: string | null;
 }
 
 interface EntryListItemProps {
@@ -95,11 +97,14 @@ export const EntryListItem = memo(function EntryListItem({
     type,
     subscriptionId,
     feedTitle,
+    siteName,
     publishedAt,
     fetchedAt,
   } = entry;
   const displayTitle = title ?? "Untitled";
-  const source = feedTitle ?? "Unknown Feed";
+  // For saved articles, prefer siteName (extracted from page metadata) over feedTitle
+  // feedTitle for saved articles is always "Saved Articles" (the feed name)
+  const source = (type === "saved" ? siteName : null) ?? feedTitle ?? "Unknown Feed";
   const date = publishedAt ?? fetchedAt;
 
   const handleClick = () => {

--- a/src/lib/hooks/useEntryListQuery.ts
+++ b/src/lib/hooks/useEntryListQuery.ts
@@ -53,6 +53,8 @@ export interface EntryListData {
   read: boolean;
   starred: boolean;
   feedTitle: string | null;
+  /** Site name for saved articles (e.g., "arXiv", "LessWrong", extracted from og:site_name) */
+  siteName: string | null;
 }
 
 /**
@@ -239,6 +241,7 @@ export function useEntryListQuery(options: UseEntryListQueryOptions): UseEntryLi
           read: entry.read,
           starred: entry.starred,
           feedTitle: entry.feedTitle,
+          siteName: entry.siteName,
         }))
       ) ?? []
     );

--- a/src/server/file/process-upload.ts
+++ b/src/server/file/process-upload.ts
@@ -33,6 +33,8 @@ export interface ProcessedFile {
   excerpt: string | null;
   /** Extracted or derived title (from filename or content) */
   title: string | null;
+  /** Extracted author (from frontmatter, metadata, or Readability) */
+  author: string | null;
   /** Original file type */
   fileType: SupportedFileType;
 }
@@ -118,6 +120,7 @@ async function processDocx(buffer: Buffer, filename: string): Promise<ProcessedF
     contentCleaned,
     excerpt: excerpt || null,
     title: cleaned?.title || titleFromFilename(filename),
+    author: cleaned?.byline || null,
     fileType: "docx",
   };
 }
@@ -134,6 +137,7 @@ function processHtml(content: string, filename: string): ProcessedFile {
       contentCleaned: cleaned.content,
       excerpt: cleaned.excerpt || generateSummary(cleaned.content) || null,
       title: cleaned.title || titleFromFilename(filename),
+      author: cleaned.byline || null,
       fileType: "html",
     };
   }
@@ -143,6 +147,7 @@ function processHtml(content: string, filename: string): ProcessedFile {
     contentCleaned: content,
     excerpt: generateSummary(content) || null,
     title: titleFromFilename(filename),
+    author: null,
     fileType: "html",
   };
 }
@@ -150,14 +155,15 @@ function processHtml(content: string, filename: string): ProcessedFile {
 /**
  * Converts Markdown to HTML using marked.
  * Markdown content is kept as-is semantically, just rendered to HTML.
- * Supports YAML frontmatter for title and description extraction.
+ * Supports YAML frontmatter for title, description, and author extraction.
  */
 async function processMarkdown(content: string, filename: string): Promise<ProcessedFile> {
-  // Convert markdown to HTML and extract title/summary from frontmatter or content
+  // Convert markdown to HTML and extract title/summary/author from frontmatter or content
   const {
     html: contentCleaned,
     title: extractedTitle,
     summary: frontmatterSummary,
+    author,
   } = await convertMarkdown(content);
   const title = extractedTitle || titleFromFilename(filename);
 
@@ -168,6 +174,7 @@ async function processMarkdown(content: string, filename: string): Promise<Proce
     contentCleaned,
     excerpt: excerpt || null,
     title,
+    author,
     fileType: "markdown",
   };
 }

--- a/src/server/markdown/index.ts
+++ b/src/server/markdown/index.ts
@@ -17,6 +17,8 @@ export interface Frontmatter {
   title?: string;
   /** Description/summary from frontmatter */
   description?: string;
+  /** Author from frontmatter */
+  author?: string;
   /** Raw frontmatter object for future extensibility */
   raw: Record<string, unknown>;
 }
@@ -73,6 +75,11 @@ export function extractFrontmatter(markdown: string): FrontmatterResult {
       frontmatter.description = parsed.description.trim();
     }
 
+    // Extract author if present and is a string
+    if (typeof parsed.author === "string" && parsed.author.trim()) {
+      frontmatter.author = parsed.author.trim();
+    }
+
     return { frontmatter, content: contentWithoutFrontmatter };
   } catch {
     // YAML parsing failed, treat as no frontmatter
@@ -106,6 +113,8 @@ export interface ProcessedMarkdown {
   title: string | null;
   /** Summary/description from frontmatter (if any) */
   summary: string | null;
+  /** Author from frontmatter (if any) */
+  author: string | null;
 }
 
 /**
@@ -138,9 +147,13 @@ export async function processMarkdown(markdown: string): Promise<ProcessedMarkdo
   // Summary comes from frontmatter description
   const summary = frontmatter?.description ?? null;
 
+  // Author comes from frontmatter
+  const author = frontmatter?.author ?? null;
+
   return {
     html: htmlWithoutHeader,
     title,
     summary,
+    author,
   };
 }

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -869,6 +869,7 @@ export const savedRouter = createTRPCRouter({
         title: finalTitle,
         excerpt: processed.excerpt,
         siteName,
+        author: processed.author,
       });
 
       logger.info("Uploaded file saved", {

--- a/tests/unit/frontend/components/EntryListItem.test.tsx
+++ b/tests/unit/frontend/components/EntryListItem.test.tsx
@@ -41,6 +41,7 @@ function createMockEntry(overrides: Partial<EntryListItemData> = {}): EntryListI
     read: false,
     starred: false,
     feedTitle: "Example Feed",
+    siteName: null,
     ...overrides,
   };
 }
@@ -73,6 +74,43 @@ describe("EntryListItem", () => {
       render(<EntryListItem entry={entry} />);
 
       expect(screen.getByText("Unknown Feed")).toBeInTheDocument();
+    });
+
+    it("renders siteName for saved articles instead of feedTitle", () => {
+      const entry = createMockEntry({
+        type: "saved",
+        feedTitle: "Saved Articles",
+        siteName: "arXiv",
+      });
+      render(<EntryListItem entry={entry} />);
+
+      // Should show siteName, not feedTitle
+      expect(screen.getByText("arXiv")).toBeInTheDocument();
+      expect(screen.queryByText("Saved Articles")).not.toBeInTheDocument();
+    });
+
+    it("falls back to feedTitle for saved articles when siteName is null", () => {
+      const entry = createMockEntry({
+        type: "saved",
+        feedTitle: "Saved Articles",
+        siteName: null,
+      });
+      render(<EntryListItem entry={entry} />);
+
+      expect(screen.getByText("Saved Articles")).toBeInTheDocument();
+    });
+
+    it("uses feedTitle for non-saved entries even when siteName is set", () => {
+      const entry = createMockEntry({
+        type: "web",
+        feedTitle: "Tech News",
+        siteName: "Example Site",
+      });
+      render(<EntryListItem entry={entry} />);
+
+      // Should show feedTitle for web entries, not siteName
+      expect(screen.getByText("Tech News")).toBeInTheDocument();
+      expect(screen.queryByText("Example Site")).not.toBeInTheDocument();
     });
 
     it("renders the summary when provided", () => {

--- a/tests/unit/markdown.test.ts
+++ b/tests/unit/markdown.test.ts
@@ -52,10 +52,47 @@ Content.`;
     const result = extractFrontmatter(markdown);
     expect(result.frontmatter?.title).toBeUndefined();
     expect(result.frontmatter?.description).toBeUndefined();
+    expect(result.frontmatter?.author).toBe("John Doe");
     expect(result.frontmatter?.raw).toEqual({
       author: "John Doe",
       date: "2024-01-15",
     });
+  });
+
+  it("extracts author from frontmatter", () => {
+    const markdown = `---
+title: My Article
+author: Jane Smith
+---
+
+Content here.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.title).toBe("My Article");
+    expect(result.frontmatter?.author).toBe("Jane Smith");
+  });
+
+  it("trims whitespace from author", () => {
+    const markdown = `---
+author: "  Padded Author  "
+---
+
+Content.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.author).toBe("Padded Author");
+  });
+
+  it("handles empty author", () => {
+    const markdown = `---
+title: My Article
+author: ""
+---
+
+Content.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.author).toBeUndefined();
   });
 
   it("handles Cloudflare docs style frontmatter", () => {
@@ -259,5 +296,53 @@ A serverless platform for building, deploying, and scaling apps across [Cloudfla
     expect(result.summary).toBe("With Cloudflare Workers, you can expect to:");
     expect(result.html).toContain("serverless platform");
     expect(result.html).toContain('<a href="https://www.cloudflare.com/network/">');
+  });
+
+  it("extracts author from frontmatter", async () => {
+    const markdown = `---
+title: My Article
+author: John Doe
+---
+
+Content here.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.author).toBe("John Doe");
+  });
+
+  it("returns null author when no author in frontmatter", async () => {
+    const markdown = `---
+title: My Article
+---
+
+Content here.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.author).toBeNull();
+  });
+
+  it("returns null author when no frontmatter", async () => {
+    const markdown = `# My Article
+
+Content here.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.author).toBeNull();
+  });
+
+  it("extracts all metadata from frontmatter", async () => {
+    const markdown = `---
+title: Complete Article
+description: A brief summary.
+author: Jane Smith
+---
+
+The full content of the article.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.title).toBe("Complete Article");
+    expect(result.summary).toBe("A brief summary.");
+    expect(result.author).toBe("Jane Smith");
+    expect(result.html).toContain("full content");
   });
 });


### PR DESCRIPTION
## Summary
- Add author field extraction to YAML frontmatter parsing in Markdown processor
- Pass author from Markdown frontmatter through saved article processing pipeline
- Include author from Readability byline for uploaded HTML/docx files
- Add comprehensive tests for author extraction in frontmatter

The site name from `og:site_name` meta tag was already being extracted and used for saved articles. This change ensures author information is also consistently extracted from all sources:
- **Markdown files**: YAML frontmatter `author` field
- **HTML files**: Extracted via Readability's byline detection  
- **DOCX files**: Extracted via Readability's byline detection after mammoth conversion

Note: Google Docs integration already supports author extraction via the API but currently returns null. The siteName is already hardcoded to "Google Docs" in the plugin.

## Test plan
- [x] Unit tests pass for markdown frontmatter author extraction
- [x] TypeScript compilation succeeds
- [x] All 1481 unit tests pass

Fixes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)