### PR TITLE
Fix MCP server URL in integrations settings

### DIFF
--- a/src/components/settings/IntegrationsSettings.tsx
+++ b/src/components/settings/IntegrationsSettings.tsx
@@ -21,7 +21,7 @@ export function IntegrationsSettings() {
     );
   }, []);
 
-  const mcpUrl = `${baseUrl}/mcp`;
+  const mcpUrl = `${baseUrl}/api/mcp`;
 
   const claudeDesktopConfig = useMemo(() => {
     return JSON.stringify(


### PR DESCRIPTION
## Summary

- The integrations settings page was constructing the MCP URL as `${baseUrl}/mcp`, but the actual Next.js API route is at `src/app/api/mcp/route.ts`, meaning the correct URL is `${baseUrl}/api/mcp`
- This caused 404 errors when users followed the setup instructions for Claude Code, Claude.ai, or Claude Desktop

## Test plan

- [ ] Open Settings > Integrations and verify the displayed MCP URL ends in `/api/mcp`
- [ ] Verify the Claude Code command, Claude.ai instructions, and Claude Desktop config all use the correct URL
- [ ] Test connecting Claude Code with the corrected URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)