### PR TITLE
Remove duplicate getDomain from EntryContentHelpers

### DIFF
--- a/src/components/entries/EntryArticle.tsx
+++ b/src/components/entries/EntryArticle.tsx
@@ -9,7 +9,8 @@
 
 import { type ReactNode, type CSSProperties, type RefObject } from "react";
 import { ExternalLinkIcon } from "@/components/ui";
-import { formatDate, getDomain } from "./EntryContentHelpers";
+import { getDomain } from "@/lib/format";
+import { formatDate } from "./EntryContentHelpers";
 import { EntryContentRenderer } from "./EntryContentRenderer";
 import { ContentSkeleton } from "./EntryContentStates";
 

--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -16,7 +16,8 @@ import { toast } from "sonner";
 import { useEntryMutations, useShowOriginalPreference } from "@/lib/hooks";
 import { ScrollContainer } from "@/components/layout/ScrollContainerContext";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
-import { EntryContentBody, getDomain } from "./EntryContentBody";
+import { getDomain } from "@/lib/format";
+import { EntryContentBody } from "./EntryContentBody";
 import { EntryContentFallback } from "./EntryContentFallback";
 
 /**

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -57,8 +57,6 @@ import { SWIPE_CONFIG } from "./EntryContentHelpers";
 import { EntryArticle } from "./EntryArticle";
 import { VoteControls } from "./VoteControls";
 
-export { getDomain } from "./EntryContentHelpers";
-
 /**
  * Props for the EntryContentBody component.
  */

--- a/src/components/entries/EntryContentFallback.tsx
+++ b/src/components/entries/EntryContentFallback.tsx
@@ -26,7 +26,8 @@ import {
   ExternalLinkIcon,
 } from "@/components/ui";
 import { EntryContentSkeleton, ContentSkeleton } from "./EntryContentStates";
-import { formatDate, getDomain } from "./EntryContentHelpers";
+import { getDomain } from "@/lib/format";
+import { formatDate } from "./EntryContentHelpers";
 import { VoteControls } from "./VoteControls";
 
 interface EntryContentFallbackProps {

--- a/src/components/entries/EntryContentHelpers.ts
+++ b/src/components/entries/EntryContentHelpers.ts
@@ -19,17 +19,6 @@ export function formatDate(date: Date): string {
 }
 
 /**
- * Extract domain from URL for display.
- */
-export function getDomain(url: string): string {
-  try {
-    return new URL(url).hostname;
-  } catch {
-    return url;
-  }
-}
-
-/**
  * Swipe gesture configuration constants.
  */
 export const SWIPE_CONFIG = {


### PR DESCRIPTION
## Summary
- Removed duplicate `getDomain` function from `EntryContentHelpers.ts` (identical to the canonical version in `src/lib/format.ts`)
- Removed the re-export from `EntryContentBody.tsx`
- Updated imports in `EntryArticle.tsx`, `EntryContentFallback.tsx`, and `EntryContent.tsx` to use `@/lib/format`

Closes #529

## Test plan
- [x] `pnpm typecheck` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)