### PR TITLE
Fix entry summaries including <title> content from HTML documents

### DIFF
--- a/src/server/html/strip-html.ts
+++ b/src/server/html/strip-html.ts
@@ -41,7 +41,7 @@ const BLOCK_TAGS = new Set([
 /**
  * Tags whose content should be skipped entirely.
  */
-const SKIP_TAGS = new Set(["script", "style"]);
+const SKIP_TAGS = new Set(["script", "style", "head"]);
 
 /**
  * Extracts text from HTML with proper spacing between block elements.

--- a/tests/unit/entry-summary.test.ts
+++ b/tests/unit/entry-summary.test.ts
@@ -100,6 +100,12 @@ describe("stripHtml", () => {
       const html = "<p>A</p><script><script>nested</script></script><p>B</p>";
       expect(stripHtml(html, 300)).toBe("A B");
     });
+
+    it("excludes head and title content from full HTML documents", () => {
+      const html =
+        "<!DOCTYPE html><html><head><title>Page Title</title></head><body><p>Body content here.</p></body></html>";
+      expect(stripHtml(html, 300)).toBe("Body content here.");
+    });
   });
 
   describe("HTML entity decoding", () => {


### PR DESCRIPTION
## Summary
- Fixes #581: LessWrong comment summaries in the entry list were prefixed with the parent page title (e.g., "Brendan Long's Shortform Chronotherapy is...")
- Root cause: `stripHtml` (used by `generateSummary`) was not skipping `<head>` content, so `<title>` text from full HTML documents (produced by `wrapHtmlFragment`) leaked into summaries
- Fix: Added `"head"` to the `SKIP_TAGS` set in `strip-html.ts`, so all metadata content inside `<head>` is excluded from text extraction

## Test plan
- [x] Added unit test verifying `<title>` content is excluded from full HTML document summaries
- [x] All 1490 existing tests pass
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)