### PR TITLE
Fix summary regenerate button returning cached result

### DIFF
--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -243,6 +243,7 @@ function EntryContentInner({
     summarizationMutation.mutate({
       entryId,
       useFullContent: isShowingFullContent,
+      regenerate: true,
     });
   }, [summarizationMutation, entryId, isShowingFullContent]);
 

--- a/src/server/trpc/routers/summarization.ts
+++ b/src/server/trpc/routers/summarization.ts
@@ -53,6 +53,11 @@ const generateInputSchema = z.object({
    * - `undefined`/omitted: Return cached summary if available, otherwise summarize feed content
    */
   useFullContent: z.boolean().optional(),
+  /**
+   * When true, skip the cache and regenerate the summary even if one exists.
+   * Used when the user explicitly clicks "Regenerate" (e.g., after changing model/settings).
+   */
+  regenerate: z.boolean().optional(),
 });
 
 // ============================================================================
@@ -254,8 +259,9 @@ export const summarizationRouter = createTRPCRouter({
         summaryRecord.modelId !== null && summaryRecord.modelId !== currentModelId;
       const settingsChanged = promptVersionChanged || modelChanged;
 
-      // Return cached summary if available and not stale (prompt version unchanged)
-      if (summaryRecord.summaryText && !promptVersionChanged) {
+      // Return cached summary if available and not stale (prompt version unchanged),
+      // unless the user explicitly requested regeneration
+      if (summaryRecord.summaryText && !promptVersionChanged && !input.regenerate) {
         return {
           summary: summaryRecord.summaryText,
           cached: true,


### PR DESCRIPTION
## Summary
- Fixes #519: The "Regenerate" button on summaries was ineffective — it would flash and then show the old cached summary
- **Root cause**: The backend always returned cached summaries when the prompt version hadn't changed, even during explicit regeneration. The model/maxWords/prompt changes were detected (`settingsChanged: true`) but didn't trigger actual regeneration.
- **Fix**: Added a `regenerate` boolean flag to the `summarization.generate` input schema. When set, the backend bypasses the cache and generates a fresh summary. The frontend passes `regenerate: true` when the user clicks the "Regenerate" button.

## Test plan
- [ ] Generate a summary for an entry
- [ ] Change summarization model in settings (e.g., Sonnet → Haiku)
- [ ] Click "Regenerate" on the same entry — should produce a new summary with the new model
- [ ] Verify normal summarization still uses cache (clicking summarize button on an already-summarized entry should toggle visibility, not regenerate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)