### PR TITLE
Add model alias entries to summarization model list

### DIFF
--- a/src/components/settings/ApiKeySettings.tsx
+++ b/src/components/settings/ApiKeySettings.tsx
@@ -426,6 +426,7 @@ export function SummarizationApiKeySettings() {
                   models.map((model) => (
                     <option key={model.id} value={model.id}>
                       {model.displayName}
+                      {model.id === defaultModelId ? " (default)" : ""}
                     </option>
                   ))
                 ) : (

--- a/tests/unit/model-aliases.test.ts
+++ b/tests/unit/model-aliases.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { addModelAliases } from "@/server/services/summarization";
+
+describe("addModelAliases", () => {
+  it("adds alias entries for models with date suffixes", () => {
+    const models = [
+      { id: "claude-sonnet-4-5-20250929", displayName: "Claude Sonnet 4.5" },
+      { id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5" },
+    ];
+
+    const result = addModelAliases(models);
+    expect(result).toEqual([
+      { id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5 (latest)" },
+      { id: "claude-sonnet-4-5-20250929", displayName: "Claude Sonnet 4.5" },
+      { id: "claude-haiku-4-5", displayName: "Claude Haiku 4.5 (latest)" },
+      { id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5" },
+    ]);
+  });
+
+  it("does not add alias for models without date suffix", () => {
+    const models = [{ id: "claude-opus-4-6", displayName: "Claude Opus 4.6" }];
+
+    const result = addModelAliases(models);
+    expect(result).toEqual([{ id: "claude-opus-4-6", displayName: "Claude Opus 4.6" }]);
+  });
+
+  it("does not add duplicate alias when ID already exists", () => {
+    const models = [
+      { id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5" },
+      { id: "claude-sonnet-4-5-20250929", displayName: "Claude Sonnet 4.5" },
+    ];
+
+    const result = addModelAliases(models);
+    expect(result).toEqual([
+      { id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5" },
+      { id: "claude-sonnet-4-5-20250929", displayName: "Claude Sonnet 4.5" },
+    ]);
+  });
+
+  it("only adds alias for the first versioned model when multiple versions exist", () => {
+    const models = [
+      { id: "claude-sonnet-4-5-20250929", displayName: "Claude Sonnet 4.5" },
+      { id: "claude-sonnet-4-5-20250801", displayName: "Claude Sonnet 4.5 (old)" },
+    ];
+
+    const result = addModelAliases(models);
+    expect(result).toEqual([
+      { id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5 (latest)" },
+      { id: "claude-sonnet-4-5-20250929", displayName: "Claude Sonnet 4.5" },
+      { id: "claude-sonnet-4-5-20250801", displayName: "Claude Sonnet 4.5 (old)" },
+    ]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(addModelAliases([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- The Anthropic models API returns versioned IDs (e.g. `claude-sonnet-4-5-20250929`) but accepts shorter aliases (e.g. `claude-sonnet-4-5`). The default model is configured as an alias, so the settings dropdown couldn't match it to any option and fell back to showing the first (newest) model.
- Derives alias entries from versioned model IDs in the backend and inserts them into the model list, each labeled "(latest)"
- Labels the default model option with "(default)" in the dropdown
- Follow-up to #521

## Test plan
- [ ] Open settings, verify the model dropdown shows alias entries like "Claude Sonnet 4.5 (latest)" alongside versioned entries
- [ ] Verify the global default model is selected and labeled "(default)"
- [ ] Verify selecting a different model still works
- [ ] `pnpm vitest run tests/unit/model-aliases.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)