### PR TITLE
Extract SettingsListSkeleton component for loading states

### DIFF
--- a/src/components/settings/SettingsListSkeleton.tsx
+++ b/src/components/settings/SettingsListSkeleton.tsx
@@ -1,0 +1,45 @@
+/**
+ * Shared loading skeleton for settings list pages.
+ *
+ * Two variants match the two card patterns used across settings pages:
+ * - "interior" (default): Skeleton rows inside a card, with p-6 padding
+ * - "card": Standalone bordered cards with spacing between them
+ */
+
+interface SettingsListSkeletonProps {
+  count?: number;
+  height?: string;
+  variant?: "interior" | "card";
+}
+
+export function SettingsListSkeleton({
+  count = 3,
+  height = "h-24",
+  variant = "interior",
+}: SettingsListSkeletonProps) {
+  const items = Array.from({ length: count }, (_, i) => i);
+
+  if (variant === "card") {
+    return (
+      <>
+        {items.map((i) => (
+          <div
+            key={i}
+            className={`${height} animate-pulse rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900`}
+          />
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      {items.map((i) => (
+        <div
+          key={i}
+          className={`mb-4 ${height} animate-pulse rounded bg-zinc-100 last:mb-0 dark:bg-zinc-800`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -13,3 +13,4 @@ export { IntegrationsSettings } from "./IntegrationsSettings";
 export { DiscordBotSettings } from "./DiscordBotSettings";
 export { AboutSection } from "./AboutSection";
 export { GroqApiKeySettings, SummarizationApiKeySettings } from "./ApiKeySettings";
+export { SettingsListSkeleton } from "./SettingsListSkeleton";

--- a/src/components/settings/pages/ApiTokensSettingsContent.tsx
+++ b/src/components/settings/pages/ApiTokensSettingsContent.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
 import { Button, Input, Alert } from "@/components/ui";
+import { SettingsListSkeleton } from "@/components/settings";
 
 /**
  * Format relative time ago
@@ -289,14 +290,7 @@ export default function ApiTokensSettingsContent() {
         </h3>
         <div className="space-y-3">
           {tokensQuery.isLoading ? (
-            <>
-              {[1, 2].map((i) => (
-                <div
-                  key={i}
-                  className="h-24 animate-pulse rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
-                />
-              ))}
-            </>
+            <SettingsListSkeleton count={2} variant="card" />
           ) : tokensQuery.error ? (
             <Alert variant="error">Failed to load tokens. Please try again.</Alert>
           ) : activeTokens.length === 0 ? (

--- a/src/components/settings/pages/BlockedSendersSettingsContent.tsx
+++ b/src/components/settings/pages/BlockedSendersSettingsContent.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
 import { Button, Alert } from "@/components/ui";
+import { SettingsListSkeleton } from "@/components/settings";
 
 // ============================================================================
 // Types
@@ -75,14 +76,7 @@ export default function BlockedSendersSettingsContent() {
       {/* Blocked Senders List */}
       <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
         {blockedQuery.isLoading ? (
-          <div className="p-6">
-            {[1, 2, 3].map((i) => (
-              <div
-                key={i}
-                className="mb-4 h-16 animate-pulse rounded bg-zinc-100 last:mb-0 dark:bg-zinc-800"
-              />
-            ))}
-          </div>
+          <SettingsListSkeleton count={3} height="h-16" />
         ) : blockedQuery.error ? (
           <div className="p-6">
             <Alert variant="error">Failed to load blocked senders. Please try again.</Alert>

--- a/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
+++ b/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
@@ -13,6 +13,7 @@ import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
 import { handleSubscriptionDeleted } from "@/lib/cache";
 import { Button, Alert } from "@/components/ui";
+import { SettingsListSkeleton } from "@/components/settings";
 import { UnsubscribeDialog } from "@/components/feeds/UnsubscribeDialog";
 
 // ============================================================================
@@ -163,14 +164,7 @@ export default function BrokenFeedsSettingsContent() {
       {/* Broken Feeds List */}
       <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
         {brokenQuery.isLoading ? (
-          <div className="p-6">
-            {[1, 2, 3].map((i) => (
-              <div
-                key={i}
-                className="mb-4 h-24 animate-pulse rounded bg-zinc-100 last:mb-0 dark:bg-zinc-800"
-              />
-            ))}
-          </div>
+          <SettingsListSkeleton />
         ) : brokenQuery.error ? (
           <div className="p-6">
             <Alert variant="error">Failed to load broken feeds. Please try again.</Alert>

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
 import { Button, Input, Alert } from "@/components/ui";
+import { SettingsListSkeleton } from "@/components/settings";
 import BlockedSendersSettingsContent from "./BlockedSendersSettingsContent";
 
 // ============================================================================
@@ -105,14 +106,7 @@ function IngestAddressesSection() {
       <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
         {/* Address List */}
         {addressesQuery.isLoading ? (
-          <div className="p-6">
-            {[1, 2].map((i) => (
-              <div
-                key={i}
-                className="mb-4 h-16 animate-pulse rounded bg-zinc-100 last:mb-0 dark:bg-zinc-800"
-              />
-            ))}
-          </div>
+          <SettingsListSkeleton count={2} height="h-16" />
         ) : addressesQuery.error ? (
           <div className="p-6">
             <Alert variant="error">Failed to load ingest addresses. Please try again.</Alert>

--- a/src/components/settings/pages/FeedStatsSettingsContent.tsx
+++ b/src/components/settings/pages/FeedStatsSettingsContent.tsx
@@ -9,6 +9,7 @@
 
 import { trpc } from "@/lib/trpc/client";
 import { Alert } from "@/components/ui";
+import { SettingsListSkeleton } from "@/components/settings";
 
 // ============================================================================
 // Types
@@ -173,14 +174,7 @@ export default function FeedStatsSettingsContent() {
       {/* Feed Stats List */}
       <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
         {statsQuery.isLoading ? (
-          <div className="p-6">
-            {[1, 2, 3].map((i) => (
-              <div
-                key={i}
-                className="mb-4 h-24 animate-pulse rounded bg-zinc-100 last:mb-0 dark:bg-zinc-800"
-              />
-            ))}
-          </div>
+          <SettingsListSkeleton />
         ) : statsQuery.error ? (
           <div className="p-6">
             <Alert variant="error">Failed to load feed statistics. Please try again.</Alert>

--- a/src/components/settings/pages/SessionsSettingsContent.tsx
+++ b/src/components/settings/pages/SessionsSettingsContent.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
 import { Button, Alert } from "@/components/ui";
+import { SettingsListSkeleton } from "@/components/settings";
 
 /**
  * Parse user agent string to extract browser and platform info.
@@ -136,14 +137,7 @@ export default function SessionsSettingsContent() {
 
       <div className="space-y-3">
         {sessionsQuery.isLoading ? (
-          <>
-            {[1, 2, 3].map((i) => (
-              <div
-                key={i}
-                className="h-24 animate-pulse rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
-              />
-            ))}
-          </>
+          <SettingsListSkeleton variant="card" />
         ) : sessionsQuery.error ? (
           <Alert variant="error">Failed to load sessions. Please try again.</Alert>
         ) : sessionsQuery.data?.sessions.length === 0 ? (


### PR DESCRIPTION
## Summary

- Extracts a shared `SettingsListSkeleton` component from duplicated loading skeleton boilerplate across 6 settings pages
- Supports two variants: `"interior"` (skeleton rows inside a card with padding) and `"card"` (standalone bordered skeleton cards), with configurable `count` and `height` props
- Replaces identical inline skeleton markup in EmailSettingsContent, BlockedSendersSettingsContent, BrokenFeedsSettingsContent, FeedStatsSettingsContent, SessionsSettingsContent, and ApiTokensSettingsContent

Closes #534

## Test plan

- [ ] Verify settings pages still show loading skeletons while data loads (throttle network in dev tools)
- [ ] Confirm both skeleton variants render correctly: interior style (Email, Blocked Senders, Broken Feeds, Feed Stats) and card style (Sessions, API Tokens)
- [ ] TypeScript compiles cleanly (`pnpm typecheck` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)