### PR TITLE
Fix read/unread button style to match other toggle buttons

### DIFF
--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -35,7 +35,6 @@ import {
   Button,
   StarIcon,
   StarFilledIcon,
-  CircleIcon,
   CircleFilledIcon,
   ExternalLinkIcon,
   ArrowLeftIcon,
@@ -492,13 +491,13 @@ export function EntryContentBody({
 
           {/* Mark read/unread button */}
           <Button
-            variant="secondary"
+            variant={read ? "primary" : "secondary"}
             size="sm"
             onClick={onToggleRead}
             aria-label={read ? "Mark as unread" : "Mark as read"}
             title="Keyboard shortcut: m"
           >
-            {read ? <CircleIcon className="h-4 w-4" /> : <CircleFilledIcon className="h-4 w-4" />}
+            <CircleFilledIcon className="h-4 w-4" />
             <span className="ml-2">{read ? "Read" : "Unread"}</span>
           </Button>
 


### PR DESCRIPTION
## Summary
- Fixes the read/unread button on the entry content view to toggle its background color (primary/secondary variant) when clicked, matching the behavior of the star button and other toggle buttons
- Uses a single consistent `CircleFilledIcon` instead of swapping between `CircleIcon` and `CircleFilledIcon`, so the icon shape doesn't change — only the button background communicates the toggle state

Closes #479

## Test plan
- [ ] Open an entry and verify the read/unread button starts with a dark background (since entries are auto-marked read)
- [ ] Click the read/unread button and verify the background toggles to white (secondary variant)
- [ ] Verify the circle icon stays the same shape regardless of toggle state
- [ ] Compare with the star button and confirm the toggle behavior is now consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)