### PR TITLE
Simplify model list by stripping date suffixes

### DIFF
--- a/src/server/services/summarization.ts
+++ b/src/server/services/summarization.ts
@@ -280,29 +280,26 @@ export interface SummarizationModel {
 }
 
 /**
- * Derives alias model IDs from versioned IDs.
+ * Strips date suffixes from versioned model IDs, keeping only the first
+ * (newest) version of each model.
  *
- * The Anthropic API returns versioned IDs like "claude-sonnet-4-5-20250929" but
- * accepts shorter aliases like "claude-sonnet-4-5". We insert alias entries so
- * that default/user model IDs (which may be aliases) appear in the list.
+ * The Anthropic API returns versioned IDs like "claude-sonnet-4-5-20250929"
+ * but accepts shorter aliases like "claude-sonnet-4-5". Since the API returns
+ * models newest-first, we keep the first occurrence of each alias and drop
+ * subsequent versions.
  */
-export function addModelAliases(models: SummarizationModel[]): SummarizationModel[] {
-  const existingIds = new Set(models.map((m) => m.id));
+export function simplifyModelIds(models: SummarizationModel[]): SummarizationModel[] {
+  const seen = new Set<string>();
   const result: SummarizationModel[] = [];
 
   for (const model of models) {
-    // Match versioned IDs like "claude-sonnet-4-5-20250929" (date suffix).
-    // Insert an alias entry (e.g. "claude-sonnet-4-5") before the first
-    // versioned entry so the alias appears next to its versioned counterpart.
-    const match = model.id.match(/^(.+)-(\d{8})$/);
-    if (match) {
-      const alias = match[1];
-      if (!existingIds.has(alias)) {
-        result.push({ id: alias, displayName: `${model.displayName} (latest)` });
-        existingIds.add(alias);
-      }
+    const match = model.id.match(/^(.+)-\d{8}$/);
+    const alias = match ? match[1] : model.id;
+
+    if (!seen.has(alias)) {
+      seen.add(alias);
+      result.push({ id: alias, displayName: model.displayName });
     }
-    result.push(model);
   }
 
   return result;
@@ -330,7 +327,7 @@ export async function listModels(userApiKey?: string | null): Promise<Summarizat
         displayName: model.display_name,
       });
     }
-    return addModelAliases(models);
+    return simplifyModelIds(models);
   } catch (error) {
     logger.error("Failed to list Anthropic models", {
       error: error instanceof Error ? error.message : String(error),

--- a/tests/unit/model-aliases.test.ts
+++ b/tests/unit/model-aliases.test.ts
@@ -1,57 +1,48 @@
 import { describe, it, expect } from "vitest";
-import { addModelAliases } from "@/server/services/summarization";
+import { simplifyModelIds } from "@/server/services/summarization";
 
-describe("addModelAliases", () => {
-  it("adds alias entries for models with date suffixes", () => {
+describe("simplifyModelIds", () => {
+  it("strips date suffixes from versioned model IDs", () => {
     const models = [
       { id: "claude-sonnet-4-5-20250929", displayName: "Claude Sonnet 4.5" },
       { id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5" },
     ];
 
-    const result = addModelAliases(models);
+    const result = simplifyModelIds(models);
     expect(result).toEqual([
-      { id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5 (latest)" },
-      { id: "claude-sonnet-4-5-20250929", displayName: "Claude Sonnet 4.5" },
-      { id: "claude-haiku-4-5", displayName: "Claude Haiku 4.5 (latest)" },
-      { id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5" },
+      { id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5" },
+      { id: "claude-haiku-4-5", displayName: "Claude Haiku 4.5" },
     ]);
   });
 
-  it("does not add alias for models without date suffix", () => {
+  it("passes through models without date suffix unchanged", () => {
     const models = [{ id: "claude-opus-4-6", displayName: "Claude Opus 4.6" }];
 
-    const result = addModelAliases(models);
+    const result = simplifyModelIds(models);
     expect(result).toEqual([{ id: "claude-opus-4-6", displayName: "Claude Opus 4.6" }]);
   });
 
-  it("does not add duplicate alias when ID already exists", () => {
+  it("deduplicates when alias and versioned ID both exist", () => {
     const models = [
       { id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5" },
       { id: "claude-sonnet-4-5-20250929", displayName: "Claude Sonnet 4.5" },
     ];
 
-    const result = addModelAliases(models);
-    expect(result).toEqual([
-      { id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5" },
-      { id: "claude-sonnet-4-5-20250929", displayName: "Claude Sonnet 4.5" },
-    ]);
+    const result = simplifyModelIds(models);
+    expect(result).toEqual([{ id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5" }]);
   });
 
-  it("only adds alias for the first versioned model when multiple versions exist", () => {
+  it("keeps only the first version when multiple versions exist", () => {
     const models = [
       { id: "claude-sonnet-4-5-20250929", displayName: "Claude Sonnet 4.5" },
       { id: "claude-sonnet-4-5-20250801", displayName: "Claude Sonnet 4.5 (old)" },
     ];
 
-    const result = addModelAliases(models);
-    expect(result).toEqual([
-      { id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5 (latest)" },
-      { id: "claude-sonnet-4-5-20250929", displayName: "Claude Sonnet 4.5" },
-      { id: "claude-sonnet-4-5-20250801", displayName: "Claude Sonnet 4.5 (old)" },
-    ]);
+    const result = simplifyModelIds(models);
+    expect(result).toEqual([{ id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5" }]);
   });
 
   it("returns empty array for empty input", () => {
-    expect(addModelAliases([])).toEqual([]);
+    expect(simplifyModelIds([])).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Instead of inserting alias entries alongside versioned ones (from #522), just strip the date suffix and deduplicate
- Users don't need to choose between monthly snapshots — the Anthropic API resolves aliases to the latest version automatically
- e.g. `claude-sonnet-4-5-20250929` becomes `claude-sonnet-4-5`, and `claude-opus-4-6` (no date suffix) stays as-is

## Test plan
- [ ] Open settings, verify the model dropdown shows clean names like "Claude Sonnet 4.5" without date suffixes
- [ ] Verify the default model is correctly selected
- [ ] `pnpm vitest run tests/unit/model-aliases.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)