### PR TITLE
SSR demo entry content for SEO

### DIFF
--- a/src/app/demo/DemoListSkeleton.tsx
+++ b/src/app/demo/DemoListSkeleton.tsx
@@ -1,0 +1,21 @@
+/**
+ * DemoListSkeleton Component
+ *
+ * Skeleton placeholder for demo list views, shared by DemoRouter (Suspense fallback)
+ * and DemoLayoutContent (SSR fallback before hydration).
+ */
+
+export function DemoListSkeleton() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
+      <div className="mb-4 sm:mb-6">
+        <div className="h-8 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+      </div>
+      <div className="space-y-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-24 animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-800" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -14,11 +14,13 @@ import Link from "next/link";
 import { ClientLink } from "@/components/ui";
 import { EntryArticle } from "@/components/entries/EntryArticle";
 import { DemoEntryList } from "./DemoEntryList";
+import { DemoListSkeleton } from "./DemoListSkeleton";
 import {
   DEMO_ENTRIES_SORTED,
   getDemoEntriesForSubscription,
   getDemoEntriesForTag,
   getDemoEntry,
+  getDemoEntryArticleProps,
   getDemoHighlightEntries,
   getDemoSubscription,
   getDemoTag,
@@ -85,13 +87,7 @@ function DemoRouterContent() {
   if (selectedEntry) {
     return (
       <EntryArticle
-        title={selectedEntry.title ?? "Untitled"}
-        url={selectedEntry.url}
-        source={selectedEntry.feedTitle ?? "Lion Reader"}
-        author={selectedEntry.author}
-        date={selectedEntry.publishedAt ?? selectedEntry.fetchedAt}
-        contentHtml={selectedEntry.contentHtml}
-        fallbackContent={selectedEntry.summary}
+        {...getDemoEntryArticleProps(selectedEntry)}
         backButton={
           <ClientLink
             href={backHref}
@@ -147,20 +143,7 @@ function DemoRouterContent() {
 
 export function DemoRouter() {
   return (
-    <Suspense
-      fallback={
-        <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
-          <div className="mb-4 sm:mb-6">
-            <div className="h-8 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-          </div>
-          <div className="space-y-4">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="h-24 animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-800" />
-            ))}
-          </div>
-        </div>
-      }
-    >
+    <Suspense fallback={<DemoListSkeleton />}>
       <DemoRouterContent />
     </Suspense>
   );

--- a/src/app/demo/all/page.tsx
+++ b/src/app/demo/all/page.tsx
@@ -1,11 +1,14 @@
 /**
  * /demo/all — All features demo page
  *
- * Route stub; content rendered by DemoRouter in the parent layout.
+ * Server component that renders EntryArticle with static demo data when
+ * ?entry= is present, enabling SSR of entry content for SEO. After
+ * hydration, DemoLayoutContent switches to DemoRouter for interactivity.
  */
 
 import { type Metadata } from "next";
-import { getDemoEntry } from "../data";
+import { EntryArticle } from "@/components/entries/EntryArticle";
+import { getDemoEntry, getDemoEntryArticleProps } from "../data";
 
 interface Props {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -20,6 +23,12 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
   };
 }
 
-export default function DemoAllPage() {
-  return null;
+export default async function DemoAllPage({ searchParams }: Props) {
+  const sp = await searchParams;
+  const entryId = typeof sp.entry === "string" ? sp.entry : undefined;
+  const entry = entryId ? getDemoEntry(entryId) : undefined;
+
+  if (!entry) return null;
+
+  return <EntryArticle {...getDemoEntryArticleProps(entry)} />;
 }

--- a/src/app/demo/data.ts
+++ b/src/app/demo/data.ts
@@ -5,6 +5,7 @@
  * structured as tags, subscriptions, and entries.
  */
 
+import { type EntryArticleProps } from "@/components/entries/EntryArticle";
 import { type EntryListData } from "@/lib/hooks";
 
 // ============================================================================
@@ -506,6 +507,24 @@ export function getDemoSubscription(subscriptionId: string): DemoSubscription | 
 /** Get entries that would appear in the "Highlights" view (starred entries) */
 export function getDemoHighlightEntries(): DemoEntry[] {
   return sortNewestFirst(DEMO_ENTRIES.filter((e) => e.starred));
+}
+
+/** Get EntryArticle props for a demo entry */
+export function getDemoEntryArticleProps(
+  entry: DemoEntry
+): Pick<
+  EntryArticleProps,
+  "title" | "url" | "source" | "author" | "date" | "contentHtml" | "fallbackContent"
+> {
+  return {
+    title: entry.title ?? "Untitled",
+    url: entry.url,
+    source: entry.feedTitle ?? "Lion Reader",
+    author: entry.author,
+    date: entry.publishedAt ?? entry.fetchedAt,
+    contentHtml: entry.contentHtml,
+    fallbackContent: entry.summary,
+  };
 }
 
 /** Total entry count */

--- a/src/app/demo/highlights/page.tsx
+++ b/src/app/demo/highlights/page.tsx
@@ -1,11 +1,14 @@
 /**
  * /demo/highlights — Highlights demo page
  *
- * Route stub; content rendered by DemoRouter in the parent layout.
+ * Server component that renders EntryArticle with static demo data when
+ * ?entry= is present, enabling SSR of entry content for SEO. After
+ * hydration, DemoLayoutContent switches to DemoRouter for interactivity.
  */
 
 import { type Metadata } from "next";
-import { getDemoEntry } from "../data";
+import { EntryArticle } from "@/components/entries/EntryArticle";
+import { getDemoEntry, getDemoEntryArticleProps } from "../data";
 
 interface Props {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -20,6 +23,12 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
   };
 }
 
-export default function DemoHighlightsPage() {
-  return null;
+export default async function DemoHighlightsPage({ searchParams }: Props) {
+  const sp = await searchParams;
+  const entryId = typeof sp.entry === "string" ? sp.entry : undefined;
+  const entry = entryId ? getDemoEntry(entryId) : undefined;
+
+  if (!entry) return null;
+
+  return <EntryArticle {...getDemoEntryArticleProps(entry)} />;
 }

--- a/src/app/demo/subscription/[id]/page.tsx
+++ b/src/app/demo/subscription/[id]/page.tsx
@@ -1,11 +1,14 @@
 /**
  * /demo/subscription/[id] — Subscription demo page
  *
- * Route stub with dynamic metadata; content rendered by DemoRouter in the parent layout.
+ * Server component that renders EntryArticle with static demo data when
+ * ?entry= is present, enabling SSR of entry content for SEO. After
+ * hydration, DemoLayoutContent switches to DemoRouter for interactivity.
  */
 
 import { type Metadata } from "next";
-import { getDemoEntry, getDemoSubscription } from "../../data";
+import { EntryArticle } from "@/components/entries/EntryArticle";
+import { getDemoEntry, getDemoEntryArticleProps, getDemoSubscription } from "../../data";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -25,6 +28,12 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   };
 }
 
-export default function DemoSubscriptionPage() {
-  return null;
+export default async function DemoSubscriptionPage({ searchParams }: Props) {
+  const sp = await searchParams;
+  const entryId = typeof sp.entry === "string" ? sp.entry : undefined;
+  const entry = entryId ? getDemoEntry(entryId) : undefined;
+
+  if (!entry) return null;
+
+  return <EntryArticle {...getDemoEntryArticleProps(entry)} />;
 }

--- a/src/app/demo/tag/[id]/page.tsx
+++ b/src/app/demo/tag/[id]/page.tsx
@@ -1,11 +1,14 @@
 /**
  * /demo/tag/[id] — Tag demo page
  *
- * Route stub with dynamic metadata; content rendered by DemoRouter in the parent layout.
+ * Server component that renders EntryArticle with static demo data when
+ * ?entry= is present, enabling SSR of entry content for SEO. After
+ * hydration, DemoLayoutContent switches to DemoRouter for interactivity.
  */
 
 import { type Metadata } from "next";
-import { getDemoEntry, getDemoTag } from "../../data";
+import { EntryArticle } from "@/components/entries/EntryArticle";
+import { getDemoEntry, getDemoEntryArticleProps, getDemoTag } from "../../data";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -25,6 +28,12 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   };
 }
 
-export default function DemoTagPage() {
-  return null;
+export default async function DemoTagPage({ searchParams }: Props) {
+  const sp = await searchParams;
+  const entryId = typeof sp.entry === "string" ? sp.entry : undefined;
+  const entry = entryId ? getDemoEntry(entryId) : undefined;
+
+  if (!entry) return null;
+
+  return <EntryArticle {...getDemoEntryArticleProps(entry)} />;
 }


### PR DESCRIPTION
## Summary

- Demo pages previously rendered entry content entirely client-side via `DemoRouter`'s `useSearchParams()` inside a `<Suspense>` boundary, so search engines only saw the skeleton fallback
- Since all demo data is static (hardcoded in `data.ts`), entry content can be server-rendered directly in each `page.tsx`
- `DemoLayoutContent` now uses hydration-based switching via `useSyncExternalStore`: shows the SSR children (with full article content) initially, then swaps to `DemoRouter` after hydration for full client-side interactivity

## Changes

- **`data.ts`**: Add `getDemoEntryArticleProps()` shared helper that maps `DemoEntry` to `EntryArticle` props
- **`DemoListSkeleton.tsx`** (new): Extract skeleton markup from `DemoRouter`'s Suspense fallback into a shared component
- **`DemoRouter.tsx`**: Use shared helper and extracted skeleton component
- **`DemoLayoutContent.tsx`**: Replace `<DemoRouter />` + hidden `{children}` with hydration-based switching (`useSyncExternalStore`)
- **`all/page.tsx`, `highlights/page.tsx`, `subscription/[id]/page.tsx`, `tag/[id]/page.tsx`**: Render `<EntryArticle>` with static demo data when `?entry=` is present

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] Visit `/demo/all?entry=welcome` and view page source — entry content should be in the HTML
- [ ] Visit `/demo/all` (no entry) — should show skeleton in source, then list after JS loads
- [ ] Client-side navigation between entries still works (click entry, back button)
- [ ] All demo routes work: `/demo/subscription/feed-types?entry=rss-atom`, `/demo/tag/features`, `/demo/highlights`

🤖 Generated with [Claude Code](https://claude.com/claude-code)