### PR TITLE
Extract duplicated select field lists in api-tokens.ts and entries.ts

### DIFF
--- a/src/server/trpc/routers/api-tokens.ts
+++ b/src/server/trpc/routers/api-tokens.ts
@@ -47,6 +47,23 @@ const createTokenOutputSchema = z.object({
 });
 
 // ============================================================================
+// Shared Select Fields
+// ============================================================================
+
+/**
+ * Fields to select when returning API token info (excludes the raw token hash).
+ */
+const apiTokenSelectFields = {
+  id: apiTokens.id,
+  name: apiTokens.name,
+  scopes: apiTokens.scopes,
+  createdAt: apiTokens.createdAt,
+  expiresAt: apiTokens.expiresAt,
+  lastUsedAt: apiTokens.lastUsedAt,
+  revokedAt: apiTokens.revokedAt,
+};
+
+// ============================================================================
 // Router
 // ============================================================================
 
@@ -56,15 +73,7 @@ export const apiTokensRouter = createTRPCRouter({
    */
   list: protectedProcedure.output(z.array(apiTokenOutputSchema)).query(async ({ ctx }) => {
     const tokens = await ctx.db
-      .select({
-        id: apiTokens.id,
-        name: apiTokens.name,
-        scopes: apiTokens.scopes,
-        createdAt: apiTokens.createdAt,
-        expiresAt: apiTokens.expiresAt,
-        lastUsedAt: apiTokens.lastUsedAt,
-        revokedAt: apiTokens.revokedAt,
-      })
+      .select(apiTokenSelectFields)
       .from(apiTokens)
       .where(eq(apiTokens.userId, ctx.session.user.id))
       .orderBy(desc(apiTokens.createdAt));
@@ -99,15 +108,7 @@ export const apiTokensRouter = createTRPCRouter({
 
       // Fetch the token info (without the raw token)
       const tokenInfo = await ctx.db
-        .select({
-          id: apiTokens.id,
-          name: apiTokens.name,
-          scopes: apiTokens.scopes,
-          createdAt: apiTokens.createdAt,
-          expiresAt: apiTokens.expiresAt,
-          lastUsedAt: apiTokens.lastUsedAt,
-          revokedAt: apiTokens.revokedAt,
-        })
+        .select(apiTokenSelectFields)
         .from(apiTokens)
         .where(and(eq(apiTokens.userId, ctx.session.user.id), isNull(apiTokens.revokedAt)))
         .orderBy(desc(apiTokens.createdAt))


### PR DESCRIPTION
## Summary

Fixes #532

- **api-tokens.ts**: Extracted `apiTokenSelectFields` constant used by both `list` and `create` procedures, eliminating the duplicated 7-field select list
- **entries.ts**: Extracted `fullEntrySelectFields` constant, `selectFullEntry()` helper, and `toFullEntry()` transformer shared by `get` and `fetchFullContent` procedures, eliminating the duplicated 20+ field select/join/transform logic

## Test plan

- [x] `pnpm typecheck` passes
- [x] ESLint passes (pre-commit hook)
- [ ] Verify `entries.get`, `entries.fetchFullContent`, `apiTokens.list`, and `apiTokens.create` still work correctly in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)