### PR TITLE
Fix mark-read flash by firing mutation before navigation

### DIFF
--- a/src/components/entries/SuspendingEntryList.tsx
+++ b/src/components/entries/SuspendingEntryList.tsx
@@ -14,7 +14,7 @@
 import { useMemo, useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { trpc } from "@/lib/trpc/client";
 import { useEntryMutations } from "@/lib/hooks";
-import { useEntryUrlState } from "@/lib/hooks/useEntryUrlState";
+import { useOpenEntry } from "@/lib/hooks/useOpenEntry";
 import { useKeyboardShortcutsContext } from "@/components/keyboard";
 import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
 import { useUrlViewPreferences } from "@/lib/hooks/useUrlViewPreferences";
@@ -27,7 +27,7 @@ interface SuspendingEntryListProps {
 }
 
 export function SuspendingEntryList({ emptyMessage }: SuspendingEntryListProps) {
-  const { openEntryId, setOpenEntryId } = useEntryUrlState();
+  const { openEntryId, openEntry, closeEntry } = useOpenEntry();
   const { showUnreadOnly, sortOrder, toggleShowUnreadOnly } = useUrlViewPreferences();
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
   const utils = trpc.useUtils();
@@ -137,15 +137,15 @@ export function SuspendingEntryList({ emptyMessage }: SuspendingEntryListProps) 
   // Navigation callbacks for keyboard shortcuts (j/k when viewing an entry)
   const goToNextEntry = useCallback(() => {
     if (nextEntryId) {
-      setOpenEntryId(nextEntryId);
+      openEntry(nextEntryId);
     }
-  }, [nextEntryId, setOpenEntryId]);
+  }, [nextEntryId, openEntry]);
 
   const goToPreviousEntry = useCallback(() => {
     if (previousEntryId) {
-      setOpenEntryId(previousEntryId);
+      openEntry(previousEntryId);
     }
-  }, [previousEntryId, setOpenEntryId]);
+  }, [previousEntryId, openEntry]);
 
   // Entry mutations
   const { toggleRead: rawToggleRead, toggleStar } = useEntryMutations();
@@ -160,16 +160,16 @@ export function SuspendingEntryList({ emptyMessage }: SuspendingEntryListProps) 
   // Entry click handler
   const handleEntryClick = useCallback(
     (entryId: string) => {
-      setOpenEntryId(entryId);
+      openEntry(entryId);
     },
-    [setOpenEntryId]
+    [openEntry]
   );
 
   // Keyboard shortcuts
   const { selectedEntryId } = useKeyboardShortcuts({
     entries,
-    onOpenEntry: setOpenEntryId,
-    onClose: () => setOpenEntryId(null),
+    onOpenEntry: openEntry,
+    onClose: closeEntry,
     isEntryOpen: !!openEntryId,
     openEntryId,
     enabled: keyboardShortcutsEnabled,

--- a/src/components/entries/UnifiedEntriesContent.tsx
+++ b/src/components/entries/UnifiedEntriesContent.tsx
@@ -23,7 +23,7 @@ import { SuspendingEntryList } from "./SuspendingEntryList";
 import { EntryListFallback } from "./EntryListFallback";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { NotFoundCard } from "@/components/ui";
-import { useEntryUrlState } from "@/lib/hooks/useEntryUrlState";
+import { useOpenEntry } from "@/lib/hooks/useOpenEntry";
 import { useUrlViewPreferences } from "@/lib/hooks/useUrlViewPreferences";
 import { useEntriesListInput } from "@/lib/hooks/useEntriesListInput";
 import { type ViewType } from "@/lib/hooks/viewPreferences";
@@ -284,7 +284,7 @@ function TitleFallback({ routeInfo }: { routeInfo: RouteInfo }) {
 function UnifiedEntriesContentInner() {
   const routeInfo = useRouteInfo();
   const { showUnreadOnly } = useUrlViewPreferences();
-  const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
+  const { openEntryId, openEntry, closeEntry } = useOpenEntry();
 
   // Get query input based on current URL - shared with SuspendingEntryList
   const queryInput = useEntriesListInput();
@@ -385,13 +385,13 @@ function UnifiedEntriesContentInner() {
   // Navigation callbacks - just update URL, React re-renders
   const handleSwipeNext = useMemo(() => {
     if (!nextEntryId) return undefined;
-    return () => setOpenEntryId(nextEntryId);
-  }, [nextEntryId, setOpenEntryId]);
+    return () => openEntry(nextEntryId);
+  }, [nextEntryId, openEntry]);
 
   const handleSwipePrevious = useMemo(() => {
     if (!previousEntryId) return undefined;
-    return () => setOpenEntryId(previousEntryId);
-  }, [previousEntryId, setOpenEntryId]);
+    return () => openEntry(previousEntryId);
+  }, [previousEntryId, openEntry]);
 
   // Show error if subscription query completed but subscription not found
   if (routeInfo.subscriptionId && !subscriptionQuery.isLoading && !subscriptionQuery.data) {

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -49,6 +49,7 @@ export {
   updateEntriesInListCache,
   updateEntriesInAffectedListCaches,
   updateEntryMetadataInCache,
+  findEntryInListCache,
   type EntryMetadataUpdate,
   type EntryContext,
   type AffectedScope,

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -14,6 +14,8 @@ export { useEntryMutations, type EntryType, type MarkAllReadOptions } from "./us
 
 export { useEntryUrlState } from "./useEntryUrlState";
 
+export { useOpenEntry } from "./useOpenEntry";
+
 export { useExpandedTags } from "./useExpandedTags";
 
 export { type EntryListData } from "./types";

--- a/src/lib/hooks/useOpenEntry.ts
+++ b/src/lib/hooks/useOpenEntry.ts
@@ -1,0 +1,83 @@
+/**
+ * useOpenEntry Hook
+ *
+ * Wraps useEntryUrlState with pre-emptive mark-read mutation for auto-mark-read.
+ * When opening an unread entry, fires the markRead mutation BEFORE updating the URL,
+ * so the optimistic update takes effect before the entry component even mounts.
+ *
+ * This eliminates the flash where entries briefly show as unread.
+ */
+
+"use client";
+
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEntryUrlState, type UseEntryUrlStateResult } from "./useEntryUrlState";
+import { useEntryMutations } from "./useEntryMutations";
+import { findEntryInListCache } from "@/lib/cache/entry-cache";
+
+export interface UseOpenEntryResult extends UseEntryUrlStateResult {
+  /**
+   * Open an entry, firing the mark-read mutation before navigation.
+   * This is the preferred way to open entries - use this instead of setOpenEntryId
+   * when opening an entry should mark it as read.
+   */
+  openEntry: (entryId: string) => void;
+}
+
+/**
+ * Hook for opening entries with pre-emptive mark-read mutations.
+ *
+ * When an entry is opened, this hook:
+ * 1. Checks if the entry is currently unread (from cache)
+ * 2. If unread, fires the markRead mutation (with optimistic update)
+ * 3. Updates the URL to show the entry
+ *
+ * By firing the mutation before updating the URL, the optimistic update takes
+ * effect before EntryContent/EntryContentFallback mount, eliminating the flash
+ * where entries briefly show as unread.
+ *
+ * Since we fire the mutation here, EntryContent's auto-mark-read effect will
+ * see the entry as already read and skip firing a duplicate mutation.
+ *
+ * @example
+ * ```tsx
+ * const { openEntryId, openEntry, closeEntry } = useOpenEntry();
+ *
+ * // Open an entry (fires mutation, then updates URL)
+ * openEntry("123");
+ *
+ * // For navigation between already-open entries, openEntry handles it
+ * openEntry("456");
+ * ```
+ */
+export function useOpenEntry(): UseOpenEntryResult {
+  const urlState = useEntryUrlState();
+  const queryClient = useQueryClient();
+  const { markRead } = useEntryMutations();
+
+  const openEntry = useCallback(
+    (entryId: string) => {
+      // Check if the entry is currently unread in the cache
+      // We look in the list cache since that's what EntryContentFallback uses
+      const cachedEntry = findEntryInListCache(queryClient, entryId);
+
+      // If entry is unread, fire the markRead mutation
+      // The mutation's onMutate will optimistically update the cache immediately,
+      // and onError will roll back if the server request fails
+      if (cachedEntry && !cachedEntry.read) {
+        markRead([entryId], true);
+      }
+
+      // Update the URL - the optimistic update has already happened synchronously
+      // in markRead's onMutate, so EntryContentFallback will see read=true
+      urlState.setOpenEntryId(entryId);
+    },
+    [queryClient, markRead, urlState]
+  );
+
+  return {
+    ...urlState,
+    openEntry,
+  };
+}


### PR DESCRIPTION
## Summary

- Introduces `useOpenEntry` hook that fires `markRead()` mutation **before** updating the URL
- The mutation's `onMutate` runs synchronously, updating the cache immediately
- When `EntryContent` mounts, the fallback and inner component both see `read=true` from the first render
- `EntryContent`'s auto-mark-read effect sees the entry is already read and skips firing a duplicate mutation
- Error handling works correctly since full mutation machinery is used (`onError` rolls back on failure)

## Problem

When opening an unread entry (clicking from list, swiping, keyboard navigation), users briefly saw the entry as unread before it switched to read. The flash happened because:

1. `setOpenEntryId(entryId)` updated the URL
2. `EntryContentFallback` rendered with cached unread state from the list
3. `EntryContentInner`'s `useEffect` fired `markRead()`
4. Optimistic update changed the cache to `read=true`
5. Components re-rendered showing read state

## Solution

The `useOpenEntry` hook wraps `useEntryUrlState` and fires the mutation before navigation:

```typescript
const openEntry = useCallback((entryId: string) => {
  const cachedEntry = findEntryInListCache(queryClient, entryId);
  if (cachedEntry && !cachedEntry.read) {
    markRead([entryId], true);  // Optimistic update happens synchronously
  }
  urlState.setOpenEntryId(entryId);  // Cache already updated
}, [queryClient, markRead, urlState]);
```

## Test plan

- [ ] Click an unread entry from the list - should show as read immediately (no flash)
- [ ] Swipe to next/previous unread entry - should show as read immediately
- [ ] Use keyboard (j/k then Enter) to navigate entries - should show as read immediately  
- [ ] Direct URL navigation (`/all?entry=123`) still works (existing auto-mark-read handles this)
- [ ] If server fails, entry should revert to unread (rollback works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)