### PR TITLE
Replace inline SVG icons with shared icon components

### DIFF
--- a/src/app/(app)/AppLayoutContent.tsx
+++ b/src/app/(app)/AppLayoutContent.tsx
@@ -11,6 +11,13 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { ClientLink } from "@/components/ui/client-link";
+import {
+  CloseIcon,
+  MenuIcon,
+  PlusIcon,
+  UserIcon,
+  ChevronDownIcon,
+} from "@/components/ui/icon-button";
 import { Toaster, toast } from "sonner";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { UserEmail } from "@/components/layout/UserEmail";
@@ -74,14 +81,7 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
                   className="flex h-10 w-10 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:text-zinc-400 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                   aria-label="Close navigation menu"
                 >
-                  <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
+                  <CloseIcon className="h-5 w-5" />
                 </button>
               }
               mobileMenuButton={
@@ -90,14 +90,7 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
                   className="flex h-10 w-10 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:text-zinc-400 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                   aria-label="Open navigation menu"
                 >
-                  <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M4 6h16M4 12h16M4 18h16"
-                    />
-                  </svg>
+                  <MenuIcon className="h-5 w-5" />
                 </button>
               }
               headerRight={
@@ -107,14 +100,7 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
                     href="/subscribe"
                     className="ui-text-sm inline-flex min-h-[40px] items-center gap-1.5 rounded-md bg-zinc-900 px-3 font-medium text-white transition-colors hover:bg-zinc-800 active:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200 dark:active:bg-zinc-300"
                   >
-                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M12 4v16m8-8H4"
-                      />
-                    </svg>
+                    <PlusIcon className="h-4 w-4" />
                     <span className="hidden sm:inline">Subscribe</span>
                   </ClientLink>
 
@@ -130,33 +116,11 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
                         <UserEmail />
                       </span>
                       <span className="sm:hidden" aria-label="Account menu">
-                        <svg
-                          className="h-5 w-5"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                          />
-                        </svg>
+                        <UserIcon className="h-5 w-5" />
                       </span>
-                      <svg
+                      <ChevronDownIcon
                         className={`h-4 w-4 transition-transform ${userMenuOpen ? "rotate-180" : ""}`}
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M19 9l-7 7-7-7"
-                        />
-                      </svg>
+                      />
                     </button>
 
                     {/* Dropdown menu */}

--- a/src/app/(auth)/auth/oauth/callback/page.tsx
+++ b/src/app/(auth)/auth/oauth/callback/page.tsx
@@ -17,6 +17,7 @@ import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc/client";
 import { broadcastOAuthComplete } from "@/lib/oauth-channel";
+import { SpinnerIcon } from "@/components/ui/icon-button";
 
 /**
  * Validation result for OAuth callback parameters
@@ -301,26 +302,7 @@ function OAuthCallbackContent() {
         </div>
       ) : (
         <div className="flex flex-col items-center gap-4">
-          <svg
-            className="h-8 w-8 animate-spin text-zinc-900 dark:text-zinc-100"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            />
-          </svg>
+          <SpinnerIcon className="h-8 w-8 text-zinc-900 dark:text-zinc-100" />
           <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
             Please wait while we complete{" "}
             {isSaveMode

--- a/src/app/(auth)/auth/oauth/complete/page.tsx
+++ b/src/app/(auth)/auth/oauth/complete/page.tsx
@@ -20,6 +20,7 @@
 import { Suspense, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { broadcastOAuthComplete } from "@/lib/oauth-channel";
+import { SpinnerIcon } from "@/components/ui/icon-button";
 
 export default function OAuthCompletePage() {
   return (
@@ -56,26 +57,7 @@ function OAuthCompleteContent() {
         Sign-in successful
       </h2>
       <div className="flex flex-col items-center gap-4">
-        <svg
-          className="h-8 w-8 animate-spin text-zinc-900 dark:text-zinc-100"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          />
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-          />
-        </svg>
+        <SpinnerIcon className="h-8 w-8 text-zinc-900 dark:text-zinc-100" />
         <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">Redirecting...</p>
       </div>
     </div>

--- a/src/app/demo/DemoLayoutContent.tsx
+++ b/src/app/demo/DemoLayoutContent.tsx
@@ -13,6 +13,7 @@
 
 import { useState, useSyncExternalStore, type ReactNode } from "react";
 import Link from "next/link";
+import { CloseIcon, MenuIcon } from "@/components/ui/icon-button";
 import { LayoutShell } from "@/components/layout/LayoutShell";
 import {
   ScrollContainerProvider,
@@ -58,14 +59,7 @@ export function DemoLayoutContent({ children }: DemoLayoutContentProps) {
                   className="flex h-10 w-10 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:text-zinc-400 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                   aria-label="Close navigation menu"
                 >
-                  <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
+                  <CloseIcon className="h-5 w-5" />
                 </button>
               }
               mobileMenuButton={
@@ -74,14 +68,7 @@ export function DemoLayoutContent({ children }: DemoLayoutContentProps) {
                   className="flex h-10 w-10 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:text-zinc-400 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                   aria-label="Open navigation menu"
                 >
-                  <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M4 6h16M4 12h16M4 18h16"
-                    />
-                  </svg>
+                  <MenuIcon className="h-5 w-5" />
                 </button>
               }
               headerRight={

--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import { ClientLink } from "@/components/ui/client-link";
 import { Button } from "@/components/ui/button";
 import {
+  ArrowLeftIcon,
   SparklesIcon,
   StarIcon,
   StarFilledIcon,
@@ -261,14 +262,7 @@ function DemoRouterContent() {
             href={backHref}
             className="ui-text-sm mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
           >
-            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M10 19l-7-7m0 0l7-7m-7 7h18"
-              />
-            </svg>
+            <ArrowLeftIcon className="h-4 w-4" />
             <span>Back to list</span>
           </ClientLink>
         }

--- a/src/app/oauth/consent/ConsentForm.tsx
+++ b/src/app/oauth/consent/ConsentForm.tsx
@@ -7,6 +7,8 @@
 
 "use client";
 
+import { CheckIcon, ShieldCheckIcon, WarningTriangleIcon } from "@/components/ui/icon-button";
+
 interface ScopeInfo {
   name: string;
   description: string;
@@ -38,19 +40,7 @@ export function ConsentForm({
       {/* Application info */}
       <div className="mb-6 text-center">
         <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-          <svg
-            className="h-8 w-8 text-zinc-600 dark:text-zinc-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
-            />
-          </svg>
+          <ShieldCheckIcon className="h-8 w-8 text-zinc-600 dark:text-zinc-400" />
         </div>
         <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
           Authorize {clientName}
@@ -68,15 +58,7 @@ export function ConsentForm({
         <ul className="space-y-2">
           {scopes.map((scope) => (
             <li key={scope.name} className="flex items-start gap-2">
-              <svg
-                className="mt-0.5 h-4 w-4 shrink-0 text-green-600 dark:text-green-400"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={2}
-                stroke="currentColor"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-              </svg>
+              <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-green-600 dark:text-green-400" />
               <span className="ui-text-sm text-zinc-700 dark:text-zinc-300">
                 {scope.description}
               </span>
@@ -87,19 +69,7 @@ export function ConsentForm({
 
       {/* Warning */}
       <div className="mb-6 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-900/50 dark:bg-amber-900/20">
-        <svg
-          className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={2}
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
-          />
-        </svg>
+        <WarningTriangleIcon className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
         <p className="ui-text-sm text-amber-800 dark:text-amber-200">
           Only authorize applications you trust. You can revoke access at any time in Settings.
         </p>

--- a/src/app/oauth/consent/page.tsx
+++ b/src/app/oauth/consent/page.tsx
@@ -7,6 +7,7 @@
 
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { WarningTriangleIcon } from "@/components/ui/icon-button";
 import { validateSession } from "@/server/auth/session";
 import { resolveClient } from "@/server/oauth/service";
 import {
@@ -137,19 +138,7 @@ function ErrorMessage({ title, message }: { title: string; message: string }) {
   return (
     <div className="text-center">
       <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/20">
-        <svg
-          className="h-6 w-6 text-red-600 dark:text-red-400"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
-          />
-        </svg>
+        <WarningTriangleIcon className="h-6 w-6 text-red-600 dark:text-red-400" />
       </div>
       <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">{title}</h2>
       <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">{message}</p>

--- a/src/app/save/page.tsx
+++ b/src/app/save/page.tsx
@@ -17,6 +17,7 @@ import { useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc/client";
 import { Button } from "@/components/ui/button";
 import { Alert } from "@/components/ui/alert";
+import { SpinnerIcon, CheckIcon, LockIcon, CloseIcon } from "@/components/ui/icon-button";
 
 export default function SavePage() {
   return (
@@ -258,26 +259,7 @@ function SaveContent() {
           {(activeMutation.isIdle || activeMutation.isPending) && (
             <div className="mt-6">
               <div className="flex justify-center">
-                <svg
-                  className="h-8 w-8 animate-spin text-zinc-600 dark:text-zinc-400"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  />
-                </svg>
+                <SpinnerIcon className="h-8 w-8 text-zinc-600 dark:text-zinc-400" />
               </div>
               <p className="ui-text-sm mt-3 text-zinc-600 dark:text-zinc-400">
                 {shareType === "file" ? "Uploading file..." : "Saving article..."}
@@ -294,15 +276,7 @@ function SaveContent() {
           {activeMutation.isSuccess && (
             <div className="mt-6">
               <div className="flex justify-center">
-                <svg
-                  className="h-8 w-8 text-green-600 dark:text-green-500"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
+                <CheckIcon className="h-8 w-8 text-green-600 dark:text-green-500" />
               </div>
               <p className="ui-text-sm mt-3 font-medium text-green-700 dark:text-green-400">
                 Saved successfully!
@@ -328,19 +302,7 @@ function SaveContent() {
               {isAuthError ? (
                 <>
                   <div className="flex justify-center">
-                    <svg
-                      className="h-8 w-8 text-amber-600 dark:text-amber-500"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-                      />
-                    </svg>
+                    <LockIcon className="h-8 w-8 text-amber-600 dark:text-amber-500" />
                   </div>
                   <Alert variant="warning" className="mt-4 text-left">
                     Your session has expired. Please sign in again to save this article.
@@ -361,19 +323,7 @@ function SaveContent() {
               needsDocsPermission || needsGoogleSignin || needsGoogleReauth ? (
                 <>
                   <div className="flex justify-center">
-                    <svg
-                      className="h-8 w-8 text-blue-600 dark:text-blue-500"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-                      />
-                    </svg>
+                    <LockIcon className="h-8 w-8 text-blue-600 dark:text-blue-500" />
                   </div>
                   <Alert variant="error" className="mt-4 text-left">
                     {needsDocsPermission
@@ -415,15 +365,7 @@ function SaveContent() {
                 <>
                   {/* General Error */}
                   <div className="flex justify-center">
-                    <svg
-                      className="h-8 w-8 text-red-600 dark:text-red-500"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
+                    <CloseIcon className="h-8 w-8 text-red-600 dark:text-red-500" />
                   </div>
                   <Alert variant="error" className="mt-4 text-left">
                     {activeMutation.error?.message ||

--- a/src/components/entries/MarkAllReadButton.tsx
+++ b/src/components/entries/MarkAllReadButton.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { useState } from "react";
+import { CheckCircleIcon } from "@/components/ui/icon-button";
 import { MarkAllReadDialog } from "@/components/feeds/MarkAllReadDialog";
 
 interface MarkAllReadButtonProps {
@@ -35,20 +36,7 @@ export function MarkAllReadButton({
         title="Mark all as read"
         aria-label="Mark all as read"
       >
-        <svg
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={1.5}
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
+        <CheckCircleIcon className="h-5 w-5" />
         <span className="ui-text-sm ml-1.5 hidden sm:inline">Mark All Read</span>
       </button>
 

--- a/src/components/entries/VoteControls.tsx
+++ b/src/components/entries/VoteControls.tsx
@@ -21,6 +21,13 @@
 
 import { useCallback } from "react";
 
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  DoubleChevronDownIcon,
+  DoubleChevronUpIcon,
+} from "@/components/ui/icon-button";
+
 interface VoteControlsProps {
   /** Explicit score set by user (-2 to +2), null if not voted */
   score: number | null;
@@ -51,58 +58,6 @@ function computeNextScore(displayScore: number, direction: "up" | "down"): numbe
   }
 }
 
-/**
- * Single chevron up icon - matches the standard icon viewBox.
- */
-function SingleChevronUpIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
-    </svg>
-  );
-}
-
-/**
- * Single chevron down icon - matches the standard icon viewBox.
- */
-function SingleChevronDownIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-    </svg>
-  );
-}
-
-/**
- * Double chevron up icon for strong votes (+2).
- * Bottom arrow matches single chevron position, top arrow appears above.
- */
-function DoubleChevronUpIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      {/* Top arrow (additional) */}
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 9l7-7 7 7" />
-      {/* Bottom arrow (same position as single chevron) */}
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
-    </svg>
-  );
-}
-
-/**
- * Double chevron down icon for strong votes (-2).
- * Top arrow matches single chevron position, bottom arrow appears below.
- */
-function DoubleChevronDownIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      {/* Top arrow (same position as single chevron) */}
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-      {/* Bottom arrow (additional) */}
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 15l-7 7-7-7" />
-    </svg>
-  );
-}
-
 export function VoteControls({ score, implicitScore, onSetScore }: VoteControlsProps) {
   const displayScore = score ?? implicitScore ?? 0;
 
@@ -121,8 +76,8 @@ export function VoteControls({ score, implicitScore, onSetScore }: VoteControlsP
   const strongDown = displayScore <= -2;
 
   // Choose icons based on score magnitude
-  const UpIcon = strongUp ? DoubleChevronUpIcon : SingleChevronUpIcon;
-  const DownIcon = strongDown ? DoubleChevronDownIcon : SingleChevronDownIcon;
+  const UpIcon = strongUp ? DoubleChevronUpIcon : ChevronUpIcon;
+  const DownIcon = strongDown ? DoubleChevronDownIcon : ChevronDownIcon;
 
   return (
     <div className="inline-flex flex-col items-center">

--- a/src/components/narration/EnhancedVoiceList.tsx
+++ b/src/components/narration/EnhancedVoiceList.tsx
@@ -11,6 +11,18 @@
 
 import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  CheckIcon,
+  AlertCircleIcon,
+  SpinnerIcon,
+  StopIcon,
+  PlayIcon,
+  TrashIcon,
+  RefreshIcon,
+  DownloadIcon,
+  CloseIcon,
+  AlertIcon,
+} from "@/components/ui/icon-button";
 import type { NarrationSettings } from "@/lib/narration/settings";
 import { useEnhancedVoices, type EnhancedVoiceState } from "./useEnhancedVoices";
 import { trackEnhancedVoiceSelected } from "@/lib/telemetry";
@@ -162,32 +174,13 @@ function VoiceItem({
               <ProgressBar progress={progress} size={voice.sizeBytes} />
             ) : isDownloaded ? (
               <div className="ui-text-xs mt-1 flex items-center gap-1 text-green-600 dark:text-green-400">
-                <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
+                <CheckIcon className="h-3.5 w-3.5" />
                 Downloaded
               </div>
             ) : hasError ? (
               <div className="mt-1 space-y-1">
                 <div className="ui-text-xs flex items-center gap-1 text-red-600 dark:text-red-400">
-                  <svg
-                    className="h-3.5 w-3.5"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
-                  </svg>
+                  <AlertCircleIcon className="h-3.5 w-3.5" />
                   {errorInfo.message}
                 </div>
                 {errorInfo.suggestion && (
@@ -209,21 +202,7 @@ function VoiceItem({
           {isDownloading ? (
             // Cancel button during download (optional - just showing spinner for now)
             <div className="ui-text-xs flex items-center gap-2 text-zinc-500 dark:text-zinc-400">
-              <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                />
-              </svg>
+              <SpinnerIcon className="h-4 w-4" />
               Downloading...
             </div>
           ) : isDownloaded ? (
@@ -245,32 +224,12 @@ function VoiceItem({
               >
                 {isThisVoicePreviewing ? (
                   <>
-                    <svg
-                      className="mr-1 h-3.5 w-3.5"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                      />
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"
-                      />
-                    </svg>
+                    <StopIcon className="mr-1 h-3.5 w-3.5" />
                     Stop
                   </>
                 ) : (
                   <>
-                    <svg className="mr-1 h-3.5 w-3.5" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M8 5v14l11-7z" />
-                    </svg>
+                    <PlayIcon className="mr-1 h-3.5 w-3.5" />
                     Preview
                   </>
                 )}
@@ -286,50 +245,19 @@ function VoiceItem({
                 className="rounded-md p-2 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
                 title="Delete voice"
               >
-                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                  />
-                </svg>
+                <TrashIcon className="h-4 w-4" />
               </button>
             </>
           ) : hasError && errorInfo.retryable ? (
             /* Retry button for retryable errors */
             <Button type="button" variant="secondary" size="sm" onClick={onRetry}>
-              <svg
-                className="mr-1 h-3.5 w-3.5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-                />
-              </svg>
+              <RefreshIcon className="mr-1 h-3.5 w-3.5" />
               Retry
             </Button>
           ) : (
             /* Download button */
             <Button type="button" variant="secondary" size="sm" onClick={onDownload}>
-              <svg
-                className="mr-1 h-3.5 w-3.5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
-                />
-              </svg>
+              <DownloadIcon className="mr-1 h-3.5 w-3.5" />
               Download
             </Button>
           )}
@@ -431,21 +359,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-8">
-        <svg className="h-6 w-6 animate-spin text-zinc-400" fill="none" viewBox="0 0 24 24">
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          />
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-          />
-        </svg>
+        <SpinnerIcon className="h-6 w-6 text-zinc-400" />
         <span className="ui-text-sm ml-2 text-zinc-500 dark:text-zinc-400">Loading voices...</span>
       </div>
     );
@@ -457,19 +371,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
       {error && (
         <div className="rounded-md bg-red-50 p-3 dark:bg-red-900/20">
           <div className="ui-text-xs flex items-start gap-2 text-red-800 dark:text-red-200">
-            <svg
-              className="mt-0.5 h-4 w-4 flex-shrink-0"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
+            <AlertCircleIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
             <div className="flex-1 space-y-1">
               <p>{error}</p>
               {lastErrorInfo?.suggestion && (
@@ -491,14 +393,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
                 onClick={clearError}
                 className="text-red-600 hover:text-red-800 dark:text-red-300 dark:hover:text-red-100"
               >
-                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
+                <CloseIcon className="h-4 w-4" />
               </button>
             </div>
           </div>
@@ -508,19 +403,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
       {/* Storage limit warning */}
       {isStorageLimitExceeded && (
         <div className="ui-text-xs flex items-start gap-2 rounded-md bg-amber-50 p-3 text-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
-          <svg
-            className="mt-0.5 h-4 w-4 flex-shrink-0"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-            />
-          </svg>
+          <AlertIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
           <span className="flex-1">
             Voice storage exceeds 200 MB. Consider removing unused voices to free up space.
           </span>

--- a/src/components/narration/EnhancedVoicesHelp.tsx
+++ b/src/components/narration/EnhancedVoicesHelp.tsx
@@ -10,6 +10,7 @@
 "use client";
 
 import { useState } from "react";
+import { ChevronDownIcon, QuestionCircleIcon } from "@/components/ui/icon-button";
 
 /**
  * FAQ item definition.
@@ -78,16 +79,11 @@ function FAQItemComponent({
         <span className="ui-text-sm font-medium text-zinc-700 dark:text-zinc-300">
           {item.question}
         </span>
-        <svg
+        <ChevronDownIcon
           className={`h-4 w-4 flex-shrink-0 text-zinc-500 transition-transform duration-200 dark:text-zinc-400 ${
             isOpen ? "rotate-180" : ""
           }`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
+        />
       </button>
       {isOpen && (
         <div className="pr-8 pb-3">
@@ -136,33 +132,16 @@ export function EnhancedVoicesHelp() {
         aria-expanded={isExpanded}
       >
         <div className="flex items-center gap-2">
-          <svg
-            className="h-4 w-4 text-zinc-500 dark:text-zinc-400"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
-          </svg>
+          <QuestionCircleIcon className="h-4 w-4 text-zinc-500 dark:text-zinc-400" />
           <span className="ui-text-sm font-medium text-zinc-700 dark:text-zinc-300">
             Help with enhanced voices
           </span>
         </div>
-        <svg
+        <ChevronDownIcon
           className={`h-4 w-4 text-zinc-500 transition-transform duration-200 dark:text-zinc-400 ${
             isExpanded ? "rotate-180" : ""
           }`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
+        />
       </button>
 
       {/* Expandable FAQ content */}

--- a/src/components/narration/NarrationSettings.tsx
+++ b/src/components/narration/NarrationSettings.tsx
@@ -11,6 +11,7 @@
 import { useState, useEffect, useCallback, useSyncExternalStore } from "react";
 import dynamic from "next/dynamic";
 import { Button } from "@/components/ui/button";
+import { AlertIcon, InfoCircleIcon } from "@/components/ui/icon-button";
 import { useNarrationSettings } from "@/lib/narration/settings";
 import { getNarrationSupportInfo, isFirefox } from "@/lib/narration/feature-detection";
 import { waitForVoices, rankVoices, findVoiceByUri } from "@/lib/narration/voices";
@@ -182,19 +183,7 @@ export function NarrationSettings() {
         <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">Narration</h2>
         <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
           <div className="flex items-start gap-3">
-            <svg
-              className="mt-0.5 h-5 w-5 flex-shrink-0 text-zinc-400 dark:text-zinc-500"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-              />
-            </svg>
+            <AlertIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-zinc-400 dark:text-zinc-500" />
             <div>
               <p className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
                 Narration Unavailable
@@ -567,19 +556,7 @@ export function NarrationSettings() {
             {/* Firefox Warning */}
             {isFirefoxBrowser && (
               <div className="ui-text-xs flex items-start gap-2 rounded-md bg-amber-50 p-3 text-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
-                <svg
-                  className="mt-0.5 h-4 w-4 flex-shrink-0"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-                  />
-                </svg>
+                <AlertIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
                 <span>
                   Firefox has limited support for pausing narration. When you pause and resume,
                   playback will restart from the beginning of the current paragraph.
@@ -593,19 +570,7 @@ export function NarrationSettings() {
         {settings.enabled && supportInfo.mediaSession && (
           <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
             <div className="ui-text-xs flex items-start gap-2 text-zinc-500 dark:text-zinc-400">
-              <svg
-                className="mt-0.5 h-4 w-4 flex-shrink-0"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
+              <InfoCircleIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
               <span>
                 Your browser supports media controls. You can control playback using your keyboard
                 media keys or lock screen controls.

--- a/src/components/settings/ApiKeySettings.tsx
+++ b/src/components/settings/ApiKeySettings.tsx
@@ -10,6 +10,7 @@
 import { useState, useCallback } from "react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
+import { CheckIcon } from "@/components/ui/icon-button";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
@@ -122,19 +123,7 @@ export function GroqApiKeySettings() {
             {hasKey ? (
               <>
                 <span className="ui-text-sm inline-flex items-center text-green-600 dark:text-green-400">
-                  <svg
-                    className="mr-1 h-4 w-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M5 13l4 4L19 7"
-                    />
-                  </svg>
+                  <CheckIcon className="mr-1 h-4 w-4" />
                   API key configured
                 </span>
                 <Button variant="secondary" size="sm" onClick={() => setIsEditing(true)}>
@@ -371,19 +360,7 @@ export function SummarizationApiKeySettings() {
                 {hasKey ? (
                   <>
                     <span className="ui-text-sm inline-flex items-center text-green-600 dark:text-green-400">
-                      <svg
-                        className="mr-1 h-4 w-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M5 13l4 4L19 7"
-                        />
-                      </svg>
+                      <CheckIcon className="mr-1 h-4 w-4" />
                       API key configured
                     </span>
                     <Button variant="secondary" size="sm" onClick={() => setIsEditing(true)}>

--- a/src/components/settings/BookmarkletSettings.tsx
+++ b/src/components/settings/BookmarkletSettings.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { useState, useMemo, useEffect, useRef } from "react";
+import { BookmarkIcon, ChevronRightIcon } from "@/components/ui/icon-button";
 
 export function BookmarkletSettings() {
   const [showCode, setShowCode] = useState(false);
@@ -91,19 +92,7 @@ export function BookmarkletSettings() {
             draggable
             className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-amber-300 bg-amber-50 px-4 py-2.5 font-medium text-amber-800 shadow-sm transition-all hover:border-amber-400 hover:bg-amber-100 hover:shadow active:scale-95 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200 dark:hover:border-amber-600 dark:hover:bg-amber-900"
           >
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
-              />
-            </svg>
+            <BookmarkIcon className="h-4 w-4" />
             Save to Lion Reader
           </a>
         </div>
@@ -136,14 +125,9 @@ export function BookmarkletSettings() {
             onClick={() => setShowCode(!showCode)}
             className="ui-text-sm inline-flex items-center gap-2 font-medium text-zinc-700 transition-colors hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-50"
           >
-            <svg
+            <ChevronRightIcon
               className={`h-4 w-4 transition-transform ${showCode ? "rotate-90" : ""}`}
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
+            />
             {showCode ? "Hide bookmarklet code" : "Show bookmarklet code"}
           </button>
 

--- a/src/components/settings/KeyboardShortcutsSettings.tsx
+++ b/src/components/settings/KeyboardShortcutsSettings.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { useKeyboardShortcutsContext } from "@/components/keyboard/KeyboardShortcutsProvider";
+import { InfoCircleIcon } from "@/components/ui/icon-button";
 
 export function KeyboardShortcutsSettings() {
   const { enabled, setEnabled, openShortcutsModal } = useKeyboardShortcutsContext();
@@ -52,14 +53,7 @@ export function KeyboardShortcutsSettings() {
             onClick={openShortcutsModal}
             className="ui-text-sm inline-flex items-center gap-2 font-medium text-zinc-700 transition-colors hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-50"
           >
-            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
+            <InfoCircleIcon className="h-4 w-4" />
             View all keyboard shortcuts
             {enabled && (
               <kbd className="ui-text-xs ml-1 rounded border border-zinc-300 bg-zinc-100 px-1.5 py-0.5 font-mono font-medium text-zinc-600 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">

--- a/src/components/settings/UnifiedSettingsContent.tsx
+++ b/src/components/settings/UnifiedSettingsContent.tsx
@@ -17,6 +17,7 @@
 
 import { usePathname } from "next/navigation";
 import { ClientLink } from "@/components/ui/client-link";
+import { ChevronLeftIcon } from "@/components/ui/icon-button";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 
 // Settings page components - directly imported (not lazy) so static content
@@ -85,14 +86,7 @@ export function UnifiedSettingsContent() {
           href="/all"
           className="ui-text-sm mb-4 inline-flex items-center text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
         >
-          <svg className="mr-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M15 19l-7-7 7-7"
-            />
-          </svg>
+          <ChevronLeftIcon className="mr-1 h-4 w-4" />
           Back to feeds
         </ClientLink>
         <h1 className="ui-text-2xl font-bold text-zinc-900 dark:text-zinc-50">Settings</h1>

--- a/src/components/settings/pages/AccountSettingsContent.tsx
+++ b/src/components/settings/pages/AccountSettingsContent.tsx
@@ -18,6 +18,7 @@ import { clientReplace } from "@/lib/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
+import { CheckIcon } from "@/components/ui/icon-button";
 import { LinkedAccounts } from "@/components/settings/LinkedAccounts";
 import { KeyboardShortcutsSettings } from "@/components/settings/KeyboardShortcutsSettings";
 import { AboutSection } from "@/components/settings/AboutSection";
@@ -127,19 +128,7 @@ function AccountInfoSection() {
               <dd className="ui-text-sm mt-1 text-zinc-900 dark:text-zinc-50">
                 {userQuery.data?.user.emailVerifiedAt ? (
                   <span className="inline-flex items-center text-green-600 dark:text-green-400">
-                    <svg
-                      className="mr-1 h-4 w-4"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M5 13l4 4L19 7"
-                      />
-                    </svg>
+                    <CheckIcon className="mr-1 h-4 w-4" />
                     Verified
                   </span>
                 ) : (

--- a/src/components/settings/pages/ApiTokensSettingsContent.tsx
+++ b/src/components/settings/pages/ApiTokensSettingsContent.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
 import { SettingsListContainer } from "@/components/settings/SettingsListContainer";
+import { CloseIcon, KeyIcon } from "@/components/ui/icon-button";
 import { formatRelativeTime } from "@/lib/format";
 
 /**
@@ -296,19 +297,7 @@ export default function ApiTokensSettingsContent() {
               >
                 <div className="flex items-center gap-2">
                   <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-200 dark:bg-zinc-800">
-                    <svg
-                      className="h-4 w-4 text-zinc-400 dark:text-zinc-600"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
+                    <CloseIcon className="h-4 w-4 text-zinc-400 dark:text-zinc-600" />
                   </div>
                   <div>
                     <p className="font-medium text-zinc-700 dark:text-zinc-400">
@@ -355,19 +344,7 @@ function ActiveTokenCard({ token, onRevoke, isRevoking }: ActiveTokenCardProps) 
           <div className="flex items-center gap-2">
             {/* Key icon */}
             <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-              <svg
-                className="h-4 w-4 text-zinc-600 dark:text-zinc-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
-                />
-              </svg>
+              <KeyIcon className="h-4 w-4 text-zinc-600 dark:text-zinc-400" />
             </div>
 
             <div className="min-w-0 flex-1">

--- a/src/components/settings/pages/BlockedSendersSettingsContent.tsx
+++ b/src/components/settings/pages/BlockedSendersSettingsContent.tsx
@@ -19,6 +19,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { SettingsListContainer } from "@/components/settings/SettingsListContainer";
+import { ProhibitionIcon, CheckIcon } from "@/components/ui/icon-button";
 import { formatRelativeTime } from "@/lib/format";
 
 // ============================================================================
@@ -77,19 +78,7 @@ function EmptyState() {
   return (
     <div className="p-8 text-center">
       <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-        <svg
-          className="h-6 w-6 text-zinc-400 dark:text-zinc-500"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
-          />
-        </svg>
+        <ProhibitionIcon className="h-6 w-6 text-zinc-400 dark:text-zinc-500" />
       </div>
       <h3 className="ui-text-sm mt-4 font-medium text-zinc-900 dark:text-zinc-50">
         No blocked senders
@@ -172,19 +161,7 @@ function BlockedSenderRow({ sender }: BlockedSenderRowProps) {
             <span>Blocked {formatRelativeTime(sender.blockedAt)}</span>
             {sender.unsubscribeSentAt && (
               <span className="flex items-center gap-1">
-                <svg
-                  className="h-3.5 w-3.5 text-green-600 dark:text-green-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
+                <CheckIcon className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
                 Unsubscribe sent
               </span>
             )}

--- a/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
+++ b/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
@@ -15,6 +15,7 @@ import { handleSubscriptionDeleted } from "@/lib/cache/operations";
 import { getFeedDisplayName, formatRelativeTime, formatFutureTime } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { SettingsListContainer } from "@/components/settings/SettingsListContainer";
+import { CheckIcon, AlertCircleIcon } from "@/components/ui/icon-button";
 import { UnsubscribeDialog } from "@/components/feeds/UnsubscribeDialog";
 
 // ============================================================================
@@ -118,14 +119,7 @@ function EmptyState() {
   return (
     <div className="p-8 text-center">
       <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
-        <svg
-          className="h-6 w-6 text-green-600 dark:text-green-400"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-        </svg>
+        <CheckIcon className="h-6 w-6 text-green-600 dark:text-green-400" />
       </div>
       <h3 className="ui-text-sm mt-4 font-medium text-zinc-900 dark:text-zinc-50">
         All feeds are working
@@ -200,19 +194,7 @@ function BrokenFeedRow({ feed, onUnsubscribe }: BrokenFeedRowProps) {
           {/* Metadata */}
           <div className="ui-text-sm mt-2 flex flex-wrap gap-x-4 gap-y-1 text-zinc-500 dark:text-zinc-400">
             <span className="flex items-center gap-1">
-              <svg
-                className="h-4 w-4 text-red-500"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
+              <AlertCircleIcon className="h-4 w-4 text-red-500" />
               {feed.consecutiveFailures} consecutive failure
               {feed.consecutiveFailures === 1 ? "" : "s"}
             </span>

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -22,6 +22,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { SettingsListContainer } from "@/components/settings/SettingsListContainer";
+import { PlusIcon, CheckIcon, CopyIcon, EditIcon } from "@/components/ui/icon-button";
 import BlockedSendersSettingsContent from "./BlockedSendersSettingsContent";
 
 // ============================================================================
@@ -170,19 +171,7 @@ function IngestAddressesSection() {
             {!isCreating && addresses.length < 5 && (
               <div className="border-t border-zinc-200 p-4 dark:border-zinc-800">
                 <Button variant="secondary" onClick={() => setIsCreating(true)}>
-                  <svg
-                    className="mr-2 h-4 w-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M12 4v16m8-8H4"
-                    />
-                  </svg>
+                  <PlusIcon className="mr-2 h-4 w-4" />
                   Create New Address
                 </Button>
               </div>
@@ -309,28 +298,9 @@ function IngestAddressRow({ address }: IngestAddressRowProps) {
               title="Copy email address"
             >
               {copied ? (
-                <svg
-                  className="h-4 w-4 text-green-600 dark:text-green-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
+                <CheckIcon className="h-4 w-4 text-green-600 dark:text-green-400" />
               ) : (
-                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-                  />
-                </svg>
+                <CopyIcon className="h-4 w-4" />
               )}
             </button>
           </div>
@@ -371,14 +341,7 @@ function IngestAddressRow({ address }: IngestAddressRowProps) {
                 className="rounded p-0.5 text-zinc-400 transition-colors hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
                 title="Edit label"
               >
-                <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
-                  />
-                </svg>
+                <EditIcon className="h-3.5 w-3.5" />
               </button>
             </div>
           )}

--- a/src/components/settings/pages/FeedStatsSettingsContent.tsx
+++ b/src/components/settings/pages/FeedStatsSettingsContent.tsx
@@ -11,6 +11,7 @@ import { trpc } from "@/lib/trpc/client";
 import { getFeedDisplayName, formatRelativeTime, formatFutureTime } from "@/lib/format";
 import { Alert } from "@/components/ui/alert";
 import { SettingsListSkeleton } from "@/components/settings/SettingsListSkeleton";
+import { RssIcon, ClockIcon, CalendarIcon, RefreshIcon } from "@/components/ui/icon-button";
 
 // ============================================================================
 // Types
@@ -151,19 +152,7 @@ function EmptyState() {
   return (
     <div className="p-8 text-center">
       <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-        <svg
-          className="h-6 w-6 text-zinc-400 dark:text-zinc-500"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M6 5c7.18 0 13 5.82 13 13M6 11a7 7 0 017 7m-6 0a1 1 0 11-2 0 1 1 0 012 0z"
-          />
-        </svg>
+        <RssIcon className="h-6 w-6 text-zinc-400 dark:text-zinc-500" />
       </div>
       <h3 className="ui-text-sm mt-4 font-medium text-zinc-900 dark:text-zinc-50">
         No feeds subscribed
@@ -266,48 +255,5 @@ function StatItem({ icon, label, value }: StatItemProps) {
         <span className="font-medium text-zinc-700 dark:text-zinc-300">{label}:</span> {value}
       </span>
     </div>
-  );
-}
-
-// ============================================================================
-// Icons
-// ============================================================================
-
-function ClockIcon() {
-  return (
-    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-      />
-    </svg>
-  );
-}
-
-function CalendarIcon() {
-  return (
-    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-      />
-    </svg>
-  );
-}
-
-function RefreshIcon() {
-  return (
-    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-      />
-    </svg>
   );
 }

--- a/src/components/settings/pages/SessionsSettingsContent.tsx
+++ b/src/components/settings/pages/SessionsSettingsContent.tsx
@@ -13,6 +13,7 @@ import { trpc } from "@/lib/trpc/client";
 import { Button } from "@/components/ui/button";
 import { Alert } from "@/components/ui/alert";
 import { SettingsListContainer } from "@/components/settings/SettingsListContainer";
+import { MobileIcon, DesktopIcon } from "@/components/ui/icon-button";
 import { formatRelativeTime } from "@/lib/format";
 
 /**
@@ -164,33 +165,9 @@ function SessionCard({ session, onRevoke, isRevoking }: SessionCardProps) {
             {/* Device icon */}
             <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
               {platform === "iOS" || platform === "Android" ? (
-                <svg
-                  className="h-4 w-4 text-zinc-600 dark:text-zinc-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
-                  />
-                </svg>
+                <MobileIcon className="h-4 w-4 text-zinc-600 dark:text-zinc-400" />
               ) : (
-                <svg
-                  className="h-4 w-4 text-zinc-600 dark:text-zinc-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                  />
-                </svg>
+                <DesktopIcon className="h-4 w-4 text-zinc-600 dark:text-zinc-400" />
               )}
             </div>
 

--- a/src/components/subscribe/SubscribeContent.tsx
+++ b/src/components/subscribe/SubscribeContent.tsx
@@ -17,6 +17,7 @@ import { clientPush } from "@/lib/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
+import { CheckCircleIcon, SpinnerIcon, ChevronRightIcon } from "@/components/ui/icon-button";
 
 // ============================================================================
 // Types
@@ -269,19 +270,7 @@ export function SubscribeContent() {
           {/* Discovery Results Card */}
           <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
             <div className="mb-4 flex items-center gap-2">
-              <svg
-                className="h-5 w-5 text-green-600 dark:text-green-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
+              <CheckCircleIcon className="h-5 w-5 text-green-600 dark:text-green-400" />
               <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
                 We found {discoveredFeeds.length} feed{discoveredFeeds.length !== 1 ? "s" : ""} on
                 this site
@@ -328,39 +317,9 @@ export function SubscribeContent() {
                       </p>
                     </div>
                     {selectedFeedUrl === feed.url && isLoading ? (
-                      <svg
-                        className="h-5 w-5 animate-spin text-zinc-500"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                      >
-                        <circle
-                          className="opacity-25"
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke="currentColor"
-                          strokeWidth="4"
-                        />
-                        <path
-                          className="opacity-75"
-                          fill="currentColor"
-                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                        />
-                      </svg>
+                      <SpinnerIcon className="h-5 w-5 text-zinc-500" />
                     ) : (
-                      <svg
-                        className="h-5 w-5 text-zinc-400"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M9 5l7 7-7 7"
-                        />
-                      </svg>
+                      <ChevronRightIcon className="h-5 w-5 text-zinc-400" />
                     )}
                   </div>
                 </button>

--- a/src/components/summarization/SummaryCard.tsx
+++ b/src/components/summarization/SummaryCard.tsx
@@ -8,28 +8,7 @@
 "use client";
 
 import { useEntryTextStyles } from "@/lib/appearance/AppearanceProvider";
-
-/**
- * Sparkles icon for AI indicator.
- */
-function SparklesIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"
-      />
-    </svg>
-  );
-}
+import { CloseIcon, SparklesIcon, SpinnerIcon } from "@/components/ui/icon-button";
 
 /**
  * Format a date for display.
@@ -85,26 +64,7 @@ export function SummaryCard({
           <span className="ui-text-sm font-medium text-blue-900 dark:text-blue-100">
             Generating summary...
           </span>
-          <svg
-            className="h-4 w-4 animate-spin text-blue-600 dark:text-blue-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            />
-          </svg>
+          <SpinnerIcon className="h-4 w-4 text-blue-600 dark:text-blue-400" />
         </div>
       </div>
     );
@@ -127,14 +87,7 @@ export function SummaryCard({
               className="rounded p-1 text-red-600 hover:bg-red-100 dark:text-red-400 dark:hover:bg-red-800/50"
               aria-label="Close"
             >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
+              <CloseIcon className="h-4 w-4" />
             </button>
           )}
         </div>
@@ -169,14 +122,7 @@ export function SummaryCard({
               className="rounded p-1 text-blue-600 hover:bg-blue-100 dark:text-blue-400 dark:hover:bg-blue-800/50"
               aria-label="Close summary"
             >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
+              <CloseIcon className="h-4 w-4" />
             </button>
           )}
         </div>

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -9,6 +9,7 @@
 
 import { Component, type ReactNode } from "react";
 import { Button } from "./button";
+import { AlertIcon } from "@/components/ui/icon-button";
 
 interface ErrorBoundaryProps {
   /**
@@ -53,20 +54,7 @@ function DefaultErrorFallback({
 }) {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center" role="alert">
-      <svg
-        className="mb-4 h-12 w-12 text-red-400 dark:text-red-500"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={1.5}
-          d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-        />
-      </svg>
+      <AlertIcon className="mb-4 h-12 w-12 text-red-400 dark:text-red-500" />
       <h2 className="ui-text-lg mb-2 font-semibold text-zinc-900 dark:text-zinc-50">
         Something went wrong
       </h2>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { ButtonHTMLAttributes, Ref } from "react";
+import { SpinnerIcon } from "@/components/ui/icon-button";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "ghost";
@@ -49,28 +50,7 @@ export function Button({
       className={`${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
       {...props}
     >
-      {loading && (
-        <svg
-          className="mr-2 -ml-1 h-4 w-4 animate-spin"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          />
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-          />
-        </svg>
-      )}
+      {loading && <SpinnerIcon className="mr-2 -ml-1 h-4 w-4" />}
       {children}
     </button>
   );

--- a/src/components/ui/icon-button.tsx
+++ b/src/components/ui/icon-button.tsx
@@ -622,3 +622,401 @@ export function WifiOnIcon({ className = "h-4 w-4" }: IconProps) {
     </svg>
   );
 }
+
+/**
+ * Plus icon
+ */
+export function PlusIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+    </svg>
+  );
+}
+
+/**
+ * Chevron up icon
+ */
+export function ChevronUpIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+    </svg>
+  );
+}
+
+/**
+ * Chevron left icon
+ */
+export function ChevronLeftIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+    </svg>
+  );
+}
+
+/**
+ * Menu/hamburger icon
+ */
+export function MenuIcon({ className = "h-5 w-5" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4 6h16M4 12h16M4 18h16"
+      />
+    </svg>
+  );
+}
+
+/**
+ * User/person icon
+ */
+export function UserIcon({ className = "h-5 w-5" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Copy/clipboard icon
+ */
+export function CopyIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Lock icon
+ */
+export function LockIcon({ className = "h-5 w-5" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Info circle icon
+ */
+export function InfoCircleIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Refresh/retry arrows icon
+ */
+export function RefreshIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Alert circle icon (exclamation in circle)
+ */
+export function AlertCircleIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Check circle icon (checkmark in circle)
+ */
+export function CheckCircleIcon({ className = "h-5 w-5" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Double chevron up icon (for strong upvote)
+ */
+export function DoubleChevronUpIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 9l7-7 7 7" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+    </svg>
+  );
+}
+
+/**
+ * Double chevron down icon (for strong downvote)
+ */
+export function DoubleChevronDownIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 15l-7 7-7-7" />
+    </svg>
+  );
+}
+
+/**
+ * Key icon (for API tokens)
+ */
+export function KeyIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Bookmark icon
+ */
+export function BookmarkIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Mobile phone icon
+ */
+export function MobileIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Desktop monitor icon
+ */
+export function DesktopIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * RSS/signal icon
+ */
+export function RssIcon({ className = "h-6 w-6" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M6 5c7.18 0 13 5.82 13 13M6 11a7 7 0 017 7m-6 0a1 1 0 11-2 0 1 1 0 012 0z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Clock icon
+ */
+export function ClockIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Calendar icon
+ */
+export function CalendarIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Shield check icon (for authorization/security)
+ */
+export function ShieldCheckIcon({ className = "h-8 w-8" }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Stop icon (circle with inner square)
+ */
+export function StopIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Question circle icon (help)
+ */
+export function QuestionCircleIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Prohibition/ban icon (circle with diagonal line)
+ */
+export function ProhibitionIcon({ className = "h-6 w-6" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Warning triangle icon (Heroicons v2 style, strokeWidth 1.5)
+ */
+export function WarningTriangleIcon({ className = "h-6 w-6" }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds 25 new icon components to the shared icon system (`icon-button.tsx`): PlusIcon, ChevronUpIcon, ChevronLeftIcon, MenuIcon, UserIcon, CopyIcon, LockIcon, InfoCircleIcon, RefreshIcon, AlertCircleIcon, CheckCircleIcon, DoubleChevronUpIcon, DoubleChevronDownIcon, KeyIcon, BookmarkIcon, MobileIcon, DesktopIcon, RssIcon, ClockIcon, CalendarIcon, ShieldCheckIcon, StopIcon, QuestionCircleIcon, ProhibitionIcon, WarningTriangleIcon
- Replaces ~70 inline SVG declarations across 28 component files with imports from `@/components/ui/icon-button`
- Net reduction of ~400 lines of code while maintaining identical visual appearance

## Test plan
- [x] `pnpm typecheck` passes with no errors
- [x] Pre-commit hooks (ESLint + Prettier) pass
- [ ] Visual inspection of affected pages to confirm icons render correctly
- [ ] Verify dark mode icon rendering

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)