### PR TITLE
Fix PWA share target destroying app state on Android

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -10,6 +10,13 @@ export default function manifest(): MetadataRoute.Manifest {
     orientation: "portrait",
     background_color: "#ffffff",
     theme_color: "#f97316",
+    // When the PWA is launched (e.g., via share target), focus the existing window
+    // instead of navigating it. This prevents Android's share target from destroying
+    // the current app state. The service worker handles the shared data via fetch
+    // event and notifies the window via postMessage for the toast.
+    launch_handler: {
+      client_mode: ["focus-existing", "auto"],
+    },
     icons: [
       {
         src: "/android-chrome-192x192.png",
@@ -34,9 +41,10 @@ export default function manifest(): MetadataRoute.Manifest {
         purpose: "maskable",
       },
     ],
-    // Share Target API: allows other Android apps to share URLs and files to Lion Reader
-    // When a user shares content, the service worker intercepts the POST request,
-    // stores the data in IndexedDB, and redirects to /save which reads it
+    // Share Target API: allows other Android apps to share URLs and files to Lion Reader.
+    // With launch_handler focus-existing, the service worker intercepts the POST,
+    // saves URLs directly via API, and notifies the focused window via postMessage.
+    // Files are stored in IndexedDB and the window redirects to /save for processing.
     share_target: {
       action: "/api/share",
       method: "POST" as const,

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -7,12 +7,15 @@
  * 2. Offline fallback for navigation requests
  *
  * For URL shares, the service worker saves directly via the API without
- * showing any intermediate UI, then redirects back into the app. Open tabs
- * are notified via postMessage so the RealtimeProvider can show a toast.
+ * showing any intermediate UI. Open tabs are notified via postMessage so
+ * the RealtimeProvider can show a toast.
  *
- * This is important because Android's share target destroys the PWA's
- * current navigation state — there's no "back" to go to. Redirecting
- * to the app root restores the app so the user can continue.
+ * With launch_handler: focus-existing in the manifest, Chrome on Android
+ * focuses the existing PWA window instead of navigating it. The service
+ * worker's fetch handler still fires for the POST, and the postMessage
+ * reaches the focused window. When the app is NOT already open,
+ * focus-existing falls back to navigate-new, and the service worker
+ * redirects to the app root with query params for the toast.
  *
  * File shares still redirect to /save because they require more complex processing.
  *


### PR DESCRIPTION
## Summary

- Android's share target replaces the PWA's entire navigation stack, leaving the user on a dead-end result page with no way back to their previous state
- Instead of showing a static HTML result page, the service worker now redirects back into the app after saving the article
- Share result (success/error) is passed via query params and displayed as a toast by `RealtimeProvider`, then cleaned from the URL
- The service worker tries to find an existing app page URL to redirect to (preserving context if possible), falling back to `/`

## Test plan

- [ ] Share a URL to Lion Reader from another app on Android — should save and redirect back into the app with a toast
- [ ] Share a URL while already viewing an article in Lion Reader — should return to the app (ideally the same page) with a toast
- [ ] Share with an expired session — should redirect to `/save` for login flow (unchanged)
- [ ] Share a file — should redirect to `/save` for processing (unchanged)
- [ ] Verify toast shows article title on successful save
- [ ] Verify toast shows error message on failed save

🤖 Generated with [Claude Code](https://claude.com/claude-code)