### PR TITLE
Extract unsubscribe link from email newsletters

### DIFF
--- a/drizzle/0051_unsubscribe_url.sql
+++ b/drizzle/0051_unsubscribe_url.sql
@@ -1,0 +1,54 @@
+-- Add unsubscribe_url column to entries table
+-- Stores the unsubscribe link extracted from newsletter email HTML content.
+-- This is separate from list_unsubscribe_mailto/https which come from email headers.
+
+ALTER TABLE entries ADD COLUMN unsubscribe_url text;
+
+-- Update the visible_entries view to include the new column.
+-- New columns must be appended at the end (CREATE OR REPLACE VIEW cannot
+-- reorder existing columns).
+CREATE OR REPLACE VIEW public.visible_entries AS
+SELECT ue.user_id,
+    e.id,
+    e.feed_id,
+    e.type,
+    e.guid,
+    e.url,
+    e.title,
+    e.author,
+    e.content_original,
+    e.content_cleaned,
+    e.summary,
+    e.site_name,
+    e.image_url,
+    e.published_at,
+    e.fetched_at,
+    e.last_seen_at,
+    e.content_hash,
+    e.full_content_hash,
+    e.spam_score,
+    e.is_spam,
+    e.list_unsubscribe_mailto,
+    e.list_unsubscribe_https,
+    e.list_unsubscribe_post,
+    e.created_at,
+    GREATEST(e.updated_at, ue.updated_at) AS updated_at,
+    e.full_content_original,
+    e.full_content_cleaned,
+    e.full_content_fetched_at,
+    e.full_content_error,
+    ue.read,
+    ue.starred,
+    ue.score,
+    ue.has_marked_read_on_list,
+    ue.has_marked_unread,
+    ue.has_starred,
+    s.id AS subscription_id,
+    esp.predicted_score,
+    esp.confidence AS prediction_confidence,
+    e.unsubscribe_url
+FROM (((public.user_entries ue
+    JOIN public.entries e ON ((e.id = ue.entry_id)))
+    LEFT JOIN public.subscriptions s ON (((s.user_id = ue.user_id) AND (e.feed_id = ANY (s.feed_ids)))))
+    LEFT JOIN public.entry_score_predictions esp ON (((esp.user_id = ue.user_id) AND (esp.entry_id = e.id))))
+WHERE ((s.unsubscribed_at IS NULL) OR (ue.starred = true));

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1770518800000,
       "tag": "0050_user_summary_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1770528800000,
+      "tag": "0051_unsubscribe_url",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.sql
+++ b/drizzle/schema.sql
@@ -71,6 +71,7 @@ CREATE TABLE public.entries (
     full_content_fetched_at timestamp with time zone,
     full_content_error text,
     full_content_hash text,
+    unsubscribe_url text,
     CONSTRAINT entries_last_seen_only_fetched CHECK (((type = 'web'::public.feed_type) = (last_seen_at IS NOT NULL))),
     CONSTRAINT entries_saved_metadata_only_saved CHECK (((type = 'saved'::public.feed_type) OR ((site_name IS NULL) AND (image_url IS NULL)))),
     CONSTRAINT entries_spam_only_email CHECK (((type = 'email'::public.feed_type) OR ((spam_score IS NULL) AND (is_spam = false)))),
@@ -408,7 +409,8 @@ CREATE VIEW public.visible_entries AS
     ue.has_starred,
     s.id AS subscription_id,
     esp.predicted_score,
-    esp.confidence AS prediction_confidence
+    esp.confidence AS prediction_confidence,
+    e.unsubscribe_url
    FROM (((public.user_entries ue
      JOIN public.entries e ON ((e.id = ue.entry_id)))
      LEFT JOIN public.subscriptions s ON (((s.user_id = ue.user_id) AND (e.feed_id = ANY (s.feed_ids)))))

--- a/src/components/entries/EntryArticle.tsx
+++ b/src/components/entries/EntryArticle.tsx
@@ -37,6 +37,8 @@ export interface EntryArticleProps {
   textStyle?: CSSProperties;
   /** Optional domain for footer link (defaults to extracting from url) */
   footerLinkDomain?: string;
+  /** Unsubscribe URL extracted from email newsletter (null for non-email entries) */
+  unsubscribeUrl?: string | null;
   /** Whether content is loading (shows skeleton) */
   isContentLoading?: boolean;
   /** Ref for the content container (for highlighting, image prefetch) */
@@ -71,6 +73,7 @@ export function EntryArticle({
   textSizeClass = "prose prose-zinc dark:prose-invert",
   textStyle,
   footerLinkDomain,
+  unsubscribeUrl,
   isContentLoading,
   contentRef,
   backButton,
@@ -175,18 +178,33 @@ export function EntryArticle({
       {/* After content slot (CTA buttons, etc.) */}
       {afterContent}
 
-      {/* Footer with original link */}
-      {url && (
+      {/* Footer with original link and unsubscribe link */}
+      {(url || unsubscribeUrl) && (
         <footer className="mt-8 border-t border-zinc-200 pt-6 sm:mt-12 sm:pt-8 dark:border-zinc-700">
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="ui-text-sm inline-flex min-h-[44px] items-center gap-2 font-medium text-blue-600 transition-colors hover:text-blue-700 active:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 dark:active:text-blue-200"
-          >
-            <ExternalLinkIcon className="h-4 w-4" />
-            Read on {displayFooterDomain}
-          </a>
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+            {url && (
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ui-text-sm inline-flex min-h-[44px] items-center gap-2 font-medium text-blue-600 transition-colors hover:text-blue-700 active:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 dark:active:text-blue-200"
+              >
+                <ExternalLinkIcon className="h-4 w-4" />
+                Read on {displayFooterDomain}
+              </a>
+            )}
+            {unsubscribeUrl && (
+              <a
+                href={unsubscribeUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ui-text-sm inline-flex min-h-[44px] items-center gap-2 font-medium text-zinc-500 transition-colors hover:text-zinc-700 active:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-300 dark:active:text-zinc-200"
+              >
+                <ExternalLinkIcon className="h-4 w-4" />
+                Unsubscribe
+              </a>
+            )}
+          </div>
         </footer>
       )}
 

--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -334,6 +334,7 @@ function EntryContentInner({
         showOriginal={showOriginal}
         setShowOriginal={setShowOriginal}
         footerLinkDomain={entry.feedUrl ? getDomain(entry.feedUrl) : undefined}
+        unsubscribeUrl={entry.unsubscribeUrl}
         onSwipeNext={onSwipeNext}
         onSwipePrevious={onSwipePrevious}
         // Full content props - only available if entry has a subscription

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -96,6 +96,8 @@ export interface EntryContentBodyProps {
   setShowOriginal: (show: boolean) => void;
   /** Optional domain for footer link (defaults to extracting from url) */
   footerLinkDomain?: string;
+  /** Unsubscribe URL extracted from email newsletter (null for non-email entries) */
+  unsubscribeUrl?: string | null;
   /** Callback when swiping to next article */
   onSwipeNext?: () => void;
   /** Callback when swiping to previous article */
@@ -173,6 +175,7 @@ export function EntryContentBody({
   showOriginal,
   setShowOriginal,
   footerLinkDomain,
+  unsubscribeUrl,
   onSwipeNext,
   onSwipePrevious,
   // Full content props
@@ -399,6 +402,7 @@ export function EntryContentBody({
       textSizeClass={textSizeClass}
       textStyle={textStyle}
       footerLinkDomain={footerLinkDomain}
+      unsubscribeUrl={unsubscribeUrl}
       isContentLoading={isContentLoading}
       contentRef={contentRef}
       onTouchStart={handleTouchStart}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -439,6 +439,9 @@ export const entries = pgTable(
     listUnsubscribeHttps: text("list_unsubscribe_https"), // https: URL from header
     listUnsubscribePost: boolean("list_unsubscribe_post"), // true if one-click POST supported
 
+    // Unsubscribe URL extracted from email HTML body (for email entries)
+    unsubscribeUrl: text("unsubscribe_url"),
+
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -698,6 +701,7 @@ export const visibleEntries = pgView("visible_entries", {
   subscriptionId: uuid("subscription_id"), // nullable - null for orphaned starred entries
   predictedScore: real("predicted_score"), // ML-predicted score, nullable
   predictionConfidence: real("prediction_confidence"), // confidence of prediction, nullable
+  unsubscribeUrl: text("unsubscribe_url"), // extracted from email HTML body
 }).existing();
 
 // ============================================================================

--- a/src/server/email/process-inbound.ts
+++ b/src/server/email/process-inbound.ts
@@ -10,7 +10,7 @@ import { eq, and, isNotNull } from "drizzle-orm";
 import { db } from "../db";
 import { generateSummary } from "../html/strip-html";
 import { cleanContent } from "../feed/content-cleaner";
-import { extractEmailUrl } from "./extract-url";
+import { extractEmailUrl, extractUnsubscribeUrl } from "./extract-url";
 import {
   feeds,
   entries,
@@ -409,6 +409,11 @@ export async function processInboundEmail(email: InboundEmail): Promise<ProcessE
   // a "Read on {domain}" link in the UI and enables full content fetching.
   const url = email.html ? extractEmailUrl(email.html) : null;
 
+  // Extract unsubscribe URL from email HTML.
+  // Many newsletters include an "unsubscribe" link in their footer. We extract this
+  // so users can navigate to the newsletter's unsubscribe page directly from the UI.
+  const unsubscribeUrl = email.html ? extractUnsubscribeUrl(email.html) : null;
+
   // Parse List-Unsubscribe headers
   const listUnsubscribeMailto = parseListUnsubscribeMailto(email.headers.listUnsubscribe);
   const listUnsubscribeHttps = parseListUnsubscribeHttps(email.headers.listUnsubscribe);
@@ -436,6 +441,7 @@ export async function processInboundEmail(email: InboundEmail): Promise<ProcessE
     listUnsubscribeMailto,
     listUnsubscribeHttps,
     listUnsubscribePost,
+    unsubscribeUrl,
   };
 
   await db.insert(entries).values(newEntry);

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -92,6 +92,7 @@ export interface EntryFull {
   feedTitle: string | null;
   feedUrl: string | null;
   siteName: string | null;
+  unsubscribeUrl: string | null;
   score: number | null;
   implicitScore: number;
 }
@@ -472,6 +473,7 @@ export async function getEntry(
       siteName: visibleEntries.siteName,
       feedTitle: feeds.title,
       feedUrl: feeds.url,
+      unsubscribeUrl: visibleEntries.unsubscribeUrl,
       score: visibleEntries.score,
       hasMarkedReadOnList: visibleEntries.hasMarkedReadOnList,
       hasMarkedUnread: visibleEntries.hasMarkedUnread,

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -129,6 +129,8 @@ const entryFullSchema = z.object({
   feedTitle: z.string().nullable(),
   feedUrl: z.string().nullable(),
   siteName: z.string().nullable(),
+  // Unsubscribe link from email HTML (for email entries)
+  unsubscribeUrl: z.string().nullable(),
   // Full content fields
   fullContentOriginal: z.string().nullable(),
   fullContentCleaned: z.string().nullable(),
@@ -271,6 +273,7 @@ const fullEntrySelectFields = {
   siteName: visibleEntries.siteName,
   feedTitle: feeds.title,
   feedUrl: feeds.url,
+  unsubscribeUrl: visibleEntries.unsubscribeUrl,
   fullContentOriginal: visibleEntries.fullContentOriginal,
   fullContentCleaned: visibleEntries.fullContentCleaned,
   fullContentFetchedAt: visibleEntries.fullContentFetchedAt,


### PR DESCRIPTION
## Summary

Closes #588

- Adds `unsubscribe_url` column to the `entries` table to store unsubscribe links extracted from newsletter email HTML
- Implements `extractUnsubscribeUrl()` function that finds `<a>` tags whose visible text contains "unsubscribe" (case-insensitive), preferring links with `/unsubscribe` in the URL path
- Extracts and stores the unsubscribe URL during email ingestion in `processInboundEmail()`
- Adds `unsubscribeUrl` to tRPC `entries.get` response and the entries service `getEntry()` (which also flows through to the MCP server)
- Displays an "Unsubscribe" link in the entry footer alongside the existing "Read on {domain}" link, with subdued styling to differentiate it
- Updates the `visible_entries` database view to include the new column

## Test plan

- [x] 15 unit tests covering basic extraction, URL filtering, and real-world newsletter patterns (Substack, Ghost, Buttondown)
- [x] All 1540 existing unit tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)