### PR TITLE
Add self-service account deletion flow

### DIFF
--- a/src/app/(app)/settings/delete-account/page.tsx
+++ b/src/app/(app)/settings/delete-account/page.tsx
@@ -1,0 +1,9 @@
+/**
+ * Delete Account Page
+ *
+ * Route marker for /settings/delete-account. AppRouter handles rendering.
+ */
+
+export default function DeleteAccountPage() {
+  return null;
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -29,7 +29,7 @@ export default function PrivacyPolicyPage() {
             Privacy Policy
           </h1>
           <p className="ui-text-sm mt-2 text-zinc-500 dark:text-zinc-400">
-            Last updated: December 2025
+            Last updated: February 2026
           </p>
         </div>
 
@@ -343,8 +343,15 @@ export default function PrivacyPolicyPage() {
                 for narration at any time
               </li>
               <li>
-                <strong>Delete:</strong> Request account deletion by contacting us (see Contact
-                section below). We are working on self-service account deletion.
+                <strong>Delete:</strong> Delete your account and all associated data at any time
+                from your{" "}
+                <Link
+                  href="/settings/delete-account"
+                  className="text-accent hover:text-accent-hover font-medium"
+                >
+                  account settings
+                </Link>
+                . Account deletion is permanent and cannot be undone.
               </li>
             </ul>
           </section>

--- a/src/components/settings/UnifiedSettingsContent.tsx
+++ b/src/components/settings/UnifiedSettingsContent.tsx
@@ -31,6 +31,7 @@ import IntegrationsSettingsContent from "./pages/IntegrationsSettingsContent";
 import FeedHealthSettingsContent from "./pages/FeedHealthSettingsContent";
 import SessionsSettingsContent from "./pages/SessionsSettingsContent";
 import AlgorithmicFeedSettingsContent from "./pages/AlgorithmicFeedSettingsContent";
+import DeleteAccountSettingsContent from "./pages/DeleteAccountSettingsContent";
 
 const settingsLinks = [
   { href: "/settings", label: "Account" },
@@ -42,6 +43,7 @@ const settingsLinks = [
   { href: "/settings/integrations", label: "Integrations" },
   { href: "/settings/feed-health", label: "Feed Health" },
   { href: "/settings/sessions", label: "Sessions" },
+  { href: "/settings/delete-account", label: "Delete Account" },
 ];
 
 /**
@@ -70,6 +72,8 @@ function SettingsContentRouter() {
       return <FeedHealthSettingsContent />;
     case "/settings/sessions":
       return <SessionsSettingsContent />;
+    case "/settings/delete-account":
+      return <DeleteAccountSettingsContent />;
     default:
       // Default to account settings for unknown paths
       return <AccountSettingsContent />;

--- a/src/components/settings/pages/DeleteAccountSettingsContent.tsx
+++ b/src/components/settings/pages/DeleteAccountSettingsContent.tsx
@@ -1,0 +1,155 @@
+/**
+ * Delete Account Settings Content
+ *
+ * Allows users to permanently delete their account.
+ * Requires typing "delete" as confirmation to prevent accidental deletion.
+ */
+
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { toast } from "sonner";
+import { trpc } from "@/lib/trpc/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Alert } from "@/components/ui/alert";
+import {
+  Dialog,
+  DialogTitle,
+  DialogDescription,
+  DialogBody,
+  DialogFooter,
+} from "@/components/ui/dialog";
+
+export default function DeleteAccountSettingsContent() {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [confirmation, setConfirmation] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  const deleteAccountMutation = trpc.users["me.deleteAccount"].useMutation({
+    onSuccess: () => {
+      // Redirect to login page after deletion
+      window.location.href = "/login";
+    },
+    onError: (err) => {
+      setError(err.message || "Failed to delete account");
+      toast.error("Failed to delete account");
+    },
+  });
+
+  // Focus the cancel button when dialog opens
+  useEffect(() => {
+    if (isDialogOpen) {
+      cancelButtonRef.current?.focus();
+    }
+  }, [isDialogOpen]);
+
+  const handleOpenDialog = () => {
+    setConfirmation("");
+    setError(null);
+    setIsDialogOpen(true);
+  };
+
+  const handleClose = () => {
+    if (deleteAccountMutation.isPending) return;
+    setIsDialogOpen(false);
+    setConfirmation("");
+    setError(null);
+  };
+
+  const handleDelete = () => {
+    if (confirmation !== "delete") {
+      setError("Please type 'delete' to confirm");
+      return;
+    }
+    setError(null);
+    deleteAccountMutation.mutate({ confirmation });
+  };
+
+  const isConfirmed = confirmation === "delete";
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <h2 className="ui-text-lg mb-4 font-semibold text-red-600 dark:text-red-400">
+          Delete Account
+        </h2>
+        <div className="rounded-lg border border-red-200 bg-white p-6 dark:border-red-900/50 dark:bg-zinc-900">
+          <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+            Permanently delete your account and all associated data. This action cannot be undone.
+          </p>
+          <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">
+            This will delete your subscriptions, reading history, starred items, tags, saved
+            articles, email ingest addresses, score models, AI summaries, sessions, API tokens, and
+            all other account data.
+          </p>
+          <div className="mt-4">
+            <Button
+              onClick={handleOpenDialog}
+              className="bg-red-600 text-white hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700"
+            >
+              Delete account
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <Dialog
+        isOpen={isDialogOpen}
+        onClose={handleClose}
+        title="Delete account"
+        titleId="delete-account-title"
+      >
+        <DialogTitle id="delete-account-title">Delete account?</DialogTitle>
+        <DialogDescription>
+          This action is permanent and cannot be undone. All your data will be deleted, including
+          subscriptions, reading history, starred items, saved articles, and account settings.
+        </DialogDescription>
+
+        <DialogBody className="mt-4">
+          {error && (
+            <Alert variant="error" className="mb-4">
+              {error}
+            </Alert>
+          )}
+          <label
+            htmlFor="delete-confirmation"
+            className="ui-text-sm text-zinc-700 dark:text-zinc-300"
+          >
+            Type <span className="font-semibold">delete</span> to confirm:
+          </label>
+          <Input
+            id="delete-confirmation"
+            type="text"
+            value={confirmation}
+            onChange={(e) => setConfirmation(e.target.value)}
+            placeholder="delete"
+            autoComplete="off"
+            disabled={deleteAccountMutation.isPending}
+            className="mt-2"
+          />
+        </DialogBody>
+
+        <DialogFooter>
+          <Button
+            ref={cancelButtonRef}
+            variant="secondary"
+            onClick={handleClose}
+            disabled={deleteAccountMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleDelete}
+            loading={deleteAccountMutation.isPending}
+            disabled={!isConfirmed}
+            className="bg-red-600 text-white hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700"
+          >
+            Delete my account
+          </Button>
+        </DialogFooter>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/server/services/users.ts
+++ b/src/server/services/users.ts
@@ -1,0 +1,112 @@
+/**
+ * Users Service
+ *
+ * Business logic for user account operations, shared across
+ * tRPC routers, MCP server, and background jobs.
+ */
+
+import { eq, sql } from "drizzle-orm";
+import type { Database } from "@/server/db";
+import { users, feeds, entries, subscriptions, userEntries, sessions } from "@/server/db/schema";
+import { getRedisClient } from "@/server/redis";
+import { logger } from "@/lib/logger";
+
+/**
+ * Deletes a user account and all associated data.
+ *
+ * Most user data is deleted automatically via CASCADE foreign keys when the
+ * user row is deleted. This function also cleans up orphaned feeds and entries
+ * that are no longer referenced by any other user.
+ *
+ * Orphan cleanup:
+ * - Web feeds with no remaining subscriptions from other users
+ * - Entries belonging to orphaned feeds (cascaded from feed deletion)
+ * - Email/saved feeds are always user-specific and cascade automatically
+ *
+ * @param db - Database instance
+ * @param userId - The user ID to delete
+ */
+export async function deleteUser(db: Database, userId: string): Promise<void> {
+  // Fetch session token hashes before deletion — CASCADE will remove sessions
+  // from the DB when the user is deleted, so we need these for Redis cleanup.
+  const sessionHashes = await db
+    .select({ tokenHash: sessions.tokenHash })
+    .from(sessions)
+    .where(eq(sessions.userId, userId));
+
+  await db.transaction(async (tx) => {
+    // Step 1: Find web feeds that will become orphaned after this user is deleted.
+    // A feed is orphaned if:
+    // - It has no subscriptions from other users
+    // - It has no user_entries from other users
+    // Email and saved feeds are user-specific and cascade automatically.
+    const orphanedFeedIds = await tx
+      .select({ id: feeds.id })
+      .from(feeds)
+      .where(
+        sql`${feeds.type} = 'web'
+          AND ${feeds.id} IN (
+            SELECT ${subscriptions.feedId} FROM ${subscriptions}
+            WHERE ${subscriptions.userId} = ${userId}
+          )
+          AND ${feeds.id} NOT IN (
+            SELECT ${subscriptions.feedId} FROM ${subscriptions}
+            WHERE ${subscriptions.userId} != ${userId}
+          )
+          AND ${feeds.id} NOT IN (
+            SELECT DISTINCT ${entries.feedId} FROM ${entries}
+            INNER JOIN ${userEntries} ON ${userEntries.entryId} = ${entries.id}
+            WHERE ${userEntries.userId} != ${userId}
+          )`
+      );
+
+    // Step 2: Delete the user. This cascades to:
+    // - sessions, api_tokens, oauth_accounts
+    // - oauth_authorization_codes, oauth_access_tokens, oauth_refresh_tokens, oauth_consent_grants
+    // - subscriptions (which cascades to subscription_tags)
+    // - user_entries, tags
+    // - ingest_addresses, blocked_senders, opml_imports
+    // - user_score_models, entry_score_predictions, entry_summaries
+    // - email/saved feeds (user_id FK with cascade)
+    // - invites.used_by_user_id is set to NULL
+    await tx.delete(users).where(eq(users.id, userId));
+
+    // Step 3: Delete orphaned web feeds (and their entries via cascade)
+    if (orphanedFeedIds.length > 0) {
+      const ids = orphanedFeedIds.map((f) => f.id);
+      await tx.delete(feeds).where(sql`${feeds.id} = ANY(${ids})`);
+    }
+  });
+
+  // Step 4: Invalidate Redis session caches using pre-fetched token hashes
+  const redis = getRedisClient();
+  if (redis && sessionHashes.length > 0) {
+    try {
+      const pipeline = redis.pipeline();
+      for (const session of sessionHashes) {
+        pipeline.del(`session:${session.tokenHash}`);
+      }
+      await pipeline.exec();
+    } catch (err) {
+      // Non-critical: sessions will fail validation anyway since user is deleted
+      logger.warn("Failed to invalidate session caches during account deletion", {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // Clean up user-specific Redis keys
+  if (redis) {
+    try {
+      await redis.del(`user:${userId}:events`);
+    } catch (err) {
+      logger.warn("Failed to clean up Redis keys during account deletion", {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  logger.info("User account deleted", { userId });
+}


### PR DESCRIPTION
## Summary
- Adds a complete account deletion feature (closes #636)
- New backend service (`src/server/services/users.ts`) that deletes the user in a transaction, cascading to all user data via foreign keys, and cleans up orphaned web feeds no longer referenced by other users
- New tRPC endpoint `me.deleteAccount` with expensive rate limiting and "delete" confirmation requirement
- New settings page at `/settings/delete-account` with a confirmation dialog requiring the user to type "delete"
- Updated privacy policy to reference self-service account deletion (replacing "contact us" language)

## What gets deleted
All user data cascades automatically via Postgres foreign keys when the user row is deleted:
- Sessions, API tokens, OAuth accounts/tokens/consent grants
- Subscriptions (and subscription tags), tags
- User entries (read/starred/score state)
- Score models and predictions, AI summaries
- Ingest addresses, blocked senders, OPML imports
- Email/saved feeds (user-specific, cascade automatically)
- Orphaned web feeds (feeds with no other subscribers or user_entries)

## Test plan
- [ ] Navigate to Settings > Delete Account
- [ ] Verify the warning text explains consequences
- [ ] Click "Delete account" button and verify dialog opens
- [ ] Verify the delete button is disabled until "delete" is typed
- [ ] Type "delete" and confirm - verify account is deleted and user is redirected to login
- [ ] Verify orphaned feed cleanup works (feed with no other subscribers is deleted)
- [ ] Verify shared feeds (subscribed by other users) are preserved
- [ ] Verify rate limiting prevents abuse
- [ ] Check privacy policy at /privacy shows updated deletion language

🤖 Generated with [Claude Code](https://claude.com/claude-code)