### PR TITLE
Remove lazy loading from settings pages for immediate title rendering

### DIFF
--- a/src/components/settings/UnifiedSettingsContent.tsx
+++ b/src/components/settings/UnifiedSettingsContent.tsx
@@ -7,27 +7,29 @@
  *
  * Includes the settings layout (sidebar navigation) and switches
  * content based on the current pathname.
+ *
+ * Settings pages are NOT lazy-loaded so that static content (titles,
+ * descriptions) can render immediately while data loads. The settings
+ * bundle is small enough that this tradeoff is worthwhile for better UX.
  */
 
 "use client";
 
-import { Suspense, lazy } from "react";
 import { usePathname } from "next/navigation";
 import { ClientLink } from "@/components/ui";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 
-// Settings page components - lazy loaded for code splitting
-const AccountSettingsContent = lazy(() => import("./pages/AccountSettingsContent"));
-const AppearanceSettingsContent = lazy(() =>
-  import("./AppearanceSettings").then((m) => ({ default: m.AppearanceSettings }))
-);
-const SessionsSettingsContent = lazy(() => import("./pages/SessionsSettingsContent"));
-const ApiTokensSettingsContent = lazy(() => import("./pages/ApiTokensSettingsContent"));
-const IntegrationsSettingsContent = lazy(() => import("./pages/IntegrationsSettingsContent"));
-const EmailSettingsContent = lazy(() => import("./pages/EmailSettingsContent"));
-const BlockedSendersSettingsContent = lazy(() => import("./pages/BlockedSendersSettingsContent"));
-const BrokenFeedsSettingsContent = lazy(() => import("./pages/BrokenFeedsSettingsContent"));
-const FeedStatsSettingsContent = lazy(() => import("./pages/FeedStatsSettingsContent"));
+// Settings page components - directly imported (not lazy) so static content
+// like titles renders immediately while data loads
+import AccountSettingsContent from "./pages/AccountSettingsContent";
+import { AppearanceSettings as AppearanceSettingsContent } from "./AppearanceSettings";
+import SessionsSettingsContent from "./pages/SessionsSettingsContent";
+import ApiTokensSettingsContent from "./pages/ApiTokensSettingsContent";
+import IntegrationsSettingsContent from "./pages/IntegrationsSettingsContent";
+import EmailSettingsContent from "./pages/EmailSettingsContent";
+import BlockedSendersSettingsContent from "./pages/BlockedSendersSettingsContent";
+import BrokenFeedsSettingsContent from "./pages/BrokenFeedsSettingsContent";
+import FeedStatsSettingsContent from "./pages/FeedStatsSettingsContent";
 
 const settingsLinks = [
   { href: "/settings", label: "Account" },
@@ -40,24 +42,6 @@ const settingsLinks = [
   { href: "/settings/broken-feeds", label: "Broken Feeds" },
   { href: "/settings/feed-stats", label: "Feed Stats" },
 ];
-
-/**
- * Loading skeleton for settings content.
- */
-function SettingsContentSkeleton() {
-  return (
-    <div className="space-y-6">
-      <div className="h-8 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        <div className="space-y-4">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="h-12 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
 
 /**
  * Renders the appropriate settings content based on pathname.
@@ -145,9 +129,7 @@ export function UnifiedSettingsContent() {
         {/* Main Content */}
         <div className="min-w-0 flex-1">
           <ErrorBoundary message="Failed to load settings">
-            <Suspense fallback={<SettingsContentSkeleton />}>
-              <SettingsContentRouter />
-            </Suspense>
+            <SettingsContentRouter />
           </ErrorBoundary>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Removes `lazy()` + `Suspense` from settings page imports
- Settings components now render static content (titles, descriptions) immediately
- Each section handles its own data loading with inline skeletons

## Problem
The previous PR (#470) tightened suspense boundaries within AccountSettingsContent, but there was still an outer `Suspense` boundary in `UnifiedSettingsContent` around lazy-loaded components. This meant users saw a generic skeleton while waiting for the JS chunk to load, before seeing any titles.

## Solution
Remove lazy loading for settings pages. The settings bundle is small and the pages are closely related, so the tradeoff of a slightly larger initial bundle for better perceived performance is worthwhile. Now:

1. Page JS is available immediately (bundled with settings layout)
2. Static content (titles, section headers) renders immediately
3. Each section shows its own inline loading skeleton for dynamic data

## Test plan
- [ ] Visit `/settings` - "Account Information", "Linked Accounts", etc. titles should appear immediately
- [ ] Visit `/settings/sessions` - "Active Sessions" title and description should appear immediately
- [ ] Visit other settings pages - titles should render before data loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)