### PR TITLE
Fix settings tabs overflowing on mobile

### DIFF
--- a/src/components/settings/UnifiedSettingsContent.tsx
+++ b/src/components/settings/UnifiedSettingsContent.tsx
@@ -105,14 +105,14 @@ export function UnifiedSettingsContent() {
       <div className="flex flex-col gap-8 md:flex-row">
         {/* Sidebar Navigation */}
         <nav className="w-full shrink-0 md:w-48">
-          <ul className="flex gap-1 md:flex-col">
+          <ul className="flex flex-wrap gap-1 overflow-x-auto md:flex-col md:flex-nowrap md:overflow-x-visible">
             {settingsLinks.map((link) => {
               const isActive = pathname === link.href;
               return (
                 <li key={link.href}>
                   <ClientLink
                     href={link.href}
-                    className={`ui-text-sm block rounded-md px-3 py-2 font-medium transition-colors ${
+                    className={`ui-text-sm block rounded-md px-3 py-2 font-medium whitespace-nowrap transition-colors ${
                       isActive
                         ? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
                         : "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"


### PR DESCRIPTION
## Summary
- Settings navigation tabs now wrap to multiple lines on mobile instead of overflowing off-screen
- Added `flex-wrap` and `overflow-x-auto` to the tab container
- Added `whitespace-nowrap` to individual tab labels to prevent mid-word breaks
- Desktop vertical sidebar layout is unchanged (`md:flex-nowrap md:overflow-x-visible`)

## Test plan
- [ ] Open settings page on a narrow mobile viewport (< 768px) and verify tabs wrap instead of overflowing
- [ ] Open settings page on desktop and verify the vertical sidebar still looks normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)