### PR TITLE
Fix demo scroll position not resetting on j/k navigation

### DIFF
--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -254,6 +254,7 @@ function DemoRouterContent() {
   if (selectedEntry) {
     return (
       <EntryArticle
+        key={selectedEntry.id}
         {...getDemoEntryArticleProps(selectedEntry)}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}


### PR DESCRIPTION
## Summary
- Adds `key={selectedEntry.id}` to `EntryArticle` in the demo's `DemoRouter`, matching the real app's `key={openEntryId}` on `EntryContent` in `UnifiedEntriesContent`
- Without a key, React reuses the same component instance when navigating between entries via j/k, preserving the scroll position from the previous article
- This caused users to see the next article scrolled partway down after scrolling in the previous one

## Why not share more code?
The real app's `EntryContent` is tightly coupled to tRPC (suspense queries, mutations for mark-read/star/score/summarization/full-content), `ScrollContainer` context, and error boundaries. The demo uses static data and local state. The presentational layer (`EntryArticle`, `EntryContentBody`) is already shared — the divergence is only in the data-fetching wrapper, which must differ between demo and real app.

The `key` prop is the idiomatic React solution and the same pattern the real app already uses.

## Test plan
- [ ] Open demo, navigate to a feed with multiple articles
- [ ] Select an article, scroll down with spacebar
- [ ] Press j to go to next article — should start at the top
- [ ] Press k to go back — should also start at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)