### PR TITLE
Update docs for TanStack DB collections migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,10 @@ src/server/
   plugins/       # Content source plugins (LessWrong, Google Docs, ArXiv, GitHub)
   mcp/           # MCP server
 src/lib/         # Shared utilities (client and server)
+  collections/   # TanStack DB collections (primary client state store)
+  hooks/         # Custom React hooks
+  cache/         # SSE event handlers and collection update operations
+  trpc/          # tRPC clients (React, vanilla, server, query-client)
 src/components/  # React components
 src/app/         # Next.js routes
 tests/unit/      # Pure logic tests (no mocks, no DB)

--- a/docs/diagrams/frontend-data-flow.d2
+++ b/docs/diagrams/frontend-data-flow.d2
@@ -1,5 +1,6 @@
-# Frontend Data Flow - React Query with Direct Cache Updates
-# Lion Reader uses React Query as the source of truth with helper functions for cache updates
+# Frontend Data Flow - TanStack DB Collections with On-Demand Loading
+# Lion Reader uses TanStack DB collections as the primary client state store,
+# with React Query for SSR prefetch seeding and entry detail views.
 
 direction: down
 
@@ -39,31 +40,43 @@ client: {
   style.fill: "#fff3e0"
 
   react_query: {
-    label: React Query Cache
+    label: React Query
     shape: cylinder
     style.fill: "#ffcc80"
 
     description: |md
-      **Server state cache**
-      - entries.list (infinite)
-      - entries.get
-      - entries.count
-      - subscriptions.list
-      - tags.list
+      **SSR prefetch + detail views**
+      - entries.get (detail view)
+      - SSR prefetch seeding
+      - imports.get/list
     |
   }
 
-  cache_helpers: {
-    label: Cache Helpers
-    shape: rectangle
+  collections: {
+    label: TanStack DB Collections
+    shape: cylinder
     style.fill: "#a5d6a7"
 
     description: |md
-      **src/lib/cache/**
-      - adjustSubscriptionUnreadCounts
-      - adjustTagUnreadCounts
-      - addSubscriptionToCache
-      - updateEntriesReadStatus
+      **Primary state store**
+      - subscriptions (local-only)
+      - tags (query-backed, eager)
+      - entries global (local-only)
+      - entries per-view (on-demand)
+      - counts (local-only)
+    |
+  }
+
+  writes: {
+    label: Collection Writes
+    shape: rectangle
+    style.fill: "#c8e6c9"
+
+    description: |md
+      **src/lib/collections/writes.ts**
+      - Dual-write: global + activeViewCollection
+      - Subscription/tag count adjustments
+      - Entry state updates (read, starred, score)
     |
   }
 }
@@ -79,19 +92,31 @@ hooks: {
   useRealtimeUpdates: {
     label: useRealtimeUpdates
     shape: rectangle
-    tooltip: "Manages SSE connection with polling fallback"
+    tooltip: "SSE connection with polling fallback, delegates to collection writes"
   }
 
   useEntryMutations: {
     label: useEntryMutations
     shape: rectangle
-    tooltip: "Mutations with direct cache updates"
+    tooltip: "Mutations with dual-write to global + view collections"
   }
 
-  useKeyboardShortcuts: {
-    label: useKeyboardShortcuts
+  useViewEntriesCollection: {
+    label: useViewEntriesCollection
     shape: rectangle
-    tooltip: "Keyboard navigation and entry selection"
+    tooltip: "Creates per-view on-demand collection with offset-to-cursor bridge"
+  }
+
+  useStableEntryList: {
+    label: useStableEntryList
+    shape: rectangle
+    tooltip: "Display stability - merges live entries with previously-seen entries"
+  }
+
+  useEntryNavigation: {
+    label: useEntryNavigation
+    shape: rectangle
+    tooltip: "External store sharing next/prev entry IDs between list and detail"
   }
 }
 
@@ -106,19 +131,19 @@ ui: {
   sidebar: {
     label: Sidebar
     shape: rectangle
-    tooltip: "Subscription list with unread counts"
+    tooltip: "Subscription list from per-tag on-demand collections"
   }
 
   unified_entries: {
     label: UnifiedEntriesContent
     shape: rectangle
-    tooltip: "Unified entry page with navigation and swipe support"
+    tooltip: "Unified entry page with swipe navigation"
   }
 
   suspending_list: {
     label: SuspendingEntryList
     shape: rectangle
-    tooltip: "Entry list with Suspense and keyboard navigation"
+    tooltip: "Entry list via useLiveInfiniteQuery over view collection"
   }
 
   entry_list: {
@@ -135,11 +160,25 @@ ui: {
 }
 
 # ==============================================================================
-# Connections - Initial Data Fetch
+# Connections - SSR Prefetch
 # ==============================================================================
 
-server.api -> client.react_query: "Initial fetch" {
+server.api -> client.react_query: "SSR prefetch" {
   style.stroke: "#1976d2"
+  style.stroke-width: 2
+}
+
+client.react_query -> client.collections: "Seed first page\n(avoid redundant fetch)" {
+  style.stroke: "#1976d2"
+  style.stroke-dash: 3
+}
+
+# ==============================================================================
+# Connections - On-Demand Loading
+# ==============================================================================
+
+server.api -> client.collections: "On-demand pages\n(vanilla tRPC client)" {
+  style.stroke: "#00796b"
   style.stroke-width: 2
 }
 
@@ -152,38 +191,38 @@ server.sse -> hooks.useRealtimeUpdates: "SSE events\n(new_entry, subscription_*)
   style.stroke-width: 2
 }
 
-hooks.useRealtimeUpdates -> client.cache_helpers: "subscription_created\nsubscription_deleted" {
+hooks.useRealtimeUpdates -> client.writes: "Update collections\n(counts, subs, entries)" {
   style.stroke: "#388e3c"
 }
 
-hooks.useRealtimeUpdates -> client.react_query: "invalidate (new_entry)" {
-  style.stroke: "#388e3c"
-  style.stroke-dash: 3
-}
-
-client.cache_helpers -> client.react_query: "Direct cache updates" {
+client.writes -> client.collections: "Write to collections" {
   style.stroke: "#00796b"
   style.stroke-width: 2
 }
 
 # ==============================================================================
-# Connections - Query Data Flow
+# Connections - Collection Data Flow
 # ==============================================================================
 
-client.react_query -> ui.unified_entries: "Paginated entries\n(non-suspending)" {
+client.collections -> hooks.useViewEntriesCollection: "Create per-view\non-demand collection" {
   style.stroke: "#7b1fa2"
 }
 
-client.react_query -> ui.suspending_list: "Paginated entries\n(suspending)" {
-  style.stroke: "#7b1fa2"
-}
-
-ui.suspending_list -> ui.entry_list: "Entries with\nread/starred state" {
+hooks.useViewEntriesCollection -> ui.suspending_list: "useLiveInfiniteQuery\n(reactive entries)" {
   style.stroke: "#7b1fa2"
   style.stroke-width: 2
 }
 
-client.react_query -> ui.sidebar: "Subscriptions/tags\nwith counts" {
+ui.suspending_list -> hooks.useStableEntryList: "Merge with\npreviously-seen entries" {
+  style.stroke: "#7b1fa2"
+}
+
+hooks.useStableEntryList -> ui.entry_list: "Stable entries\n(no disappearing)" {
+  style.stroke: "#7b1fa2"
+  style.stroke-width: 2
+}
+
+client.collections -> ui.sidebar: "Per-tag subscription\ncollections" {
   style.stroke: "#7b1fa2"
 }
 
@@ -199,33 +238,37 @@ hooks.useEntryMutations -> server.api: "1. Server mutation" {
   style.stroke: "#f57c00"
 }
 
-server.api -> hooks.useEntryMutations: "2. Response with\nsubscription context" {
+server.api -> hooks.useEntryMutations: "2. Response" {
   style.stroke: "#f57c00"
   style.stroke-dash: 3
 }
 
-hooks.useEntryMutations -> client.cache_helpers: "3. Update counts\n(instant)" {
+hooks.useEntryMutations -> client.writes: "3. Dual-write\n(global + view)" {
   style.stroke: "#f57c00"
   style.stroke-width: 2
 }
 
-hooks.useEntryMutations -> client.react_query: "4. Invalidate\nentry lists" {
-  style.stroke: "#f57c00"
-  style.stroke-dash: 3
-}
-
 # ==============================================================================
-# Connections - Navigation and Keyboard
+# Connections - Entry Navigation
 # ==============================================================================
 
-ui.suspending_list -> hooks.useKeyboardShortcuts: "Keyboard navigation" {
+ui.suspending_list -> hooks.useEntryNavigation: "Publish next/prev\nentry IDs" {
   style.stroke: "#9e9e9e"
   style.stroke-dash: 3
 }
 
-ui.unified_entries -> ui.entry_content: "Entry view with\nswipe navigation" {
+hooks.useEntryNavigation -> ui.unified_entries: "Consume next/prev\nfor swipe" {
   style.stroke: "#9e9e9e"
   style.stroke-dash: 3
+}
+
+ui.unified_entries -> ui.entry_content: "Entry detail view" {
+  style.stroke: "#9e9e9e"
+  style.stroke-dash: 3
+}
+
+client.react_query -> ui.entry_content: "entries.get\n(full content)" {
+  style.stroke: "#1976d2"
 }
 
 # ==============================================================================
@@ -238,10 +281,10 @@ legend: {
   style.fill: "#fafafa"
   style.stroke: "#e0e0e0"
 
-  initial: "Blue: Initial data fetch"
-  realtime: "Green: Real-time updates (SSE)"
-  query: "Purple: Query data flow"
-  mutation: "Orange: User mutations"
-  cache: "Teal: Direct cache updates"
-  dashed: "Dashed: Invalidation"
+  initial: "Blue: SSR prefetch + detail views (React Query)"
+  ondemand: "Teal: On-demand loading + collection writes"
+  realtime: "Green: Real-time updates (SSE → collections)"
+  query: "Purple: Collection data flow to UI"
+  mutation: "Orange: User mutations (dual-write)"
+  nav: "Gray: Navigation state"
 }

--- a/docs/diagrams/sse-cache-updates.d2
+++ b/docs/diagrams/sse-cache-updates.d2
@@ -1,7 +1,8 @@
-# SSE Event Flow and Cache Update Architecture
+# SSE Event Flow and Collection Update Architecture
 #
 # This diagram shows how events flow from backend origins through Redis pub/sub
-# to the SSE endpoint, and how the frontend handles them to update caches.
+# to the SSE endpoint, and how the frontend handles them to update TanStack DB
+# collections and React Query caches.
 
 direction: down
 
@@ -35,12 +36,28 @@ event-sources: Event Sources {
     saved-updated: publishEntryUpdated(savedFeedId, entryId)
   }
 
+  entries-router: Entries Router {
+    style.fill: "#e0e7ff"
+    tooltip: "src/server/trpc/routers/entries.ts"
+
+    entry-state-changed: publishEntryStateChanged(userId, entryId, read, starred)
+  }
+
   subscriptions-router: Subscriptions Router {
     style.fill: "#e0e7ff"
     tooltip: "src/server/trpc/routers/subscriptions.ts"
 
     sub-created: publishSubscriptionCreated(userId, feedId, subscriptionId, subscription, feed)
     sub-deleted: publishSubscriptionDeleted(userId, feedId, subscriptionId)
+  }
+
+  tags-service: Tags Service {
+    style.fill: "#e0e7ff"
+    tooltip: "src/server/services/tags.ts"
+
+    tag-created: publishTagCreated(userId, tag)
+    tag-updated: publishTagUpdated(userId, tag)
+    tag-deleted: publishTagDeleted(userId, tagId)
   }
 
   job-handlers: Background Jobs {
@@ -81,8 +98,10 @@ redis: Redis Pub/Sub {
       Pattern: user:{userId}:events
 
       Events:
+      - entry_state_changed (entryId, read, starred)
       - subscription_created (full subscription + feed data)
       - subscription_deleted (subscriptionId)
+      - tag_created / tag_updated / tag_deleted
       - import_progress (per-feed progress)
       - import_completed (final counts)
     |
@@ -146,16 +165,18 @@ frontend: Frontend (useRealtimeUpdates) {
       - connected
       - new_entry
       - entry_updated
+      - entry_state_changed
       - subscription_created
       - subscription_deleted
+      - tag_created / tag_updated / tag_deleted
       - import_progress
       - import_completed
     |
   }
 
-  handle-event: Event Handler {
+  handle-event: handleSyncEvent {
     style.fill: "#f5d0fe"
-    tooltip: "handleEvent callback"
+    tooltip: "src/lib/cache/event-handlers.ts - unified handler for SSE + polling"
   }
 
   polling-fallback: Polling Fallback {
@@ -166,29 +187,29 @@ frontend: Frontend (useRealtimeUpdates) {
       - Poll sync.changes every 30s
       - Retry SSE every 60s
       - Uses granular cursors per entity type
+      - Same handleSyncEvent handler as SSE
     |
   }
 }
 
 # ==============================================================================
-# CACHE UPDATE OPERATIONS
+# COLLECTION UPDATE OPERATIONS
 # ==============================================================================
 
-cache-ops: Cache Operations {
+cache-ops: Collection & Cache Operations {
   style.fill: "#fff7ed"
-  tooltip: "src/lib/cache/operations.ts"
+  tooltip: "src/lib/cache/event-handlers.ts + operations.ts + collections/writes.ts"
 
   new-entry-handler: handleNewEntry {
     style.fill: "#fed7aa"
 
     updates: |
-      Updates (surgical, no refetch):
-      - subscriptions.list: unreadCount += 1
-      - tags.list: unreadCount += 1
-      - entries.count({}): unread += 1, total += 1
-      - entries.count({ type: "saved" }): if feedType === "saved"
+      Collection updates (no refetch):
+      - subscriptions collection: unreadCount += 1
+      - tags collection: unreadCount += 1
+      - counts collection: unread += 1, total += 1
 
-      Does NOT invalidate entries.list
+      Does NOT invalidate entry lists
       (entries appear on navigation)
     |
   }
@@ -197,12 +218,26 @@ cache-ops: Cache Operations {
     style.fill: "#fed7aa"
 
     updates: |
-      Direct updates (metadata from event):
+      React Query (detail view):
       - entries.get: title, author, summary, url, publishedAt
-      - entries.list: same metadata fields (in-place)
 
-      Invalidations:
-      - entries.get({ id }): refetch full content
+      Collection (list view):
+      - entries collection: metadata update via
+        updateEntryMetadataInCollection()
+    |
+  }
+
+  entry-state-handler: entry_state_changed {
+    style.fill: "#fed7aa"
+
+    updates: |
+      React Query (detail view):
+      - entries.get: read, starred state
+
+      Collection (list view):
+      - entries collection: read/starred via
+        updateEntryReadInCollection()
+        updateEntryStarredInCollection()
     |
   }
 
@@ -210,13 +245,10 @@ cache-ops: Cache Operations {
     style.fill: "#fed7aa"
 
     updates: |
-      Direct updates (no refetch):
-      - subscriptions.list: add subscription
-      - tags.list: feedCount += 1, unreadCount += N
-      - entries.count({}): unread += N, total += N
-
-      Targeted invalidations:
-      - subscriptions.list per-tag queries (affected tags only)
+      Collection updates (no refetch):
+      - subscriptions collection: add subscription
+      - tags collection: feedCount += 1, unreadCount += N
+      - counts collection: unread += N, total += N
     |
   }
 
@@ -224,13 +256,22 @@ cache-ops: Cache Operations {
     style.fill: "#fed7aa"
 
     updates: |
-      Direct updates (no refetch):
-      - subscriptions.list: remove subscription
-      - tags.list: feedCount -= 1, unreadCount -= N
-      - entries.count({}): unread -= N, total -= N
+      Collection updates (no refetch):
+      - subscriptions collection: remove subscription
+      - tags collection: feedCount -= 1, unreadCount -= N
+      - counts collection: unread -= N, total -= N
 
-      Invalidations:
+      React Query invalidation:
       - entries.list (entries should be filtered out)
+    |
+  }
+
+  tag-handlers: tag_created / tag_updated / tag_deleted {
+    style.fill: "#fed7aa"
+
+    updates: |
+      Collection updates (no refetch):
+      - tags collection: add/update/remove tag
     |
   }
 
@@ -238,11 +279,7 @@ cache-ops: Cache Operations {
     style.fill: "#fed7aa"
 
     updates: |
-      import_progress:
-      - imports.get({ id }): invalidate
-      - imports.list: invalidate
-
-      import_completed:
+      React Query invalidations (no collection):
       - imports.get({ id }): invalidate
       - imports.list: invalidate
       (entry/subscription updates handled by individual events)
@@ -270,10 +307,22 @@ event-sources.saved-service.saved-updated -> redis.feed-channels: entry_updated 
   style.stroke: "#2563eb"
 }
 
+event-sources.entries-router.entry-state-changed -> redis.user-channels: entry_state_changed {
+  style.stroke: "#7c3aed"
+}
 event-sources.subscriptions-router.sub-created -> redis.user-channels: subscription_created {
   style.stroke: "#7c3aed"
 }
 event-sources.subscriptions-router.sub-deleted -> redis.user-channels: subscription_deleted {
+  style.stroke: "#7c3aed"
+}
+event-sources.tags-service.tag-created -> redis.user-channels: tag_created {
+  style.stroke: "#7c3aed"
+}
+event-sources.tags-service.tag-updated -> redis.user-channels: tag_updated {
+  style.stroke: "#7c3aed"
+}
+event-sources.tags-service.tag-deleted -> redis.user-channels: tag_deleted {
   style.stroke: "#7c3aed"
 }
 event-sources.job-handlers.import-sub-created -> redis.user-channels: subscription_created {
@@ -324,10 +373,16 @@ frontend.handle-event -> cache-ops.new-entry-handler: new_entry + feedType {
 frontend.handle-event -> cache-ops.entry-updated-handler: entry_updated {
   style.stroke: "#ea580c"
 }
+frontend.handle-event -> cache-ops.entry-state-handler: entry_state_changed {
+  style.stroke: "#ea580c"
+}
 frontend.handle-event -> cache-ops.sub-created-handler: subscription_created {
   style.stroke: "#ea580c"
 }
 frontend.handle-event -> cache-ops.sub-deleted-handler: subscription_deleted {
+  style.stroke: "#ea580c"
+}
+frontend.handle-event -> cache-ops.tag-handlers: tag_* {
   style.stroke: "#ea580c"
 }
 frontend.handle-event -> cache-ops.import-handlers: import_* {
@@ -346,7 +401,7 @@ entry-types: Entry Type Differences {
     description: |
       - Published from entry-processor
       - Has subscriptionId
-      - Updates subscription + tag unread counts
+      - Updates subscription + tag collections (unread counts)
     |
   }
 
@@ -355,7 +410,7 @@ entry-types: Entry Type Differences {
     description: |
       - Published from email inbound processor
       - Has subscriptionId
-      - Updates subscription + tag unread counts
+      - Updates subscription + tag collections (unread counts)
     |
   }
 
@@ -364,49 +419,58 @@ entry-types: Entry Type Differences {
     description: |
       - Published from saved service/router
       - subscriptionId is NULL (no subscription row)
-      - Updates entries.count({ type: "saved" })
+      - Updates counts collection (saved count)
       - Does NOT update subscription/tag counts
     |
   }
 }
 
 # ==============================================================================
-# CACHE UPDATE STRATEGY NOTES
+# UPDATE STRATEGY NOTES
 # ==============================================================================
 
-strategy-notes: Cache Strategy {
+strategy-notes: Update Strategy {
   style.fill: "#ecfccb"
 
-  direct-updates: Direct Updates (preferred) {
+  collection-writes: Collection Writes (preferred) {
     style.fill: "#d9f99d"
     description: |
-      Surgical updates avoid refetch:
+      Direct writes to TanStack DB collections:
       - Subscription unread counts
-      - Tag unread counts
+      - Tag unread/feed counts
       - Global entry counts
-      - Entry read/starred state
-      - Subscription list add/remove
+      - Entry read/starred/score state
+      - Subscription add/remove
+      - Tag add/update/remove
+
+      Live queries react automatically.
     |
   }
 
-  invalidations: Invalidations (force refetch) {
+  react-query: React Query (detail + imports) {
     style.fill: "#d9f99d"
     description: |
-      Force refetch when necessary:
-      - Entry lists (too many filter combinations)
-      - Entry content on update
-      - Import progress (complex state)
+      entries.get setData for detail view:
+      - Entry metadata updates
+      - Entry state changes (read/starred)
+
+      Invalidations for imports:
+      - imports.get/list on progress/completion
     |
   }
 
   design-rationale: Design Rationale {
     style.fill: "#d9f99d"
     description: |
-      entries.list is NOT invalidated on new_entry:
-      - Too many filter combinations (sub, tag, unread, starred)
+      Entry lists are NOT refreshed on new_entry:
+      - On-demand collections only fetch when scrolled
       - User won't see new entries until navigation
       - Unread counts still update (sidebar shows activity)
       - Keeps scrolling smooth without flicker
+
+      Display stability via useStableEntryList:
+      - Previously-seen entries stay visible after state change
+      - Resets only on view navigation
     |
   }
 }

--- a/docs/features/optimistic-updates-and-cache-management.md
+++ b/docs/features/optimistic-updates-and-cache-management.md
@@ -1,9 +1,11 @@
 # Optimistic Updates and Cache Management Optimization
 
-**Status:** Draft
+**Status:** Largely Superseded
 **Created:** 2026-01-10
 **Author:** Claude
 **Related Issues:** N/A
+
+> **Note (2026-02):** Most of the cache management concerns in this document have been superseded by the migration to TanStack DB collections (Phases 4-6). Sidebar counts, entry lists, subscription state, and tag state are now managed via TanStack DB collections with direct writes instead of React Query cache manipulation. React Query is only used for SSR prefetch seeding, entry detail views (`entries.get`), and import progress tracking. The SSE event handler (`handleSyncEvent`) now writes directly to collections. See `src/lib/collections/` for the current architecture.
 
 ## Overview
 

--- a/docs/features/query-normalization-plan.md
+++ b/docs/features/query-normalization-plan.md
@@ -1,5 +1,7 @@
 # Query Normalization Design
 
+> **Note (2026-02):** This plan has been superseded by the migration to TanStack DB collections (Phases 4-6). Entry data is now managed through TanStack DB collections rather than React Query cache entries, eliminating the cross-query duplication problem. See `src/lib/collections/` for the current architecture.
+
 ## Problem
 
 Entry data is duplicated across multiple React Query cache entries:


### PR DESCRIPTION
## Summary

- Update DESIGN.md with new Client-Side State Management section documenting TanStack DB collections architecture, data flow, key hooks, and React Query's remaining role
- Rewrite `frontend-data-flow.d2` diagram from React Query-centric to TanStack DB collections-centric architecture
- Update `sse-cache-updates.d2` diagram with new event types (`entry_state_changed`, `tag_*`), new event sources (entries router, tags service), and collection-based update operations
- Add `collections/`, `hooks/`, `cache/`, `trpc/` to CLAUDE.md project structure
- Mark `optimistic-updates-and-cache-management.md` and `query-normalization-plan.md` as superseded

## Test plan

- [ ] Review DESIGN.md for accuracy against current codebase
- [ ] Render D2 diagrams to verify they parse correctly
- [ ] Verify no stale React Query references remain in primary docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)