### PR TITLE
Add usage limits to prevent abuse and OOM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -230,6 +230,31 @@ ALLOW_ALL_SIGNUPS=false
 # DISCORD_ERROR_EMOJI=😿
 
 # =============================================================================
+# Usage Limits (Optional)
+# =============================================================================
+# These limits protect against abuse and prevent out-of-memory crashes from
+# oversized content. All limits have sane defaults. Adjust as needed.
+
+# Maximum number of active subscriptions per user (default: 500)
+# MAX_SUBSCRIPTIONS_PER_USER=500
+
+# Maximum feed response size in bytes (default: 10MB = 10485760)
+# Feeds larger than this are rejected during streaming (no OOM risk).
+# MAX_FEED_SIZE_BYTES=10485760
+
+# Maximum number of entries parsed from a single feed (default: 100)
+# Entries beyond this limit are silently dropped.
+# MAX_FEED_ENTRIES=100
+
+# Maximum saved article page size in bytes (default: 5MB = 5242880)
+# Also applies to uploaded articles.
+# MAX_SAVED_ARTICLE_SIZE_BYTES=5242880
+
+# Maximum email newsletter content size in bytes (default: 2MB = 2097152)
+# Emails exceeding this are rejected before processing.
+# MAX_EMAIL_SIZE_BYTES=2097152
+
+# =============================================================================
 # Observability (Optional)
 # =============================================================================
 # Sentry DSN for error tracking

--- a/src/server/config/env.ts
+++ b/src/server/config/env.ts
@@ -107,6 +107,31 @@ export const githubConfig = {
   apiToken: process.env.GITHUB_API_TOKEN,
 };
 
+/**
+ * Usage limits configuration.
+ * These limits protect against abuse and prevent OOM from oversized content.
+ * All limits are configurable via environment variables.
+ */
+export const usageLimitsConfig = {
+  /** Maximum number of active subscriptions per user (default: 500). */
+  maxSubscriptionsPerUser: parseInt(process.env.MAX_SUBSCRIPTIONS_PER_USER || "500", 10),
+
+  /** Maximum feed response size in bytes (default: 10MB). Checked during streaming to avoid OOM. */
+  maxFeedSizeBytes: parseInt(process.env.MAX_FEED_SIZE_BYTES || String(10 * 1024 * 1024), 10),
+
+  /** Maximum number of entries to parse from a single feed (default: 100). */
+  maxFeedEntries: parseInt(process.env.MAX_FEED_ENTRIES || "100", 10),
+
+  /** Maximum saved article page size in bytes (default: 5MB). */
+  maxSavedArticleSizeBytes: parseInt(
+    process.env.MAX_SAVED_ARTICLE_SIZE_BYTES || String(5 * 1024 * 1024),
+    10
+  ),
+
+  /** Maximum email content size in bytes (default: 2MB). Emails larger than this are rejected. */
+  maxEmailSizeBytes: parseInt(process.env.MAX_EMAIL_SIZE_BYTES || String(2 * 1024 * 1024), 10),
+};
+
 export const storageConfig = {
   /** S3 bucket name for storing images */
   bucket: process.env.STORAGE_BUCKET,

--- a/src/server/feed/parser.ts
+++ b/src/server/feed/parser.ts
@@ -13,14 +13,17 @@ import {
   detectFeedType as detectFeedTypeInternal,
   UnknownFeedFormatError,
 } from "./streaming/parser";
+import { usageLimitsConfig } from "../config/env";
 
 // Re-export for backwards compatibility
 export { UnknownFeedFormatError };
 /**
- * Converts a FeedParseResult to a ParsedFeed.
- * The only difference is the field name: entries -> items.
+ * Converts a FeedParseResult to a ParsedFeed, applying the entry count limit.
+ * Entries beyond the limit are silently dropped (we keep the most recent ones,
+ * which are typically at the top of the feed).
  */
-function resultToParsedFeed(result: FeedParseResult): ParsedFeed {
+function resultToParsedFeed(result: FeedParseResult, maxEntries?: number): ParsedFeed {
+  const limit = maxEntries ?? usageLimitsConfig.maxFeedEntries;
   return {
     title: result.title,
     description: result.description,
@@ -30,7 +33,7 @@ function resultToParsedFeed(result: FeedParseResult): ParsedFeed {
     selfUrl: result.selfUrl,
     ttlMinutes: result.ttlMinutes,
     syndication: result.syndication,
-    items: result.entries,
+    items: result.entries.slice(0, limit),
   };
 }
 

--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -778,6 +778,21 @@ async function processFetchResult(feed: Feed, result: FetchFeedResult): Promise<
       return handleTemporaryError(feed, result.message, now);
     }
 
+    case "content_too_large": {
+      // Feed is too large - this is a persistent error, schedule far in future
+      const nextFetch = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000); // 7 days
+      await updateFeedOnError(feed.id, result.message, now, nextFetch);
+      return {
+        success: false,
+        nextRunAt: nextFetch,
+        error: result.message,
+        metadata: {
+          permanent: true,
+          maxBytes: result.maxBytes,
+        },
+      };
+    }
+
     case "server_error":
     case "rate_limited":
     case "network_error":

--- a/src/server/trpc/errors.ts
+++ b/src/server/trpc/errors.ts
@@ -63,6 +63,10 @@ const ErrorCodes = {
   PARSE_ERROR: "PARSE_ERROR",
   SAVED_ARTICLE_FETCH_ERROR: "SAVED_ARTICLE_FETCH_ERROR",
 
+  // Payload too large errors (413)
+  CONTENT_TOO_LARGE: "CONTENT_TOO_LARGE",
+  MAX_SUBSCRIPTIONS_REACHED: "MAX_SUBSCRIPTIONS_REACHED",
+
   // Bad gateway errors (502)
   SITE_BLOCKED: "SITE_BLOCKED",
 } as const;
@@ -120,6 +124,8 @@ const errorCodeToTRPCCode: Record<
   FEED_FETCH_ERROR: "INTERNAL_SERVER_ERROR",
   PARSE_ERROR: "INTERNAL_SERVER_ERROR",
   SAVED_ARTICLE_FETCH_ERROR: "INTERNAL_SERVER_ERROR",
+  CONTENT_TOO_LARGE: "BAD_REQUEST",
+  MAX_SUBSCRIPTIONS_REACHED: "BAD_REQUEST",
   SITE_BLOCKED: "BAD_GATEWAY",
 };
 
@@ -268,6 +274,21 @@ export const errors = {
 
   inviteAlreadyUsed: () =>
     createError(ErrorCodes.INVITE_ALREADY_USED, "Invite token has already been used"),
+
+  // Usage limit errors
+  contentTooLarge: (resource: string, maxBytes: number) =>
+    createError(
+      ErrorCodes.CONTENT_TOO_LARGE,
+      `${resource} exceeds the maximum size of ${Math.round(maxBytes / (1024 * 1024))}MB`,
+      { maxBytes }
+    ),
+
+  maxSubscriptionsReached: (limit: number) =>
+    createError(
+      ErrorCodes.MAX_SUBSCRIPTIONS_REACHED,
+      `You have reached the maximum number of subscriptions (${limit})`,
+      { limit }
+    ),
 
   // Admin errors
   adminSecretNotConfigured: () =>


### PR DESCRIPTION
## Summary

Closes #628

Adds configurable usage limits to protect against abuse and prevent out-of-memory crashes when opening the app to public users:

- **Max feed size (10MB default)**: Streaming size check on HTTP responses prevents OOM. Checks Content-Length header first for early rejection, then enforces limit while streaming decompressed chunks — this also protects against zip bombs.
- **Max feed entries (100 default)**: Limits entries parsed from a single feed. Entries beyond the limit are silently dropped.
- **Max subscriptions per user (500 default)**: Enforced on new subscription creation (reactivations exempt). Applies to manual subscribe, feed discovery, and OPML import.
- **Max saved article size (5MB default)**: Applied to URL fetches (streaming), plugin content, and uploaded articles.
- **Max email size (2MB default)**: Rejects oversized newsletter emails before any processing.

All limits are configurable via environment variables and documented in `.env.example`.

### Key implementation details

- Shared `readResponseWithSizeLimit` / `readResponseBufferWithSizeLimit` helpers in `http/fetch.ts` enforce size limits during streaming — never loads the full body into memory before checking
- Feed fetcher returns a new `content_too_large` status that the job handler treats as a persistent error (7-day retry)
- New error codes: `CONTENT_TOO_LARGE` and `MAX_SUBSCRIPTIONS_REACHED`
- Size limits apply to both the normal fetch path and plugin content paths

### Files changed

| File | Change |
|------|--------|
| `src/server/config/env.ts` | New `usageLimitsConfig` with env var parsing |
| `src/server/http/fetch.ts` | `ContentTooLargeError`, streaming size-limited readers, size limits on `fetchUrl` and `fetchHtmlPage` |
| `src/server/feed/fetcher.ts` | Streaming size limit on feed body, new `content_too_large` result type |
| `src/server/feed/parser.ts` | Entry count limit applied after parsing |
| `src/server/trpc/routers/subscriptions.ts` | Subscription count check before creating new subscriptions |
| `src/server/email/process-inbound.ts` | Email content size check |
| `src/server/services/saved.ts` | Size checks for saved/uploaded articles |
| `src/server/jobs/handlers.ts` | Handle `content_too_large` fetch result |
| `src/server/trpc/errors.ts` | New error codes and helpers |
| `.env.example` | Document all new env vars |

## Test plan

- [ ] Verify typecheck passes (`pnpm typecheck`)
- [ ] Test subscribing to a feed normally still works
- [ ] Test saving an article still works
- [ ] Test that oversized feeds are rejected (can test by setting `MAX_FEED_SIZE_BYTES=100`)
- [ ] Test subscription limit by setting `MAX_SUBSCRIPTIONS_PER_USER=1` and subscribing to 2 feeds
- [ ] Verify OPML import respects subscription limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)