### PR TITLE
Extract canonical URL from newsletter emails

### DIFF
--- a/src/server/email/extract-url.ts
+++ b/src/server/email/extract-url.ts
@@ -1,0 +1,231 @@
+/**
+ * Extract the canonical URL from newsletter email HTML.
+ *
+ * Many newsletter platforms (Substack, Buttondown, Ghost, etc.) include
+ * a link to the web version of the post in the email HTML. This module
+ * extracts that URL so entries have a "Read on {domain}" link.
+ *
+ * Strategy:
+ * 1. Look for `<a>` tags inside heading elements (h1-h3) - the post title link
+ * 2. Filter out tracking/redirect URLs and return a clean canonical URL
+ *
+ * Uses htmlparser2 for SAX-style streaming parsing per project conventions.
+ */
+
+import { Parser } from "htmlparser2";
+
+/**
+ * Domains that host tracking redirects rather than actual content.
+ * URLs on these domains should be skipped when looking for canonical URLs.
+ */
+const TRACKING_DOMAINS = new Set([
+  "email.mg1.substack.com",
+  "email.mg2.substack.com",
+  "click.convertkit-mail.com",
+  "click.convertkit-mail2.com",
+  "email.mailgun.com",
+  "links.email.example.com",
+  "trk.klclick.com",
+  "t.co",
+  "bit.ly",
+]);
+
+/**
+ * URL path patterns that indicate tracking pixels, unsubscribe links,
+ * or other non-content URLs.
+ */
+const NON_CONTENT_PATH_PATTERNS = [
+  /\/unsubscribe/i,
+  /\/subscribe/i,
+  /\/manage[_-]?preferences/i,
+  /\/email[_-]?preferences/i,
+  /\/open\?/i, // tracking pixels
+  /\/click\?/i, // click tracking
+];
+
+/**
+ * Checks if a URL is likely a content URL rather than tracking/navigation.
+ *
+ * @param url - The URL to check
+ * @returns true if the URL appears to be a content URL
+ */
+function isContentUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+
+    // Must be http or https
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return false;
+    }
+
+    // Skip known tracking domains
+    if (TRACKING_DOMAINS.has(parsed.hostname)) {
+      return false;
+    }
+
+    // Skip non-content paths
+    for (const pattern of NON_CONTENT_PATH_PATTERNS) {
+      if (pattern.test(parsed.pathname + parsed.search)) {
+        return false;
+      }
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves Substack app-link URLs to their canonical form.
+ *
+ * Substack emails use URLs like:
+ *   https://substack.com/app-link/post?publication_id=89120&post_id=182110210&...
+ *
+ * The "Read in app" links use the cleaner form:
+ *   https://open.substack.com/pub/{publication}/p/{slug}
+ *
+ * Since we can't resolve the app-link to a clean URL without fetching it,
+ * we pass through any URL that looks like it points to real content.
+ *
+ * @param url - The URL to check/resolve
+ * @returns The URL if it's usable, or null if it should be skipped
+ */
+function resolveSubstackUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+
+    // Skip substack.com/app-link URLs - they're deep links to the app,
+    // not web-accessible content
+    if (parsed.hostname === "substack.com" && parsed.pathname.startsWith("/app-link/")) {
+      return null;
+    }
+
+    // open.substack.com/pub/*/p/* URLs are clean canonical URLs
+    if (parsed.hostname === "open.substack.com") {
+      // Strip tracking parameters but keep the path
+      const clean = new URL(parsed.pathname, "https://open.substack.com");
+      return clean.href;
+    }
+
+    // *.substack.com URLs with /p/ paths are canonical post URLs
+    if (parsed.hostname.endsWith(".substack.com") && parsed.pathname.startsWith("/p/")) {
+      // Strip tracking parameters
+      const clean = new URL(parsed.pathname, `https://${parsed.hostname}`);
+      return clean.href;
+    }
+
+    return url;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Cleans a URL by removing common tracking parameters.
+ *
+ * @param url - The URL to clean
+ * @returns The cleaned URL
+ */
+function cleanTrackingParams(url: string): string {
+  try {
+    const parsed = new URL(url);
+
+    const trackingParams = [
+      "utm_source",
+      "utm_medium",
+      "utm_campaign",
+      "utm_content",
+      "utm_term",
+      "r",
+      "token",
+      "isFreemail",
+      "action",
+      "triggerShare",
+      "submitLike",
+      "comments",
+    ];
+
+    for (const param of trackingParams) {
+      parsed.searchParams.delete(param);
+    }
+
+    // If no search params remain, remove the trailing ?
+    if (parsed.searchParams.toString() === "") {
+      return parsed.origin + parsed.pathname + parsed.hash;
+    }
+
+    return parsed.href;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Extracts the canonical post URL from newsletter email HTML.
+ *
+ * Looks for `<a>` tags inside heading elements (h1-h3), which is the most
+ * common pattern across newsletter platforms for linking to the web version
+ * of a post.
+ *
+ * @param html - The email HTML content
+ * @returns The extracted URL, or null if no suitable URL was found
+ */
+export function extractEmailUrl(html: string): string | null {
+  if (!html) {
+    return null;
+  }
+
+  let headingDepth = 0;
+  let currentHeadingLevel = 0;
+  let foundUrl: string | null = null;
+
+  const parser = new Parser(
+    {
+      onopentagname(name) {
+        const tag = name.toLowerCase();
+
+        // Track heading elements
+        if (tag === "h1" || tag === "h2" || tag === "h3") {
+          headingDepth++;
+          currentHeadingLevel = parseInt(tag[1]);
+        }
+      },
+      onopentag(name, attribs) {
+        const tag = name.toLowerCase();
+
+        // Look for <a> tags inside headings
+        if (tag === "a" && headingDepth > 0 && attribs.href) {
+          const href = attribs.href;
+
+          // Check if it's a Substack URL that needs special handling
+          const resolved = resolveSubstackUrl(href);
+          if (!resolved) {
+            return;
+          }
+
+          // Check if it's a content URL (not tracking/unsubscribe)
+          if (isContentUrl(resolved)) {
+            const cleaned = cleanTrackingParams(resolved);
+            if (!foundUrl || currentHeadingLevel < parseInt(foundUrl[0])) {
+              foundUrl = cleaned;
+              parser.pause();
+            }
+          }
+        }
+      },
+      onclosetag(name) {
+        const tag = name.toLowerCase();
+        if (tag === "h1" || tag === "h2" || tag === "h3") {
+          headingDepth--;
+        }
+      },
+    },
+    { decodeEntities: true }
+  );
+
+  parser.write(html);
+  parser.end();
+
+  return foundUrl;
+}

--- a/tests/unit/email-extract-url.test.ts
+++ b/tests/unit/email-extract-url.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for extracting canonical URLs from newsletter email HTML.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractEmailUrl } from "@/server/email/extract-url";
+
+describe("extractEmailUrl", () => {
+  describe("Substack emails", () => {
+    it("extracts URL from Substack post title h1", () => {
+      const html = `
+        <h1 class="post-title published">
+          <a href="https://open.substack.com/pub/astralcodexten/p/political-backflow-from-europe?utm_source=post-email-title&utm_campaign=email-post-title&isFreemail=false&r=67xro&token=abc123">
+            Political Backflow From Europe
+          </a>
+        </h1>
+      `;
+      expect(extractEmailUrl(html)).toBe(
+        "https://open.substack.com/pub/astralcodexten/p/political-backflow-from-europe"
+      );
+    });
+
+    it("strips tracking parameters from open.substack.com URLs", () => {
+      const html = `
+        <h1>
+          <a href="https://open.substack.com/pub/test/p/my-post?utm_source=email&utm_campaign=test&r=abc">
+            Test Post
+          </a>
+        </h1>
+      `;
+      expect(extractEmailUrl(html)).toBe("https://open.substack.com/pub/test/p/my-post");
+    });
+
+    it("skips substack.com/app-link URLs", () => {
+      // app-link URLs are deep links, not web URLs
+      const html = `
+        <h1>
+          <a href="https://substack.com/app-link/post?publication_id=89120&post_id=182110210&utm_source=post-email-title">
+            Title
+          </a>
+        </h1>
+      `;
+      expect(extractEmailUrl(html)).toBeNull();
+    });
+
+    it("handles custom domain Substack (not *.substack.com)", () => {
+      const html = `
+        <h1>
+          <a href="https://www.astralcodexten.com/p/political-backflow-from-europe?utm_source=email">
+            Political Backflow From Europe
+          </a>
+        </h1>
+      `;
+      expect(extractEmailUrl(html)).toBe(
+        "https://www.astralcodexten.com/p/political-backflow-from-europe"
+      );
+    });
+
+    it("handles *.substack.com/p/ URLs with tracking params", () => {
+      const html = `
+        <h1>
+          <a href="https://mysubstack.substack.com/p/my-post?utm_source=email&utm_medium=reader&r=abc">
+            My Post
+          </a>
+        </h1>
+      `;
+      expect(extractEmailUrl(html)).toBe("https://mysubstack.substack.com/p/my-post");
+    });
+  });
+
+  describe("general newsletter emails", () => {
+    it("extracts URL from h1 > a", () => {
+      const html = `
+        <div>Some header content</div>
+        <h1><a href="https://example.com/post/123">My Great Article</a></h1>
+        <p>Some content...</p>
+      `;
+      expect(extractEmailUrl(html)).toBe("https://example.com/post/123");
+    });
+
+    it("extracts URL from h2 > a", () => {
+      const html = `
+        <div>Header</div>
+        <h2><a href="https://blog.example.com/article">Article Title</a></h2>
+        <p>Content...</p>
+      `;
+      expect(extractEmailUrl(html)).toBe("https://blog.example.com/article");
+    });
+
+    it("extracts URL from h3 > a", () => {
+      const html = `
+        <h3><a href="https://example.com/post">Post Title</a></h3>
+      `;
+      expect(extractEmailUrl(html)).toBe("https://example.com/post");
+    });
+
+    it("prefers h1 link (stops at first heading link)", () => {
+      const html = `
+        <h1><a href="https://example.com/main-post">Main Title</a></h1>
+        <h2><a href="https://example.com/secondary">Secondary</a></h2>
+      `;
+      expect(extractEmailUrl(html)).toBe("https://example.com/main-post");
+    });
+
+    it("handles nested elements inside heading", () => {
+      const html = `
+        <h1>
+          <strong>
+            <a href="https://example.com/post">
+              Bold Title
+            </a>
+          </strong>
+        </h1>
+      `;
+      expect(extractEmailUrl(html)).toBe("https://example.com/post");
+    });
+
+    it("strips common tracking parameters", () => {
+      const html = `
+        <h1><a href="https://example.com/post?utm_source=email&utm_medium=newsletter&utm_campaign=weekly">Title</a></h1>
+      `;
+      expect(extractEmailUrl(html)).toBe("https://example.com/post");
+    });
+
+    it("preserves non-tracking query parameters", () => {
+      const html = `
+        <h1><a href="https://example.com/post?id=123&category=tech&utm_source=email">Title</a></h1>
+      `;
+      expect(extractEmailUrl(html)).toBe("https://example.com/post?id=123&category=tech");
+    });
+  });
+
+  describe("URLs to skip", () => {
+    it("skips mailto: links", () => {
+      const html = `
+        <h1><a href="mailto:contact@example.com">Contact Us</a></h1>
+      `;
+      expect(extractEmailUrl(html)).toBeNull();
+    });
+
+    it("skips unsubscribe links", () => {
+      const html = `
+        <h1><a href="https://example.com/unsubscribe?token=abc">Unsubscribe</a></h1>
+      `;
+      expect(extractEmailUrl(html)).toBeNull();
+    });
+
+    it("skips subscribe links", () => {
+      const html = `
+        <h1><a href="https://example.com/subscribe?ref=email">Subscribe</a></h1>
+      `;
+      expect(extractEmailUrl(html)).toBeNull();
+    });
+
+    it("ignores links outside heading elements", () => {
+      const html = `
+        <p><a href="https://example.com/not-the-title">Some link</a></p>
+        <a href="https://example.com/another-link">Another link</a>
+      `;
+      expect(extractEmailUrl(html)).toBeNull();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns null for empty string", () => {
+      expect(extractEmailUrl("")).toBeNull();
+    });
+
+    it("returns null for HTML with no headings", () => {
+      const html = `
+        <div>
+          <p>Just some content</p>
+          <a href="https://example.com">Link</a>
+        </div>
+      `;
+      expect(extractEmailUrl(html)).toBeNull();
+    });
+
+    it("returns null for headings without links", () => {
+      const html = `
+        <h1>Title Without Link</h1>
+        <p>Content</p>
+      `;
+      expect(extractEmailUrl(html)).toBeNull();
+    });
+
+    it("returns null for headings with empty href", () => {
+      const html = `<h1><a href="">Title</a></h1>`;
+      expect(extractEmailUrl(html)).toBeNull();
+    });
+
+    it("handles malformed HTML gracefully", () => {
+      const html = `<h1><a href="https://example.com/post">Title`;
+      // htmlparser2 handles malformed HTML - should still extract
+      expect(extractEmailUrl(html)).toBe("https://example.com/post");
+    });
+  });
+
+  describe("real-world Substack email fragment", () => {
+    it("extracts URL from realistic Substack email structure", () => {
+      // Simplified but representative Substack email structure
+      const html = `
+        <table role="presentation" width="100%">
+          <tbody><tr><td></td><td class="content" width="550" align="left">
+            <div class="post typography" dir="auto">
+              <div class="post-header" role="region">
+                <h1 class="post-title published title-X77sOw" dir="auto">
+                  <a href="https://open.substack.com/pub/astralcodexten/p/political-backflow-from-europe?utm_source=post-email-title&amp;utm_campaign=email-post-title&amp;isFreemail=false&amp;r=67xro&amp;token=eyJ1c2VyX2lkIjoxMDQ0ODA1MiwicG9zdF9pZCI6MTgyMTEwMjEwfQ.test" target="_blank" rel="noopener noreferrer">
+                    Political Backflow From Europe
+                  </a>
+                </h1>
+                <h3 class="subtitle">Some subtitle text...</h3>
+              </div>
+            </div>
+            <div class="post typography" dir="auto">
+              <div class="body markup" dir="auto">
+                <p>The European discourse can be...</p>
+              </div>
+            </div>
+          </td><td></td></tr></tbody>
+        </table>
+      `;
+      expect(extractEmailUrl(html)).toBe(
+        "https://open.substack.com/pub/astralcodexten/p/political-backflow-from-europe"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #585

- Adds URL extraction from newsletter email HTML during email ingestion
- Looks for `<a>` tags inside heading elements (h1-h3), which is the most common pattern across newsletter platforms (Substack, Ghost, Buttondown, etc.) for linking to the web version of a post
- Handles Substack-specific URL patterns (strips tracking params from `open.substack.com` and `*.substack.com/p/` URLs, skips `substack.com/app-link/` deep links)
- Strips common tracking parameters (utm_*, token, etc.) from all URLs
- Skips non-content URLs (unsubscribe, subscribe, tracking pixels)
- Sets the extracted URL on email entries, enabling the "Read on {domain}" link in the UI and full content fetching

## Test plan

- [x] 22 unit tests covering Substack emails, general newsletters, edge cases, and URL filtering
- [x] All 1512 existing unit tests pass
- [x] TypeScript type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)