### PR TITLE
Add FreshRSS-compatible Google Reader API paths

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -80,6 +80,21 @@ const nextConfig: NextConfig = {
     // Inject git commit SHA at build time
     GIT_COMMIT_SHA: getGitCommitSha(),
   },
+  // Rewrite FreshRSS-style Google Reader API paths to our standard paths.
+  // Many Android clients (FocusReader, SmartRSS, etc.) configured as "FreshRSS"
+  // prepend /api/greader.php to all Google Reader API paths.
+  async rewrites() {
+    return [
+      {
+        source: "/api/greader.php/accounts/:path*",
+        destination: "/accounts/:path*",
+      },
+      {
+        source: "/api/greader.php/reader/:path*",
+        destination: "/reader/:path*",
+      },
+    ];
+  },
   // Cache static assets for 1 day to reduce unnecessary requests
   async headers() {
     return [

--- a/src/app/api/greader.php/route.ts
+++ b/src/app/api/greader.php/route.ts
@@ -1,0 +1,21 @@
+/**
+ * FreshRSS-compatible health check endpoint.
+ *
+ * GET /api/greader.php
+ *
+ * Many Google Reader API clients (FocusReader, SmartRSS, etc.) check this
+ * endpoint to verify the server is reachable before attempting authentication.
+ * FreshRSS returns "OK" at this path, so we do the same.
+ *
+ * Actual API requests to /api/greader.php/accounts/... and
+ * /api/greader.php/reader/... are handled via Next.js rewrites in next.config.ts.
+ */
+
+export const dynamic = "force-dynamic";
+
+export function GET(): Response {
+  return new Response("OK", {
+    status: 200,
+    headers: { "Content-Type": "text/plain; charset=UTF-8" },
+  });
+}

--- a/src/components/settings/GoogleReaderApiSettings.tsx
+++ b/src/components/settings/GoogleReaderApiSettings.tsx
@@ -62,6 +62,12 @@ export function GoogleReaderApiSettings() {
               <strong className="text-zinc-900 dark:text-zinc-200">Read You</strong> (Android)
             </li>
             <li>
+              <strong className="text-zinc-900 dark:text-zinc-200">FocusReader</strong> (Android)
+            </li>
+            <li>
+              <strong className="text-zinc-900 dark:text-zinc-200">SmartRSS</strong> (Android)
+            </li>
+            <li>
               <strong className="text-zinc-900 dark:text-zinc-200">NewsFlash</strong> (Linux)
             </li>
           </ul>
@@ -71,8 +77,8 @@ export function GoogleReaderApiSettings() {
         <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
           <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Setup</h3>
           <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-            In your app&apos;s account settings, choose &ldquo;Google Reader&rdquo; or &ldquo;Google
-            Reader API&rdquo; as the service type, then enter:
+            In your app&apos;s account settings, choose &ldquo;Google Reader&rdquo;, &ldquo;Google
+            Reader API&rdquo;, or &ldquo;FreshRSS&rdquo; as the service type, then enter:
           </p>
           <ul className="ui-text-sm mt-3 space-y-2 text-zinc-600 dark:text-zinc-400">
             <li>
@@ -80,6 +86,14 @@ export function GoogleReaderApiSettings() {
               <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
                 {baseUrl}
               </code>
+              {baseUrl && (
+                <span className="ui-text-xs mt-1 block text-zinc-400 dark:text-zinc-500">
+                  If using FreshRSS mode:{" "}
+                  <code className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
+                    {baseUrl}/api/greader.php
+                  </code>
+                </span>
+              )}
             </li>
             <li>
               <strong className="text-zinc-900 dark:text-zinc-200">Email:</strong> Your Lion Reader


### PR DESCRIPTION
## Summary

- Adds Next.js rewrites so `/api/greader.php/accounts/*` and `/api/greader.php/reader/*` route to our standard Google Reader API paths
- Adds a health check endpoint at `/api/greader.php` returning "OK" (matching FreshRSS behavior)
- Updates the settings page to mention FreshRSS as a service type option and show the FreshRSS-compatible URL
- Adds FocusReader and SmartRSS to the compatible apps list

## Context

Many Android RSS clients (FocusReader, SmartRSS, etc.) only offer "FreshRSS" as a service type for connecting to self-hosted Google Reader API servers. When configured this way, they prepend `/api/greader.php` to all API paths (e.g., `/api/greader.php/accounts/ClientLogin` instead of `/accounts/ClientLogin`). This caused 404 errors since our routes are at the standard Google Reader paths.

The FreshRSS server itself [strips this prefix](https://github.com/FreshRSS/FreshRSS/blob/edge/p/api/greader.php) with `preg_replace('%^(/api)?(/greader\.php)?%', '', $pathInfo)`, so we add equivalent rewrites in Next.js config.

## Test plan

- [ ] Verify `/api/greader.php` returns "OK" (health check)
- [ ] Test FreshRSS-style auth: `POST /api/greader.php/accounts/ClientLogin` works
- [ ] Test FreshRSS-style API: `GET /api/greader.php/reader/api/0/subscription/list` works
- [ ] Standard paths (`/accounts/ClientLogin`, `/reader/api/0/*`) still work
- [ ] Test with FocusReader or SmartRSS on Android using FreshRSS service type
- [ ] Settings page shows both standard and FreshRSS URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)