### PR TITLE
Refresh entry list when clicking the current sidebar link

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -57,12 +57,11 @@ export function Sidebar({ onClose }: SidebarProps) {
   });
 
   const handleNavigate = () => {
-    // Mark entry list queries as stale so they refetch when mounted
-    // Use refetchType: 'none' to avoid refetching the current (soon-to-be-unmounted) query
-    // The new view's query will refetch on mount because it's now stale
+    // Mark entry list queries as stale and refetch active ones.
+    // This ensures clicking the current page's link refreshes the list,
+    // while cross-page navigation also works (new query fetches on mount).
     queryClient.invalidateQueries({
       queryKey: [["entries", "list"]],
-      refetchType: "none",
     });
     onClose?.();
   };


### PR DESCRIPTION
## Summary
- Removes `refetchType: 'none'` from the sidebar's entry list cache invalidation so that clicking a sidebar link for the page you're already on triggers a refetch of the active query
- Previously, clicking "All" while already on "All" did nothing because the invalidation only marked queries stale without refetching active ones — cross-page navigation worked (new query fetches on mount) but same-page clicks were silently ignored

## Test plan
- [ ] Navigate to "All Items", then click "All Items" again — entry list should refresh
- [ ] Navigate between different sidebar links (All → Starred → Saved) — should still work as before
- [ ] Navigate to a tag or subscription, then click it again — should refresh
- [ ] Verify no double-fetching issues on cross-page navigation (network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)