### PR TITLE
Reorganize settings pages into logical groups

### DIFF
--- a/src/app/(app)/settings/ai/page.tsx
+++ b/src/app/(app)/settings/ai/page.tsx
@@ -1,0 +1,9 @@
+/**
+ * AI & Narration Page
+ *
+ * Route marker for /settings/ai. AppRouter handles rendering.
+ */
+
+export default function AiPage() {
+  return null;
+}

--- a/src/app/(app)/settings/api-tokens/page.tsx
+++ b/src/app/(app)/settings/api-tokens/page.tsx
@@ -1,9 +1,0 @@
-/**
- * API Tokens Page
- *
- * Route marker for /settings/api-tokens. AppRouter handles rendering.
- */
-
-export default function ApiTokensPage() {
-  return null;
-}

--- a/src/app/(app)/settings/blocked-senders/page.tsx
+++ b/src/app/(app)/settings/blocked-senders/page.tsx
@@ -1,9 +1,0 @@
-/**
- * Blocked Senders Page
- *
- * Route marker for /settings/blocked-senders. AppRouter handles rendering.
- */
-
-export default function BlockedSendersPage() {
-  return null;
-}

--- a/src/app/(app)/settings/broken-feeds/page.tsx
+++ b/src/app/(app)/settings/broken-feeds/page.tsx
@@ -1,9 +1,0 @@
-/**
- * Broken Feeds Page
- *
- * Route marker for /settings/broken-feeds. AppRouter handles rendering.
- */
-
-export default function BrokenFeedsPage() {
-  return null;
-}

--- a/src/app/(app)/settings/feed-health/page.tsx
+++ b/src/app/(app)/settings/feed-health/page.tsx
@@ -1,0 +1,9 @@
+/**
+ * Feed Health Page
+ *
+ * Route marker for /settings/feed-health. AppRouter handles rendering.
+ */
+
+export default function FeedHealthPage() {
+  return null;
+}

--- a/src/app/(app)/settings/feed-stats/page.tsx
+++ b/src/app/(app)/settings/feed-stats/page.tsx
@@ -1,9 +1,0 @@
-/**
- * Feed Stats Page
- *
- * Route marker for /settings/feed-stats. AppRouter handles rendering.
- */
-
-export default function FeedStatsPage() {
-  return null;
-}

--- a/src/app/(app)/settings/subscriptions/page.tsx
+++ b/src/app/(app)/settings/subscriptions/page.tsx
@@ -1,0 +1,9 @@
+/**
+ * Subscriptions Page
+ *
+ * Route marker for /settings/subscriptions. AppRouter handles rendering.
+ */
+
+export default function SubscriptionsPage() {
+  return null;
+}

--- a/src/components/settings/IntegrationsSettings.tsx
+++ b/src/components/settings/IntegrationsSettings.tsx
@@ -8,7 +8,6 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ClientLink } from "@/components/ui";
 
 export function IntegrationsSettings() {
   const [copiedSection, setCopiedSection] = useState<string | null>(null);
@@ -142,22 +141,6 @@ export function IntegrationsSettings() {
               {copiedSection === "claude-desktop" ? "Copied!" : "Copy"}
             </button>
           </div>
-        </div>
-
-        {/* API Tokens Link */}
-        <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
-          <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-            Need to manage API tokens or create custom integrations?
-          </p>
-          <ClientLink
-            href="/settings/api-tokens"
-            className="ui-text-sm mt-2 inline-flex items-center gap-1 font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-          >
-            Manage API Tokens
-            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </ClientLink>
         </div>
 
         {/* Note about MCP URL */}

--- a/src/components/settings/UnifiedSettingsContent.tsx
+++ b/src/components/settings/UnifiedSettingsContent.tsx
@@ -23,24 +23,22 @@ import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 // like titles renders immediately while data loads
 import AccountSettingsContent from "./pages/AccountSettingsContent";
 import { AppearanceSettings as AppearanceSettingsContent } from "./AppearanceSettings";
-import SessionsSettingsContent from "./pages/SessionsSettingsContent";
-import ApiTokensSettingsContent from "./pages/ApiTokensSettingsContent";
-import IntegrationsSettingsContent from "./pages/IntegrationsSettingsContent";
+import SubscriptionsSettingsContent from "./pages/SubscriptionsSettingsContent";
 import EmailSettingsContent from "./pages/EmailSettingsContent";
-import BlockedSendersSettingsContent from "./pages/BlockedSendersSettingsContent";
-import BrokenFeedsSettingsContent from "./pages/BrokenFeedsSettingsContent";
-import FeedStatsSettingsContent from "./pages/FeedStatsSettingsContent";
+import AiSettingsContent from "./pages/AiSettingsContent";
+import IntegrationsSettingsContent from "./pages/IntegrationsSettingsContent";
+import FeedHealthSettingsContent from "./pages/FeedHealthSettingsContent";
+import SessionsSettingsContent from "./pages/SessionsSettingsContent";
 
 const settingsLinks = [
   { href: "/settings", label: "Account" },
   { href: "/settings/appearance", label: "Appearance" },
-  { href: "/settings/sessions", label: "Sessions" },
-  { href: "/settings/api-tokens", label: "API Tokens" },
+  { href: "/settings/subscriptions", label: "Subscriptions" },
+  { href: "/settings/email", label: "Email" },
+  { href: "/settings/ai", label: "AI & Narration" },
   { href: "/settings/integrations", label: "Integrations" },
-  { href: "/settings/email", label: "Email Subscriptions" },
-  { href: "/settings/blocked-senders", label: "Blocked Senders" },
-  { href: "/settings/broken-feeds", label: "Broken Feeds" },
-  { href: "/settings/feed-stats", label: "Feed Stats" },
+  { href: "/settings/feed-health", label: "Feed Health" },
+  { href: "/settings/sessions", label: "Sessions" },
 ];
 
 /**
@@ -55,20 +53,18 @@ function SettingsContentRouter() {
       return <AccountSettingsContent />;
     case "/settings/appearance":
       return <AppearanceSettingsContent />;
-    case "/settings/sessions":
-      return <SessionsSettingsContent />;
-    case "/settings/api-tokens":
-      return <ApiTokensSettingsContent />;
-    case "/settings/integrations":
-      return <IntegrationsSettingsContent />;
+    case "/settings/subscriptions":
+      return <SubscriptionsSettingsContent />;
     case "/settings/email":
       return <EmailSettingsContent />;
-    case "/settings/blocked-senders":
-      return <BlockedSendersSettingsContent />;
-    case "/settings/broken-feeds":
-      return <BrokenFeedsSettingsContent />;
-    case "/settings/feed-stats":
-      return <FeedStatsSettingsContent />;
+    case "/settings/ai":
+      return <AiSettingsContent />;
+    case "/settings/integrations":
+      return <IntegrationsSettingsContent />;
+    case "/settings/feed-health":
+      return <FeedHealthSettingsContent />;
+    case "/settings/sessions":
+      return <SessionsSettingsContent />;
     default:
       // Default to account settings for unknown paths
       return <AccountSettingsContent />;

--- a/src/components/settings/pages/AccountSettingsContent.tsx
+++ b/src/components/settings/pages/AccountSettingsContent.tsx
@@ -16,17 +16,7 @@ import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
 import { clientReplace } from "@/lib/navigation";
 import { Button, Input, Alert } from "@/components/ui";
-import {
-  OpmlImportExport,
-  LinkedAccounts,
-  KeyboardShortcutsSettings,
-  TagManagement,
-  AboutSection,
-  GroqApiKeySettings,
-  SummarizationApiKeySettings,
-} from "@/components/settings";
-// Import directly from file to avoid barrel export pulling in piper-tts-web
-import { NarrationSettings } from "@/components/narration/NarrationSettings";
+import { LinkedAccounts, KeyboardShortcutsSettings, AboutSection } from "@/components/settings";
 
 /**
  * Handles OAuth link success/error messages from query params.
@@ -82,23 +72,6 @@ function OAuthMessages() {
     <>
       {linkSuccessMessage && <Alert variant="success">{linkSuccessMessage}</Alert>}
       {linkErrorMessage && <Alert variant="error">{linkErrorMessage}</Alert>}
-    </>
-  );
-}
-
-function ApiKeySettingsSections() {
-  const preferencesQuery = trpc.users["me.preferences"].useQuery();
-  const canConfigure = preferencesQuery.data?.canConfigureApiKeys ?? false;
-
-  if (preferencesQuery.isLoading || !canConfigure) return null;
-
-  return (
-    <>
-      {/* AI Text Processing (Groq API key) - near narration */}
-      <GroqApiKeySettings />
-
-      {/* Summaries (Anthropic API key + model) */}
-      <SummarizationApiKeySettings />
     </>
   );
 }
@@ -377,20 +350,8 @@ export default function AccountSettingsContent() {
       {/* Linked Accounts Section - uses SettingsSection which shows title during load */}
       <LinkedAccounts />
 
-      {/* Tags Section - uses SettingsSection which shows title during load */}
-      <TagManagement />
-
       {/* Password Section - shows title immediately, content loads inline */}
       <PasswordSection />
-
-      {/* OPML Import/Export Section - fully static, no data fetching */}
-      <OpmlImportExport />
-
-      {/* AI API key settings - only shown when encryption is configured */}
-      <ApiKeySettingsSections />
-
-      {/* Narration Section - fully static/client-side */}
-      <NarrationSettings />
 
       {/* Keyboard Shortcuts Section - fully static */}
       <KeyboardShortcutsSettings />

--- a/src/components/settings/pages/AiSettingsContent.tsx
+++ b/src/components/settings/pages/AiSettingsContent.tsx
@@ -1,0 +1,42 @@
+/**
+ * AI & Narration Settings Content
+ *
+ * Page for AI-powered features: API keys for text processing and summarization,
+ * and text-to-speech narration configuration.
+ */
+
+"use client";
+
+import { trpc } from "@/lib/trpc/client";
+import { GroqApiKeySettings, SummarizationApiKeySettings } from "@/components/settings";
+// Import directly from file to avoid barrel export pulling in piper-tts-web
+import { NarrationSettings } from "@/components/narration/NarrationSettings";
+
+function ApiKeySettingsSections() {
+  const preferencesQuery = trpc.users["me.preferences"].useQuery();
+  const canConfigure = preferencesQuery.data?.canConfigureApiKeys ?? false;
+
+  if (preferencesQuery.isLoading || !canConfigure) return null;
+
+  return (
+    <>
+      {/* AI Text Processing (Groq API key) */}
+      <GroqApiKeySettings />
+
+      {/* Summaries (Anthropic API key + model) */}
+      <SummarizationApiKeySettings />
+    </>
+  );
+}
+
+export default function AiSettingsContent() {
+  return (
+    <div className="space-y-8">
+      {/* AI API key settings - only shown when encryption is configured */}
+      <ApiKeySettingsSections />
+
+      {/* Narration Section */}
+      <NarrationSettings />
+    </div>
+  );
+}

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
 import { Button, Input, Alert } from "@/components/ui";
+import BlockedSendersSettingsContent from "./BlockedSendersSettingsContent";
 
 // ============================================================================
 // Types
@@ -48,6 +49,9 @@ export default function EmailSettingsContent() {
 
       {/* Spam Preference Section */}
       <SpamPreferenceSection />
+
+      {/* Blocked Senders Section */}
+      <BlockedSendersSettingsContent />
     </div>
   );
 }

--- a/src/components/settings/pages/FeedHealthSettingsContent.tsx
+++ b/src/components/settings/pages/FeedHealthSettingsContent.tsx
@@ -1,0 +1,23 @@
+/**
+ * Feed Health Settings Content
+ *
+ * Combined page for monitoring feed status: broken feeds with errors
+ * and overall feed statistics.
+ */
+
+"use client";
+
+import BrokenFeedsSettingsContent from "./BrokenFeedsSettingsContent";
+import FeedStatsSettingsContent from "./FeedStatsSettingsContent";
+
+export default function FeedHealthSettingsContent() {
+  return (
+    <div className="space-y-12">
+      {/* Broken Feeds - actionable issues first */}
+      <BrokenFeedsSettingsContent />
+
+      {/* Feed Statistics - overview of all feeds */}
+      <FeedStatsSettingsContent />
+    </div>
+  );
+}

--- a/src/components/settings/pages/IntegrationsSettingsContent.tsx
+++ b/src/components/settings/pages/IntegrationsSettingsContent.tsx
@@ -1,7 +1,8 @@
 /**
  * Integrations Settings Content
  *
- * Page for browser extensions, bookmarklets, Discord bot, and AI integrations.
+ * Page for browser extensions, bookmarklets, Discord bot, AI integrations,
+ * and API token management.
  */
 
 "use client";
@@ -11,6 +12,7 @@ import {
   DiscordBotSettings,
   IntegrationsSettings,
 } from "@/components/settings";
+import ApiTokensSettingsContent from "./ApiTokensSettingsContent";
 
 export default function IntegrationsSettingsContent() {
   return (
@@ -23,6 +25,9 @@ export default function IntegrationsSettingsContent() {
 
       {/* AI Integrations (MCP) */}
       <IntegrationsSettings />
+
+      {/* API Tokens */}
+      <ApiTokensSettingsContent />
     </div>
   );
 }

--- a/src/components/settings/pages/SubscriptionsSettingsContent.tsx
+++ b/src/components/settings/pages/SubscriptionsSettingsContent.tsx
@@ -1,0 +1,21 @@
+/**
+ * Subscriptions Settings Content
+ *
+ * Page for managing subscription organization: tags and OPML import/export.
+ */
+
+"use client";
+
+import { OpmlImportExport, TagManagement } from "@/components/settings";
+
+export default function SubscriptionsSettingsContent() {
+  return (
+    <div className="space-y-8">
+      {/* Tags Section */}
+      <TagManagement />
+
+      {/* OPML Import/Export Section */}
+      <OpmlImportExport />
+    </div>
+  );
+}

--- a/src/server/mcp/README.md
+++ b/src/server/mcp/README.md
@@ -29,7 +29,7 @@ Connect to your Lion Reader account at **lionreader.com** (or `localhost:3000` f
 
 #### Step 1: Create an API Token
 
-1. Go to **lionreader.com/settings/api-tokens** (or `localhost:3000/settings/api-tokens`)
+1. Go to **lionreader.com/settings/integrations** (or `localhost:3000/settings/integrations`)
 2. Click "Create API Token"
 3. Name it "Claude Desktop" or "MCP"
 4. Select scope: **`mcp`** (full MCP access)


### PR DESCRIPTION
## Summary
- Reorganizes settings from 9 flat tabs into 8 logically grouped tabs
- Declutters the Account page by moving unrelated sections to dedicated tabs
- Merges closely related tabs: Blocked Senders into Email, API Tokens into Integrations, Broken Feeds + Feed Stats into Feed Health
- Creates new grouped tabs: Subscriptions (tags + OPML), AI & Narration (API keys + narration)

### New tab structure

| Tab | Contents |
|-----|----------|
| **Account** | Account info, linked accounts, password, keyboard shortcuts, privacy, about |
| **Appearance** | Theme, text settings |
| **Subscriptions** | Tags, OPML import/export |
| **Email** | Ingest addresses, spam toggle, blocked senders |
| **AI & Narration** | Groq/Anthropic API keys, narration settings |
| **Integrations** | Bookmarklet, Discord, MCP, API tokens |
| **Feed Health** | Broken feeds, feed statistics |
| **Sessions** | Active sessions |

## Test plan
- [ ] Verify each settings tab loads and displays its sections correctly
- [ ] Verify navigation between tabs works on both mobile and desktop
- [ ] Verify old routes fall through to default (Account)

Generated with [Claude Code](https://claude.com/claude-code)