### PR TITLE
Refactor optimistic updates and merge star/unstar endpoints

### DIFF
--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -28,10 +28,17 @@ export {
   handleNewEntry,
   setCounts,
   setBulkCounts,
+  // Optimistic update helpers
+  applyOptimisticReadUpdate,
+  rollbackOptimisticReadUpdate,
+  applyOptimisticStarredUpdate,
+  rollbackOptimisticStarredUpdate,
   type EntryWithContext,
   type SubscriptionData,
   type UnreadCounts,
   type BulkUnreadCounts,
+  type OptimisticReadContext,
+  type OptimisticStarredContext,
 } from "./operations";
 
 // Low-level helpers (for special cases)

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -538,7 +538,7 @@ describe("Entries", () => {
       const ctx = createAuthContext(userId);
       const caller = createCaller(ctx);
 
-      const result = await caller.entries.star({ id: entryId });
+      const result = await caller.entries.setStarred({ id: entryId, starred: true });
 
       expect(result.entry.id).toBe(entryId);
       expect(result.entry.starred).toBe(true);
@@ -564,7 +564,7 @@ describe("Entries", () => {
       const ctx = createAuthContext(userId);
       const caller = createCaller(ctx);
 
-      const result = await caller.entries.unstar({ id: entryId });
+      const result = await caller.entries.setStarred({ id: entryId, starred: false });
 
       expect(result.entry.id).toBe(entryId);
       expect(result.entry.starred).toBe(false);
@@ -592,7 +592,7 @@ describe("Entries", () => {
       const ctx2 = createAuthContext(user2Id);
       const caller2 = createCaller(ctx2);
 
-      await expect(caller2.entries.star({ id: entryId })).rejects.toThrow();
+      await expect(caller2.entries.setStarred({ id: entryId, starred: true })).rejects.toThrow();
     });
   });
 
@@ -834,7 +834,11 @@ describe("Entries", () => {
       const caller = createCaller(ctx);
 
       // Star with newer timestamp should succeed
-      const result = await caller.entries.star({ id: entryId, changedAt: newTimestamp });
+      const result = await caller.entries.setStarred({
+        id: entryId,
+        starred: true,
+        changedAt: newTimestamp,
+      });
 
       expect(result.entry.starred).toBe(true);
 
@@ -864,7 +868,11 @@ describe("Entries", () => {
       const caller = createCaller(ctx);
 
       // Unstar with older timestamp should be rejected
-      const result = await caller.entries.unstar({ id: entryId, changedAt: olderTimestamp });
+      const result = await caller.entries.setStarred({
+        id: entryId,
+        starred: false,
+        changedAt: olderTimestamp,
+      });
 
       // Returns final state (still starred)
       expect(result.entry.starred).toBe(true);

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -569,7 +569,7 @@ describe("Saved Articles API", () => {
       const ctx = createAuthContext(userId);
       const caller = createCaller(ctx);
 
-      const result = await caller.entries.star({ id: articleId });
+      const result = await caller.entries.setStarred({ id: articleId, starred: true });
       expect(result.entry.id).toBe(articleId);
       expect(result.entry.starred).toBe(true);
       expect(result.entry.read).toBe(false);
@@ -588,9 +588,9 @@ describe("Saved Articles API", () => {
       const ctx = createAuthContext(userId);
       const caller = createCaller(ctx);
 
-      await expect(caller.entries.star({ id: generateUuidv7() })).rejects.toThrow(
-        "Entry not found"
-      );
+      await expect(
+        caller.entries.setStarred({ id: generateUuidv7(), starred: true })
+      ).rejects.toThrow("Entry not found");
     });
 
     it("throws error when starring another user's article", async () => {
@@ -602,7 +602,9 @@ describe("Saved Articles API", () => {
       const ctx = createAuthContext(userId2);
       const caller = createCaller(ctx);
 
-      await expect(caller.entries.star({ id: articleId })).rejects.toThrow("Entry not found");
+      await expect(caller.entries.setStarred({ id: articleId, starred: true })).rejects.toThrow(
+        "Entry not found"
+      );
 
       // Verify not starred in user_entries
       const dbUserEntry = await db
@@ -622,7 +624,7 @@ describe("Saved Articles API", () => {
       const ctx = createAuthContext(userId);
       const caller = createCaller(ctx);
 
-      const result = await caller.entries.unstar({ id: articleId });
+      const result = await caller.entries.setStarred({ id: articleId, starred: false });
       expect(result.entry.id).toBe(articleId);
       expect(result.entry.starred).toBe(false);
       expect(result.entry.read).toBe(false);
@@ -641,9 +643,9 @@ describe("Saved Articles API", () => {
       const ctx = createAuthContext(userId);
       const caller = createCaller(ctx);
 
-      await expect(caller.entries.unstar({ id: generateUuidv7() })).rejects.toThrow(
-        "Entry not found"
-      );
+      await expect(
+        caller.entries.setStarred({ id: generateUuidv7(), starred: false })
+      ).rejects.toThrow("Entry not found");
     });
 
     it("throws error when unstarring another user's article", async () => {
@@ -655,7 +657,9 @@ describe("Saved Articles API", () => {
       const ctx = createAuthContext(userId2);
       const caller = createCaller(ctx);
 
-      await expect(caller.entries.unstar({ id: articleId })).rejects.toThrow("Entry not found");
+      await expect(caller.entries.setStarred({ id: articleId, starred: false })).rejects.toThrow(
+        "Entry not found"
+      );
 
       // Verify still starred in user_entries
       const dbUserEntry = await db
@@ -702,22 +706,13 @@ describe("Saved Articles API", () => {
       ).rejects.toThrow("You must be logged in");
     });
 
-    it("requires authentication for star", async () => {
+    it("requires authentication for setStarred", async () => {
       const ctx = createUnauthContext();
       const caller = createCaller(ctx);
 
-      await expect(caller.entries.star({ id: generateUuidv7() })).rejects.toThrow(
-        "You must be logged in"
-      );
-    });
-
-    it("requires authentication for unstar", async () => {
-      const ctx = createUnauthContext();
-      const caller = createCaller(ctx);
-
-      await expect(caller.entries.unstar({ id: generateUuidv7() })).rejects.toThrow(
-        "You must be logged in"
-      );
+      await expect(
+        caller.entries.setStarred({ id: generateUuidv7(), starred: true })
+      ).rejects.toThrow("You must be logged in");
     });
 
     it("requires authentication for save", async () => {


### PR DESCRIPTION
## Summary
- Adds cache helper functions for optimistic updates to centralize logic
- Merges separate `star`/`unstar` tRPC endpoints into single `setStarred` endpoint

## Changes

### Cache Helper Functions (`src/lib/cache/operations.ts`)
- `applyOptimisticReadUpdate()` - Cancels queries, snapshots state, applies optimistic update
- `rollbackOptimisticReadUpdate()` - Reverts to previous state on error
- `applyOptimisticStarredUpdate()` - Same pattern for starred status
- `rollbackOptimisticStarredUpdate()` - Reverts starred status on error

### Merged star/unstar Endpoints
- **Backend**: Replaced `star` and `unstar` with single `setStarred` endpoint accepting `{ id, starred: boolean, changedAt? }`
- **Frontend**: Uses single `setStarredMutation` internally; `star()`, `unstar()`, `toggleStar()` convenience functions unchanged

### Benefits
- Centralized optimistic update logic integrates properly with cache update system
- Single endpoint is simpler and more consistent with other APIs (like `markRead`)
- Easier to maintain and extend

## Test plan
- [x] TypeScript compiles with no errors
- [x] All 416 frontend unit tests pass
- [ ] Manual testing: Toggle starred status, verify instant UI update
- [ ] Manual testing: Disconnect network, toggle star, verify error toast and rollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)