### PR TITLE
Fix SpinnerIcon not animating when custom className is passed

### DIFF
--- a/src/components/entries/EntryListStates.tsx
+++ b/src/components/entries/EntryListStates.tsx
@@ -61,7 +61,7 @@ export function EntryListError({ message, onRetry }: EntryListErrorProps) {
 export function EntryListLoadingMore({ label = "Loading more..." }: { label?: string }) {
   return (
     <div className="flex items-center justify-center py-4" role="status" aria-label={label}>
-      <SpinnerIcon className="h-5 w-5 animate-spin text-zinc-500" />
+      <SpinnerIcon className="h-5 w-5 text-zinc-500" />
       <span className="sr-only">{label}</span>
     </div>
   );

--- a/src/components/ui/icon-button.tsx
+++ b/src/components/ui/icon-button.tsx
@@ -202,9 +202,9 @@ export function StarFilledIcon({ className = "h-4 w-4" }: IconProps) {
 /**
  * Loading spinner icon (animated)
  */
-export function SpinnerIcon({ className = "h-4 w-4 animate-spin" }: IconProps) {
+export function SpinnerIcon({ className = "h-4 w-4" }: IconProps) {
   return (
-    <svg className={className} fill="none" viewBox="0 0 24 24">
+    <svg className={`animate-spin ${className}`} fill="none" viewBox="0 0 24 24">
       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
       <path
         className="opacity-75"


### PR DESCRIPTION
## Summary
- Fixes #478 - The summarizing button (and other SpinnerIcon usages) were not animating because `animate-spin` was only in the default `className` parameter
- When callers passed a custom `className` (e.g., `"h-4 w-4"` or `"h-5 w-5 text-zinc-500"`), it overrode the default entirely, losing the spin animation
- Moved `animate-spin` into the SVG element itself so it always applies, regardless of the `className` prop

## Test plan
- [ ] Verify the Summarize button spinner animates while generating a summary
- [ ] Verify the full content fetch spinner animates while fetching
- [ ] Verify OAuth sign-in button spinners animate during loading
- [ ] Verify OPML import/export spinners animate during operations
- [ ] Verify narration loading spinner animates

🤖 Generated with [Claude Code](https://claude.com/claude-code)