### PR TITLE
Remove duplicate buildSubscriptionBaseQuery between router and service

### DIFF
--- a/src/server/services/subscriptions.ts
+++ b/src/server/services/subscriptions.ts
@@ -41,7 +41,7 @@ export interface Subscription {
  * Builds the base query for fetching subscriptions using the user_feeds view.
  * Includes unread counts and tags.
  */
-function buildSubscriptionBaseQuery(db: typeof dbType, userId: string) {
+export function buildSubscriptionBaseQuery(db: typeof dbType, userId: string) {
   // Subquery to get unread counts per feed
   const unreadCountsSubquery = db
     .select({
@@ -105,12 +105,12 @@ function buildSubscriptionBaseQuery(db: typeof dbType, userId: string) {
 /**
  * Type for a row returned by buildSubscriptionBaseQuery.
  */
-type SubscriptionQueryRow = Awaited<ReturnType<typeof buildSubscriptionBaseQuery>>[number];
+export type SubscriptionQueryRow = Awaited<ReturnType<typeof buildSubscriptionBaseQuery>>[number];
 
 /**
  * Transforms a subscription query row into the output format.
  */
-function formatSubscriptionRow(row: SubscriptionQueryRow): Subscription {
+export function formatSubscriptionRow(row: SubscriptionQueryRow): Subscription {
   return {
     id: row.id,
     type: row.type,


### PR DESCRIPTION
## Summary

- Removes ~110 lines of exact duplication of `buildSubscriptionBaseQuery`, `SubscriptionQueryRow`, and `formatSubscriptionRow` from the subscriptions router
- Exports these from `src/server/services/subscriptions.ts` as the single source of truth
- Updates the router's `.get` procedure to delegate to `subscriptionsService.getSubscription()` (matching how `.list` already works)

Closes #550

## Test plan

- [x] `pnpm typecheck` passes
- [ ] Verify subscription list and get endpoints work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)