### PR TITLE
Hide empty tags and subscriptions in the sidebar

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -18,8 +18,10 @@ import { trpc } from "@/lib/trpc/client";
 import { handleSubscriptionDeleted } from "@/lib/cache/operations";
 import { UnsubscribeDialog } from "@/components/feeds/UnsubscribeDialog";
 import { EditSubscriptionDialog } from "@/components/feeds/EditSubscriptionDialog";
+import { useSidebarUnreadOnly } from "@/lib/hooks/useSidebarUnreadOnly";
 import { SidebarNav } from "./SidebarNav";
 import { TagList } from "./TagList";
+import { SidebarUnreadToggle } from "./SidebarUnreadToggle";
 
 interface SidebarProps {
   onClose?: () => void;
@@ -27,6 +29,7 @@ interface SidebarProps {
 
 export function Sidebar({ onClose }: SidebarProps) {
   const queryClient = useQueryClient();
+  const { sidebarUnreadOnly, toggleSidebarUnreadOnly } = useSidebarUnreadOnly();
   const [unsubscribeTarget, setUnsubscribeTarget] = useState<{
     id: string;
     title: string;
@@ -85,8 +88,13 @@ export function Sidebar({ onClose }: SidebarProps) {
         {/* Main Navigation with streaming counts */}
         <SidebarNav onNavigate={handleNavigate} />
 
-        {/* Divider */}
-        <div className="mx-3 border-t border-zinc-200 dark:border-zinc-700" />
+        {/* Divider with unread toggle */}
+        <div className="mx-3 flex items-center gap-2 border-t border-zinc-200 pt-2 dark:border-zinc-700">
+          <span className="ui-text-xs flex-1 font-medium text-zinc-500 dark:text-zinc-400">
+            Feeds
+          </span>
+          <SidebarUnreadToggle unreadOnly={sidebarUnreadOnly} onToggle={toggleSidebarUnreadOnly} />
+        </div>
 
         {/* Scrollable area with tags and feeds */}
         <div className="flex-1 overflow-y-auto p-3">
@@ -94,6 +102,7 @@ export function Sidebar({ onClose }: SidebarProps) {
             onNavigate={handleNavigate}
             onEdit={handleEdit}
             onUnsubscribe={handleUnsubscribe}
+            unreadOnly={sidebarUnreadOnly}
           />
         </div>
       </nav>

--- a/src/components/layout/SidebarUnreadToggle.tsx
+++ b/src/components/layout/SidebarUnreadToggle.tsx
@@ -1,0 +1,83 @@
+/**
+ * SidebarUnreadToggle Component
+ *
+ * A small toggle button for the sidebar that switches between showing
+ * all tags/subscriptions or only those with unread entries.
+ */
+
+"use client";
+
+/**
+ * Eye icon (showing all) - local component because it needs suppressHydrationWarning
+ * on the SVG element since the toggle state comes from localStorage.
+ */
+function EyeIcon() {
+  return (
+    <svg
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      suppressHydrationWarning
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Eye-slash icon (unread only) - local component because it needs suppressHydrationWarning
+ * on the SVG element since the toggle state comes from localStorage.
+ */
+function EyeSlashIcon() {
+  return (
+    <svg
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      suppressHydrationWarning
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+      />
+    </svg>
+  );
+}
+
+interface SidebarUnreadToggleProps {
+  unreadOnly: boolean;
+  onToggle: () => void;
+}
+
+export function SidebarUnreadToggle({ unreadOnly, onToggle }: SidebarUnreadToggleProps) {
+  const label = unreadOnly ? "Show all feeds" : "Show unread only";
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="rounded p-1 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+      title={label}
+      aria-label={label}
+      aria-pressed={unreadOnly}
+      suppressHydrationWarning
+    >
+      {unreadOnly ? <EyeSlashIcon /> : <EyeIcon />}
+    </button>
+  );
+}

--- a/src/components/layout/TagSubscriptionList.tsx
+++ b/src/components/layout/TagSubscriptionList.tsx
@@ -30,6 +30,8 @@ interface TagSubscriptionListProps {
   }) => void;
   /** Callback to unsubscribe */
   onUnsubscribe: (sub: { id: string; title: string }) => void;
+  /** When true, only show subscriptions with unread entries */
+  unreadOnly: boolean;
 }
 
 export function TagSubscriptionList({
@@ -39,11 +41,12 @@ export function TagSubscriptionList({
   onClose,
   onEdit,
   onUnsubscribe,
+  unreadOnly,
 }: TagSubscriptionListProps) {
   const sentinelRef = useRef<HTMLLIElement>(null);
 
   const subscriptionsQuery = trpc.subscriptions.list.useInfiniteQuery(
-    { tagId, uncategorized, limit: 50 },
+    { tagId, uncategorized, unreadOnly: unreadOnly || undefined, limit: 50 },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
     }

--- a/src/lib/hooks/useSidebarUnreadOnly.ts
+++ b/src/lib/hooks/useSidebarUnreadOnly.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+/**
+ * useSidebarUnreadOnly Hook
+ *
+ * Manages whether the sidebar shows only tags/subscriptions with unread entries.
+ * State is persisted to localStorage.
+ *
+ * Uses useSyncExternalStore to avoid hydration mismatches - the server
+ * always renders with unreadOnly=true (default), and the client reads from
+ * localStorage after hydration.
+ */
+
+const STORAGE_KEY = "lion-reader-sidebar-unread-only";
+
+// In-memory cache to avoid re-reading localStorage on every subscription
+let cachedValue: boolean | null = null;
+let listeners: Array<() => void> = [];
+
+function getValue(): boolean {
+  if (cachedValue !== null) {
+    return cachedValue;
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored !== null) {
+      cachedValue = stored === "true";
+      return cachedValue;
+    }
+  } catch (error) {
+    console.error("Failed to read sidebar unread only from localStorage:", error);
+  }
+
+  // Default: show only unread
+  cachedValue = true;
+  return cachedValue;
+}
+
+function setValue(newValue: boolean): void {
+  cachedValue = newValue;
+
+  try {
+    localStorage.setItem(STORAGE_KEY, String(newValue));
+  } catch (error) {
+    console.error("Failed to save sidebar unread only to localStorage:", error);
+  }
+
+  listeners.forEach((listener) => listener());
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.push(listener);
+  return () => {
+    listeners = listeners.filter((l) => l !== listener);
+  };
+}
+
+function getSnapshot(): boolean {
+  return getValue();
+}
+
+// Server always returns true (default: unread only)
+function getServerSnapshot(): boolean {
+  return true;
+}
+
+export interface UseSidebarUnreadOnlyResult {
+  /** Whether to show only tags/subscriptions with unread entries */
+  sidebarUnreadOnly: boolean;
+  /** Toggle the sidebar unread filter */
+  toggleSidebarUnreadOnly: () => void;
+}
+
+export function useSidebarUnreadOnly(): UseSidebarUnreadOnlyResult {
+  const sidebarUnreadOnly = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const toggleSidebarUnreadOnly = useCallback(() => {
+    setValue(!getValue());
+  }, []);
+
+  return {
+    sidebarUnreadOnly,
+    toggleSidebarUnreadOnly,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #582

- Adds a sidebar-specific unread toggle (eye icon) between the navigation links and the feeds section
- When active (default), hides tags and subscriptions that have zero unread entries
- The currently active tag/uncategorized section is always shown even when it has no unread entries
- State is persisted to localStorage using the same `useSyncExternalStore` pattern as expanded tags
- Shows "No unread feeds" message when filtering hides everything (distinct from "No subscriptions yet")

## Implementation

- **`useSidebarUnreadOnly` hook** - localStorage-backed toggle state with SSR-safe hydration
- **`SidebarUnreadToggle` component** - Small eye/eye-slash toggle button with local SVG icons (needs `suppressHydrationWarning` for localStorage-dependent state)
- **`TagList`** - Filters tags by `unreadCount > 0` when unreadOnly is active; always shows the currently navigated tag
- **`TagSubscriptionList`** - Passes `unreadOnly` to the `subscriptions.list` infinite query, which filters server-side via the existing `unreadOnly` parameter

## Test plan

- [ ] Verify sidebar shows all tags/subscriptions when toggle is set to "Show all"
- [ ] Verify sidebar hides tags with 0 unread when toggle is set to "Unread only" (default)
- [ ] Verify the currently active tag is always visible regardless of filter
- [ ] Verify expanded tag sections only show subscriptions with unread entries when filtering
- [ ] Verify toggle state persists across page refreshes (localStorage)
- [ ] Verify "No unread feeds" message appears when all feeds are read
- [ ] Verify no hydration mismatches on initial load
- [ ] Verify cache operations (marking read, new entries via SSE) still update sidebar counts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)