### PR TITLE
Add algorithmic feed controls setting (#614)

### DIFF
--- a/drizzle/0054_algorithmic_feed_setting.sql
+++ b/drizzle/0054_algorithmic_feed_setting.sql
@@ -1,0 +1,4 @@
+-- Add algorithmic_feed_enabled preference to users table.
+-- When disabled, score models are not trained, the algorithmic feed is hidden,
+-- and vote controls are not shown. Defaults to true (enabled).
+ALTER TABLE users ADD COLUMN algorithmic_feed_enabled boolean NOT NULL DEFAULT true;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1770548800000,
       "tag": "0053_visible_entries_read_changed_at",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1770558800000,
+      "tag": "0054_algorithmic_feed_setting",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/settings/algorithmic-feed/page.tsx
+++ b/src/app/(app)/settings/algorithmic-feed/page.tsx
@@ -1,0 +1,9 @@
+/**
+ * Algorithmic Feed Settings Page
+ *
+ * Route marker for /settings/algorithmic-feed. AppRouter handles rendering.
+ */
+
+export default function AlgorithmicFeedPage() {
+  return null;
+}

--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -88,6 +88,10 @@ function EntryContentInner({
   trpc.entries.get.useQuery({ id: nextEntryId! }, { enabled: !!nextEntryId });
   trpc.entries.get.useQuery({ id: previousEntryId! }, { enabled: !!previousEntryId });
 
+  // Check if algorithmic feed is enabled to decide whether to show vote controls
+  const preferencesQuery = trpc.users["me.preferences"].useQuery();
+  const algorithmicFeedEnabled = preferencesQuery.data?.algorithmicFeedEnabled ?? true;
+
   // Get fetchFullContent setting directly from entry (included in entries.get response)
   // This avoids a separate subscriptions.get query
   const fetchFullContent = entry?.fetchFullContent ?? false;
@@ -354,10 +358,10 @@ function EntryContentInner({
         onSummarize={handleSummarize}
         onSummaryClose={handleSummaryClose}
         onSummaryRegenerate={handleSummaryRegenerate}
-        // Score props
+        // Score props - only show vote controls when algorithmic feed is enabled
         score={entry.score ?? null}
         implicitScore={entry.implicitScore ?? 0}
-        onSetScore={handleSetScore}
+        onSetScore={algorithmicFeedEnabled ? handleSetScore : undefined}
       />
     </ScrollContainer>
   );

--- a/src/components/layout/SidebarNav.tsx
+++ b/src/components/layout/SidebarNav.tsx
@@ -47,7 +47,8 @@ function SavedCount() {
 }
 
 /**
- * Best feed nav link with count, only visible if user has scored entries.
+ * Best feed nav link with count, only visible if user has scored entries
+ * and the algorithmic feed enabled (both checked server-side by hasScoredEntries).
  * Shares the same unread count as All Items.
  */
 function BestNavLink({ isActive, onNavigate }: { isActive: boolean; onNavigate: () => void }) {

--- a/src/components/settings/UnifiedSettingsContent.tsx
+++ b/src/components/settings/UnifiedSettingsContent.tsx
@@ -30,6 +30,7 @@ import AiSettingsContent from "./pages/AiSettingsContent";
 import IntegrationsSettingsContent from "./pages/IntegrationsSettingsContent";
 import FeedHealthSettingsContent from "./pages/FeedHealthSettingsContent";
 import SessionsSettingsContent from "./pages/SessionsSettingsContent";
+import AlgorithmicFeedSettingsContent from "./pages/AlgorithmicFeedSettingsContent";
 
 const settingsLinks = [
   { href: "/settings", label: "Account" },
@@ -37,6 +38,7 @@ const settingsLinks = [
   { href: "/settings/subscriptions", label: "Subscriptions" },
   { href: "/settings/email", label: "Email" },
   { href: "/settings/ai", label: "AI & Narration" },
+  { href: "/settings/algorithmic-feed", label: "Algorithmic Feed" },
   { href: "/settings/integrations", label: "Integrations" },
   { href: "/settings/feed-health", label: "Feed Health" },
   { href: "/settings/sessions", label: "Sessions" },
@@ -60,6 +62,8 @@ function SettingsContentRouter() {
       return <EmailSettingsContent />;
     case "/settings/ai":
       return <AiSettingsContent />;
+    case "/settings/algorithmic-feed":
+      return <AlgorithmicFeedSettingsContent />;
     case "/settings/integrations":
       return <IntegrationsSettingsContent />;
     case "/settings/feed-health":

--- a/src/components/settings/pages/AlgorithmicFeedSettingsContent.tsx
+++ b/src/components/settings/pages/AlgorithmicFeedSettingsContent.tsx
@@ -1,0 +1,113 @@
+/**
+ * Algorithmic Feed Settings Content
+ *
+ * Settings page for enabling/disabling the algorithmic feed feature.
+ * When disabled, score models are not trained, the "Best" feed is hidden,
+ * and voting controls are not shown.
+ */
+
+"use client";
+
+import { toast } from "sonner";
+import { trpc } from "@/lib/trpc/client";
+
+export default function AlgorithmicFeedSettingsContent() {
+  return (
+    <div className="space-y-8">
+      {/* Page Header */}
+      <div>
+        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+          Algorithmic Feed
+        </h2>
+        <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+          Configure the algorithmic feed that learns your preferences and ranks entries by predicted
+          interest.
+        </p>
+      </div>
+
+      <AlgorithmicFeedToggle />
+    </div>
+  );
+}
+
+function AlgorithmicFeedToggle() {
+  const preferencesQuery = trpc.users["me.preferences"].useQuery();
+  const utils = trpc.useUtils();
+
+  const updateMutation = trpc.users["me.updatePreferences"].useMutation({
+    onMutate: async (newPrefs) => {
+      await utils.users["me.preferences"].cancel();
+
+      const previousPrefs = utils.users["me.preferences"].getData();
+
+      utils.users["me.preferences"].setData(undefined, (old) =>
+        old
+          ? {
+              ...old,
+              algorithmicFeedEnabled: newPrefs.algorithmicFeedEnabled ?? old.algorithmicFeedEnabled,
+            }
+          : undefined
+      );
+
+      return { previousPrefs };
+    },
+    onError: (_error, _newPrefs, context) => {
+      if (context?.previousPrefs) {
+        utils.users["me.preferences"].setData(undefined, context.previousPrefs);
+      }
+      toast.error("Failed to update preference");
+    },
+    onSuccess: () => {
+      toast.success("Preference updated");
+      // Invalidate sidebar queries that depend on this setting
+      utils.entries.hasScoredEntries.invalidate();
+    },
+    onSettled: (_data, error) => {
+      if (error) {
+        utils.users["me.preferences"].invalidate();
+      }
+    },
+  });
+
+  const enabled = preferencesQuery.data?.algorithmicFeedEnabled ?? true;
+
+  const handleToggle = () => {
+    updateMutation.mutate({ algorithmicFeedEnabled: !enabled });
+  };
+
+  return (
+    <section>
+      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="flex items-center justify-between">
+          <div>
+            <h4 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
+              Enable algorithmic feed
+            </h4>
+            <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+              Train a personalized model based on your reading habits and votes. When enabled, a
+              &quot;Best&quot; feed sorts entries by predicted interest and voting controls appear
+              on entries.
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={enabled}
+            onClick={handleToggle}
+            disabled={preferencesQuery.isLoading || updateMutation.isPending}
+            className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-zinc-900 ${
+              enabled ? "bg-zinc-900 dark:bg-zinc-50" : "bg-zinc-200 dark:bg-zinc-700"
+            }`}
+          >
+            <span
+              aria-hidden="true"
+              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
+                enabled ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -388,15 +388,9 @@ function SpamPreferenceSection() {
       const previousPrefs = utils.users["me.preferences"].getData();
 
       // Optimistically update
-      utils.users["me.preferences"].setData(undefined, (old) => ({
-        showSpam: newPrefs.showSpam ?? old?.showSpam ?? false,
-        canConfigureApiKeys: old?.canConfigureApiKeys ?? false,
-        hasGroqApiKey: old?.hasGroqApiKey ?? false,
-        hasAnthropicApiKey: old?.hasAnthropicApiKey ?? false,
-        summarizationModel: old?.summarizationModel ?? null,
-        summarizationMaxWords: old?.summarizationMaxWords ?? null,
-        summarizationPrompt: old?.summarizationPrompt ?? null,
-      }));
+      utils.users["me.preferences"].setData(undefined, (old) =>
+        old ? { ...old, showSpam: newPrefs.showSpam ?? old.showSpam } : undefined
+      );
 
       return { previousPrefs };
     },

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -67,6 +67,7 @@ interface CachedSession {
   userPasswordHash: string | null;
   userInviteId: string | null;
   userShowSpam: boolean;
+  userAlgorithmicFeedEnabled: boolean;
   userGroqApiKey: string | null;
   userAnthropicApiKey: string | null;
   userSummarizationModel: string | null;
@@ -206,6 +207,7 @@ function serializeForCache(data: SessionData): string {
     userPasswordHash: data.user.passwordHash,
     userInviteId: data.user.inviteId ?? null,
     userShowSpam: data.user.showSpam,
+    userAlgorithmicFeedEnabled: data.user.algorithmicFeedEnabled,
     userGroqApiKey: data.user.groqApiKey ?? null,
     userAnthropicApiKey: data.user.anthropicApiKey ?? null,
     userSummarizationModel: data.user.summarizationModel ?? null,
@@ -241,6 +243,7 @@ function deserializeFromCache(data: string): SessionData {
       passwordHash: cached.userPasswordHash,
       inviteId: cached.userInviteId ?? null,
       showSpam: cached.userShowSpam ?? false,
+      algorithmicFeedEnabled: cached.userAlgorithmicFeedEnabled ?? true,
       groqApiKey: cached.userGroqApiKey ?? null,
       anthropicApiKey: cached.userAnthropicApiKey ?? null,
       summarizationModel: cached.userSummarizationModel ?? null,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -62,6 +62,7 @@ export const users = pgTable("users", {
 
   // Preferences
   showSpam: boolean("show_spam").notNull().default(false), // Show spam entries from email feeds
+  algorithmicFeedEnabled: boolean("algorithmic_feed_enabled").notNull().default(true), // Enable algorithmic feed, voting, and model training
 
   // User-configured API keys (override server defaults when set)
   groqApiKey: text("groq_api_key"), // For narration LLM preprocessing

--- a/src/server/jobs/queue.ts
+++ b/src/server/jobs/queue.ts
@@ -510,6 +510,7 @@ export async function claimScoreTrainingJob(): Promise<Job | null> {
   const modelAgeThreshold = new Date(now.getTime() - 24 * 60 * 60 * 1000); // 24 hours
 
   // Find a user who needs training:
+  // - Has algorithmic feed enabled
   // - Has 20+ scored entries
   // - Model is missing OR model is stale (> 24h old)
   // - Doesn't have a training job currently running
@@ -518,11 +519,13 @@ export async function claimScoreTrainingJob(): Promise<Job | null> {
       SELECT ue.user_id
       FROM user_entries ue
       INNER JOIN entries e ON e.id = ue.entry_id
-      WHERE ue.score IS NOT NULL
+      INNER JOIN users u ON u.id = ue.user_id
+      WHERE u.algorithmic_feed_enabled = true
+        AND (ue.score IS NOT NULL
          OR ue.has_starred = true
          OR ue.has_marked_unread = true
          OR ue.has_marked_read_on_list = true
-         OR e.type = 'saved'
+         OR e.type = 'saved')
       GROUP BY ue.user_id
       HAVING count(*) >= 20
     ),
@@ -561,11 +564,13 @@ export async function claimScoreTrainingJob(): Promise<Job | null> {
       SELECT ue.user_id
       FROM user_entries ue
       INNER JOIN entries e ON e.id = ue.entry_id
-      WHERE ue.score IS NOT NULL
+      INNER JOIN users u ON u.id = ue.user_id
+      WHERE u.algorithmic_feed_enabled = true
+        AND (ue.score IS NOT NULL
          OR ue.has_starred = true
          OR ue.has_marked_unread = true
          OR ue.has_marked_read_on_list = true
-         OR e.type = 'saved'
+         OR e.type = 'saved')
       GROUP BY ue.user_id
       HAVING count(*) >= 20
     )

--- a/src/server/services/score-prediction.ts
+++ b/src/server/services/score-prediction.ts
@@ -558,12 +558,15 @@ export async function predictScoresForFeedEntries(
   // Find users who:
   // 1. Have an active subscription to this feed
   // 2. Have a trained model
+  // 3. Have the algorithmic feed enabled
   const usersWithModels = await db.execute<{ user_id: string }>(sql`
     SELECT DISTINCT s.user_id
     FROM subscriptions s
     INNER JOIN user_score_models usm ON usm.user_id = s.user_id
+    INNER JOIN users u ON u.id = s.user_id
     WHERE s.feed_id = ${feedId}
       AND s.unsubscribed_at IS NULL
+      AND u.algorithmic_feed_enabled = true
   `);
 
   if (usersWithModels.rows.length === 0) {

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -1002,10 +1002,11 @@ export const entriesRouter = createTRPCRouter({
     }),
 
   /**
-   * Check if the user has scored any entries.
+   * Check if the user has scored any entries and has the algorithmic feed enabled.
    *
-   * Returns true if the user has explicitly scored at least one entry,
-   * which is the prerequisite for the algorithmic feed to be useful.
+   * Returns true if the user has the algorithmic feed enabled AND has explicitly
+   * scored at least one entry, which is the prerequisite for the algorithmic feed
+   * to be useful.
    */
   hasScoredEntries: protectedProcedure
     .meta({
@@ -1018,6 +1019,11 @@ export const entriesRouter = createTRPCRouter({
     })
     .output(z.object({ hasScoredEntries: z.boolean() }))
     .query(async ({ ctx }) => {
+      // Short-circuit: if algorithmic feed is disabled, no need to query
+      if (!ctx.session.user.algorithmicFeedEnabled) {
+        return { hasScoredEntries: false };
+      }
+
       const userId = ctx.session.user.id;
       const result = await ctx.db
         .select({ id: userEntries.entryId })

--- a/src/server/trpc/routers/users.ts
+++ b/src/server/trpc/routers/users.ts
@@ -322,6 +322,7 @@ export const usersRouter = createTRPCRouter({
     .output(
       z.object({
         showSpam: z.boolean(),
+        algorithmicFeedEnabled: z.boolean(),
         canConfigureApiKeys: z.boolean(),
         hasGroqApiKey: z.boolean(),
         hasAnthropicApiKey: z.boolean(),
@@ -335,6 +336,7 @@ export const usersRouter = createTRPCRouter({
       // Never expose raw API keys — only whether they are set
       return {
         showSpam: ctx.session.user.showSpam,
+        algorithmicFeedEnabled: ctx.session.user.algorithmicFeedEnabled,
         canConfigureApiKeys: isEncryptionConfigured(),
         hasGroqApiKey: !!ctx.session.user.groqApiKey,
         hasAnthropicApiKey: !!ctx.session.user.anthropicApiKey,
@@ -361,6 +363,7 @@ export const usersRouter = createTRPCRouter({
     .input(
       z.object({
         showSpam: z.boolean().optional(),
+        algorithmicFeedEnabled: z.boolean().optional(),
         // API keys: empty string clears the key, non-empty sets it
         groqApiKey: z.string().optional(),
         anthropicApiKey: z.string().optional(),
@@ -373,6 +376,7 @@ export const usersRouter = createTRPCRouter({
     .output(
       z.object({
         showSpam: z.boolean(),
+        algorithmicFeedEnabled: z.boolean(),
         canConfigureApiKeys: z.boolean(),
         hasGroqApiKey: z.boolean(),
         hasAnthropicApiKey: z.boolean(),
@@ -397,6 +401,7 @@ export const usersRouter = createTRPCRouter({
       // Build update object with only provided fields
       const updateData: {
         showSpam?: boolean;
+        algorithmicFeedEnabled?: boolean;
         groqApiKey?: string | null;
         anthropicApiKey?: string | null;
         summarizationModel?: string | null;
@@ -409,6 +414,10 @@ export const usersRouter = createTRPCRouter({
 
       if (input.showSpam !== undefined) {
         updateData.showSpam = input.showSpam;
+      }
+
+      if (input.algorithmicFeedEnabled !== undefined) {
+        updateData.algorithmicFeedEnabled = input.algorithmicFeedEnabled;
       }
 
       if (input.groqApiKey !== undefined) {
@@ -444,6 +453,7 @@ export const usersRouter = createTRPCRouter({
       const updatedUser = await ctx.db
         .select({
           showSpam: users.showSpam,
+          algorithmicFeedEnabled: users.algorithmicFeedEnabled,
           groqApiKey: users.groqApiKey,
           anthropicApiKey: users.anthropicApiKey,
           summarizationModel: users.summarizationModel,
@@ -456,6 +466,7 @@ export const usersRouter = createTRPCRouter({
 
       return {
         showSpam: updatedUser[0]?.showSpam ?? false,
+        algorithmicFeedEnabled: updatedUser[0]?.algorithmicFeedEnabled ?? true,
         canConfigureApiKeys: isEncryptionConfigured(),
         hasGroqApiKey: !!updatedUser[0]?.groqApiKey,
         hasAnthropicApiKey: !!updatedUser[0]?.anthropicApiKey,

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -57,6 +57,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        algorithmicFeedEnabled: true,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/feed-redirect.test.ts
+++ b/tests/integration/feed-redirect.test.ts
@@ -72,6 +72,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        algorithmicFeedEnabled: true,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/opml-import.test.ts
+++ b/tests/integration/opml-import.test.ts
@@ -64,6 +64,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        algorithmicFeedEnabled: true,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -66,6 +66,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        algorithmicFeedEnabled: true,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/subscriptions.test.ts
+++ b/tests/integration/subscriptions.test.ts
@@ -59,6 +59,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        algorithmicFeedEnabled: true,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/tags.test.ts
+++ b/tests/integration/tags.test.ts
@@ -67,6 +67,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        algorithmicFeedEnabled: true,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,


### PR DESCRIPTION
## Summary
- Adds a new `algorithmic_feed_enabled` user preference (defaults to `true`) that controls visibility and behavior of the algorithmic feed feature
- New settings page at `/settings/algorithmic-feed` with a toggle to enable/disable the feature
- When disabled: hides the "Best" nav link in the sidebar, hides vote controls on entries, and skips score model training and inline predictions for the user

## Changes
- **Database**: New migration `0054_algorithmic_feed_setting.sql` adds `algorithmic_feed_enabled` boolean column to `users` table
- **Backend**: Session cache, preferences API (query + mutation), and users router all extended with the new field
- **Frontend**: New `AlgorithmicFeedSettingsContent` settings page with toggle, `SidebarNav` checks preference before showing Best link, `EntryContent` conditionally passes `onSetScore` to hide vote controls
- **Jobs**: `claimScoreTrainingJob` query filters out users with `algorithmic_feed_enabled = false`
- **Score prediction**: `predictScoresForFeedEntries` skips users with the feature disabled

Closes #614

## Test plan
- [ ] Verify the new settings page renders at `/settings/algorithmic-feed`
- [ ] Toggle the setting off and verify the "Best" nav link disappears
- [ ] Verify vote controls (up/down chevrons) disappear on entry content when disabled
- [ ] Toggle the setting back on and verify everything reappears
- [ ] Verify new users default to enabled (algorithmic feed visible)
- [ ] Run `pnpm typecheck` - passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)