### PR TITLE
Switch PWA share target back to auto-closing save page

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -10,13 +10,6 @@ export default function manifest(): MetadataRoute.Manifest {
     orientation: "portrait",
     background_color: "#ffffff",
     theme_color: "#f97316",
-    // When the PWA is launched (e.g., via share target), focus the existing window
-    // instead of navigating it. This prevents Android's share target from destroying
-    // the current app state. The service worker handles the shared data via fetch
-    // event and notifies the window via postMessage for the toast.
-    launch_handler: {
-      client_mode: ["focus-existing", "auto"],
-    },
     icons: [
       {
         src: "/android-chrome-192x192.png",
@@ -42,9 +35,8 @@ export default function manifest(): MetadataRoute.Manifest {
       },
     ],
     // Share Target API: allows other Android apps to share URLs and files to Lion Reader.
-    // With launch_handler focus-existing, the service worker intercepts the POST,
-    // saves URLs directly via API, and notifies the focused window via postMessage.
-    // Files are stored in IndexedDB and the window redirects to /save for processing.
+    // The service worker intercepts the POST and redirects to /save, which handles
+    // saving the article and auto-closes itself.
     share_target: {
       action: "/api/share",
       method: "POST" as const,

--- a/src/components/layout/RealtimeProvider.tsx
+++ b/src/components/layout/RealtimeProvider.tsx
@@ -4,31 +4,15 @@
  * Manages the SSE connection for real-time updates and optionally displays
  * a connection status indicator.
  *
- * Also handles messages from the service worker (e.g., share target results)
- * to show toast notifications.
- *
  * This component should be used in the app layout to enable real-time updates
  * for authenticated users.
  */
 
 "use client";
 
-import { type ReactNode, useEffect } from "react";
-import { toast } from "sonner";
-import { useSearchParams, useRouter } from "next/navigation";
+import { type ReactNode } from "react";
 import { useRealtimeUpdates, type SyncCursors } from "@/lib/hooks/useRealtimeUpdates";
 import { ConnectionStatusIndicator } from "./ConnectionStatusIndicator";
-
-/**
- * Message format from service worker for share target results.
- */
-interface ShareResultMessage {
-  type: "share-result";
-  success: boolean;
-  url?: string;
-  title?: string;
-  error?: string;
-}
 
 interface RealtimeProviderProps {
   /**
@@ -80,82 +64,6 @@ export function RealtimeProvider({
   showStatusIndicator = true,
 }: RealtimeProviderProps) {
   const { status, reconnect } = useRealtimeUpdates(initialCursors);
-  const searchParams = useSearchParams();
-  const router = useRouter();
-
-  // Check for share result query params (set by service worker redirect after
-  // Android share target). Android destroys the PWA's navigation state on share,
-  // so postMessage may not reach the new page. The SW passes the result via URL.
-  useEffect(() => {
-    const shared = searchParams.get("shared");
-    if (!shared) return;
-
-    if (shared === "saved") {
-      const title = searchParams.get("sharedTitle");
-      toast.success("Article saved", {
-        description: title || undefined,
-      });
-    } else if (shared === "error") {
-      const error = searchParams.get("sharedError");
-      toast.error("Failed to save article", {
-        description: error || undefined,
-      });
-    }
-
-    // Clean up query params without a full navigation
-    const url = new URL(window.location.href);
-    url.searchParams.delete("shared");
-    url.searchParams.delete("sharedTitle");
-    url.searchParams.delete("sharedError");
-    router.replace(url.pathname + url.search, { scroll: false });
-  }, [searchParams, router]);
-
-  // Set up launchQueue consumer for focus-existing launch_handler.
-  // When the PWA is already open and receives a share target launch,
-  // the browser focuses this window and enqueues a LaunchParams instead of
-  // navigating. The service worker's fetch handler does the actual saving
-  // and sends a postMessage (handled below). We just need to consume the
-  // launch event so the browser doesn't fall back to default behavior.
-  useEffect(() => {
-    if (!("launchQueue" in window)) return;
-
-    (
-      window as {
-        launchQueue: { setConsumer: (cb: (params: { targetURL?: string }) => void) => void };
-      }
-    ).launchQueue.setConsumer(() => {
-      // The service worker handles the actual save via its fetch event
-      // handler and notifies us via postMessage. Nothing to do here.
-    });
-  }, []);
-
-  // Listen for messages from service worker (e.g., share target results)
-  useEffect(() => {
-    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
-      return;
-    }
-
-    const handleMessage = (event: MessageEvent) => {
-      const data = event.data as ShareResultMessage | undefined;
-
-      if (data?.type === "share-result") {
-        if (data.success) {
-          toast.success("Article saved", {
-            description: data.title || data.url,
-          });
-        } else {
-          toast.error("Failed to save article", {
-            description: data.error || data.url,
-          });
-        }
-      }
-    };
-
-    navigator.serviceWorker.addEventListener("message", handleMessage);
-    return () => {
-      navigator.serviceWorker.removeEventListener("message", handleMessage);
-    };
-  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Summary

Fixes #566

- Remove `launch_handler` from PWA manifest (the `focus-existing` mode didn't actually prevent Android from destroying app state)
- Simplify service worker to redirect URL shares to `/save` instead of trying to save directly via API and redirecting back to the app with toast query params
- Remove share result handling from `RealtimeProvider` (query param toast, `launchQueue` consumer, service worker `postMessage` listener) since all shares now go through the `/save` page

The `/save` page already handles saving articles and auto-closing itself, which is more useful behavior than destroying the app state and showing a toast.

## Test plan

- [ ] Share a URL to Lion Reader from another app on Android — should open /save, save the article, and auto-close
- [ ] Share a file to Lion Reader — should open /save, upload, and auto-close
- [ ] Share with an expired session — should redirect to /save for login flow
- [ ] Bookmarklet still works — /save page unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)