### PR TITLE
Share target: save URLs directly without navigation

### DIFF
--- a/src/components/layout/RealtimeProvider.tsx
+++ b/src/components/layout/RealtimeProvider.tsx
@@ -4,15 +4,30 @@
  * Manages the SSE connection for real-time updates and optionally displays
  * a connection status indicator.
  *
+ * Also handles messages from the service worker (e.g., share target results)
+ * to show toast notifications.
+ *
  * This component should be used in the app layout to enable real-time updates
  * for authenticated users.
  */
 
 "use client";
 
-import { type ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
+import { toast } from "sonner";
 import { useRealtimeUpdates, type SyncCursors } from "@/lib/hooks/useRealtimeUpdates";
 import { ConnectionStatusIndicator } from "./ConnectionStatusIndicator";
+
+/**
+ * Message format from service worker for share target results.
+ */
+interface ShareResultMessage {
+  type: "share-result";
+  success: boolean;
+  url?: string;
+  title?: string;
+  error?: string;
+}
 
 interface RealtimeProviderProps {
   /**
@@ -64,6 +79,34 @@ export function RealtimeProvider({
   showStatusIndicator = true,
 }: RealtimeProviderProps) {
   const { status, reconnect } = useRealtimeUpdates(initialCursors);
+
+  // Listen for messages from service worker (e.g., share target results)
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+      return;
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      const data = event.data as ShareResultMessage | undefined;
+
+      if (data?.type === "share-result") {
+        if (data.success) {
+          toast.success("Article saved", {
+            description: data.title || data.url,
+          });
+        } else {
+          toast.error("Failed to save article", {
+            description: data.error || data.url,
+          });
+        }
+      }
+    };
+
+    navigator.serviceWorker.addEventListener("message", handleMessage);
+    return () => {
+      navigator.serviceWorker.removeEventListener("message", handleMessage);
+    };
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Summary

- When sharing a URL to Lion Reader via the PWA share target, the service worker now saves the article directly via the API without navigating away from the current page
- This allows users to share links from within Lion Reader back to itself without losing their place
- Open tabs receive a toast notification about the save result

## Changes

- **Service worker** (`worker/index.ts`):
  - Calls `/api/v1/saved` directly with session cookie instead of redirecting
  - Returns a minimal auto-closing success/error page (for visual feedback)
  - Notifies all open tabs via `postMessage` about the result
  - Falls back to `/save` page redirect if not authenticated

- **RealtimeProvider** (`src/components/layout/RealtimeProvider.tsx`):
  - Listens for service worker messages
  - Shows toast notifications for share success/failure

## What still works unchanged

- **Bookmarklet**: Opens `/save` in a popup window (unchanged)
- **Browser extension**: Uses direct API call with stored token (unchanged)
- **File shares**: Redirect to `/save` for complex processing (unchanged)

## Test plan

- [ ] Share a URL from another app to Lion Reader PWA → should save and show success page
- [ ] Share a link from within Lion Reader to Lion Reader → should save without losing current page, show toast
- [ ] Share when not logged in → should redirect to /save for login flow
- [ ] Use bookmarklet → should still open popup and save normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)