### PR TITLE
Fix ArXiv plugin: broken image URLs for saved HTML papers

### DIFF
--- a/src/server/feed/arxiv.ts
+++ b/src/server/feed/arxiv.ts
@@ -29,7 +29,7 @@ import { USER_AGENT } from "@/server/http/user-agent";
  * Paper IDs can be in old format (hep-th/9901001) or new format (2601.04649).
  */
 const ARXIV_URL_PATTERN =
-  /^https?:\/\/(?:www\.)?arxiv\.org\/(abs|pdf|html)\/([a-zA-Z0-9.\-/]+?)(?:\.pdf)?(?:v\d+)?(?:[?#].*)?$/;
+  /^https?:\/\/(?:www\.)?arxiv\.org\/(abs|pdf|html)\/([a-zA-Z0-9.\-/]+?(?:v\d+)?)(?:\.pdf)?(?:[?#].*)?$/;
 
 /**
  * Checks if a URL is an ArXiv paper URL (abs, pdf, or html).

--- a/src/server/plugins/arxiv.ts
+++ b/src/server/plugins/arxiv.ts
@@ -26,10 +26,20 @@ export const arxivPlugin: UrlPlugin = {
     savedArticle: {
       async fetchContent(url: URL): Promise<SavedArticleContent | null> {
         try {
-          // Determine the best URL to fetch (HTML version if available)
-          const fetchUrl = await getArxivFetchUrl(url.href);
-          if (!fetchUrl) {
-            return null;
+          // For /html/ URLs, fetch directly; for /abs/ and /pdf/, try to find the HTML version
+          const isHtmlUrl = /^\/html\//.test(url.pathname);
+          let fetchUrl: string;
+
+          if (isHtmlUrl) {
+            // Already an HTML URL - fetch it directly
+            fetchUrl = url.href;
+          } else {
+            // Try to transform abs/pdf to HTML
+            const transformed = await getArxivFetchUrl(url.href);
+            if (!transformed) {
+              return null;
+            }
+            fetchUrl = transformed;
           }
 
           logger.debug("Fetching ArXiv paper", {

--- a/tests/unit/arxiv.test.ts
+++ b/tests/unit/arxiv.test.ts
@@ -106,9 +106,10 @@ describe("ArXiv URL detection", () => {
       expect(extractPaperId("https://arxiv.org/html/2601.04649")).toBe("2601.04649");
     });
 
-    it("extracts paper ID without version number", () => {
-      expect(extractPaperId("https://arxiv.org/abs/2601.04649v1")).toBe("2601.04649");
-      expect(extractPaperId("https://arxiv.org/abs/2601.04649v12")).toBe("2601.04649");
+    it("extracts paper ID with version number preserved", () => {
+      expect(extractPaperId("https://arxiv.org/abs/2601.04649v1")).toBe("2601.04649v1");
+      expect(extractPaperId("https://arxiv.org/abs/2601.04649v12")).toBe("2601.04649v12");
+      expect(extractPaperId("https://arxiv.org/html/2602.04118v1")).toBe("2602.04118v1");
     });
 
     it("extracts paper ID from old format URLs", () => {
@@ -142,6 +143,10 @@ describe("ArXiv URL detection", () => {
   describe("buildArxivHtmlUrl", () => {
     it("builds HTML URL from new format paper ID", () => {
       expect(buildArxivHtmlUrl("2601.04649")).toBe("https://arxiv.org/html/2601.04649");
+    });
+
+    it("builds HTML URL from paper ID with version", () => {
+      expect(buildArxivHtmlUrl("2601.04649v1")).toBe("https://arxiv.org/html/2601.04649v1");
     });
 
     it("builds HTML URL from old format paper ID", () => {


### PR DESCRIPTION
## Summary

- ArXiv plugin's `fetchContent` returned `null` for `/html/` URLs because `getArxivFetchUrl` only handles `abs`/`pdf` URLs — now fetches `/html/` URLs directly
- `ARXIV_URL_PATTERN` regex stripped the version suffix (`v1`) from paper IDs, causing incorrect URL construction — version is now preserved in extracted paper ID
- Readability strips `<base href>` tags during content cleaning, losing base URL information that sites like ArXiv rely on for relative URL resolution. Added `extractBaseHref()` to capture `<base href>` from raw HTML before Readability processes it. This is a general fix — any site using `<base>` tags benefits, not just ArXiv.

### Root cause of the image issue

ArXiv HTML pages include `<base href="/html/2602.04118v1/"/>` (with trailing slash), which browsers use to resolve relative image paths like `x1.png` → `/html/2602.04118v1/x1.png`. But Readability strips `<head>` including `<base>`, so `absolutizeUrls` fell back to the page URL (`/html/2602.04118v1` without trailing slash), and `new URL("x1.png", "https://arxiv.org/html/2602.04118v1")` resolves to `/html/x1.png`.

## Test plan

- [x] All unit tests pass (1625 + 8 new `extractBaseHref` tests + 1 new `cleanContent` integration test)
- [x] Typecheck passes
- [ ] Save `https://arxiv.org/html/2602.04118v1` and verify images load correctly
- [ ] Save `https://arxiv.org/abs/2601.04649v1` and verify it fetches the HTML version with correct image paths
- [ ] Save `https://arxiv.org/abs/2601.04649` (no version) and verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)