### PR TITLE
Replace inline confirmation dialogs with Dialog component

### DIFF
--- a/src/components/settings/pages/BlockedSendersSettingsContent.tsx
+++ b/src/components/settings/pages/BlockedSendersSettingsContent.tsx
@@ -10,7 +10,15 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
-import { Button, Alert } from "@/components/ui";
+import {
+  Button,
+  Alert,
+  Dialog,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui";
 import { SettingsListSkeleton } from "@/components/settings";
 
 // ============================================================================
@@ -159,38 +167,33 @@ function BlockedSenderRow({ sender }: BlockedSenderRowProps) {
   return (
     <div className="p-4">
       {/* Unblock Confirmation Dialog */}
-      {showUnblockConfirm && (
-        <>
-          <div
-            className="fixed inset-0 z-50 bg-black/50"
+      <Dialog
+        isOpen={showUnblockConfirm}
+        onClose={() => setShowUnblockConfirm(false)}
+        title="Unblock Sender"
+        size="sm"
+      >
+        <DialogHeader>
+          <DialogTitle>Unblock Sender</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to unblock{" "}
+            <span className="font-medium">{sender.senderEmail}</span>? Future emails from this
+            sender will be accepted again.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="secondary"
             onClick={() => setShowUnblockConfirm(false)}
-          />
-          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-            <div className="w-full max-w-sm rounded-lg border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-700 dark:bg-zinc-900">
-              <h3 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-                Unblock Sender
-              </h3>
-              <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">
-                Are you sure you want to unblock{" "}
-                <span className="font-medium">{sender.senderEmail}</span>? Future emails from this
-                sender will be accepted again.
-              </p>
-              <div className="mt-4 flex justify-end gap-3">
-                <Button
-                  variant="secondary"
-                  onClick={() => setShowUnblockConfirm(false)}
-                  disabled={unblockMutation.isPending}
-                >
-                  Cancel
-                </Button>
-                <Button onClick={handleUnblock} loading={unblockMutation.isPending}>
-                  Unblock
-                </Button>
-              </div>
-            </div>
-          </div>
-        </>
-      )}
+            disabled={unblockMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleUnblock} loading={unblockMutation.isPending}>
+            Unblock
+          </Button>
+        </DialogFooter>
+      </Dialog>
 
       {/* Main Row Content */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -11,7 +11,16 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
-import { Button, Input, Alert } from "@/components/ui";
+import {
+  Button,
+  Input,
+  Alert,
+  Dialog,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui";
 import { SettingsListSkeleton } from "@/components/settings";
 import BlockedSendersSettingsContent from "./BlockedSendersSettingsContent";
 
@@ -247,42 +256,37 @@ function IngestAddressRow({ address }: IngestAddressRowProps) {
   return (
     <div className="p-4">
       {/* Delete Confirmation Dialog */}
-      {showDeleteConfirm && (
-        <>
-          <div
-            className="fixed inset-0 z-50 bg-black/50"
+      <Dialog
+        isOpen={showDeleteConfirm}
+        onClose={() => setShowDeleteConfirm(false)}
+        title="Delete Ingest Address"
+        size="sm"
+      >
+        <DialogHeader>
+          <DialogTitle>Delete Ingest Address</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete this address? Future emails sent to{" "}
+            <span className="font-medium">{address.email}</span> will be rejected. Existing feeds
+            and entries will not be affected.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="secondary"
             onClick={() => setShowDeleteConfirm(false)}
-          />
-          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-            <div className="w-full max-w-sm rounded-lg border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-700 dark:bg-zinc-900">
-              <h3 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-                Delete Ingest Address
-              </h3>
-              <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">
-                Are you sure you want to delete this address? Future emails sent to{" "}
-                <span className="font-medium">{address.email}</span> will be rejected. Existing
-                feeds and entries will not be affected.
-              </p>
-              <div className="mt-4 flex justify-end gap-3">
-                <Button
-                  variant="secondary"
-                  onClick={() => setShowDeleteConfirm(false)}
-                  disabled={deleteMutation.isPending}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  onClick={handleDelete}
-                  loading={deleteMutation.isPending}
-                  className="bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700"
-                >
-                  Delete
-                </Button>
-              </div>
-            </div>
-          </div>
-        </>
-      )}
+            disabled={deleteMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleDelete}
+            loading={deleteMutation.isPending}
+            className="bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700"
+          >
+            Delete
+          </Button>
+        </DialogFooter>
+      </Dialog>
 
       {/* Main Row Content */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">


### PR DESCRIPTION
## Summary
- Replaces manual inline modal implementations (fixed backdrop + centered content) in three components with the existing `Dialog` component from `@/components/ui`
- Affected files: `BlockedSendersSettingsContent.tsx`, `EmailSettingsContent.tsx`, `FileUploadButton.tsx`
- Improves accessibility (focus trap, escape-to-close, scroll lock) and consistency with the rest of the codebase

Fixes #530

## Test plan
- [ ] Verify the unblock confirmation dialog in Blocked Senders settings opens/closes correctly
- [ ] Verify the delete confirmation dialog in Email settings opens/closes correctly  
- [ ] Verify the file upload dialog in Saved articles opens/closes correctly, including drag-and-drop
- [ ] Verify escape key closes all three dialogs
- [ ] Verify backdrop click closes all three dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)