### PR TITLE
Link demo article titles to their source PRs (#487)

### DIFF
--- a/src/app/demo/articles/ai-summaries.ts
+++ b/src/app/demo/articles/ai-summaries.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "ai-summaries",
   subscriptionId: "reading-experience",
   type: "web",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/298",
   title: "AI Summaries",
   author: null,
   summary: "Generate concise AI summaries to quickly triage your reading list.",

--- a/src/app/demo/articles/appearance.ts
+++ b/src/app/demo/articles/appearance.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "appearance",
   subscriptionId: "reading-experience",
   type: "web",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/304",
   title: "Appearance & Themes",
   author: null,
   summary: "Customize fonts, text size, alignment, and switch between light and dark themes.",

--- a/src/app/demo/articles/email-newsletters.ts
+++ b/src/app/demo/articles/email-newsletters.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "email-newsletters",
   subscriptionId: "feed-types",
   type: "email",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/47",
   title: "Email Newsletters",
   author: null,
   summary: "Read newsletters alongside your feeds with unique ingest email addresses.",

--- a/src/app/demo/articles/full-content.ts
+++ b/src/app/demo/articles/full-content.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "full-content",
   subscriptionId: "reading-experience",
   type: "web",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/287",
   title: "Full Content Fetching",
   author: null,
   summary: "Read complete articles inside Lion Reader, even when feeds only provide excerpts.",

--- a/src/app/demo/articles/json-feed.ts
+++ b/src/app/demo/articles/json-feed.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "json-feed",
   subscriptionId: "feed-types",
   type: "web",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/188",
   title: "JSON Feed Support",
   author: null,
   summary:

--- a/src/app/demo/articles/keyboard-shortcuts.ts
+++ b/src/app/demo/articles/keyboard-shortcuts.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "keyboard-shortcuts",
   subscriptionId: "reading-experience",
   type: "web",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/68",
   title: "Keyboard Shortcuts",
   author: null,
   summary: "Navigate your entire reading workflow without touching the mouse.",

--- a/src/app/demo/articles/mcp-server.ts
+++ b/src/app/demo/articles/mcp-server.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "mcp-server",
   subscriptionId: "integrations",
   type: "web",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/285",
   title: "MCP Server",
   author: null,
   summary: "Connect Lion Reader to AI assistants like Claude via the Model Context Protocol.",

--- a/src/app/demo/articles/opml.ts
+++ b/src/app/demo/articles/opml.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "opml",
   subscriptionId: "organization",
   type: "web",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/74",
   title: "OPML Import & Export",
   author: null,
   summary:

--- a/src/app/demo/articles/pwa.ts
+++ b/src/app/demo/articles/pwa.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "pwa",
   subscriptionId: "integrations",
   type: "web",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/413",
   title: "Progressive Web App",
   author: null,
   summary: "Install Lion Reader on your phone or desktop for a native app-like experience.",

--- a/src/app/demo/articles/save-for-later.ts
+++ b/src/app/demo/articles/save-for-later.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "save-for-later",
   subscriptionId: "feed-types",
   type: "saved",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/57",
   title: "Save for Later",
   author: null,
   summary: "Save any web page, upload documents, or capture articles for later reading.",

--- a/src/app/demo/articles/scoring.ts
+++ b/src/app/demo/articles/scoring.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "scoring",
   subscriptionId: "organization",
   type: "web",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/450",
   title: "Entry Scoring & Recommendations",
   author: null,
   summary:

--- a/src/app/demo/articles/tags.ts
+++ b/src/app/demo/articles/tags.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "tags",
   subscriptionId: "organization",
   type: "web",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/92",
   title: "Tags & Folders",
   author: null,
   summary: "Organize subscriptions with color-coded tags and browse entries by category.",

--- a/src/app/demo/articles/text-to-speech.ts
+++ b/src/app/demo/articles/text-to-speech.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "text-to-speech",
   subscriptionId: "reading-experience",
   type: "web",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/15",
   title: "Text-to-Speech Narration",
   author: null,
   summary:

--- a/src/app/demo/articles/websub.ts
+++ b/src/app/demo/articles/websub.ts
@@ -4,7 +4,7 @@ const article: DemoArticle = {
   id: "websub",
   subscriptionId: "integrations",
   type: "web",
-  url: null,
+  url: "https://github.com/brendanlong/lion-reader/pull/271",
   title: "WebSub Push Notifications",
   author: null,
   summary: "Receive instant updates from feeds that support the W3C WebSub push protocol.",


### PR DESCRIPTION
## Summary
- Set the `url` field on 14 demo articles to point to the GitHub PR that introduced each feature
- Article titles in the demo now become clickable links to the implementation history
- Articles without a clear single source PR (RSS/Atom, Search, Real-Time, Welcome, Auth) remain unlinked

Closes #487

## Test plan
- [ ] Visit the demo page and verify article titles are now clickable links
- [ ] Verify links open the correct GitHub PR for each article
- [ ] Verify articles without URLs (RSS/Atom, Search, Real-Time, Welcome, Auth) still render as plain headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)