### PR TITLE
Add keyboard and swipe navigation to demo

### DIFF
--- a/src/app/demo/DemoEntryList.tsx
+++ b/src/app/demo/DemoEntryList.tsx
@@ -27,9 +27,10 @@ const STATIC_QUERY_STATE: ExternalQueryState = {
 interface DemoEntryListProps {
   entries: DemoEntry[];
   backHref: string;
+  selectedEntryId?: string | null;
 }
 
-export function DemoEntryList({ entries, backHref }: DemoEntryListProps) {
+export function DemoEntryList({ entries, backHref, selectedEntryId }: DemoEntryListProps) {
   const demoState = useDemoState();
 
   const handleToggleRead = useCallback(
@@ -50,6 +51,7 @@ export function DemoEntryList({ entries, backHref }: DemoEntryListProps) {
     <EntryList
       externalEntries={entries}
       externalQueryState={STATIC_QUERY_STATE}
+      selectedEntryId={selectedEntryId}
       onEntryClick={(id) => {
         clientPush(`${backHref}?entry=${id}`);
       }}


### PR DESCRIPTION
## Summary

- Wires up the existing `useKeyboardShortcuts` hook in the demo page to support j/k keyboard navigation, o/Enter to open entries, Escape to close, s to star, m to toggle read, and u to toggle unread filter
- Adds swipe gesture handling (left/right) for navigating between entries in the detail view, using the same `SWIPE_CONFIG` thresholds as the real app
- Passes `selectedEntryId` through to `EntryList` for visual highlighting of the keyboard-selected entry

Closes #491

## Test plan

- [ ] Open the demo page, press j/k to navigate the entry list — selected entry should be highlighted
- [ ] Press o or Enter to open the selected entry
- [ ] While viewing an entry, press j/k to navigate to next/previous entry
- [ ] Press Escape to return to the list
- [ ] Press s to star/unstar the selected entry in the list
- [ ] Press u to toggle the unread-only filter
- [ ] On a touch device, swipe left/right while viewing an entry to navigate between entries
- [ ] Verify the demo still works normally with mouse/click navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)