### PR TITLE
Prefetch entries.hasScoredEntries in app layout

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -8,6 +8,7 @@
  * - auth.me (user info for header)
  * - tags.list (sidebar tag structure and unread counts)
  * - entries.count (all/starred/saved counts for sidebar)
+ * - entries.hasScoredEntries (sidebar "Best" link visibility)
  * - sync.cursors (lightweight max timestamps for SSE cursor initialization)
  * - summarization.isAvailable (for entry content summarization button)
  *
@@ -62,6 +63,7 @@ export default async function AppLayout({ children }: AppLayoutProps) {
     trpc.entries.count.prefetch({}),
     trpc.entries.count.prefetch({ type: "saved" }),
     trpc.entries.count.prefetch({ starredOnly: true }),
+    trpc.entries.hasScoredEntries.prefetch(), // For sidebar "Best" link visibility
     trpc.summarization.isAvailable.prefetch(), // For entry content summarization button
   ]);
   const initialCursors = await trpc.sync.cursors(); // Lightweight cursor-only query


### PR DESCRIPTION
## Summary
- Adds `trpc.entries.hasScoredEntries.prefetch()` to the app layout's server-side prefetch list, alongside existing prefetches for `tags.list`, `entries.count`, etc.
- This eliminates the client-side fetch that was delaying the "Best" link appearance in the sidebar after page load.

Closes #618

## Test plan
- [ ] Verify the "Best" link in the sidebar appears immediately on page load (no flash/delay) for users with scored entries
- [ ] Verify the "Best" link still doesn't appear for users without scored entries or with algorithmic feed disabled
- [ ] Verify no additional client-side request to `entries.hasScoredEntries` after initial page load (data should be hydrated from server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)