### PR TITLE
Add AI summaries to demo with Summarize button

### DIFF
--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -11,18 +11,20 @@
 
 "use client";
 
-import { useMemo, useEffect, useCallback, useRef, Suspense } from "react";
+import { useMemo, useEffect, useCallback, useRef, useState, Suspense } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import {
   ClientLink,
   Button,
+  SparklesIcon,
   StarIcon,
   StarFilledIcon,
   CircleIcon,
   CircleFilledIcon,
 } from "@/components/ui";
 import { EntryArticle } from "@/components/entries/EntryArticle";
+import { SummaryCard } from "@/components/summarization/SummaryCard";
 import { SWIPE_CONFIG } from "@/components/entries/EntryContentHelpers";
 import { SortToggle } from "@/components/entries/SortToggle";
 import { UnreadToggle } from "@/components/entries/UnreadToggle";
@@ -47,6 +49,7 @@ function DemoRouterContent() {
   const searchParams = useSearchParams();
   const entryId = searchParams.get("entry");
   const demoState = useDemoState();
+  const [showSummaryForEntry, setShowSummaryForEntry] = useState<string | null>(null);
 
   // Parse the pathname to determine the current view
   const subscriptionMatch = pathname.match(/^\/demo\/subscription\/([^/]+)/);
@@ -305,25 +308,59 @@ function DemoRouterContent() {
               )}
               <span className="ml-2">{selectedEntry.read ? "Read" : "Unread"}</span>
             </Button>
+
+            {/* Summarize button */}
+            <Button
+              variant={showSummaryForEntry === selectedEntry.id ? "primary" : "secondary"}
+              size="sm"
+              onClick={() =>
+                setShowSummaryForEntry(
+                  showSummaryForEntry === selectedEntry.id ? null : selectedEntry.id
+                )
+              }
+              className={
+                showSummaryForEntry === selectedEntry.id
+                  ? "bg-blue-500 text-white hover:bg-blue-600 dark:bg-blue-500 dark:text-white dark:hover:bg-blue-600"
+                  : ""
+              }
+              aria-label={
+                showSummaryForEntry === selectedEntry.id ? "Hide summary" : "Show AI summary"
+              }
+            >
+              <SparklesIcon className="h-4 w-4" />
+              <span className="ml-2">
+                {showSummaryForEntry === selectedEntry.id ? "Hide Summary" : "Summarize"}
+              </span>
+            </Button>
           </div>
         }
         beforeContent={
-          selectedEntry.id === "welcome" ? (
-            <div className="mb-6 flex flex-col items-center gap-4 rounded-lg border border-zinc-200 bg-white p-6 sm:flex-row sm:justify-center dark:border-zinc-800 dark:bg-zinc-900">
-              <Link
-                href="/register"
-                className="ui-text-base inline-flex h-12 w-full items-center justify-center rounded-md bg-zinc-900 px-6 font-medium text-white transition-colors hover:bg-zinc-800 sm:w-auto dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-              >
-                Get started
-              </Link>
-              <Link
-                href="/login"
-                className="ui-text-base inline-flex h-12 w-full items-center justify-center rounded-md border border-zinc-300 bg-white px-6 font-medium text-zinc-900 transition-colors hover:bg-zinc-50 sm:w-auto dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800"
-              >
-                Sign in
-              </Link>
-            </div>
-          ) : undefined
+          <>
+            {showSummaryForEntry === selectedEntry.id && (
+              <SummaryCard
+                summary={selectedEntry.summaryHtml}
+                modelId="claude-sonnet-4-5-20250929"
+                generatedAt={new Date("2026-02-07")}
+                onClose={() => setShowSummaryForEntry(null)}
+              />
+            )}
+            {selectedEntry.id === "welcome" && (
+              <div className="mb-6 flex flex-col items-center gap-4 rounded-lg border border-zinc-200 bg-white p-6 sm:flex-row sm:justify-center dark:border-zinc-800 dark:bg-zinc-900">
+                <Link
+                  href="/register"
+                  className="ui-text-base inline-flex h-12 w-full items-center justify-center rounded-md bg-zinc-900 px-6 font-medium text-white transition-colors hover:bg-zinc-800 sm:w-auto dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                >
+                  Get started
+                </Link>
+                <Link
+                  href="/login"
+                  className="ui-text-base inline-flex h-12 w-full items-center justify-center rounded-md border border-zinc-300 bg-white px-6 font-medium text-zinc-900 transition-colors hover:bg-zinc-50 sm:w-auto dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800"
+                >
+                  Sign in
+                </Link>
+              </div>
+            )}
+          </>
         }
       />
     );

--- a/src/app/demo/articles/ai-summaries.ts
+++ b/src/app/demo/articles/ai-summaries.ts
@@ -10,6 +10,15 @@ const article: DemoArticle = {
   summary: "Generate concise AI summaries to quickly triage your reading list.",
   publishedAt: new Date("2026-01-16T12:00:00Z"),
   starred: false,
+  summaryHtml: `<p>Lion Reader&#39;s AI summarization feature helps you triage unread articles by generating concise overviews only when requested. <strong>Key features:</strong></p>
+<ul>
+<li><strong>Privacy-first approach</strong>: Summaries are generated on-demand when you click &quot;Summarize,&quot; not automatically, avoiding unnecessary API costs and data sharing</li>
+<li><strong>2-3 paragraph overviews</strong> powered by Anthropic Claude that highlight main topics, key findings, and conclusions</li>
+<li><strong>Intelligent caching</strong>: Summaries are cached by content hash and shared across users, providing instant results for previously summarized articles</li>
+<li><strong>Configurable models</strong>: Choose between quality and speed based on your preferences</li>
+<li><strong>Full content support</strong>: Works with both feed excerpts and full-fetched articles, ensuring complete context</li>
+</ul>
+<p>Particularly useful for working through large backlogs—scan summaries to identify must-reads versus skippable content, then focus your attention on what matters most.</p>`,
   contentHtml: `
     <h2>AI Summaries</h2>
 

--- a/src/app/demo/articles/appearance.ts
+++ b/src/app/demo/articles/appearance.ts
@@ -10,6 +10,15 @@ const article: DemoArticle = {
   summary: "Customize fonts, text size, alignment, and switch between light and dark themes.",
   publishedAt: new Date("2025-12-28T12:00:00Z"),
   starred: false,
+  summaryHtml: `<p>Lion Reader provides comprehensive customization options to create your ideal reading environment. <strong>Dark mode</strong> fully integrates with system preferences or manual toggle using next-themes.</p>
+<p><strong>Typography controls</strong> include:</p>
+<ul>
+<li>Multiple font families (System, Merriweather, Literata, Inter, Source Sans)</li>
+<li>Text size options from small to extra-large with responsive scaling</li>
+<li>Choice between left-aligned or justified text alignment</li>
+</ul>
+<p>All settings save locally and apply instantly.</p>
+<p>As a <strong>Progressive Web App</strong>, Lion Reader can be installed on desktop or mobile devices for a native app-like experience, with portrait orientation lock on mobile for optimal reading comfort.</p>`,
   contentHtml: `
     <h2>Appearance &amp; Themes</h2>
 

--- a/src/app/demo/articles/auth-security.ts
+++ b/src/app/demo/articles/auth-security.ts
@@ -10,6 +10,11 @@ const article: DemoArticle = {
   summary: "Sign in with email, Google, Apple, or Discord. API tokens for extensions and MCP.",
   publishedAt: new Date("2025-12-26T11:00:00Z"),
   starred: false,
+  summaryHtml: `<p>Lion Reader offers multiple authentication methods including email/password (with Argon2 hashing), Google OAuth, Apple Sign-In, and Discord OAuth. All OAuth providers are optional per deployment.</p>
+<p><strong>Session Management:</strong> Sessions use SHA-256 hashed tokens with Redis caching, active session tracking showing device/IP/timestamp, and instant revocation capabilities.</p>
+<p><strong>API Tokens:</strong> Connect external tools with scoped permissions, expiration dates, and usage tracking—ideal for browser extensions, MCP server, or Discord bot integration.</p>
+<p><strong>Security Features:</strong> Rate limiting via Redis, per-domain feed fetching throttling, HMAC webhook verification, XSS content sanitization, and optional invite-only mode.</p>
+<p><strong>Privacy:</strong> Subscription-based entry visibility (only see content fetched after subscribing), starred entries remain visible after unsubscribing, soft deletes preserve read state, and no tracking or data sharing with third parties.</p>`,
   contentHtml: `
     <h2>Authentication &amp; Security</h2>
 

--- a/src/app/demo/articles/email-newsletters.ts
+++ b/src/app/demo/articles/email-newsletters.ts
@@ -10,6 +10,23 @@ const article: DemoArticle = {
   summary: "Read newsletters alongside your feeds with unique ingest email addresses.",
   publishedAt: new Date("2025-12-30T12:00:00Z"),
   starred: false,
+  summaryHtml: `<p>Lion Reader solves the problem of email-only content by allowing users to <strong>create unique ingest email addresses</strong> (up to 5 per account) for subscribing to newsletters. Each newsletter sender automatically becomes a separate subscription in your feed reader.</p>
+<p><strong>Key features:</strong></p>
+<ul>
+<li>Subscribe to any email newsletter using generated addresses</li>
+<li>Newsletters are processed via Mailgun webhook integration and appear as regular feed entries</li>
+<li>Full feature parity with RSS feeds: starring, read/unread status, search, and tagging</li>
+<li>Label addresses for organization (e.g., &quot;Tech Newsletters&quot;)</li>
+</ul>
+<p><strong>Security measures:</strong></p>
+<ul>
+<li>HMAC signature verification ensures email authenticity</li>
+<li>Message-ID deduplication prevents duplicates</li>
+<li>Provider-level spam filtering</li>
+<li>Ability to block specific senders</li>
+<li>Supports List-Unsubscribe headers for one-click unsubscribe</li>
+</ul>
+<p>Email newsletters are treated as first-class subscriptions, unifying email and web content in a single timeline.</p>`,
   contentHtml: `
     <h2>Email Newsletters: Bring Inbox Content to Your Feed Reader</h2>
 

--- a/src/app/demo/articles/full-content.ts
+++ b/src/app/demo/articles/full-content.ts
@@ -10,6 +10,17 @@ const article: DemoArticle = {
   summary: "Read complete articles inside Lion Reader, even when feeds only provide excerpts.",
   publishedAt: new Date("2026-01-15T12:00:00Z"),
   starred: false,
+  summaryHtml: `<p><strong>Lion Reader</strong> automatically fetches full article content from RSS feeds that only provide excerpts, eliminating the need to switch between your feed reader and a web browser.</p>
+<p><strong>Key features:</strong></p>
+<ul>
+<li><strong>On-demand fetching</strong>: Get complete articles with a single button press</li>
+<li><strong>Mozilla Readability</strong>: Uses Firefox Reader View&#39;s algorithm to extract clean article text while removing ads and navigation clutter</li>
+<li><strong>Flexible options</strong>: Enable automatic full-content fetching per subscription or toggle manually as needed</li>
+<li><strong>Content preservation</strong>: Maintains images, code blocks, formatting, and document structure</li>
+<li><strong>Markdown support</strong>: Converts Markdown to HTML using the marked library</li>
+<li><strong>Graceful fallback</strong>: Displays original feed content if extraction fails</li>
+</ul>
+<p>This keeps you in your reading flow without context switching, helping you stay focused on the content that matters.</p>`,
   contentHtml: `
     <h2>Full Content Fetching</h2>
 

--- a/src/app/demo/articles/json-feed.ts
+++ b/src/app/demo/articles/json-feed.ts
@@ -11,6 +11,15 @@ const article: DemoArticle = {
     "Native support for JSON Feed, a modern syndication format that uses JSON instead of XML.",
   publishedAt: new Date("2025-12-26T14:00:00Z"),
   starred: false,
+  summaryHtml: `<p><strong>JSON Feed</strong> is a modern syndication format that uses JSON instead of XML, making feed creation and parsing significantly simpler. Launched in 2017 as an alternative to RSS and Atom, it was designed with contemporary web development practices in mind.</p>
+<p><strong>Key advantages:</strong></p>
+<ul>
+<li><strong>Developer-friendly</strong>: No complex XML parsing libraries needed—just use built-in JSON encoders/decoders</li>
+<li><strong>Feature-complete</strong>: Supports attachments, multiple authors, tags, HTML and plain text content, and custom extensions</li>
+<li><strong>Reduced complexity</strong>: Eliminates XML&#39;s verbose schemas and namespace handling</li>
+</ul>
+<p><strong>For Lion Reader users</strong>, JSON Feed works seamlessly alongside RSS and Atom—the app auto-detects and treats all formats equally. Simply paste any URL to subscribe.</p>
+<p><strong>For publishers</strong>, generating a JSON Feed is straightforward using any language&#39;s native JSON support, reducing bugs and making syndication more reliable.</p>`,
   contentHtml: `
     <h2>JSON Feed: Syndication for the Modern Web</h2>
 

--- a/src/app/demo/articles/keyboard-shortcuts.ts
+++ b/src/app/demo/articles/keyboard-shortcuts.ts
@@ -10,6 +10,11 @@ const article: DemoArticle = {
   summary: "Navigate your entire reading workflow without touching the mouse.",
   publishedAt: new Date("2025-12-27T14:00:00Z"),
   starred: false,
+  summaryHtml: `<p>Lion Reader offers comprehensive keyboard navigation inspired by Vim, enabling fast, mouse-free reading workflows.</p>
+<p><strong>List Navigation:</strong> Use <code>j</code>/<code>k</code> to move down/up through entries, <code>Enter</code> to open, <code>n</code>/<code>p</code> to jump between articles, and <code>Escape</code> to close.</p>
+<p><strong>Entry Actions:</strong> Press <code>m</code> to mark read/unread, <code>s</code> to star/unstar, and <code>v</code> to open the original URL in a new tab.</p>
+<p><strong>Section Navigation:</strong> Two-key combinations starting with <code>g</code> jump between major sections: <code>g+a</code> for All Items, <code>g+s</code> for Starred, <code>g+l</code> for Saved articles.</p>
+<p><strong>Smart Design:</strong> Shortcuts automatically disable when typing in search fields or text inputs, preventing accidental navigation. Touch devices feature 44px minimum touch targets following WCAG accessibility guidelines, ensuring the interface works seamlessly with both keyboard and touch input methods.</p>`,
   contentHtml: `
     <h2>Keyboard Shortcuts</h2>
 

--- a/src/app/demo/articles/mcp-server.ts
+++ b/src/app/demo/articles/mcp-server.ts
@@ -10,6 +10,14 @@ const article: DemoArticle = {
   summary: "Connect Lion Reader to AI assistants like Claude via the Model Context Protocol.",
   publishedAt: new Date("2026-01-14T12:00:00Z"),
   starred: false,
+  summaryHtml: `<p>The <strong>Model Context Protocol (MCP)</strong> is an open standard that enables AI assistants like Claude to connect directly to applications and data sources. Lion Reader&#39;s MCP server provides secure, local access to your feed reader data without sending information to external servers.</p>
+<p>The server offers comprehensive tools including:</p>
+<ul>
+<li><strong>Entry management</strong>: list, search, read, star, and count entries</li>
+<li><strong>Article saving</strong>: save URLs or upload Markdown content for later reading</li>
+<li><strong>Subscription management</strong>: list, search, and view subscription details</li>
+</ul>
+<p>Built with the official MCP TypeScript SDK, the server uses the same services layer as the web UI, ensuring consistent behavior across interfaces. Access is secured through API tokens with configurable scoped permissions, compatible with Claude Desktop and other MCP-supporting assistants.</p>`,
   contentHtml: `
     <h2>What is MCP?</h2>
 

--- a/src/app/demo/articles/open-source.ts
+++ b/src/app/demo/articles/open-source.ts
@@ -11,6 +11,18 @@ const article: DemoArticle = {
     "Lion Reader is fully open source. Self-host it, explore the code, or contribute on GitHub.",
   publishedAt: new Date("2025-12-26T10:00:00Z"),
   starred: false,
+  summaryHtml: `<p><strong>Lion Reader</strong> is a fully open source, self-hostable RSS reader where you own your data completely. Built with a modern tech stack including Next.js 16, React 19, and tRPC for type-safe APIs, it uses PostgreSQL with Drizzle ORM and Redis for caching and real-time updates.</p>
+<p><strong>Key features:</strong></p>
+<ul>
+<li>Custom authentication with OAuth support (Google, Apple, Discord)</li>
+<li>AI-powered summaries via Anthropic SDK and Groq for narration</li>
+<li>Stateless architecture enabling horizontal scaling</li>
+<li>Efficient feed sharing across users with privacy boundaries</li>
+<li>Background job queue for reliable feed fetching</li>
+<li>Cursor-based pagination using UUIDv7</li>
+<li>Real-time updates via Server-Sent Events</li>
+</ul>
+<p>Deployed on Fly.io with Docker Compose for local development. The codebase emphasizes type safety, no vendor lock-in, and maintainability. Contributions welcome on GitHub.</p>`,
   contentHtml: `
     <h2>Open Source &amp; Self-Hostable</h2>
 

--- a/src/app/demo/articles/opml.ts
+++ b/src/app/demo/articles/opml.ts
@@ -11,6 +11,24 @@ const article: DemoArticle = {
     "Migrate to or from Lion Reader with standard OPML files, or back up your subscriptions.",
   publishedAt: new Date("2025-12-28T14:00:00Z"),
   starred: false,
+  summaryHtml: `<p>Lion Reader supports OPML (Outline Processor Markup Language) for seamless subscription portability between feed readers.</p>
+<p><strong>Import Features:</strong></p>
+<ul>
+<li>Upload OPML files from any reader (Feedly, Inoreader, NetNewsWire, etc.)</li>
+<li>Background processing with real-time progress via Server-Sent Events</li>
+<li>Automatic feed validation and active status checking</li>
+<li>Preserves folder/tag structure from original reader</li>
+<li>Smart duplicate detection to skip existing subscriptions</li>
+<li>Detailed per-feed status reports (success, skipped, errors)</li>
+<li>Includes dedicated Feedbin migration support</li>
+</ul>
+<p><strong>Export Features:</strong></p>
+<ul>
+<li>One-click OPML 2.0 export of all subscriptions</li>
+<li>Includes custom titles and complete tag/folder hierarchy</li>
+<li>Compatible with any OPML-supporting reader</li>
+<li>Ideal for backups, migrations, or sharing curated lists</li>
+</ul>`,
   contentHtml: `
     <h2>Portable Subscriptions</h2>
 

--- a/src/app/demo/articles/pwa.ts
+++ b/src/app/demo/articles/pwa.ts
@@ -10,6 +10,17 @@ const article: DemoArticle = {
   summary: "Install Lion Reader on your phone or desktop for a native app-like experience.",
   publishedAt: new Date("2026-01-08T12:00:00Z"),
   starred: false,
+  summaryHtml: `<p><strong>Lion Reader is a Progressive Web App (PWA)</strong> that can be installed on any device—desktop or mobile—without app stores, providing a native app-like experience.</p>
+<p><strong>Key features:</strong></p>
+<ul>
+<li><p><strong>Share target integration</strong>: Install on your phone to save articles directly from any app&#39;s native share menu. It accepts not just URLs, but also PDFs, Markdown, and Word files.</p>
+</li>
+<li><p><strong>Mobile optimizations</strong>: Portrait orientation lock for distraction-free reading and push notifications for new entries.</p>
+</li>
+<li><p><strong>Single codebase</strong>: Updates deploy simultaneously across all platforms without app store reviews. Features and fixes ship instantly to web, desktop, and mobile.</p>
+</li>
+</ul>
+<p>Lion Reader functions as a universal inbox for anything you want to read later, combining native app convenience with web flexibility.</p>`,
   contentHtml: `
     <h2>Install Anywhere</h2>
 

--- a/src/app/demo/articles/real-time.ts
+++ b/src/app/demo/articles/real-time.ts
@@ -10,6 +10,14 @@ const article: DemoArticle = {
   summary: "See new entries appear instantly with Server-Sent Events and smart cache invalidation.",
   publishedAt: new Date("2025-12-28T16:00:00Z"),
   starred: false,
+  summaryHtml: `<p>Lion Reader uses <strong>Server-Sent Events (SSE)</strong> with Redis pub/sub for real-time updates without polling. When feed workers fetch new content, they publish to Redis channels that browsers listen to via open SSE connections.</p>
+<p><strong>Channel architecture:</strong></p>
+<ul>
+<li><strong>Per-feed channels</strong> — Each feed has its own channel; connections only subscribe to feeds you follow</li>
+<li><strong>Per-user channels</strong> — Account-level events like subscription changes sync across devices</li>
+</ul>
+<p><strong>Event types</strong> include new entries, content updates, subscription changes, and OPML import progress.</p>
+<p>When events arrive, Lion Reader triggers <strong>targeted React Query cache invalidations</strong> for automatic UI updates. Optimistic updates make actions like starring feel instant. The system includes heartbeat keepalives for reliability and gracefully degrades to timestamp-based sync if Redis fails. Adding new subscriptions dynamically updates your SSE channel subscriptions without reconnecting.</p>`,
   contentHtml: `
     <h2>Server-Sent Events Architecture</h2>
 

--- a/src/app/demo/articles/rss-atom.ts
+++ b/src/app/demo/articles/rss-atom.ts
@@ -10,6 +10,11 @@ const article: DemoArticle = {
   summary: "Subscribe to any RSS 2.0 or Atom feed with automatic detection and efficient polling.",
   publishedAt: new Date("2025-12-26T12:00:00Z"),
   starred: false,
+  summaryHtml: `<p>Lion Reader provides comprehensive RSS/Atom feed support with intelligent fetching and efficient parsing:</p>
+<p><strong>Feed Format Support</strong>: Compatible with RSS 2.0, Atom 1.0, and JSON Feed. Automatically discovers feeds by checking HTML link tags and common paths like /feed, /rss, and /atom.xml.</p>
+<p><strong>Smart Polling</strong>: Uses HTTP conditional requests (ETag, If-Modified-Since headers) to minimize bandwidth, receiving 304 Not Modified responses when content is unchanged. Respects Cache-Control headers while maintaining 1-minute to 7-day polling bounds.</p>
+<p><strong>Error Resilience</strong>: Intelligently handles redirects—tracking 301 permanent redirects and updating URLs after 3 confirmations, while following temporary redirects without changing stored URLs. Applies exponential backoff (max 7 days) for failed fetches.</p>
+<p><strong>Performance</strong>: Leverages fast-xml-parser in SAX streaming mode for memory-efficient parsing of feeds of any size.</p>`,
   contentHtml: `
     <h2>Modern Syndication with RSS &amp; Atom</h2>
 

--- a/src/app/demo/articles/save-for-later.ts
+++ b/src/app/demo/articles/save-for-later.ts
@@ -10,6 +10,18 @@ const article: DemoArticle = {
   summary: "Save any web page, upload documents, or capture articles for later reading.",
   publishedAt: new Date("2025-12-27T16:00:00Z"),
   starred: false,
+  summaryHtml: `<p><strong>Lion Reader&#39;s Save for Later</strong> feature captures web pages, documents, and articles for distraction-free reading using Mozilla&#39;s Readability algorithm to extract clean content.</p>
+<p><strong>Multiple saving methods:</strong></p>
+<ul>
+<li>Browser bookmarklet for one-click saving</li>
+<li>PWA share target for mobile devices</li>
+<li>MCP integration with AI assistants</li>
+<li>tRPC API for automation</li>
+<li>Discord bot commands</li>
+<li>Direct file uploads (PDFs, Markdown, Word docs)</li>
+<li>Google Docs import with OAuth</li>
+</ul>
+<p><strong>Organization features:</strong><br>Customize metadata (title, description, author) when saving. Saved articles integrate fully with Lion Reader—star, tag, search, and browse chronologically. Content is preserved permanently, preventing link rot common with traditional bookmarks. All saved items appear in a dedicated sidebar section while remaining part of your complete reading archive.</p>`,
   contentHtml: `
     <h2>Save for Later: Your Personal Reading Archive</h2>
 

--- a/src/app/demo/articles/scoring.ts
+++ b/src/app/demo/articles/scoring.ts
@@ -11,6 +11,28 @@ const article: DemoArticle = {
     "Rate articles and get personalized score predictions powered by on-device machine learning.",
   publishedAt: new Date("2026-01-20T12:00:00Z"),
   starred: false,
+  summaryHtml: `<p><strong>Lion Reader</strong> uses a hybrid approach to learn your reading preferences and recommend content:</p>
+<p><strong>Explicit Ratings</strong></p>
+<ul>
+<li>Rate articles on a 5-point scale (−2 to +2) using LessWrong-style voting controls</li>
+<li>Directly shapes your preference profile</li>
+</ul>
+<p><strong>Implicit Signals</strong></p>
+<ul>
+<li>Starring entries: +2 (strong interest)</li>
+<li>Marking unread: +1 (moderate interest)</li>
+<li>Marking read without opening: −1 (low interest)</li>
+</ul>
+<p><strong>On-Device ML Model</strong></p>
+<ul>
+<li>Trains locally after you&#39;ve rated 20+ entries</li>
+<li>Uses TF-IDF vectorization with Ridge Regression</li>
+<li>Titles weighted 2x; includes per-feed features to capture source-level trust</li>
+<li>Runs entirely in-browser via ONNX Runtime WebAssembly</li>
+<li>Complete privacy—no data leaves your device</li>
+<li>Automatically scores new entries with confidence indicators</li>
+<li>Cross-validated for prediction quality (MAE and Pearson correlation)</li>
+</ul>`,
   contentHtml: `
     <h2>Rate Your Reading</h2>
 

--- a/src/app/demo/articles/search.ts
+++ b/src/app/demo/articles/search.ts
@@ -10,6 +10,16 @@ const article: DemoArticle = {
   summary: "Search across all your entries by title, content, or both with instant results.",
   publishedAt: new Date("2025-12-28T10:00:00Z"),
   starred: false,
+  summaryHtml: `<p>Lion Reader&#39;s full-text search uses PostgreSQL with English language stemming to deliver fast, relevant results across your entire archive. You can search by title, content, or both, with configurable scope to narrow your focus.</p>
+<p><strong>Key Features:</strong></p>
+<ul>
+<li><strong>Flexible filtering</strong> — Combine search with subscription, tag, read/unread state, starred status, or entry type</li>
+<li><strong>Relevance ranking</strong> — Results ranked by PostgreSQL&#39;s ts_rank algorithm, prioritizing title matches over body text</li>
+<li><strong>High performance</strong> — Database-level full-text indexing ensures speed even with thousands of entries</li>
+<li><strong>Cursor-based pagination</strong> — Scroll through unlimited results without performance degradation</li>
+<li><strong>Universal availability</strong> — Search works in the web UI, tRPC API, and MCP server for AI assistant integrations</li>
+</ul>
+<p>The search makes it easy to find specific content within a newsletter, across saved articles, or just your starred items.</p>`,
   contentHtml: `
     <h2>Search Everything, Instantly</h2>
 

--- a/src/app/demo/articles/tags.ts
+++ b/src/app/demo/articles/tags.ts
@@ -10,6 +10,21 @@ const article: DemoArticle = {
   summary: "Organize subscriptions with color-coded tags and browse entries by category.",
   publishedAt: new Date("2025-12-27T10:00:00Z"),
   starred: false,
+  summaryHtml: `<p><strong>Lion Reader</strong> provides flexible organization tools for managing subscriptions across RSS feeds, email newsletters, and saved articles:</p>
+<p><strong>Tagging System:</strong></p>
+<ul>
+<li>Create custom tags with names and colors using a hex color picker</li>
+<li>Tags are many-to-many—each subscription can belong to multiple categories</li>
+<li>Browse entries filtered by tag with real-time unread counts in the sidebar</li>
+<li>Uncategorized subscriptions remain accessible in a dedicated section</li>
+</ul>
+<p><strong>Subscription Management:</strong></p>
+<ul>
+<li>Rename any subscription to your preferred title, overriding the original feed name</li>
+<li>Soft deletion preserves your read and starred history when unsubscribing</li>
+<li>Resubscribing later restores your complete reading history</li>
+</ul>
+<p>The system provides real-time updates across all features, ensuring unread counts and tag organization stay current as you read and as new content arrives.</p>`,
   contentHtml: `
     <h2>Organize Your Way</h2>
 

--- a/src/app/demo/articles/text-to-speech.ts
+++ b/src/app/demo/articles/text-to-speech.ts
@@ -11,6 +11,26 @@ const article: DemoArticle = {
     "Listen to articles read aloud with AI-enhanced text preprocessing and paragraph highlighting.",
   publishedAt: new Date("2025-12-27T18:00:00Z"),
   starred: false,
+  summaryHtml: `<p>Lion Reader converts articles into natural-sounding audio through a two-stage process:</p>
+<p><strong>Stage 1: AI Text Preprocessing</strong></p>
+<ul>
+<li>Article content is processed by an LLM (Llama 3.1 via Groq) to optimize for speech</li>
+<li>Expands abbreviations, converts URLs to readable phrases, and formats lists/tables naturally</li>
+<li>Maintains paragraph-level mapping for synchronized highlighting</li>
+<li>Results are cached by content hash to avoid reprocessing</li>
+</ul>
+<p><strong>Stage 2: Audio Synthesis</strong></p>
+<ul>
+<li><strong>Web Speech API</strong>: Instant narration using browser&#39;s built-in voices (free)</li>
+<li><strong>Piper TTS</strong>: Higher-quality neural voices running locally via WebAssembly (no server costs)</li>
+</ul>
+<p><strong>Features</strong></p>
+<ul>
+<li>Synchronized paragraph highlighting and auto-scrolling</li>
+<li>Playback speed control and paragraph-level navigation</li>
+<li>Media session integration for lock screen controls</li>
+<li>Graceful fallback to plain text if AI service is unavailable</li>
+</ul>`,
   contentHtml: `
     <h2>Text-to-Speech Narration</h2>
 

--- a/src/app/demo/articles/types.ts
+++ b/src/app/demo/articles/types.ts
@@ -15,4 +15,6 @@ export interface DemoArticle {
   publishedAt: Date;
   starred: boolean;
   contentHtml: string;
+  /** Pre-generated AI summary HTML (from Claude Sonnet) for the demo summary card */
+  summaryHtml: string;
 }

--- a/src/app/demo/articles/websub.ts
+++ b/src/app/demo/articles/websub.ts
@@ -10,6 +10,15 @@ const article: DemoArticle = {
   summary: "Receive instant updates from feeds that support the W3C WebSub push protocol.",
   publishedAt: new Date("2025-12-27T10:00:00Z"),
   starred: false,
+  summaryHtml: `<p><strong>WebSub</strong> is a W3C standard that enables real-time content delivery by pushing updates directly to subscribers instead of requiring repeated polling. When you subscribe to a compatible feed, Lion Reader automatically detects the WebSub hub URL, subscribes via a verification handshake, and receives instant notifications when new content is published.</p>
+<p><strong>Key benefits:</strong></p>
+<ul>
+<li><strong>Near-instant delivery</strong> — content arrives in seconds</li>
+<li><strong>Reduced server load</strong> — fewer requests for both readers and publishers</li>
+<li><strong>Lower bandwidth usage</strong> — no repeated fetching of unchanged feeds</li>
+<li><strong>Better user experience</strong> — immediate updates for time-sensitive content</li>
+</ul>
+<p>Lion Reader handles WebSub detection, subscription, renewal, and error handling automatically. For feeds without WebSub support, the app seamlessly falls back to traditional polling.</p>`,
   contentHtml: `
     <h2>What is WebSub?</h2>
 

--- a/src/app/demo/articles/welcome.ts
+++ b/src/app/demo/articles/welcome.ts
@@ -10,6 +10,17 @@ const article: DemoArticle = {
   summary: "A modern, fast, and open-source feed reader. Explore the demo to see what it can do.",
   publishedAt: new Date(),
   starred: true,
+  summaryHtml: `<p>Lion Reader is a modern, self-hostable RSS feed reader that consolidates content from RSS/Atom/JSON feeds, email newsletters, and saved articles into a unified interface.</p>
+<p><strong>Key capabilities:</strong></p>
+<ul>
+<li><strong>AI-powered features</strong> — Claude-powered summaries, text-to-speech narration, and on-device ML predictions for article relevance</li>
+<li><strong>MCP integration</strong> — Connect AI assistants like Claude Desktop to search and manage your feeds via the Model Context Protocol</li>
+<li><strong>Keyboard-first navigation</strong> — Complete control without using a mouse</li>
+<li><strong>Real-time updates</strong> — Instant content delivery via Server-Sent Events</li>
+<li><strong>Progressive Web App</strong> — Install on desktop or mobile for native app experience</li>
+<li><strong>Privacy-focused</strong> — Open source and self-hostable with no tracking or ads</li>
+</ul>
+<p>The demo showcases feed types, reading experience features, organization tools, and integration capabilities. Users can sign up for the hosted version or self-host their own instance.</p>`,
   contentHtml: `
     <h2>Welcome to Lion Reader</h2>
 

--- a/src/app/demo/data.ts
+++ b/src/app/demo/data.ts
@@ -33,6 +33,8 @@ export interface DemoSubscription {
 export interface DemoEntry extends EntryListData {
   /** Pre-sanitized HTML content for the detail view */
   contentHtml: string;
+  /** Pre-generated AI summary HTML for the summary card */
+  summaryHtml: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- **Pre-generated AI summaries** for all 20 demo articles using the real summarization prompt (Claude Sonnet), converted from Markdown to HTML with `marked` (same as production pipeline)
- **Summarize button** added to the demo entry detail view, matching the production app's blue-highlighted toggle
- **SummaryCard** displays above article content with model attribution ("Claude Sonnet 4.5"), generated date, and close/collapse controls

Closes #489

## Test plan
- [ ] Visit `/demo` and open any article
- [ ] Click the "Summarize" button — verify the AI Summary card appears above the content
- [ ] Verify the summary content is well-formatted HTML with bullet points, bold text, etc.
- [ ] Click "Hide Summary" — verify the card disappears and button returns to default state
- [ ] Click the close (X) button on the summary card — verify it dismisses
- [ ] Click the collapse/expand chevron — verify the card collapses and expands
- [ ] Navigate between articles — verify summary state resets appropriately
- [ ] Verify the Welcome article still shows both the CTA and summary card when both are active
- [ ] Test in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)