### PR TITLE
Lock PWA to portrait orientation

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -7,6 +7,7 @@ export default function manifest(): MetadataRoute.Manifest {
     description: "A modern feed reader",
     start_url: "/",
     display: "standalone",
+    orientation: "portrait",
     background_color: "#ffffff",
     theme_color: "#f97316",
     icons: [


### PR DESCRIPTION
## Summary
- Adds `orientation: "portrait"` to the web app manifest to prevent auto-rotation
- This respects the user's system-wide rotation lock preference

## Test plan
- [ ] Install the PWA on a mobile device
- [ ] Verify the app stays in portrait mode when rotating the device

🤖 Generated with [Claude Code](https://claude.com/claude-code)