### PR TITLE
Add proper OpenGraph metadata to demo pages

### DIFF
--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -125,7 +125,7 @@ function DemoRouterContent() {
   // Keep document.title in sync during client-side navigation
   useEffect(() => {
     const title = selectedEntry?.title ?? pageTitle;
-    document.title = `${title} - Lion Reader Demo`;
+    document.title = `${title} - Lion Reader`;
   }, [selectedEntry, pageTitle]);
 
   // Build the back-to-list href (pathname without query params)

--- a/src/app/demo/all/page.tsx
+++ b/src/app/demo/all/page.tsx
@@ -18,8 +18,14 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
   const sp = await searchParams;
   const entryId = typeof sp.entry === "string" ? sp.entry : undefined;
   const entry = entryId ? getDemoEntry(entryId) : undefined;
+  const title = entry?.title ? `${entry.title} - Lion Reader` : "All Features - Lion Reader";
+  const description =
+    entry?.summary ??
+    "Explore all of Lion Reader's features: feed support, reading experience, organization, and integrations.";
   return {
-    title: entry?.title ? `${entry.title} - Lion Reader Demo` : "All Features - Lion Reader Demo",
+    title,
+    description,
+    openGraph: { title, description },
   };
 }
 

--- a/src/app/demo/data.ts
+++ b/src/app/demo/data.ts
@@ -20,6 +20,7 @@ export interface DemoTag {
   id: string;
   name: string;
   color: string;
+  description: string;
   subscriptionIds: string[];
 }
 
@@ -27,6 +28,7 @@ export interface DemoSubscription {
   id: string;
   title: string;
   tagId: string;
+  description: string;
   entryCount: number;
 }
 
@@ -46,12 +48,15 @@ export const DEMO_TAGS: DemoTag[] = [
     id: "about",
     name: "About",
     color: "#10b981",
+    description: "Learn about Lion Reader — a modern, open-source feed reader you can self-host.",
     subscriptionIds: ["lion-reader"],
   },
   {
     id: "features",
     name: "Features",
     color: "#3b82f6",
+    description:
+      "Explore Lion Reader's features: feed support, reading tools, organization, and integrations.",
     subscriptionIds: ["feed-types", "reading-experience", "organization", "integrations"],
   },
 ];
@@ -60,12 +65,35 @@ export const DEMO_TAGS: DemoTag[] = [
 // Subscription config (title + tag mapping)
 // ============================================================================
 
-const SUBSCRIPTION_CONFIG: Record<string, { title: string; tagId: string }> = {
-  "feed-types": { title: "Feed Types", tagId: "features" },
-  "reading-experience": { title: "Reading Experience", tagId: "features" },
-  organization: { title: "Organization & Search", tagId: "features" },
-  integrations: { title: "Integrations & Sync", tagId: "features" },
-  "lion-reader": { title: "Lion Reader", tagId: "about" },
+const SUBSCRIPTION_CONFIG: Record<string, { title: string; tagId: string; description: string }> = {
+  "feed-types": {
+    title: "Feed Types",
+    tagId: "features",
+    description: "RSS, Atom, JSON Feed, email newsletters, and saved articles — all in one place.",
+  },
+  "reading-experience": {
+    title: "Reading Experience",
+    tagId: "features",
+    description:
+      "Full content fetching, customizable themes, text-to-speech narration, AI summaries, and keyboard shortcuts.",
+  },
+  organization: {
+    title: "Organization & Search",
+    tagId: "features",
+    description:
+      "Tags, full-text search, ML-powered scoring, and OPML import/export for organizing your feeds.",
+  },
+  integrations: {
+    title: "Integrations & Sync",
+    tagId: "features",
+    description:
+      "MCP server for AI assistants, WebSub push, real-time updates, and installable PWA support.",
+  },
+  "lion-reader": {
+    title: "Lion Reader",
+    tagId: "about",
+    description: "A modern, fast, and open-source feed reader you can self-host.",
+  },
 };
 
 // ============================================================================
@@ -87,6 +115,7 @@ export const DEMO_SUBSCRIPTIONS: DemoSubscription[] = Object.entries(SUBSCRIPTIO
     id,
     title: config.title,
     tagId: config.tagId,
+    description: config.description,
     entryCount: entryCountBySubscription.get(id) ?? 0,
   })
 );

--- a/src/app/demo/highlights/page.tsx
+++ b/src/app/demo/highlights/page.tsx
@@ -18,8 +18,12 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
   const sp = await searchParams;
   const entryId = typeof sp.entry === "string" ? sp.entry : undefined;
   const entry = entryId ? getDemoEntry(entryId) : undefined;
+  const title = entry?.title ? `${entry.title} - Lion Reader` : "Highlights - Lion Reader";
+  const description = entry?.summary ?? "Starred and highlighted articles in Lion Reader.";
   return {
-    title: entry?.title ? `${entry.title} - Lion Reader Demo` : "Highlights - Lion Reader Demo",
+    title,
+    description,
+    openGraph: { title, description },
   };
 }
 

--- a/src/app/demo/layout.tsx
+++ b/src/app/demo/layout.tsx
@@ -10,9 +10,8 @@ import { type Metadata } from "next";
 import { DemoLayoutContent } from "./DemoLayoutContent";
 
 export const metadata: Metadata = {
-  title: "Lion Reader Demo",
-  description:
-    "Explore Lion Reader's features with this interactive demo. A modern, fast, and open-source feed reader.",
+  title: "Lion Reader",
+  description: "A modern, fast, and open-source feed reader you can self-host.",
 };
 
 export default function DemoLayout({ children }: { children: ReactNode }) {

--- a/src/app/demo/subscription/[id]/page.tsx
+++ b/src/app/demo/subscription/[id]/page.tsx
@@ -21,10 +21,14 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   const entryId = typeof sp.entry === "string" ? sp.entry : undefined;
   const entry = entryId ? getDemoEntry(entryId) : undefined;
   const subscription = getDemoSubscription(id);
+  const title = entry?.title
+    ? `${entry.title} - Lion Reader`
+    : `${subscription?.title ?? "Subscription"} - Lion Reader`;
+  const description = entry?.summary ?? subscription?.description;
   return {
-    title: entry?.title
-      ? `${entry.title} - Lion Reader Demo`
-      : `${subscription?.title ?? "Subscription"} - Lion Reader Demo`,
+    title,
+    description,
+    openGraph: { title, description },
   };
 }
 

--- a/src/app/demo/tag/[id]/page.tsx
+++ b/src/app/demo/tag/[id]/page.tsx
@@ -21,10 +21,14 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   const entryId = typeof sp.entry === "string" ? sp.entry : undefined;
   const entry = entryId ? getDemoEntry(entryId) : undefined;
   const tag = getDemoTag(id);
+  const title = entry?.title
+    ? `${entry.title} - Lion Reader`
+    : `${tag?.name ?? "Tag"} - Lion Reader`;
+  const description = entry?.summary ?? tag?.description;
   return {
-    title: entry?.title
-      ? `${entry.title} - Lion Reader Demo`
-      : `${tag?.name ?? "Tag"} - Lion Reader Demo`,
+    title,
+    description,
+    openGraph: { title, description },
   };
 }
 


### PR DESCRIPTION
## Summary
- Set explicit `openGraph` title and description in `generateMetadata` to fix ampersand encoding in titles like "Authentication & Security" showing as `&amp;` in OG tags
- Change title suffix from "Lion Reader Demo" to "Lion Reader" (both server-rendered metadata and client-side `document.title`)
- Use each article's `summary` field as the OG description when viewing an entry
- Add per-subscription and per-tag descriptions for list pages (e.g. "RSS, Atom, JSON Feed, email newsletters, and saved articles — all in one place." for the Feed Types subscription)

## Test plan
- [ ] Visit `/demo/tag/about?entry=auth-security` and verify OG tags show "Authentication & Security - Lion Reader" (no `&amp;`)
- [ ] Verify browser tab title shows "Authentication & Security - Lion Reader" (not "Lion Reader Demo")
- [ ] Check OG description for an entry page uses the article summary
- [ ] Check OG description for a list page (e.g. `/demo/all`) uses the list description
- [ ] Verify client-side navigation updates `document.title` with "- Lion Reader" suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)