### PR TITLE
Add WebSub unsubscribe verification support (#403)

### DIFF
--- a/drizzle/0052_websub_unsubscribe.sql
+++ b/drizzle/0052_websub_unsubscribe.sql
@@ -1,0 +1,5 @@
+-- Add unsubscribe_requested_at column to websub_subscriptions table.
+-- Tracks when we've requested an unsubscribe from a hub, so we can
+-- confirm unsubscribe verification callbacks per W3C WebSub spec Section 5.3.
+
+ALTER TABLE websub_subscriptions ADD COLUMN unsubscribe_requested_at timestamp with time zone;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1770528800000,
       "tag": "0051_unsubscribe_url",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1770538800000,
+      "tag": "0052_websub_unsubscribe",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.sql
+++ b/drizzle/schema.sql
@@ -429,7 +429,8 @@ CREATE TABLE public.websub_subscriptions (
     last_challenge_at timestamp with time zone,
     last_error text,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    unsubscribe_requested_at timestamp with time zone
 );
 
 ALTER TABLE ONLY public.api_tokens

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -771,6 +771,7 @@ export const websubSubscriptions = pgTable(
 
     lastChallengeAt: timestamp("last_challenge_at", { withTimezone: true }), // Last verification attempt
     lastError: text("last_error"), // Last error message if any
+    unsubscribeRequestedAt: timestamp("unsubscribe_requested_at", { withTimezone: true }), // When we requested unsubscribe from hub
 
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),


### PR DESCRIPTION
## Summary

- Handle `hub.mode=unsubscribe` verification callbacks per [W3C WebSub spec Section 5.3](https://www.w3.org/TR/websub/#hub-verifies-intent), which requires subscribers to confirm unsubscribe requests from hubs
- Add `unsubscribe_requested_at` column to `websub_subscriptions` to distinguish between requested and hub-initiated unsubscribes
- Both requested and hub-initiated unsubscribes are confirmed (returning the challenge), since rejecting a hub's decision is unlikely to be productive
- Hub-initiated unsubscribes are noted in `lastError` for observability

Closes #403

## Test plan

- [x] Typecheck passes (`pnpm typecheck`)
- [x] All 21 WebSub integration tests pass, including 4 new tests:
  - Confirms unsubscribe when we requested it (clears `lastError`, marks unsubscribed)
  - Confirms hub-initiated unsubscribe (sets `lastError` note, marks unsubscribed)
  - Rejects unsubscribe with topic mismatch
  - Updated "unsupported mode" test to use `invalid` instead of `unsubscribe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)