### PR TITLE
Add Terms of Service link to settings

### DIFF
--- a/src/components/settings/pages/AccountSettingsContent.tsx
+++ b/src/components/settings/pages/AccountSettingsContent.tsx
@@ -358,12 +358,15 @@ export default function AccountSettingsContent() {
           <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
             Learn more about how we collect, use, and protect your data.
           </p>
-          <div className="mt-4">
+          <div className="mt-4 flex gap-4">
             <a
               href="/privacy"
               className="ui-text-sm text-accent hover:text-accent-hover font-medium"
             >
               View Privacy Policy &rarr;
+            </a>
+            <a href="/terms" className="ui-text-sm text-accent hover:text-accent-hover font-medium">
+              View Terms of Service &rarr;
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Adds a "View Terms of Service →" link next to the existing "View Privacy Policy →" link in the Privacy & Legal section of account settings

## Test plan
- [ ] Navigate to Settings and verify both links appear side by side in the Privacy & Legal section
- [ ] Click "View Terms of Service →" and verify it navigates to `/terms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)