### PR TITLE
Fix title not loading on direct page load

### DIFF
--- a/src/components/entries/EntryListTitle.tsx
+++ b/src/components/entries/EntryListTitle.tsx
@@ -1,0 +1,75 @@
+/**
+ * EntryListTitle Component
+ *
+ * Reactively reads subscription/tag titles from TanStack DB collections.
+ * Uses useLiveQuery with findOne() so the title re-renders automatically
+ * when the data appears in the collection (e.g., after SSR prefetch
+ * hydrates or a validation query populates it).
+ *
+ * Loaded via dynamic() with ssr: false because useLiveQuery uses
+ * useSyncExternalStore without getServerSnapshot.
+ */
+
+"use client";
+
+import { eq } from "@tanstack/db";
+import { useLiveQuery } from "@tanstack/react-db";
+import { TitleSkeleton, TitleText } from "./EntryPageLayout";
+import { useCollections } from "@/lib/collections/context";
+
+interface EntryListTitleProps {
+  routeInfo: {
+    title: string | null;
+    subscriptionId?: string;
+    tagId?: string;
+  };
+}
+
+export function EntryListTitle({ routeInfo }: EntryListTitleProps) {
+  const { subscriptions, tags } = useCollections();
+
+  // Reactive lookup — re-renders when the subscription appears in the collection
+  const { data: subscription } = useLiveQuery(
+    (q) =>
+      q
+        .from({ s: subscriptions })
+        .where(({ s }) => eq(s.id, routeInfo.subscriptionId ?? ""))
+        .findOne(),
+    [routeInfo.subscriptionId]
+  );
+
+  // Reactive lookup — re-renders when the tag appears in the collection
+  const { data: tag } = useLiveQuery(
+    (q) =>
+      q
+        .from({ t: tags })
+        .where(({ t }) => eq(t.id, routeInfo.tagId ?? ""))
+        .findOne(),
+    [routeInfo.tagId]
+  );
+
+  // Static title
+  if (routeInfo.title !== null) {
+    return <TitleText>{routeInfo.title}</TitleText>;
+  }
+
+  // Subscription title
+  if (routeInfo.subscriptionId) {
+    if (subscription) {
+      return (
+        <TitleText>{subscription.title ?? subscription.originalTitle ?? "Untitled Feed"}</TitleText>
+      );
+    }
+    return <TitleSkeleton />;
+  }
+
+  // Tag title
+  if (routeInfo.tagId) {
+    if (tag) {
+      return <TitleText>{tag.name}</TitleText>;
+    }
+    return <TitleSkeleton />;
+  }
+
+  return <TitleText>All Items</TitleText>;
+}


### PR DESCRIPTION
## Summary

- Fix subscription/tag page titles staying as skeleton on direct page load (hard refresh)
- Root cause: `collections.subscriptions.get()` / `collections.tags.get()` are non-reactive snapshots — they don't trigger re-renders when the collection updates
- On direct load, collections are empty → skeleton renders → data arrives → no re-render
- On client-side navigation, the sidebar has already populated collections, so `.get()` succeeds immediately (which is why it worked in that case)

## Changes

- Extract `EntryListTitle` into its own component using `useLiveQuery` with `findOne()` for reactive lookups
- When subscription/tag data arrives in the collection (via SSR prefetch hydration or the validation query's upsert), `useLiveQuery` automatically re-renders with the title
- Load via `dynamic()` with `ssr: false` since `useLiveQuery` uses `useSyncExternalStore` without `getServerSnapshot`

## Test plan

- [ ] Hard refresh `/subscription/[id]` — title loads (skeleton briefly, then title)
- [ ] Hard refresh `/tag/[tagId]` — title loads (skeleton briefly, then title)
- [ ] Client-side navigate to subscription/tag — title still shows instantly
- [ ] `/all`, `/starred`, `/saved` static titles still render immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)