### PR TITLE
Improve SSR prefetching by including subscription data in entry response

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -4,11 +4,12 @@
  * Server component wrapper that provides TRPCProvider and prefetches common data.
  * The actual layout UI is in AppLayoutContent.
  *
- * Prefetches data used across all pages (sidebar, header):
+ * Prefetches data used across all pages (sidebar, header, entry content):
  * - auth.me (user info for header)
  * - tags.list (sidebar tag structure and unread counts)
  * - entries.count (all/starred/saved counts for sidebar)
  * - sync.changes (for initial delta sync cursors)
+ * - summarization.isAvailable (for entry content summarization button)
  *
  * Note: entries.list is prefetched per-page in EntryListPage based on route-specific filters
  *
@@ -60,6 +61,7 @@ export default async function AppLayout({ children }: AppLayoutProps) {
     trpc.entries.count.prefetch({ type: "saved" }),
     trpc.entries.count.prefetch({ starredOnly: true }),
     trpc.sync.changes.prefetch({}), // Initial sync with no cursors
+    trpc.summarization.isAvailable.prefetch(), // For entry content summarization button
   ]);
 
   return (

--- a/src/lib/cache/entry-cache.ts
+++ b/src/lib/cache/entry-cache.ts
@@ -422,6 +422,7 @@ export function findEntryInListCache(
 /**
  * Converts a list item to the full entry response format for use as placeholder data.
  * Content fields are set to null since they're not available in list data.
+ * fetchFullContent defaults to false until the full entry loads.
  *
  * @param listItem - Entry data from the list
  * @returns Object matching the entries.get response shape
@@ -436,6 +437,7 @@ export function listItemToPlaceholderEntry(listItem: EntryListItem): {
     fullContentCleaned: null;
     fullContentFetchedAt: null;
     fullContentError: null;
+    fetchFullContent: boolean;
   };
 } {
   return {
@@ -449,6 +451,8 @@ export function listItemToPlaceholderEntry(listItem: EntryListItem): {
       fullContentCleaned: null,
       fullContentFetchedAt: null,
       fullContentError: null,
+      // Default until full entry loads
+      fetchFullContent: false,
     },
   };
 }


### PR DESCRIPTION
## Summary
- Add `summarization.isAvailable` to layout prefetch so it's available when viewing entries
- Include `fetchFullContent` and `subscriptionTags` directly in `entries.get` response
- Update EntryContent to use inline subscription data instead of separate `subscriptions.get` query

## Problem
Fixes #466 - SSR prefetching was not working consistently because:
1. `summarization.isAvailable` was fetched on every entry open but not prefetched in the layout
2. `entries.get` required a separate `subscriptions.get` query to get `fetchFullContent` setting and tags

## Changes
- Layout prefetching now includes `summarization.isAvailable`
- Entry API responses now include subscription data inline (`fetchFullContent`, `subscriptionTags`)
- EntryContent component uses this inline data instead of making a separate query
- entry-cache placeholder data includes the new subscription fields
- `entries.fetchFullContent` mutation also includes the subscription data in its response

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [ ] Verify network requests when opening `/all` page (should not see extra `subscriptions.get` or `summarization.isAvailable` queries)
- [ ] Verify entry page loads without separate subscription query

🤖 Generated with [Claude Code](https://claude.com/claude-code)