### PR TITLE
Hide author when it matches feed name

### DIFF
--- a/src/components/entries/EntryArticle.tsx
+++ b/src/components/entries/EntryArticle.tsx
@@ -116,7 +116,7 @@ export function EntryArticle({
             {/* Meta row: Source, Author, Date */}
             <div className="ui-text-xs sm:ui-text-sm flex flex-wrap items-center gap-x-3 gap-y-1 text-zinc-600 sm:gap-x-4 sm:gap-y-2 dark:text-zinc-400">
               <span className="font-medium">{source}</span>
-              {author && (
+              {author && author.toLowerCase().trim() !== source.toLowerCase().trim() && (
                 <>
                   <span
                     aria-hidden="true"

--- a/src/components/entries/EntryContentFallback.tsx
+++ b/src/components/entries/EntryContentFallback.tsx
@@ -135,18 +135,19 @@ export function EntryContentFallback({ entryId, onBack }: EntryContentFallbackPr
               {/* Meta row: Source, Author, Date */}
               <div className="ui-text-xs sm:ui-text-sm flex flex-wrap items-center gap-x-3 gap-y-1 text-zinc-600 sm:gap-x-4 sm:gap-y-2 dark:text-zinc-400">
                 <span className="font-medium">{source}</span>
-                {cachedEntry.author && (
-                  <>
-                    <span
-                      aria-hidden="true"
-                      className="hidden text-zinc-400 sm:inline dark:text-zinc-600"
-                    >
-                      |
-                    </span>
-                    <span className="hidden sm:inline">by {cachedEntry.author}</span>
-                    <span className="sm:hidden">- {cachedEntry.author}</span>
-                  </>
-                )}
+                {cachedEntry.author &&
+                  cachedEntry.author.toLowerCase().trim() !== source.toLowerCase().trim() && (
+                    <>
+                      <span
+                        aria-hidden="true"
+                        className="hidden text-zinc-400 sm:inline dark:text-zinc-600"
+                      >
+                        |
+                      </span>
+                      <span className="hidden sm:inline">by {cachedEntry.author}</span>
+                      <span className="sm:hidden">- {cachedEntry.author}</span>
+                    </>
+                  )}
                 <span
                   aria-hidden="true"
                   className="hidden text-zinc-400 sm:inline dark:text-zinc-600"


### PR DESCRIPTION
## Summary
- Hide the author in the entry detail view and its suspense fallback when the author name matches the feed/source name (case-insensitive comparison)
- Prevents redundant display like "Hacker News | by Hacker News | 2h ago"

## Changes
- `EntryArticle.tsx`: Skip rendering author when it equals the source name
- `EntryContentFallback.tsx`: Same logic for the suspense fallback view

## Test plan
- [ ] Open an entry where the author matches the feed name — author should be hidden
- [ ] Open an entry where the author differs from the feed name — author should still display
- [ ] Verify the fallback/loading state also hides the author correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)