### PR TITLE
Add browser extension demo article

### DIFF
--- a/src/app/demo/articles/browser-extension.ts
+++ b/src/app/demo/articles/browser-extension.ts
@@ -1,0 +1,57 @@
+import { type DemoArticle } from "./types";
+
+const article: DemoArticle = {
+  id: "browser-extension",
+  subscriptionId: "integrations",
+  type: "web",
+  url: "https://addons.mozilla.org/en-US/firefox/addon/lion-reader/",
+  title: "Browser Extension",
+  author: null,
+  summary:
+    "Save articles to Lion Reader with one click using the browser extension for Firefox and Chrome.",
+  publishedAt: new Date("2026-01-10T12:00:00Z"),
+  starred: false,
+  summaryHtml: `<p>The Lion Reader browser extension lets you save any web page for later reading with a single click, a keyboard shortcut, or the right-click context menu. Available for <strong>Firefox</strong> (published on AMO) and <strong>Chrome</strong> (coming soon), the extension automatically extracts article content using Mozilla Readability, stores an API token for future saves, and handles Google Docs with automatic OAuth.</p>`,
+  contentHtml: `
+    <h2>Save While You Browse</h2>
+
+    <p>The Lion Reader browser extension is the fastest way to save articles as you come across them. Instead of switching to the Lion Reader tab to paste a URL, just click the toolbar button and the article is saved immediately. The extension uses the same content extraction as the rest of Lion Reader &mdash; Mozilla&rsquo;s <a href="https://github.com/mozilla/readability" target="_blank" rel="noopener noreferrer">Readability algorithm</a> &mdash; so you get clean, distraction-free content every time.</p>
+
+    <h3>Three Ways to Save</h3>
+
+    <ul>
+      <li><strong>Toolbar button</strong> &mdash; Click the Lion Reader icon in your browser toolbar to save the current page</li>
+      <li><strong>Keyboard shortcut</strong> &mdash; Press <kbd>Ctrl+Shift+S</kbd> (or <kbd>Cmd+Shift+S</kbd> on Mac) for instant saving without reaching for the mouse</li>
+      <li><strong>Context menu</strong> &mdash; Right-click any page or link and select &ldquo;Save to Lion Reader&rdquo; to save it</li>
+    </ul>
+
+    <h3>How It Works</h3>
+
+    <p>The first time you save an article, the extension opens a tab to authenticate with your Lion Reader account. Once logged in, the article is saved and the extension receives a scoped API token for future saves. From then on, saving is instant &mdash; the extension calls the Lion Reader API directly without needing to open any tabs.</p>
+
+    <p>Saved articles appear in your <strong>Saved</strong> section in the sidebar, fully integrated with the rest of Lion Reader. You can star them, tag them, search across them, read them with text-to-speech, and generate AI summaries &mdash; everything you can do with RSS entries.</p>
+
+    <h3>Google Docs Support</h3>
+
+    <p>When you save a Google Docs URL, the extension detects it automatically and prompts for the necessary OAuth permissions. Once granted, Lion Reader fetches the document content directly from the Google Docs API, preserving formatting and structure far better than a regular web page save.</p>
+
+    <h3>Installation</h3>
+
+    <p>The extension is available for Firefox and Chrome:</p>
+
+    <ul>
+      <li><strong>Firefox</strong> &mdash; Install from <a href="https://addons.mozilla.org/en-US/firefox/addon/lion-reader/" target="_blank" rel="noopener noreferrer">Firefox Add-ons (AMO)</a></li>
+      <li><strong>Chrome</strong> &mdash; Coming soon to the Chrome Web Store. In the meantime, the extension can be loaded manually for development.</li>
+    </ul>
+
+    <h3>Self-Hosted Instances</h3>
+
+    <p>If you&rsquo;re running a self-hosted Lion Reader instance, the extension can be configured to point to your server. By default it connects to <code>lionreader.com</code>, but you can change the backend URL in the extension&rsquo;s settings to use <code>localhost:3000</code> or any other Lion Reader deployment.</p>
+
+    <h3>Other Ways to Save</h3>
+
+    <p>The browser extension is one of several ways to save articles in Lion Reader. You can also save via the <a href="/demo/all?entry=save-for-later">bookmarklet</a>, the <a href="/demo/all?entry=pwa">PWA share target</a> on mobile, the <a href="/demo/all?entry=discord-bot">Discord bot</a>, or the <a href="/demo/all?entry=mcp-server">MCP server</a> from AI assistants. All methods use the same underlying save service, so your saved articles end up in the same place regardless of how you captured them.</p>
+  `,
+};
+
+export default article;

--- a/src/app/demo/articles/index.ts
+++ b/src/app/demo/articles/index.ts
@@ -24,6 +24,7 @@ import opml from "./opml";
 // Integrations & Sync
 import mcpServer from "./mcp-server";
 import discordBot from "./discord-bot";
+import browserExtension from "./browser-extension";
 import plugins from "./plugins";
 import websub from "./websub";
 import pwa from "./pwa";
@@ -55,6 +56,7 @@ export const DEMO_ARTICLES: DemoArticle[] = [
   // Integrations & Sync
   mcpServer,
   discordBot,
+  browserExtension,
   plugins,
   websub,
   pwa,

--- a/src/app/demo/articles/save-for-later.ts
+++ b/src/app/demo/articles/save-for-later.ts
@@ -19,6 +19,7 @@ const article: DemoArticle = {
     <p>Lion Reader offers flexibility in how you capture content for later reading:</p>
 
     <ul>
+      <li><strong>Browser extension</strong> &mdash; Save from Firefox or Chrome with a click, keyboard shortcut, or context menu</li>
       <li><strong>Browser bookmarklet</strong> &mdash; One-click saving from any page while browsing</li>
       <li><strong>PWA share target</strong> &mdash; Use your phone&rsquo;s native share menu to send articles directly to Lion Reader</li>
       <li><strong>MCP integration</strong> &mdash; Save articles via AI assistants like Claude</li>


### PR DESCRIPTION
## Summary
- Adds a new demo article under **Integrations & Sync** covering the Lion Reader browser extension
- Documents toolbar button, keyboard shortcut (Ctrl+Shift+S), and context menu save methods
- Covers the auth flow, Google Docs support, self-hosted configuration, and links to the [Firefox AMO listing](https://addons.mozilla.org/en-US/firefox/addon/lion-reader/)
- Notes Chrome extension is coming soon
- Cross-links to related save methods (bookmarklet, PWA, Discord bot, MCP server)
- Updates the **Save for Later** article to mention the browser extension as a save method

## Test plan
- [ ] Visit /demo and navigate to Integrations & Sync subscription
- [ ] Verify the Browser Extension article appears and renders correctly
- [ ] Check cross-links to other demo articles work (Save for Later, PWA, Discord Bot, MCP Server)
- [ ] Verify the Save for Later article now lists browser extension as first save method
- [ ] Check the Firefox AMO link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)