### PR TITLE
Add sticky bottom controls for article star/read actions

### DIFF
--- a/src/components/entries/EntryArticle.tsx
+++ b/src/components/entries/EntryArticle.tsx
@@ -52,6 +52,8 @@ export interface EntryArticleProps {
   beforeContent?: ReactNode;
   /** Content inserted after the article content (e.g., CTA buttons in demo) */
   afterContent?: ReactNode;
+  /** Sticky controls that appear when the main action buttons scroll out of view */
+  stickyControls?: ReactNode;
   /** Touch event handlers for swipe gestures */
   onTouchStart?: React.TouchEventHandler;
   onTouchEnd?: React.TouchEventHandler;
@@ -76,6 +78,7 @@ export function EntryArticle({
   actionButtons,
   beforeContent,
   afterContent,
+  stickyControls,
   onTouchStart,
   onTouchEnd,
 }: EntryArticleProps) {
@@ -186,6 +189,9 @@ export function EntryArticle({
           </a>
         </footer>
       )}
+
+      {/* Sticky controls slot - shown when main action buttons scroll out of view */}
+      {stickyControls}
     </article>
   );
 }

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -53,6 +53,7 @@ import { useEntryTextStyles } from "@/lib/appearance/AppearanceProvider";
 import { useImagePrefetch } from "@/lib/hooks/useImagePrefetch";
 import { SWIPE_CONFIG } from "./EntryContentHelpers";
 import { EntryArticle } from "./EntryArticle";
+import { StickyEntryControls } from "./StickyEntryControls";
 import { VoteControls } from "./VoteControls";
 
 /**
@@ -201,6 +202,7 @@ export function EntryContentBody({
   onSetScore,
 }: EntryContentBodyProps) {
   const contentRef = useRef<HTMLDivElement>(null);
+  const actionButtonsRef = useRef<HTMLDivElement>(null);
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
 
   // Determine if we're showing full content
@@ -424,7 +426,7 @@ export function EntryContentBody({
         ) : undefined
       }
       actionButtons={
-        <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+        <div ref={actionButtonsRef} className="flex flex-wrap items-center gap-2 sm:gap-3">
           {/* Star button */}
           <Button
             variant={starred ? "primary" : "secondary"}
@@ -573,6 +575,15 @@ export function EntryContentBody({
             />
           )}
         </>
+      }
+      stickyControls={
+        <StickyEntryControls
+          actionButtonsRef={actionButtonsRef}
+          starred={starred}
+          read={read}
+          onToggleStar={onToggleStar}
+          onToggleRead={onToggleRead}
+        />
       }
     />
   );

--- a/src/components/entries/StickyEntryControls.tsx
+++ b/src/components/entries/StickyEntryControls.tsx
@@ -1,0 +1,99 @@
+/**
+ * StickyEntryControls Component
+ *
+ * A sticky bottom bar that shows star and read/unread controls
+ * when the main action buttons have scrolled out of view.
+ * Uses IntersectionObserver to detect when the main buttons are hidden.
+ */
+
+"use client";
+
+import { useState, useEffect, type RefObject } from "react";
+import {
+  StarIcon,
+  StarFilledIcon,
+  CircleIcon,
+  CircleFilledIcon,
+} from "@/components/ui/icon-button";
+import { useScrollContainer } from "@/components/layout/ScrollContainerContext";
+
+interface StickyEntryControlsProps {
+  /** Ref to the main action buttons element to observe */
+  actionButtonsRef: RefObject<HTMLElement | null>;
+  /** Whether the article is starred */
+  starred: boolean;
+  /** Whether the article has been read */
+  read: boolean;
+  /** Callback to toggle star status */
+  onToggleStar: () => void;
+  /** Callback to toggle read status */
+  onToggleRead: () => void;
+}
+
+export function StickyEntryControls({
+  actionButtonsRef,
+  starred,
+  read,
+  onToggleStar,
+  onToggleRead,
+}: StickyEntryControlsProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const scrollContainerRef = useScrollContainer();
+
+  useEffect(() => {
+    const target = actionButtonsRef.current;
+    if (!target) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        // Show sticky controls when the main buttons are NOT intersecting
+        setIsVisible(!entry.isIntersecting);
+      },
+      {
+        root: scrollContainerRef?.current ?? null,
+        threshold: 0,
+      }
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [actionButtonsRef, scrollContainerRef]);
+
+  if (!isVisible) return null;
+
+  return (
+    <div className="pointer-events-none sticky bottom-0 -mx-4 flex justify-center px-4 pb-4">
+      <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-zinc-200 bg-white/95 px-3 py-1.5 shadow-lg backdrop-blur-sm dark:border-zinc-700 dark:bg-zinc-900/95">
+        {/* Star button */}
+        <button
+          onClick={onToggleStar}
+          className={`flex min-h-[36px] min-w-[36px] items-center justify-center rounded-full transition-colors ${
+            starred
+              ? "text-amber-500 hover:bg-amber-50 dark:hover:bg-amber-950"
+              : "text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+          }`}
+          aria-label={starred ? "Remove from starred" : "Add to starred"}
+        >
+          {starred ? <StarFilledIcon className="h-5 w-5" /> : <StarIcon className="h-5 w-5" />}
+        </button>
+
+        {/* Divider */}
+        <div className="h-5 w-px bg-zinc-200 dark:bg-zinc-700" />
+
+        {/* Read/unread button */}
+        <button
+          onClick={onToggleRead}
+          className={`flex min-h-[36px] min-w-[36px] items-center justify-center rounded-full transition-colors ${
+            !read
+              ? "text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-950"
+              : "text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+          }`}
+          aria-label={read ? "Mark as unread" : "Mark as read"}
+          title="Keyboard shortcut: m"
+        >
+          {read ? <CircleIcon className="h-5 w-5" /> : <CircleFilledIcon className="h-5 w-5" />}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a floating pill at the bottom of the article view with star and read/unread controls that appears when the main action buttons in the header scroll out of view
- Uses IntersectionObserver (with the scroll container as root) to detect when the header controls are hidden
- Keeps the controls accessible on both desktop and mobile without making the entire header sticky (which would use too much vertical space)

Fixes #548

## Implementation

- **`StickyEntryControls`** (new): Client component that observes the action buttons ref via IntersectionObserver and renders a floating pill with star/read controls when the main buttons are off-screen
- **`EntryArticle`**: Added `stickyControls` slot prop for the sticky controls (keeps the component SSR-safe)
- **`EntryContentBody`**: Added ref to the action buttons div and wires up the `StickyEntryControls` component

## Test plan

- [ ] Open a long article and scroll down - sticky controls should appear at the bottom
- [ ] Scroll back up to the header - sticky controls should disappear
- [ ] Click star in sticky controls - should toggle star state (both buttons update)
- [ ] Click read/unread in sticky controls - should toggle read state
- [ ] Verify dark mode styling looks correct
- [ ] Test on mobile viewport - controls should be accessible and properly sized
- [ ] Verify the "m" keyboard shortcut still works while sticky controls are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)