### PR TITLE
Deduplicate getFeedDisplayName into shared helper

### DIFF
--- a/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
+++ b/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
@@ -12,6 +12,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
 import { handleSubscriptionDeleted } from "@/lib/cache";
+import { getFeedDisplayName } from "@/lib/format";
 import { Button, Alert } from "@/components/ui";
 import { UnsubscribeDialog } from "@/components/feeds/UnsubscribeDialog";
 
@@ -92,22 +93,6 @@ function formatFutureDate(date: Date | null): string {
   } else {
     return `In ${diffDays} day${diffDays === 1 ? "" : "s"}`;
   }
-}
-
-/**
- * Get display name for a feed
- */
-function getFeedDisplayName(feed: BrokenFeed): string {
-  if (feed.title) return feed.title;
-  if (feed.url) {
-    try {
-      const url = new URL(feed.url);
-      return url.hostname;
-    } catch {
-      return feed.url;
-    }
-  }
-  return "Unknown Feed";
 }
 
 // ============================================================================

--- a/src/components/settings/pages/FeedStatsSettingsContent.tsx
+++ b/src/components/settings/pages/FeedStatsSettingsContent.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { trpc } from "@/lib/trpc/client";
+import { getFeedDisplayName } from "@/lib/format";
 import { Alert } from "@/components/ui";
 
 // ============================================================================
@@ -92,23 +93,6 @@ function formatFutureDate(date: Date | null): string {
   } else {
     return `In ${diffDays} day${diffDays === 1 ? "" : "s"}`;
   }
-}
-
-/**
- * Get display name for a feed
- */
-function getFeedDisplayName(feed: FeedStats): string {
-  if (feed.customTitle) return feed.customTitle;
-  if (feed.title) return feed.title;
-  if (feed.url) {
-    try {
-      const url = new URL(feed.url);
-      return url.hostname;
-    } catch {
-      return feed.url;
-    }
-  }
-  return "Unknown Feed";
 }
 
 /**

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -43,3 +43,18 @@ export function getDomain(url: string): string {
     return url;
   }
 }
+
+/**
+ * Get display name for a feed, using a fallback chain:
+ * customTitle → title → URL domain → "Unknown Feed"
+ */
+export function getFeedDisplayName(feed: {
+  customTitle?: string | null;
+  title: string | null;
+  url: string | null;
+}): string {
+  if (feed.customTitle) return feed.customTitle;
+  if (feed.title) return feed.title;
+  if (feed.url) return getDomain(feed.url);
+  return "Unknown Feed";
+}


### PR DESCRIPTION
## Summary
- Extracted `getFeedDisplayName` from `BrokenFeedsSettingsContent` and `FeedStatsSettingsContent` into `src/lib/format.ts`
- The shared version handles the full fallback chain: `customTitle` → `title` → URL domain → `"Unknown Feed"`
- Reuses the existing `getDomain` helper already in `format.ts`

Fixes #535

## Test plan
- [x] `pnpm typecheck` passes
- [ ] Verify broken feeds page still shows feed names correctly
- [ ] Verify feed stats page still shows feed names correctly (including custom titles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)