### PR TITLE
Deduplicate DEFAULT_MODEL and DEFAULT_MAX_WORDS into shared constants

### DIFF
--- a/src/components/settings/ApiKeySettings.tsx
+++ b/src/components/settings/ApiKeySettings.tsx
@@ -13,8 +13,10 @@ import { trpc } from "@/lib/trpc/client";
 import { CheckIcon } from "@/components/ui/icon-button";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-
-const DEFAULT_MODEL = "claude-sonnet-4-6";
+import {
+  DEFAULT_SUMMARIZATION_MODEL,
+  DEFAULT_SUMMARIZATION_MAX_WORDS,
+} from "@/lib/summarization/constants";
 
 /**
  * Groq API key settings, displayed near the narration settings.
@@ -183,7 +185,7 @@ export function SummarizationApiKeySettings() {
   const currentMaxWords = preferencesQuery.data?.summarizationMaxWords ?? null;
   const currentPrompt = preferencesQuery.data?.summarizationPrompt ?? null;
   const models = modelsQuery.data?.models ?? [];
-  const defaultModelId = modelsQuery.data?.defaultModelId ?? DEFAULT_MODEL;
+  const defaultModelId = modelsQuery.data?.defaultModelId ?? DEFAULT_SUMMARIZATION_MODEL;
   const defaultPrompt = defaultPromptQuery.data?.prompt ?? "";
 
   const handleSave = useCallback(() => {
@@ -439,7 +441,7 @@ export function SummarizationApiKeySettings() {
                     type="number"
                     min={1}
                     max={10000}
-                    placeholder="150"
+                    placeholder={String(DEFAULT_SUMMARIZATION_MAX_WORDS)}
                     value={maxWordsInput}
                     onChange={(e) => setMaxWordsInput(e.target.value)}
                     disabled={updatePreferences.isPending}
@@ -467,7 +469,7 @@ export function SummarizationApiKeySettings() {
               ) : (
                 <div className="flex items-center gap-3">
                   <span className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-                    {currentMaxWords ?? "150 (default)"}
+                    {currentMaxWords ?? `${DEFAULT_SUMMARIZATION_MAX_WORDS} (default)`}
                   </span>
                   <Button
                     variant="secondary"

--- a/src/lib/summarization/constants.ts
+++ b/src/lib/summarization/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared constants for summarization functionality.
+ *
+ * These are used by both the server service and frontend settings UI.
+ */
+
+/**
+ * Default Anthropic model for summarization.
+ */
+export const DEFAULT_SUMMARIZATION_MODEL = "claude-sonnet-4-6";
+
+/**
+ * Default maximum words for generated summaries.
+ */
+export const DEFAULT_SUMMARIZATION_MAX_WORDS = 150;

--- a/src/server/services/summarization.ts
+++ b/src/server/services/summarization.ts
@@ -9,6 +9,10 @@ import Anthropic from "@anthropic-ai/sdk";
 import { marked } from "marked";
 import { logger } from "@/lib/logger";
 import { htmlToPlainText } from "@/lib/narration/html-to-narration-input";
+import {
+  DEFAULT_SUMMARIZATION_MODEL,
+  DEFAULT_SUMMARIZATION_MAX_WORDS,
+} from "@/lib/summarization/constants";
 
 // Configure marked for safe rendering
 marked.setOptions({
@@ -21,16 +25,6 @@ marked.setOptions({
  * to invalidate cached summaries.
  */
 export const CURRENT_PROMPT_VERSION = 3;
-
-/**
- * Default model for summarization.
- */
-const DEFAULT_MODEL = "claude-sonnet-4-6";
-
-/**
- * Default maximum words for summaries.
- */
-const DEFAULT_MAX_WORDS = 150;
 
 /**
  * Maximum content length to send to the LLM (in characters).
@@ -58,7 +52,7 @@ function getMaxWords(userMaxWords?: number | null): number {
       return parsed;
     }
   }
-  return DEFAULT_MAX_WORDS;
+  return DEFAULT_SUMMARIZATION_MAX_WORDS;
 }
 
 /**
@@ -211,7 +205,8 @@ export async function generateSummary(
   }
 
   // Priority: user model > environment > default
-  const modelId = options?.userModel || process.env.SUMMARIZATION_MODEL || DEFAULT_MODEL;
+  const modelId =
+    options?.userModel || process.env.SUMMARIZATION_MODEL || DEFAULT_SUMMARIZATION_MODEL;
 
   try {
     const response = await client.messages.create({
@@ -268,7 +263,7 @@ export function isSummarizationAvailable(userApiKey?: string | null): boolean {
  * @param userModel - Optional user-configured model
  */
 export function getSummarizationModelId(userModel?: string | null): string {
-  return userModel || process.env.SUMMARIZATION_MODEL || DEFAULT_MODEL;
+  return userModel || process.env.SUMMARIZATION_MODEL || DEFAULT_SUMMARIZATION_MODEL;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extracts `DEFAULT_MODEL` and `DEFAULT_MAX_WORDS` from both `ApiKeySettings.tsx` and `summarization.ts` into a new shared constants file at `src/lib/summarization/constants.ts`
- Replaces hardcoded `"150"` strings in the settings UI with the shared `DEFAULT_SUMMARIZATION_MAX_WORDS` constant
- Follows the existing pattern established by `src/lib/narration/constants.ts`

Fixes #593

## Test plan
- [x] `pnpm typecheck` passes
- [ ] Verify summarization settings page still displays correct defaults
- [ ] Verify summarization generation still uses correct model and max words

🤖 Generated with [Claude Code](https://claude.com/claude-code)