### PR TITLE
Add Wallabag API demo page and cross-references

### DIFF
--- a/src/app/demo/articles/browser-extension.ts
+++ b/src/app/demo/articles/browser-extension.ts
@@ -50,7 +50,7 @@ const article: DemoArticle = {
 
     <h3>Other Ways to Save</h3>
 
-    <p>The browser extension is one of several ways to save articles in Lion Reader. You can also save via the <a href="/demo/all?entry=save-for-later">bookmarklet</a>, the <a href="/demo/all?entry=pwa">PWA share target</a> on mobile, the <a href="/demo/all?entry=discord-bot">Discord bot</a>, or the <a href="/demo/all?entry=mcp-server">MCP server</a> from AI assistants. All methods use the same underlying save service, so your saved articles end up in the same place regardless of how you captured them.</p>
+    <p>The browser extension is one of several ways to save articles in Lion Reader. You can also save via the <a href="/demo/all?entry=save-for-later">bookmarklet</a>, the <a href="/demo/all?entry=wallabag-api">Wallabag app</a> on mobile, the <a href="/demo/all?entry=pwa">PWA share target</a>, the <a href="/demo/all?entry=discord-bot">Discord bot</a>, or the <a href="/demo/all?entry=mcp-server">MCP server</a> from AI assistants. All methods use the same underlying save service, so your saved articles end up in the same place regardless of how you captured them.</p>
   `,
 };
 

--- a/src/app/demo/articles/index.ts
+++ b/src/app/demo/articles/index.ts
@@ -25,6 +25,7 @@ import googleReaderApi from "./google-reader-api";
 import mcpServer from "./mcp-server";
 import discordBot from "./discord-bot";
 import browserExtension from "./browser-extension";
+import wallabagApi from "./wallabag-api";
 import plugins from "./plugins";
 import websub from "./websub";
 import pwa from "./pwa";
@@ -58,6 +59,7 @@ export const DEMO_ARTICLES: DemoArticle[] = [
   mcpServer,
   discordBot,
   browserExtension,
+  wallabagApi,
   plugins,
   websub,
   pwa,

--- a/src/app/demo/articles/save-for-later.ts
+++ b/src/app/demo/articles/save-for-later.ts
@@ -24,6 +24,7 @@ const article: DemoArticle = {
       <li><strong>PWA share target</strong> &mdash; Use your phone&rsquo;s native share menu to send articles directly to Lion Reader</li>
       <li><strong>MCP integration</strong> &mdash; Save articles via AI assistants like Claude</li>
       <li><strong>tRPC API</strong> &mdash; Programmatic saving for automation and integrations</li>
+      <li><strong>Wallabag app</strong> &mdash; Use the Wallabag mobile app&rsquo;s share intent to save URLs from any app on your phone</li>
       <li><strong>Discord bot</strong> &mdash; Save articles shared in Discord channels</li>
       <li><strong>File upload</strong> &mdash; Upload Markdown files, Word documents, and HTML files directly</li>
       <li><strong>Google Docs import</strong> &mdash; Import Google Docs directly with the optional OAuth scope (powered by the <strong>Plugin System</strong>)</li>

--- a/src/app/demo/articles/wallabag-api.ts
+++ b/src/app/demo/articles/wallabag-api.ts
@@ -1,0 +1,71 @@
+import { type DemoArticle } from "./types";
+
+const article: DemoArticle = {
+  id: "wallabag-api",
+  subscriptionId: "integrations",
+  type: "web",
+  url: "https://github.com/brendanlong/lion-reader/pull/652",
+  title: "Wallabag API",
+  author: null,
+  summary:
+    "Save articles from your phone using the Wallabag app's share intent with Lion Reader's Wallabag-compatible API.",
+  publishedAt: new Date("2026-02-22T20:33:00Z"),
+  starred: false,
+  summaryHtml: `<p>Lion Reader implements a <strong>Wallabag-compatible API</strong> that lets you use the official Wallabag mobile apps on Android and iOS to save articles directly to your Lion Reader account. Share any URL from your phone to the Wallabag app, and it appears in Lion Reader as a saved article. The API also supports viewing, archiving, starring, and deleting saved articles from the app.</p>`,
+  contentHtml: `
+    <h2>Save Articles from Your Phone</h2>
+
+    <p>One of the most convenient ways to save articles for later reading is through your phone&rsquo;s share menu. The <a href="https://wallabag.org/" target="_blank" rel="noopener noreferrer">Wallabag</a> mobile apps for Android and iOS register as share targets on your device, so you can save a URL from any app &mdash; your browser, Twitter, Reddit, Mastodon, or anywhere else &mdash; by tapping &ldquo;Share&rdquo; and selecting Wallabag. Lion Reader implements the Wallabag API as a compatibility layer, so these apps work seamlessly with your Lion Reader account.</p>
+
+    <h3>Compatible Apps</h3>
+
+    <p>The official Wallabag apps work with Lion Reader out of the box:</p>
+
+    <ul>
+      <li><strong><a href="https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche" target="_blank" rel="noopener noreferrer">wallabag</a></strong> &mdash; The official Wallabag app for Android, with share intent support and offline reading</li>
+      <li><strong><a href="https://apps.apple.com/app/wallabag-2-official/id1170800946" target="_blank" rel="noopener noreferrer">wallabag 2</a></strong> &mdash; The official Wallabag app for iOS, with share extension and offline reading</li>
+    </ul>
+
+    <h3>What You Can Do</h3>
+
+    <p>The Wallabag API is scoped to <strong>saved articles</strong> in Lion Reader, matching the read-it-later interface that Wallabag apps expect. Through the app you can:</p>
+
+    <ul>
+      <li><strong>Save URLs</strong> &mdash; Share any URL to the Wallabag app to save it to Lion Reader</li>
+      <li><strong>Browse saved articles</strong> &mdash; View your saved articles list with pagination and filtering</li>
+      <li><strong>Read offline</strong> &mdash; The app caches articles for offline reading</li>
+      <li><strong>Archive articles</strong> &mdash; Mark articles as read (archived) from the app</li>
+      <li><strong>Star articles</strong> &mdash; Star your favorites for quick access</li>
+      <li><strong>Search</strong> &mdash; Full-text search across your saved articles</li>
+      <li><strong>Delete</strong> &mdash; Remove saved articles you no longer need</li>
+    </ul>
+
+    <h3>Setup</h3>
+
+    <p>Setting up is straightforward. In the Wallabag app, go to Settings and enter:</p>
+
+    <ol>
+      <li><strong>Server URL</strong> &mdash; Your Lion Reader URL with the Wallabag path (e.g., <code>https://lionreader.com/api/wallabag</code>)</li>
+      <li><strong>Client ID</strong> &mdash; <code>wallabag</code></li>
+      <li><strong>Client Secret</strong> &mdash; <code>wallabag</code></li>
+      <li><strong>Username</strong> &mdash; Your Lion Reader email address</li>
+      <li><strong>Password</strong> &mdash; Your Lion Reader password</li>
+    </ol>
+
+    <p>Lion Reader also provides a <strong>QR code</strong> and a <strong>deep link</strong> in Settings &gt; Integrations that pre-fill the server URL and your email address, so you only need to enter your password.</p>
+
+    <h3>How It Works</h3>
+
+    <p>The Wallabag API is implemented as a thin translation layer under <code>/api/wallabag/</code>. It follows the same pattern as the <a href="/demo/all?entry=google-reader-api">Google Reader API</a> &mdash; each endpoint translates between the Wallabag wire format and Lion Reader&rsquo;s existing services layer. This means saving an article through the Wallabag app uses the same <code>saveArticle</code> service as the web UI, <a href="/demo/all?entry=browser-extension">browser extension</a>, <a href="/demo/all?entry=mcp-server">MCP server</a>, and <a href="/demo/all?entry=discord-bot">Discord bot</a>.</p>
+
+    <p>Authentication uses OAuth 2.0 password grant, reusing Lion Reader&rsquo;s existing token infrastructure. The client ID and secret are both <code>wallabag</code> &mdash; since Lion Reader validates credentials directly against user accounts, there is no need for per-client registration.</p>
+
+    <p>Entry IDs are mapped between Lion Reader&rsquo;s UUIDv7 format and Wallabag&rsquo;s integer IDs using a deterministic SHA-256 hash. This mapping is stable and reversible without storing any extra data.</p>
+
+    <h3>Other Ways to Save</h3>
+
+    <p>The Wallabag app is one of several ways to save articles in Lion Reader. You can also save via the <a href="/demo/all?entry=browser-extension">browser extension</a>, the <a href="/demo/all?entry=save-for-later">bookmarklet</a>, the <a href="/demo/all?entry=pwa">PWA share target</a>, the <a href="/demo/all?entry=discord-bot">Discord bot</a>, or the <a href="/demo/all?entry=mcp-server">MCP server</a> from AI assistants. All methods use the same underlying save service, so your saved articles end up in the same place regardless of how you captured them.</p>
+  `,
+};
+
+export default article;

--- a/src/app/demo/data.ts
+++ b/src/app/demo/data.ts
@@ -87,7 +87,7 @@ const SUBSCRIPTION_CONFIG: Record<string, { title: string; tagId: string; descri
     title: "Integrations & Sync",
     tagId: "features",
     description:
-      "MCP server for AI assistants, WebSub push, real-time updates, and installable PWA support.",
+      "Google Reader and Wallabag APIs, MCP server for AI assistants, WebSub push, real-time updates, and installable PWA support.",
   },
   "lion-reader": {
     title: "Lion Reader",


### PR DESCRIPTION
## Summary

Closes #653

- Adds a new demo article for the Wallabag API integration, covering setup instructions, compatible apps (Android/iOS), what users can do through the app, and how the API works as a thin translation layer
- Updates the Save for Later article to list the Wallabag app as a save method
- Updates the Browser Extension article's "Other Ways to Save" section to cross-reference the Wallabag app
- Updates the Integrations & Sync subscription description to mention the Wallabag API

## Test plan

- [ ] Visit `/demo/all?entry=wallabag-api` and verify the new article renders correctly
- [ ] Verify cross-links from the Wallabag article to Google Reader API, browser extension, MCP server, Discord bot, bookmarklet, and PWA all work
- [ ] Visit `/demo/all?entry=save-for-later` and verify the Wallabag app is listed as a save method
- [ ] Visit `/demo/all?entry=browser-extension` and verify the Wallabag app appears in "Other Ways to Save"
- [ ] Check that the Integrations & Sync subscription in the demo sidebar shows the updated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)