### PR TITLE
Enable open signups in production

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -27,7 +27,7 @@ primary_region = "lax"
   discord = "node dist/discord-bot.js"
 
 [env]
-  ALLOW_ALL_SIGNUPS = "false"
+  ALLOW_ALL_SIGNUPS = "true"
   ALLOWED_SIGNUP_PROVIDERS = "apple,google"
   NEXT_PUBLIC_APP_URL = "https://lionreader.com"
   NODE_ENV = "production"


### PR DESCRIPTION
## Summary
- Sets `ALLOW_ALL_SIGNUPS` to `"true"` in `fly.toml` so anyone can register without an invite code
- OAuth providers (Apple, Google) remain configured as the allowed signup providers

## Test plan
- [ ] Deploy to production and verify the registration page no longer requires an invite token
- [ ] Verify existing users are unaffected

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)