### PR TITLE
Publish algorithmic feed demo article

### DIFF
--- a/src/app/demo/articles/index.ts
+++ b/src/app/demo/articles/index.ts
@@ -17,8 +17,7 @@ import keyboardShortcuts from "./keyboard-shortcuts";
 // Organization & Search
 import tags from "./tags";
 import search from "./search";
-// TODO Publish this once the feature is actually finished: https://github.com/brendanlong/lion-reader/issues/323
-// import scoring from "./scoring";
+import scoring from "./scoring";
 import opml from "./opml";
 
 // Integrations & Sync
@@ -52,7 +51,7 @@ export const DEMO_ARTICLES: DemoArticle[] = [
   // Organization & Search
   tags,
   search,
-  // scoring,
+  scoring,
   opml,
   // Integrations & Sync
   googleReaderApi,

--- a/src/app/demo/articles/scoring.ts
+++ b/src/app/demo/articles/scoring.ts
@@ -1,39 +1,43 @@
 import { type DemoArticle } from "./types";
 
-// TODO Publish this once the feature is actually finished: https://github.com/brendanlong/lion-reader/issues/323
 const article: DemoArticle = {
   id: "scoring",
   subscriptionId: "organization",
   type: "web",
-  url: "https://github.com/brendanlong/lion-reader/pull/450",
-  title: "Entry Scoring & Recommendations",
+  url: "https://github.com/brendanlong/lion-reader/pull/615",
+  title: "Algorithmic Feed & Entry Scoring",
   author: null,
   summary:
-    "Rate articles and get personalized score predictions powered by server-side machine learning.",
-  publishedAt: new Date("2026-01-20T12:00:00Z"),
+    "Rate articles and get a personalized Best feed powered by server-side machine learning.",
+  publishedAt: new Date("2026-02-21T02:49:57Z"),
   starred: false,
-  summaryHtml: `<p>Lion Reader learns your preferences through explicit voting and implicit signals like starring or marking entries read. After 20+ ratings, it trains a <strong>server-side ML model</strong> using TF-IDF and Ridge Regression to predict scores for new content, automatically scoring new entries as feeds are fetched.</p>`,
+  summaryHtml: `<p>Lion Reader uses machine learning to create a personalized <strong>Best feed</strong> by predicting which articles you&rsquo;ll enjoy. It learns from your explicit ratings (&minus;2 to +2) and implicit behavior (starring, saving, quick-marking). The TF-IDF model includes per-feed preferences and confidence-based scoring adjustments.</p>`,
   contentHtml: `
+    <h2>The Best Feed</h2>
+
+    <p>Once you start rating articles, a <strong>Best</strong> link appears in the sidebar. This algorithmic feed shows all your unread entries sorted by predicted score, surfacing the content you&rsquo;re most likely to enjoy. It updates automatically as new articles arrive and get scored.</p>
+
     <h2>Rate Your Reading</h2>
 
-    <p>Lion Reader tracks your preferences through both explicit voting and implicit behavior. Explicit voting uses a 5-point scale from &minus;2 to +2 with upvote/downvote controls. Rate articles directly to build your preference profile.</p>
+    <p>Lion Reader tracks your preferences through both explicit voting and implicit behavior. Voting uses a 5-point scale from &minus;2 to +2 with upvote and downvote controls. Tap the up arrow to vote +1, tap again to boost to +2, and tap a third time to clear. Downvoting works the same way in the other direction.</p>
 
-    <p>Your implicit behavior also contributes to scoring. Starring an entry signals strong interest (+2), marking an entry as unread to come back to it later shows moderate interest (+1), and marking an entry as read from the list without opening it indicates low interest (&minus;1). Over time, these signals combine to create a detailed picture of what you value.</p>
+    <p>Your implicit behavior also contributes to scoring. Starring an entry signals strong interest (+2), saving an article for later indicates moderate interest (+1), and marking an entry as read from the list without opening it indicates low interest (&minus;1). Explicit votes always take priority over implicit signals.</p>
 
     <h3>Server-Side Machine Learning</h3>
 
-    <p>Once you&rsquo;ve rated at least 20 entries, Lion Reader trains a machine learning model to predict scores for new content. The model uses TF-IDF text vectorization combined with Ridge Regression, with titles weighted 2x during feature extraction. Per-feed features capture your source-level preferences, so the model learns not just what topics you like, but which publications you trust.</p>
+    <p>Once you&rsquo;ve rated at least 20 entries, Lion Reader trains a machine learning model to predict scores for new content. The model uses TF-IDF text vectorization with bigrams, combined with Ridge Regression. Titles are weighted 2x during feature extraction, and per-feed features capture your source-level preferences &mdash; so the model learns not just what topics you like, but which publications you trust.</p>
 
-    <p>The model is cross-validated using Mean Absolute Error (MAE) and Pearson correlation metrics to ensure prediction quality. Predictions include confidence scores, helping you understand when recommendations are strong versus tentative. New entries are automatically scored after feed fetches, helping you prioritize the content you&rsquo;re most likely to enjoy.</p>
+    <p>The model is cross-validated using Mean Absolute Error (MAE) and Pearson correlation metrics to ensure prediction quality. Predictions are tempered by a confidence score based on how well the model recognizes an entry&rsquo;s vocabulary and feed &mdash; uncertain predictions are pulled toward zero so they don&rsquo;t dominate your Best feed. New entries are automatically scored right after feed fetches, and the model retrains weekly as you continue rating.</p>
 
     <p>Scoring features:</p>
     <ul>
-      <li><strong>Explicit voting</strong> &mdash; &minus;2 to +2 scale with upvote/downvote controls</li>
-      <li><strong>Implicit signals</strong> &mdash; Starring (+2), marking unread (+1), quick-mark-read (&minus;1)</li>
-      <li><strong>Server-side ML</strong> &mdash; TF-IDF + Ridge Regression model</li>
+      <li><strong>Best feed</strong> &mdash; All unread entries sorted by predicted score</li>
+      <li><strong>Explicit voting</strong> &mdash; &minus;2 to +2 scale with cycling up/down controls</li>
+      <li><strong>Implicit signals</strong> &mdash; Starring (+2), saving (+1), quick-mark-read (&minus;1)</li>
+      <li><strong>Server-side ML</strong> &mdash; TF-IDF with bigrams + Ridge Regression</li>
       <li><strong>Per-feed features</strong> &mdash; Learns source-level preferences</li>
-      <li><strong>Confidence scores</strong> &mdash; Know how strong each prediction is</li>
-      <li><strong>Automatic scoring</strong> &mdash; New entries scored after feed fetches</li>
+      <li><strong>Confidence-based shrinkage</strong> &mdash; Uncertain predictions move toward zero</li>
+      <li><strong>Automatic scoring</strong> &mdash; New entries scored after feed fetches, model retrains weekly</li>
     </ul>
   `,
 };

--- a/src/app/demo/articles/welcome.ts
+++ b/src/app/demo/articles/welcome.ts
@@ -26,7 +26,7 @@ const article: DemoArticle = {
       <li><strong>Real-time updates</strong> &mdash; New entries appear instantly via Server-Sent Events. No refreshing, no polling, just seamless updates as content arrives.</li>
       <li><strong>Progressive Web App</strong> &mdash; Install Lion Reader on desktop or mobile for a native app experience. Share articles directly from your phone.</li>
       <li><strong>Privacy-focused</strong> &mdash; Self-hostable and open source. No ads, no data selling, no third-party analytics. You control your data completely.</li>
-      <li><strong>Smart scoring</strong> &mdash; Rate articles and Lion Reader learns your preferences using TF-IDF and Ridge Regression to predict scores for new content.</li>
+      <li><strong>Algorithmic feed</strong> &mdash; Rate articles and Lion Reader trains a machine learning model to predict scores. The Best feed surfaces your highest-scored unread entries automatically.</li>
     </ul>
 
     <h3>Explore the Demo</h3>
@@ -36,7 +36,7 @@ const article: DemoArticle = {
     <ul>
       <li><strong>Feed Types</strong> &mdash; See how Lion Reader handles RSS feeds, email newsletters, and saved articles</li>
       <li><strong>Reading Experience</strong> &mdash; Explore full content fetching, AI summaries, text-to-speech, and keyboard navigation</li>
-      <li><strong>Organization &amp; Search</strong> &mdash; Learn about tags, full-text search, ML-powered scoring, and OPML import/export</li>
+      <li><strong>Organization &amp; Search</strong> &mdash; Learn about tags, full-text search, the algorithmic feed, and OPML import/export</li>
       <li><strong>Integrations &amp; Sync</strong> &mdash; Discover MCP integration, WebSub push, the PWA, and real-time updates</li>
     </ul>
 


### PR DESCRIPTION
## Summary

- Publishes the scoring/algorithmic feed demo article, which was previously commented out pending completion of #323
- Updates article content to accurately reflect the implemented feature (PR #615):
  - Renamed from "Entry Scoring & Recommendations" to "Algorithmic Feed & Entry Scoring"
  - Added description of the Best feed (the main user-facing feature)
  - Corrected implicit signal values (saving = +1, not marking unread; marking unread = 0 in code)
  - Added details about bigrams, confidence-based shrinkage, weekly retraining
  - Updated voting UI description to match the cycling chevron controls
  - Set date to PR #615 merge time (2026-02-21) and URL to PR #615
- Updated welcome article to reference "Algorithmic feed" instead of "Smart scoring"

## Test plan

- [ ] Visit the demo page and verify the scoring article appears under Organization & Search
- [ ] Verify article content is accurate and well-formatted
- [ ] Verify welcome article references are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)