### PR TITLE
Add HTTP Link header discovery for WebSub hub URLs

### DIFF
--- a/src/server/feed/link-header.ts
+++ b/src/server/feed/link-header.ts
@@ -1,0 +1,106 @@
+/**
+ * HTTP Link header parser for WebSub discovery.
+ *
+ * Parses RFC 5988 / RFC 8288 Link headers to extract hub and self URLs
+ * for WebSub (PubSubHubbub) discovery.
+ *
+ * @see https://www.w3.org/TR/websub/#discovery
+ * @see https://datatracker.ietf.org/doc/html/rfc8288
+ */
+
+/**
+ * Result of parsing Link headers for WebSub-relevant links.
+ */
+export interface WebSubLinkHeaders {
+  /** WebSub hub URL from Link header with rel="hub" */
+  hubUrl?: string;
+  /** Self/topic URL from Link header with rel="self" */
+  selfUrl?: string;
+}
+
+/**
+ * Parses HTTP Link headers to extract WebSub hub and self URLs.
+ *
+ * Handles multiple Link headers (comma-separated or multiple header values)
+ * per RFC 8288. Each link value has the format:
+ *   <url>; param1=value1; param2=value2
+ *
+ * We extract links where rel="hub" or rel="self".
+ *
+ * @param linkHeader - The raw Link header value (may contain multiple comma-separated links)
+ * @returns Extracted hub and self URLs, if found
+ *
+ * @example
+ * parseWebSubLinkHeaders('<https://hub.example.com/>; rel="hub", <https://example.com/feed>; rel="self"')
+ * // => { hubUrl: "https://hub.example.com/", selfUrl: "https://example.com/feed" }
+ */
+export function parseWebSubLinkHeaders(linkHeader: string): WebSubLinkHeaders {
+  const result: WebSubLinkHeaders = {};
+
+  // Split on commas that are outside angle brackets to separate individual links.
+  // A Link header can contain multiple links: <url1>; rel="hub", <url2>; rel="self"
+  // We need to be careful not to split on commas inside the URL itself.
+  const links = splitLinkHeader(linkHeader);
+
+  for (const link of links) {
+    const trimmed = link.trim();
+    if (!trimmed) continue;
+
+    // Extract the URL from <...>
+    const urlMatch = trimmed.match(/^<([^>]*)>/);
+    if (!urlMatch) continue;
+
+    const url = urlMatch[1];
+
+    // Extract the rel parameter value
+    // Handles both quoted and unquoted values: rel="hub" or rel=hub
+    const relMatch = trimmed.match(/;\s*rel\s*=\s*"?([^";,\s]+)"?/i);
+    if (!relMatch) continue;
+
+    const rel = relMatch[1].toLowerCase();
+
+    if (rel === "hub" && url) {
+      result.hubUrl = url;
+    } else if (rel === "self" && url) {
+      result.selfUrl = url;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Splits a Link header value into individual link entries.
+ *
+ * Handles commas that separate links while avoiding splitting on commas
+ * that appear inside angle-bracketed URLs.
+ *
+ * @param header - The raw Link header value
+ * @returns Array of individual link strings
+ */
+function splitLinkHeader(header: string): string[] {
+  const links: string[] = [];
+  let current = "";
+  let insideAngleBrackets = false;
+
+  for (const char of header) {
+    if (char === "<") {
+      insideAngleBrackets = true;
+      current += char;
+    } else if (char === ">") {
+      insideAngleBrackets = false;
+      current += char;
+    } else if (char === "," && !insideAngleBrackets) {
+      links.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  if (current.trim()) {
+    links.push(current);
+  }
+
+  return links;
+}

--- a/tests/unit/link-header.test.ts
+++ b/tests/unit/link-header.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for HTTP Link header parsing for WebSub discovery.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseWebSubLinkHeaders } from "../../src/server/feed/link-header";
+
+describe("parseWebSubLinkHeaders", () => {
+  describe("hub URL extraction", () => {
+    it("extracts hub URL from Link header with quoted rel", () => {
+      const result = parseWebSubLinkHeaders('<https://hub.example.com/>; rel="hub"');
+
+      expect(result.hubUrl).toBe("https://hub.example.com/");
+    });
+
+    it("extracts hub URL from Link header with unquoted rel", () => {
+      const result = parseWebSubLinkHeaders("<https://hub.example.com/>; rel=hub");
+
+      expect(result.hubUrl).toBe("https://hub.example.com/");
+    });
+
+    it("extracts hub URL case-insensitively for rel parameter name", () => {
+      const result = parseWebSubLinkHeaders('<https://hub.example.com/>; REL="hub"');
+
+      expect(result.hubUrl).toBe("https://hub.example.com/");
+    });
+  });
+
+  describe("self URL extraction", () => {
+    it("extracts self URL from Link header", () => {
+      const result = parseWebSubLinkHeaders('<https://example.com/feed.xml>; rel="self"');
+
+      expect(result.selfUrl).toBe("https://example.com/feed.xml");
+    });
+
+    it("extracts self URL with unquoted rel", () => {
+      const result = parseWebSubLinkHeaders("<https://example.com/feed.xml>; rel=self");
+
+      expect(result.selfUrl).toBe("https://example.com/feed.xml");
+    });
+  });
+
+  describe("multiple links", () => {
+    it("extracts both hub and self from comma-separated Link header", () => {
+      const result = parseWebSubLinkHeaders(
+        '<https://hub.example.com/>; rel="hub", <https://example.com/feed.xml>; rel="self"'
+      );
+
+      expect(result.hubUrl).toBe("https://hub.example.com/");
+      expect(result.selfUrl).toBe("https://example.com/feed.xml");
+    });
+
+    it("ignores non-websub link relations", () => {
+      const result = parseWebSubLinkHeaders(
+        '<https://hub.example.com/>; rel="hub", <https://example.com/style.css>; rel="stylesheet", <https://example.com/feed.xml>; rel="self"'
+      );
+
+      expect(result.hubUrl).toBe("https://hub.example.com/");
+      expect(result.selfUrl).toBe("https://example.com/feed.xml");
+    });
+
+    it("uses the last hub URL when multiple are present", () => {
+      const result = parseWebSubLinkHeaders(
+        '<https://hub1.example.com/>; rel="hub", <https://hub2.example.com/>; rel="hub"'
+      );
+
+      expect(result.hubUrl).toBe("https://hub2.example.com/");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns empty object for empty string", () => {
+      const result = parseWebSubLinkHeaders("");
+
+      expect(result.hubUrl).toBeUndefined();
+      expect(result.selfUrl).toBeUndefined();
+    });
+
+    it("returns empty object for header with no recognizable links", () => {
+      const result = parseWebSubLinkHeaders("not a valid link header");
+
+      expect(result.hubUrl).toBeUndefined();
+      expect(result.selfUrl).toBeUndefined();
+    });
+
+    it("handles extra whitespace", () => {
+      const result = parseWebSubLinkHeaders(
+        '  <https://hub.example.com/>  ;  rel="hub"  ,  <https://example.com/feed.xml>  ;  rel="self"  '
+      );
+
+      expect(result.hubUrl).toBe("https://hub.example.com/");
+      expect(result.selfUrl).toBe("https://example.com/feed.xml");
+    });
+
+    it("handles URLs with commas inside angle brackets", () => {
+      const result = parseWebSubLinkHeaders('<https://hub.example.com/path?a=1,b=2>; rel="hub"');
+
+      expect(result.hubUrl).toBe("https://hub.example.com/path?a=1,b=2");
+    });
+
+    it("handles Link header with additional parameters", () => {
+      const result = parseWebSubLinkHeaders(
+        '<https://hub.example.com/>; rel="hub"; type="application/atom+xml"'
+      );
+
+      expect(result.hubUrl).toBe("https://hub.example.com/");
+    });
+
+    it("skips links without a URL in angle brackets", () => {
+      const result = parseWebSubLinkHeaders('https://hub.example.com/; rel="hub"');
+
+      expect(result.hubUrl).toBeUndefined();
+    });
+
+    it("skips links without a rel parameter", () => {
+      const result = parseWebSubLinkHeaders("<https://hub.example.com/>");
+
+      expect(result.hubUrl).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #404

- Parse HTTP `Link` headers during feed fetching to discover WebSub hub and self URLs per [W3C WebSub spec §4](https://www.w3.org/TR/websub/#discovery)
- HTTP Link header values take precedence over embedded feed XML `<link>` elements, matching the spec's priority order
- Add `parseWebSubLinkHeaders()` utility with robust RFC 8288 Link header parsing (handles comma-separated links, URLs containing commas, quoted/unquoted rel values)

## Changes

- **`src/server/feed/link-header.ts`** (new): Link header parser extracting `rel="hub"` and `rel="self"` URLs
- **`src/server/feed/fetcher.ts`**: Parse Link headers from HTTP responses and include in `FetchSuccessResult`
- **`src/server/jobs/handlers.ts`**: Merge Link header hub/self URLs with feed-embedded values (headers take precedence)
- **`tests/unit/link-header.test.ts`** (new): 15 unit tests covering hub/self extraction, multiple links, edge cases

## Test plan

- [x] All 15 new unit tests pass
- [x] All existing feed parser tests pass (77 tests)
- [x] TypeScript typecheck passes
- [ ] Manual test: Subscribe to a feed that advertises its hub only via HTTP Link headers and verify WebSub subscription is initiated

🤖 Generated with [Claude Code](https://claude.com/claude-code)