### PR TITLE
Add uncertainty-aware sorting to Best feed

### DIFF
--- a/drizzle/0055_best_feed_weights.sql
+++ b/drizzle/0055_best_feed_weights.sql
@@ -1,0 +1,5 @@
+-- Add user-configurable weights for the Best feed sorting formula.
+-- The Best feed sorts by: score_weight * predicted_score + uncertainty_weight * (1 - confidence).
+-- Both default to 1.0.
+ALTER TABLE users ADD COLUMN best_feed_score_weight real NOT NULL DEFAULT 1;
+ALTER TABLE users ADD COLUMN best_feed_uncertainty_weight real NOT NULL DEFAULT 1;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1770558800000,
       "tag": "0054_algorithmic_feed_setting",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1770568800000,
+      "tag": "0055_best_feed_weights",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.sql
+++ b/drizzle/schema.sql
@@ -368,7 +368,10 @@ CREATE TABLE public.users (
     anthropic_api_key text,
     summarization_model text,
     summarization_max_words integer,
-    summarization_prompt text
+    summarization_prompt text,
+    algorithmic_feed_enabled boolean DEFAULT true NOT NULL,
+    best_feed_score_weight real DEFAULT 1 NOT NULL,
+    best_feed_uncertainty_weight real DEFAULT 1 NOT NULL
 );
 
 CREATE VIEW public.visible_entries AS

--- a/src/components/settings/pages/AlgorithmicFeedSettingsContent.tsx
+++ b/src/components/settings/pages/AlgorithmicFeedSettingsContent.tsx
@@ -1,17 +1,27 @@
 /**
  * Algorithmic Feed Settings Content
  *
- * Settings page for enabling/disabling the algorithmic feed feature.
+ * Settings page for enabling/disabling the algorithmic feed feature
+ * and configuring Best feed sorting weights.
  * When disabled, score models are not trained, the "Best" feed is hidden,
  * and voting controls are not shown.
  */
 
 "use client";
 
+import { useState, useCallback } from "react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
+import type { inferRouterOutputs } from "@trpc/server";
+import type { AppRouter } from "@/server/trpc/root";
+
+type Preferences = inferRouterOutputs<AppRouter>["users"]["me.preferences"];
 
 export default function AlgorithmicFeedSettingsContent() {
+  const preferencesQuery = trpc.users["me.preferences"].useQuery();
+  const preferences = preferencesQuery.data;
+  const enabled = preferences?.algorithmicFeedEnabled ?? true;
+
   return (
     <div className="space-y-8">
       {/* Page Header */}
@@ -25,13 +35,15 @@ export default function AlgorithmicFeedSettingsContent() {
         </p>
       </div>
 
-      <AlgorithmicFeedToggle />
+      <AlgorithmicFeedToggle enabled={enabled} isLoading={preferencesQuery.isLoading} />
+      {enabled && (
+        <BestFeedWeights preferences={preferences} isLoading={preferencesQuery.isLoading} />
+      )}
     </div>
   );
 }
 
-function AlgorithmicFeedToggle() {
-  const preferencesQuery = trpc.users["me.preferences"].useQuery();
+function AlgorithmicFeedToggle({ enabled, isLoading }: { enabled: boolean; isLoading: boolean }) {
   const utils = trpc.useUtils();
 
   const updateMutation = trpc.users["me.updatePreferences"].useMutation({
@@ -69,8 +81,6 @@ function AlgorithmicFeedToggle() {
     },
   });
 
-  const enabled = preferencesQuery.data?.algorithmicFeedEnabled ?? true;
-
   const handleToggle = () => {
     updateMutation.mutate({ algorithmicFeedEnabled: !enabled });
   };
@@ -94,7 +104,7 @@ function AlgorithmicFeedToggle() {
             role="switch"
             aria-checked={enabled}
             onClick={handleToggle}
-            disabled={preferencesQuery.isLoading || updateMutation.isPending}
+            disabled={isLoading || updateMutation.isPending}
             className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-zinc-900 ${
               enabled ? "bg-zinc-900 dark:bg-zinc-50" : "bg-zinc-200 dark:bg-zinc-700"
             }`}
@@ -109,5 +119,153 @@ function AlgorithmicFeedToggle() {
         </div>
       </div>
     </section>
+  );
+}
+
+function BestFeedWeights({
+  preferences,
+  isLoading,
+}: {
+  preferences: Preferences | undefined;
+  isLoading: boolean;
+}) {
+  const utils = trpc.useUtils();
+
+  const serverScoreWeight = preferences?.bestFeedScoreWeight ?? 1;
+  const serverUncertaintyWeight = preferences?.bestFeedUncertaintyWeight ?? 1;
+
+  const [scoreWeight, setScoreWeight] = useState<number | null>(null);
+  const [uncertaintyWeight, setUncertaintyWeight] = useState<number | null>(null);
+
+  // Use local state if user is editing, otherwise use server state
+  const displayScoreWeight = scoreWeight ?? serverScoreWeight;
+  const displayUncertaintyWeight = uncertaintyWeight ?? serverUncertaintyWeight;
+
+  const updateMutation = trpc.users["me.updatePreferences"].useMutation({
+    onMutate: async (newPrefs) => {
+      await utils.users["me.preferences"].cancel();
+      const previousPrefs = utils.users["me.preferences"].getData();
+
+      utils.users["me.preferences"].setData(undefined, (old) =>
+        old
+          ? {
+              ...old,
+              bestFeedScoreWeight: newPrefs.bestFeedScoreWeight ?? old.bestFeedScoreWeight,
+              bestFeedUncertaintyWeight:
+                newPrefs.bestFeedUncertaintyWeight ?? old.bestFeedUncertaintyWeight,
+            }
+          : undefined
+      );
+
+      return { previousPrefs };
+    },
+    onError: (_error, _newPrefs, context) => {
+      if (context?.previousPrefs) {
+        utils.users["me.preferences"].setData(undefined, context.previousPrefs);
+      }
+      toast.error("Failed to update weights");
+    },
+    onSuccess: () => {
+      toast.success("Weights updated");
+      // Invalidate the Best feed query since sort order changed
+      utils.entries.list.invalidate();
+    },
+    onSettled: (_data, error) => {
+      // Clear local state so we use server values
+      setScoreWeight(null);
+      setUncertaintyWeight(null);
+      if (error) {
+        utils.users["me.preferences"].invalidate();
+      }
+    },
+  });
+
+  const handleSave = useCallback(() => {
+    updateMutation.mutate({
+      bestFeedScoreWeight: displayScoreWeight,
+      bestFeedUncertaintyWeight: displayUncertaintyWeight,
+    });
+  }, [updateMutation, displayScoreWeight, displayUncertaintyWeight]);
+
+  const hasChanges =
+    displayScoreWeight !== serverScoreWeight ||
+    displayUncertaintyWeight !== serverUncertaintyWeight;
+
+  return (
+    <section>
+      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="mb-4">
+          <h4 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
+            Best feed sorting weights
+          </h4>
+          <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+            Control how the Best feed ranks entries. The sort formula is: score weight &times;
+            predicted score + uncertainty weight &times; uncertainty. Higher uncertainty weight
+            surfaces entries the model is less sure about, helping you discover new content.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <WeightSlider
+            label="Score weight"
+            value={displayScoreWeight}
+            onChange={setScoreWeight}
+            disabled={isLoading || updateMutation.isPending}
+          />
+          <WeightSlider
+            label="Uncertainty weight"
+            value={displayUncertaintyWeight}
+            onChange={setUncertaintyWeight}
+            disabled={isLoading || updateMutation.isPending}
+          />
+        </div>
+
+        {hasChanges && (
+          <div className="mt-4 flex justify-end">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={updateMutation.isPending}
+              className="ui-text-sm rounded-md bg-zinc-900 px-3 py-1.5 font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+            >
+              Save
+            </button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function WeightSlider({
+  label,
+  value,
+  onChange,
+  disabled,
+}: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-4">
+      <label className="ui-text-sm w-40 flex-shrink-0 text-zinc-700 dark:text-zinc-300">
+        {label}
+      </label>
+      <input
+        type="range"
+        min={0}
+        max={5}
+        step={0.1}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        disabled={disabled}
+        className="h-2 flex-1 cursor-pointer appearance-none rounded-lg bg-zinc-200 accent-zinc-900 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-700 dark:accent-zinc-50"
+      />
+      <span className="ui-text-sm w-10 text-right text-zinc-600 tabular-nums dark:text-zinc-400">
+        {value.toFixed(1)}
+      </span>
+    </div>
   );
 }

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -73,6 +73,8 @@ interface CachedSession {
   userSummarizationModel: string | null;
   userSummarizationMaxWords: number | null;
   userSummarizationPrompt: string | null;
+  userBestFeedScoreWeight: number;
+  userBestFeedUncertaintyWeight: number;
 }
 
 // ============================================================================
@@ -213,6 +215,8 @@ function serializeForCache(data: SessionData): string {
     userSummarizationModel: data.user.summarizationModel ?? null,
     userSummarizationMaxWords: data.user.summarizationMaxWords ?? null,
     userSummarizationPrompt: data.user.summarizationPrompt ?? null,
+    userBestFeedScoreWeight: data.user.bestFeedScoreWeight,
+    userBestFeedUncertaintyWeight: data.user.bestFeedUncertaintyWeight,
   };
   return JSON.stringify(cached);
 }
@@ -249,6 +253,8 @@ function deserializeFromCache(data: string): SessionData {
       summarizationModel: cached.userSummarizationModel ?? null,
       summarizationMaxWords: cached.userSummarizationMaxWords ?? null,
       summarizationPrompt: cached.userSummarizationPrompt ?? null,
+      bestFeedScoreWeight: cached.userBestFeedScoreWeight ?? 1,
+      bestFeedUncertaintyWeight: cached.userBestFeedUncertaintyWeight ?? 1,
     },
   };
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -71,6 +71,10 @@ export const users = pgTable("users", {
   summarizationMaxWords: integer("summarization_max_words"), // Override SUMMARIZATION_MAX_WORDS
   summarizationPrompt: text("summarization_prompt"), // Custom summarization prompt
 
+  // Best feed sorting weights: sort by score_weight * predicted_score + uncertainty_weight * (1 - confidence)
+  bestFeedScoreWeight: real("best_feed_score_weight").notNull().default(1),
+  bestFeedUncertaintyWeight: real("best_feed_uncertainty_weight").notNull().default(1),
+
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -492,6 +492,8 @@ export const entriesRouter = createTRPCRouter({
         cursor: input.cursor,
         limit: input.limit,
         showSpam,
+        bestFeedScoreWeight: ctx.session.user.bestFeedScoreWeight,
+        bestFeedUncertaintyWeight: ctx.session.user.bestFeedUncertaintyWeight,
       });
     }),
 

--- a/src/server/trpc/routers/users.ts
+++ b/src/server/trpc/routers/users.ts
@@ -329,6 +329,8 @@ export const usersRouter = createTRPCRouter({
         summarizationModel: z.string().nullable(),
         summarizationMaxWords: z.number().nullable(),
         summarizationPrompt: z.string().nullable(),
+        bestFeedScoreWeight: z.number(),
+        bestFeedUncertaintyWeight: z.number(),
       })
     )
     .query(async ({ ctx }) => {
@@ -343,6 +345,8 @@ export const usersRouter = createTRPCRouter({
         summarizationModel: ctx.session.user.summarizationModel,
         summarizationMaxWords: ctx.session.user.summarizationMaxWords,
         summarizationPrompt: ctx.session.user.summarizationPrompt,
+        bestFeedScoreWeight: ctx.session.user.bestFeedScoreWeight,
+        bestFeedUncertaintyWeight: ctx.session.user.bestFeedUncertaintyWeight,
       };
     }),
 
@@ -371,6 +375,9 @@ export const usersRouter = createTRPCRouter({
         // Summarization settings: null clears (reverts to default)
         summarizationMaxWords: z.number().int().min(1).max(10000).nullable().optional(),
         summarizationPrompt: z.string().max(10000).nullable().optional(),
+        // Best feed sorting weights
+        bestFeedScoreWeight: z.number().min(0).max(10).optional(),
+        bestFeedUncertaintyWeight: z.number().min(0).max(10).optional(),
       })
     )
     .output(
@@ -383,6 +390,8 @@ export const usersRouter = createTRPCRouter({
         summarizationModel: z.string().nullable(),
         summarizationMaxWords: z.number().nullable(),
         summarizationPrompt: z.string().nullable(),
+        bestFeedScoreWeight: z.number(),
+        bestFeedUncertaintyWeight: z.number(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -407,6 +416,8 @@ export const usersRouter = createTRPCRouter({
         summarizationModel?: string | null;
         summarizationMaxWords?: number | null;
         summarizationPrompt?: string | null;
+        bestFeedScoreWeight?: number;
+        bestFeedUncertaintyWeight?: number;
         updatedAt: Date;
       } = {
         updatedAt: new Date(),
@@ -443,6 +454,14 @@ export const usersRouter = createTRPCRouter({
         updateData.summarizationPrompt = input.summarizationPrompt;
       }
 
+      if (input.bestFeedScoreWeight !== undefined) {
+        updateData.bestFeedScoreWeight = input.bestFeedScoreWeight;
+      }
+
+      if (input.bestFeedUncertaintyWeight !== undefined) {
+        updateData.bestFeedUncertaintyWeight = input.bestFeedUncertaintyWeight;
+      }
+
       // Update user preferences in database
       await ctx.db.update(users).set(updateData).where(eq(users.id, userId));
 
@@ -459,6 +478,8 @@ export const usersRouter = createTRPCRouter({
           summarizationModel: users.summarizationModel,
           summarizationMaxWords: users.summarizationMaxWords,
           summarizationPrompt: users.summarizationPrompt,
+          bestFeedScoreWeight: users.bestFeedScoreWeight,
+          bestFeedUncertaintyWeight: users.bestFeedUncertaintyWeight,
         })
         .from(users)
         .where(eq(users.id, userId))
@@ -473,6 +494,8 @@ export const usersRouter = createTRPCRouter({
         summarizationModel: updatedUser[0]?.summarizationModel ?? null,
         summarizationMaxWords: updatedUser[0]?.summarizationMaxWords ?? null,
         summarizationPrompt: updatedUser[0]?.summarizationPrompt ?? null,
+        bestFeedScoreWeight: updatedUser[0]?.bestFeedScoreWeight ?? 1,
+        bestFeedUncertaintyWeight: updatedUser[0]?.bestFeedUncertaintyWeight ?? 1,
       };
     }),
 });

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -63,6 +63,8 @@ function createAuthContext(userId: string): Context {
         summarizationModel: null,
         summarizationMaxWords: null,
         summarizationPrompt: null,
+        bestFeedScoreWeight: 1,
+        bestFeedUncertaintyWeight: 1,
         createdAt: now,
         updatedAt: now,
       },

--- a/tests/integration/feed-redirect.test.ts
+++ b/tests/integration/feed-redirect.test.ts
@@ -78,6 +78,8 @@ function createAuthContext(userId: string): Context {
         summarizationModel: null,
         summarizationMaxWords: null,
         summarizationPrompt: null,
+        bestFeedScoreWeight: 1,
+        bestFeedUncertaintyWeight: 1,
         createdAt: now,
         updatedAt: now,
       },

--- a/tests/integration/opml-import.test.ts
+++ b/tests/integration/opml-import.test.ts
@@ -70,6 +70,8 @@ function createAuthContext(userId: string): Context {
         summarizationModel: null,
         summarizationMaxWords: null,
         summarizationPrompt: null,
+        bestFeedScoreWeight: 1,
+        bestFeedUncertaintyWeight: 1,
         createdAt: now,
         updatedAt: now,
       },

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -72,6 +72,8 @@ function createAuthContext(userId: string): Context {
         summarizationModel: null,
         summarizationMaxWords: null,
         summarizationPrompt: null,
+        bestFeedScoreWeight: 1,
+        bestFeedUncertaintyWeight: 1,
         createdAt: now,
         updatedAt: now,
       },

--- a/tests/integration/subscriptions.test.ts
+++ b/tests/integration/subscriptions.test.ts
@@ -65,6 +65,8 @@ function createAuthContext(userId: string): Context {
         summarizationModel: null,
         summarizationMaxWords: null,
         summarizationPrompt: null,
+        bestFeedScoreWeight: 1,
+        bestFeedUncertaintyWeight: 1,
         createdAt: now,
         updatedAt: now,
       },

--- a/tests/integration/tags.test.ts
+++ b/tests/integration/tags.test.ts
@@ -73,6 +73,8 @@ function createAuthContext(userId: string): Context {
         summarizationModel: null,
         summarizationMaxWords: null,
         summarizationPrompt: null,
+        bestFeedScoreWeight: 1,
+        bestFeedUncertaintyWeight: 1,
         createdAt: now,
         updatedAt: now,
       },


### PR DESCRIPTION
## Summary
- The Best feed now sorts by `score_weight * predicted_score + uncertainty_weight * (1 - confidence)` instead of purely by predicted score
- Both weights default to 1 and are user-configurable via sliders in the Algorithmic Feed settings page
- Changing weights invalidates the Best entries query so entries re-sort immediately

This addresses the filter bubble problem where users only see articles they already know they like. Higher uncertainty weight surfaces entries the model is less sure about (e.g. from newly added feeds), encouraging content discovery.

Closes #631

## Changes
- **Migration** (`drizzle/0055_best_feed_weights.sql`): Adds `best_feed_score_weight` and `best_feed_uncertainty_weight` columns to users table
- **Schema** (`src/server/db/schema.ts`): New user preference columns
- **Session cache** (`src/server/auth/session.ts`): Serialize/deserialize new fields
- **Preferences API** (`src/server/trpc/routers/users.ts`): Expose and update weights
- **Entries service** (`src/server/services/entries.ts`): Weighted formula for predictedScore sorting using \`CASE WHEN\` with confidence from the visible_entries view
- **Entries router** (`src/server/trpc/routers/entries.ts`): Pass weights from session to service
- **Settings UI** (`AlgorithmicFeedSettingsContent.tsx`): Weight sliders (0-5, step 0.1) with Save button, shown only when algorithmic feed is enabled
- **Tests**: Updated integration test user fixtures

## Test plan
- [ ] Verify typecheck passes
- [ ] Test Best feed sorting with default weights (should behave similarly to before, but with uncertainty bonus)
- [ ] Test changing weights in settings and verify Best feed re-sorts
- [ ] Test with weights set to 0 for score (pure exploration) and 0 for uncertainty (pure exploitation)
- [ ] Verify settings UI shows/hides weight controls based on algorithmic feed toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)