### PR TITLE
Update default model to Claude Sonnet 4.6

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,8 +102,8 @@ ALLOW_ALL_SIGNUPS=false
 # If not set, summarization feature will be disabled
 # ANTHROPIC_API_KEY=sk-ant-...
 
-# Model to use for summarization (default: claude-sonnet-4-5)
-# SUMMARIZATION_MODEL=claude-sonnet-4-5
+# Model to use for summarization (default: claude-sonnet-4-6)
+# SUMMARIZATION_MODEL=claude-sonnet-4-6
 
 # Maximum words for generated summaries
 # SUMMARIZATION_MAX_WORDS=150
@@ -271,7 +271,7 @@ ALLOW_ALL_SIGNUPS=false
 # AI Features:
 #   fly secrets set GROQ_API_KEY="gsk_..."
 #   fly secrets set ANTHROPIC_API_KEY="sk-ant-..."
-#   fly secrets set SUMMARIZATION_MODEL="claude-sonnet-4-5"
+#   fly secrets set SUMMARIZATION_MODEL="claude-sonnet-4-6"
 #   fly secrets set SUMMARIZATION_MAX_WORDS="300"
 #
 # Google Integration:

--- a/docs/features/ai-summarization-design.md
+++ b/docs/features/ai-summarization-design.md
@@ -54,8 +54,8 @@ The default provider is Anthropic Claude Sonnet. Configuration via environment v
 # Anthropic (default)
 ANTHROPIC_API_KEY=sk-ant-...
 
-# Optional: Override model (default: claude-sonnet-4-5)
-SUMMARIZATION_MODEL=claude-sonnet-4-5
+# Optional: Override model (default: claude-sonnet-4-6)
+SUMMARIZATION_MODEL=claude-sonnet-4-6
 ```
 
 ### Provider Abstraction

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     ]
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.71.2",
+    "@anthropic-ai/sdk": "^0.75.0",
     "@aws-sdk/client-s3": "^3.971.0",
     "@ducanh2912/next-pwa": "^10.2.9",
     "@mintplex-labs/piper-tts-web": "^1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.71.2
-        version: 0.71.2(zod@4.3.5)
+        specifier: ^0.75.0
+        version: 0.75.0(zod@4.3.5)
       '@aws-sdk/client-s3':
         specifier: ^3.971.0
         version: 3.971.0
@@ -220,8 +220,8 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@anthropic-ai/sdk@0.71.2':
-    resolution: {integrity: sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==}
+  '@anthropic-ai/sdk@0.75.0':
+    resolution: {integrity: sha512-Xr/BESTYMOnpyOK7Gxie2LWc+G5f9+xZEYVAuWtDdYDtINocoe046gszFMeRJZ2FfySyGxdF3OHKYwB6/+p4uQ==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2875,6 +2875,9 @@ packages:
   '@types/node@20.19.30':
     resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
 
+  '@types/node@20.19.33':
+    resolution: {integrity: sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==}
+
   '@types/pg-pool@2.0.6':
     resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
 
@@ -3213,6 +3216,9 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-escapes@7.2.0:
     resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
@@ -3855,6 +3861,10 @@ packages:
 
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.19.0:
+    resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
@@ -6252,6 +6262,10 @@ packages:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
     engines: {node: '>=10.13.0'}
 
+  webpack-sources@3.3.4:
+    resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
+    engines: {node: '>=10.13.0'}
+
   webpack-virtual-modules@0.5.0:
     resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
 
@@ -6462,7 +6476,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/sdk@0.71.2(zod@4.3.5)':
+  '@anthropic-ai/sdk@0.75.0(zod@4.3.5)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -9506,6 +9520,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@20.19.33':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/pg-pool@2.0.6':
     dependencies:
       '@types/pg': 8.16.0
@@ -9850,17 +9868,17 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ajv-formats@2.1.1(ajv@8.17.1):
+  ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
 
-  ajv-keywords@5.1.0(ajv@8.17.1):
+  ajv-keywords@5.1.0(ajv@8.18.0):
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
       fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
@@ -9871,6 +9889,13 @@ snapshots:
       uri-js: 4.4.1
 
   ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
@@ -10458,6 +10483,11 @@ snapshots:
   encodeurl@2.0.0: {}
 
   enhanced-resolve@5.18.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.0
+
+  enhanced-resolve@5.19.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
@@ -11573,7 +11603,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 20.19.33
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -12513,9 +12543,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      ajv-keywords: 5.1.0(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv-keywords: 5.1.0(ajv@8.18.0)
 
   semver@6.3.1: {}
 
@@ -13190,6 +13220,8 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
+  webpack-sources@3.3.4: {}
+
   webpack-virtual-modules@0.5.0: {}
 
   webpack@5.104.1(esbuild@0.27.2):
@@ -13204,7 +13236,7 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.15.0)
       browserslist: 4.28.1
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.18.4
+      enhanced-resolve: 5.19.0
       es-module-lexer: 2.0.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -13218,7 +13250,7 @@ snapshots:
       tapable: 2.3.0
       terser-webpack-plugin: 5.3.16(esbuild@0.27.2)(webpack@5.104.1(esbuild@0.27.2))
       watchpack: 2.5.1
-      webpack-sources: 3.3.3
+      webpack-sources: 3.3.4
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -333,7 +333,7 @@ function DemoRouterContent() {
             {showSummaryForEntry === selectedEntry.id && (
               <SummaryCard
                 summary={selectedEntry.summaryHtml}
-                modelId="claude-sonnet-4-5-20250929"
+                modelId="claude-sonnet-4-6"
                 generatedAt={new Date("2026-02-07")}
                 onClose={() => setShowSummaryForEntry(null)}
               />

--- a/src/components/settings/ApiKeySettings.tsx
+++ b/src/components/settings/ApiKeySettings.tsx
@@ -14,7 +14,7 @@ import { CheckIcon } from "@/components/ui/icon-button";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
-const DEFAULT_MODEL = "claude-sonnet-4-5";
+const DEFAULT_MODEL = "claude-sonnet-4-6";
 
 /**
  * Groq API key settings, displayed near the narration settings.

--- a/src/server/services/summarization.ts
+++ b/src/server/services/summarization.ts
@@ -25,7 +25,7 @@ export const CURRENT_PROMPT_VERSION = 3;
 /**
  * Default model for summarization.
  */
-const DEFAULT_MODEL = "claude-sonnet-4-5";
+const DEFAULT_MODEL = "claude-sonnet-4-6";
 
 /**
  * Default maximum words for summaries.


### PR DESCRIPTION
## Summary
- Update default summarization model from `claude-sonnet-4-5` to `claude-sonnet-4-6`
- Bump `@anthropic-ai/sdk` from 0.71.2 to 0.75.0
- Update all references in code, config, and docs

Closes #591

## Test plan
- [x] TypeScript typecheck passes
- [x] Unit tests pass (model alias tests)
- [ ] Verify summarization works with new model in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)