### PR TITLE
Remove unread bonus from implicit score

### DIFF
--- a/src/lib/cache/entry-cache.ts
+++ b/src/lib/cache/entry-cache.ts
@@ -50,7 +50,12 @@ interface InfiniteData {
 export function updateEntriesInListCache(
   queryClient: QueryClient,
   entryIds: string[],
-  updates: Partial<{ read: boolean; starred: boolean; score: number | null; implicitScore: number }>
+  updates: Partial<{
+    read: boolean;
+    starred: boolean;
+    score: number | null;
+    implicitScore: number;
+  }>
 ): void {
   const entryIdSet = new Set(entryIds);
 

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -128,10 +128,11 @@ export interface MarkReadResult {
 /**
  * Computes the implicit score from boolean signal flags and entry type.
  *
- * Priority: starred (+2) > unread (+1) > read-on-list (-1) > saved default (+1) > default (0)
+ * Priority: starred (+2) > unread (0) > read-on-list (-1) > saved default (+1) > default (0)
  *
- * Saved articles default to +1 because the user explicitly saved them, indicating interest.
- * Other signals apply on top, so a saved article marked read from list becomes -1.
+ * Marking unread overrides read-on-list (returns 0 instead of -1) but doesn't
+ * give a positive bonus. Saved articles default to +1 because the user explicitly
+ * saved them, indicating interest.
  */
 export function computeImplicitScore(
   hasStarred: boolean,
@@ -140,7 +141,7 @@ export function computeImplicitScore(
   type?: "web" | "email" | "saved"
 ): number {
   if (hasStarred) return 2;
-  if (hasMarkedUnread) return 1;
+  if (hasMarkedUnread) return 0;
   if (hasMarkedReadOnList) return -1;
   // Saved articles default to +1 since user explicitly saved them
   if (type === "saved") return 1;

--- a/src/server/services/score-prediction.ts
+++ b/src/server/services/score-prediction.ts
@@ -82,7 +82,7 @@ export interface ScorePrediction {
  *
  * Implicit score mapping:
  * - has_starred = +2
- * - has_marked_unread = +1
+ * - has_marked_unread = 0 (overrides read-on-list but no positive bonus)
  * - type = 'saved' = +1
  * - has_marked_read_on_list = -1
  * - default = 0
@@ -101,7 +101,7 @@ function computeEffectiveScore(row: {
 
   // Implicit score based on user actions
   if (row.hasStarred) return 2;
-  if (row.hasMarkedUnread) return 1;
+  if (row.hasMarkedUnread) return 0;
   if (row.type === "saved") return 1;
   if (row.hasMarkedReadOnList) return -1;
 


### PR DESCRIPTION
## Summary

- Changes implicit score for "marked unread" from +1 to 0 (still overrides the -1 from "marked read from feed")
- Updates `computeEffectiveScore` in score-prediction.ts to match (for ML training data)
- No type changes needed — default implicit score remains 0

New implicit score logic: starred=+2, marked unread=0, marked read from feed=-1, saved=+1, default=0

## Test plan

- [x] TypeScript typecheck passes
- [x] All unit tests pass
- [ ] Verify marking unread no longer gives a positive score bonus
- [ ] Verify marking unread still overrides "marked read from feed" (shows 0 instead of -1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)