### PR TITLE
Support per-user summarization settings

### DIFF
--- a/drizzle/0050_user_summary_settings.sql
+++ b/drizzle/0050_user_summary_settings.sql
@@ -1,0 +1,14 @@
+-- Add per-user summarization settings (max words and custom prompt)
+-- These override the server defaults (SUMMARIZATION_MAX_WORDS env var and built-in prompt)
+ALTER TABLE users ADD COLUMN summarization_max_words integer;
+ALTER TABLE users ADD COLUMN summarization_prompt text;
+
+-- Make entry_summaries per-user so different settings produce separate cached summaries
+ALTER TABLE entry_summaries ADD COLUMN user_id uuid REFERENCES users(id) ON DELETE CASCADE;
+
+-- Drop the old unique constraint on content_hash alone
+ALTER TABLE entry_summaries DROP CONSTRAINT entry_summaries_content_hash_key;
+
+-- Add a new unique constraint on (user_id, content_hash) for per-user caching
+-- user_id can be null for legacy summaries generated before this migration
+ALTER TABLE entry_summaries ADD CONSTRAINT entry_summaries_user_content_unique UNIQUE (user_id, content_hash);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1770508800000,
       "tag": "0049_user_api_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1770518800000,
+      "tag": "0050_user_summary_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.sql
+++ b/drizzle/schema.sql
@@ -95,7 +95,8 @@ CREATE TABLE public.entry_summaries (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     generated_at timestamp with time zone,
     error text,
-    error_at timestamp with time zone
+    error_at timestamp with time zone,
+    user_id uuid
 );
 
 CREATE TABLE public.feeds (
@@ -361,7 +362,12 @@ CREATE TABLE public.users (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     invite_id uuid,
-    show_spam boolean DEFAULT false NOT NULL
+    show_spam boolean DEFAULT false NOT NULL,
+    groq_api_key text,
+    anthropic_api_key text,
+    summarization_model text,
+    summarization_max_words integer,
+    summarization_prompt text
 );
 
 CREATE VIEW public.visible_entries AS
@@ -440,10 +446,10 @@ ALTER TABLE ONLY public.entry_score_predictions
     ADD CONSTRAINT entry_score_predictions_pkey PRIMARY KEY (user_id, entry_id);
 
 ALTER TABLE ONLY public.entry_summaries
-    ADD CONSTRAINT entry_summaries_content_hash_key UNIQUE (content_hash);
+    ADD CONSTRAINT entry_summaries_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY public.entry_summaries
-    ADD CONSTRAINT entry_summaries_pkey PRIMARY KEY (id);
+    ADD CONSTRAINT entry_summaries_user_content_unique UNIQUE (user_id, content_hash);
 
 ALTER TABLE ONLY public.feeds
     ADD CONSTRAINT feeds_pkey PRIMARY KEY (id);
@@ -691,6 +697,9 @@ ALTER TABLE ONLY public.entry_score_predictions
 
 ALTER TABLE ONLY public.entry_score_predictions
     ADD CONSTRAINT entry_score_predictions_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.entry_summaries
+    ADD CONSTRAINT entry_summaries_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY public.feeds
     ADD CONSTRAINT feeds_user_id_users_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -423,6 +423,8 @@ function SpamPreferenceSection() {
         hasGroqApiKey: old?.hasGroqApiKey ?? false,
         hasAnthropicApiKey: old?.hasAnthropicApiKey ?? false,
         summarizationModel: old?.summarizationModel ?? null,
+        summarizationMaxWords: old?.summarizationMaxWords ?? null,
+        summarizationPrompt: old?.summarizationPrompt ?? null,
       }));
 
       return { previousPrefs };

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -70,6 +70,8 @@ interface CachedSession {
   userGroqApiKey: string | null;
   userAnthropicApiKey: string | null;
   userSummarizationModel: string | null;
+  userSummarizationMaxWords: number | null;
+  userSummarizationPrompt: string | null;
 }
 
 // ============================================================================
@@ -207,6 +209,8 @@ function serializeForCache(data: SessionData): string {
     userGroqApiKey: data.user.groqApiKey ?? null,
     userAnthropicApiKey: data.user.anthropicApiKey ?? null,
     userSummarizationModel: data.user.summarizationModel ?? null,
+    userSummarizationMaxWords: data.user.summarizationMaxWords ?? null,
+    userSummarizationPrompt: data.user.summarizationPrompt ?? null,
   };
   return JSON.stringify(cached);
 }
@@ -240,6 +244,8 @@ function deserializeFromCache(data: string): SessionData {
       groqApiKey: cached.userGroqApiKey ?? null,
       anthropicApiKey: cached.userAnthropicApiKey ?? null,
       summarizationModel: cached.userSummarizationModel ?? null,
+      summarizationMaxWords: cached.userSummarizationMaxWords ?? null,
+      summarizationPrompt: cached.userSummarizationPrompt ?? null,
     },
   };
 }

--- a/src/server/trpc/routers/users.ts
+++ b/src/server/trpc/routers/users.ts
@@ -326,6 +326,8 @@ export const usersRouter = createTRPCRouter({
         hasGroqApiKey: z.boolean(),
         hasAnthropicApiKey: z.boolean(),
         summarizationModel: z.string().nullable(),
+        summarizationMaxWords: z.number().nullable(),
+        summarizationPrompt: z.string().nullable(),
       })
     )
     .query(async ({ ctx }) => {
@@ -337,6 +339,8 @@ export const usersRouter = createTRPCRouter({
         hasGroqApiKey: !!ctx.session.user.groqApiKey,
         hasAnthropicApiKey: !!ctx.session.user.anthropicApiKey,
         summarizationModel: ctx.session.user.summarizationModel,
+        summarizationMaxWords: ctx.session.user.summarizationMaxWords,
+        summarizationPrompt: ctx.session.user.summarizationPrompt,
       };
     }),
 
@@ -361,6 +365,9 @@ export const usersRouter = createTRPCRouter({
         groqApiKey: z.string().optional(),
         anthropicApiKey: z.string().optional(),
         summarizationModel: z.string().optional(),
+        // Summarization settings: null clears (reverts to default)
+        summarizationMaxWords: z.number().int().min(1).max(10000).nullable().optional(),
+        summarizationPrompt: z.string().max(10000).nullable().optional(),
       })
     )
     .output(
@@ -370,6 +377,8 @@ export const usersRouter = createTRPCRouter({
         hasGroqApiKey: z.boolean(),
         hasAnthropicApiKey: z.boolean(),
         summarizationModel: z.string().nullable(),
+        summarizationMaxWords: z.number().nullable(),
+        summarizationPrompt: z.string().nullable(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -391,6 +400,8 @@ export const usersRouter = createTRPCRouter({
         groqApiKey?: string | null;
         anthropicApiKey?: string | null;
         summarizationModel?: string | null;
+        summarizationMaxWords?: number | null;
+        summarizationPrompt?: string | null;
         updatedAt: Date;
       } = {
         updatedAt: new Date(),
@@ -415,6 +426,14 @@ export const usersRouter = createTRPCRouter({
         updateData.summarizationModel = input.summarizationModel || null;
       }
 
+      if (input.summarizationMaxWords !== undefined) {
+        updateData.summarizationMaxWords = input.summarizationMaxWords;
+      }
+
+      if (input.summarizationPrompt !== undefined) {
+        updateData.summarizationPrompt = input.summarizationPrompt;
+      }
+
       // Update user preferences in database
       await ctx.db.update(users).set(updateData).where(eq(users.id, userId));
 
@@ -428,6 +447,8 @@ export const usersRouter = createTRPCRouter({
           groqApiKey: users.groqApiKey,
           anthropicApiKey: users.anthropicApiKey,
           summarizationModel: users.summarizationModel,
+          summarizationMaxWords: users.summarizationMaxWords,
+          summarizationPrompt: users.summarizationPrompt,
         })
         .from(users)
         .where(eq(users.id, userId))
@@ -439,6 +460,8 @@ export const usersRouter = createTRPCRouter({
         hasGroqApiKey: !!updatedUser[0]?.groqApiKey,
         hasAnthropicApiKey: !!updatedUser[0]?.anthropicApiKey,
         summarizationModel: updatedUser[0]?.summarizationModel ?? null,
+        summarizationMaxWords: updatedUser[0]?.summarizationMaxWords ?? null,
+        summarizationPrompt: updatedUser[0]?.summarizationPrompt ?? null,
       };
     }),
 });

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -60,6 +60,8 @@ function createAuthContext(userId: string): Context {
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,
+        summarizationMaxWords: null,
+        summarizationPrompt: null,
         createdAt: now,
         updatedAt: now,
       },

--- a/tests/integration/feed-redirect.test.ts
+++ b/tests/integration/feed-redirect.test.ts
@@ -75,6 +75,8 @@ function createAuthContext(userId: string): Context {
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,
+        summarizationMaxWords: null,
+        summarizationPrompt: null,
         createdAt: now,
         updatedAt: now,
       },

--- a/tests/integration/opml-import.test.ts
+++ b/tests/integration/opml-import.test.ts
@@ -67,6 +67,8 @@ function createAuthContext(userId: string): Context {
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,
+        summarizationMaxWords: null,
+        summarizationPrompt: null,
         createdAt: now,
         updatedAt: now,
       },

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -69,6 +69,8 @@ function createAuthContext(userId: string): Context {
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,
+        summarizationMaxWords: null,
+        summarizationPrompt: null,
         createdAt: now,
         updatedAt: now,
       },

--- a/tests/integration/subscriptions.test.ts
+++ b/tests/integration/subscriptions.test.ts
@@ -62,6 +62,8 @@ function createAuthContext(userId: string): Context {
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,
+        summarizationMaxWords: null,
+        summarizationPrompt: null,
         createdAt: now,
         updatedAt: now,
       },

--- a/tests/integration/tags.test.ts
+++ b/tests/integration/tags.test.ts
@@ -70,6 +70,8 @@ function createAuthContext(userId: string): Context {
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,
+        summarizationMaxWords: null,
+        summarizationPrompt: null,
         createdAt: now,
         updatedAt: now,
       },


### PR DESCRIPTION
## Summary
- Adds user-level overrides for summary max words and custom prompt template (#516)
- Isolates summary cache per-user by adding `user_id` to `entry_summaries` table with `(user_id, content_hash)` unique constraint, so different user settings produce separate cached results
- Exposes max words and custom prompt controls in the Summaries settings UI, with template variable documentation (`{{content}}`, `{{title}}`, `{{maxWords}}`)

## Changes
- **Migration 0050**: Adds `summarization_max_words` and `summarization_prompt` to `users`, adds `user_id` to `entry_summaries` with per-user unique constraint
- **Summarization service**: Prompt is now a template with `{{content}}`, `{{title}}`, `{{maxWords}}` variables; accepts user-level max words and custom prompt
- **Session cache**: Propagates new user fields through Redis cache
- **Users API**: `me.preferences` and `me.updatePreferences` support new fields
- **Summarization API**: All `entry_summaries` queries scoped by `userId`; new `defaultPrompt` endpoint for frontend
- **Settings UI**: Max words input and custom prompt textarea with reset-to-default

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 279 integration tests pass (14 test files)
- [ ] Manual: verify max words setting persists and affects summary generation
- [ ] Manual: verify custom prompt with template variables works
- [ ] Manual: verify resetting to defaults works

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)