### PR TITLE
Optimize score model training and prediction performance

### DIFF
--- a/src/server/ml/ridge.ts
+++ b/src/server/ml/ridge.ts
@@ -54,17 +54,22 @@ function mean(arr: number[]): number {
 
 /**
  * Computes feature means from sparse vectors.
- * Returns a dense array of means (one per feature).
+ * Returns a Float64Array of means (one per feature).
  */
-function computeFeatureMeans(X: SparseVector[], numFeatures: number, nSamples: number): number[] {
-  const sums = new Array<number>(numFeatures).fill(0);
+function computeFeatureMeans(
+  X: SparseVector[],
+  numFeatures: number,
+  nSamples: number
+): Float64Array {
+  const sums = new Float64Array(numFeatures);
   for (const vec of X) {
     for (const [index, value] of vec) {
       sums[index] += value;
     }
   }
+  const invN = 1 / nSamples;
   for (let j = 0; j < numFeatures; j++) {
-    sums[j] /= nSamples;
+    sums[j] *= invN;
   }
   return sums;
 }
@@ -81,7 +86,7 @@ function computeFeatureMeans(X: SparseVector[], numFeatures: number, nSamples: n
 function sparseXtX(
   X: SparseVector[],
   numFeatures: number,
-  featureMeans: number[] | null
+  featureMeans: Float64Array | null
 ): Float64Array {
   const p = numFeatures;
   // Use a flat Float64Array for better memory efficiency than number[][]
@@ -137,7 +142,7 @@ function sparseXty(
   X: SparseVector[],
   y: number[],
   numFeatures: number,
-  featureMeans: number[] | null
+  featureMeans: Float64Array | null
 ): Float64Array {
   const result = new Float64Array(numFeatures);
 
@@ -184,7 +189,7 @@ function choleskySolve(
   b: Float64Array,
   n: number,
   alpha: number
-): number[] | null {
+): Float64Array | null {
   // Add regularization in-place: A += αI
   for (let i = 0; i < n; i++) {
     A[i * n + i] += alpha;
@@ -212,7 +217,7 @@ function choleskySolve(
   }
 
   // Forward substitution: L z = b
-  const z = new Array<number>(n);
+  const z = new Float64Array(n);
   for (let i = 0; i < n; i++) {
     let sum = b[i];
     for (let k = 0; k < i; k++) {
@@ -222,7 +227,7 @@ function choleskySolve(
   }
 
   // Back substitution: L^T x = z
-  const x = new Array<number>(n);
+  const x = new Float64Array(n);
   for (let i = n - 1; i >= 0; i--) {
     let sum = z[i];
     for (let k = i + 1; k < n; k++) {
@@ -303,7 +308,7 @@ export class RidgeRegression {
     }
 
     this.model = {
-      weights,
+      weights: Array.from(weights),
       intercept,
       alpha: this.config.alpha,
       numFeatures,

--- a/src/server/services/score-prediction.ts
+++ b/src/server/services/score-prediction.ts
@@ -477,13 +477,15 @@ export async function predictScores(
 
   for (const entry of entriesToPredict) {
     const text = extractEntryText(entry);
-    const tfidfVector = vectorizer.transformSingle(text);
+
+    // transformWithCoverage computes TF-IDF vector and feature coverage in a single
+    // tokenization pass, avoiding the overhead of tokenizing the text twice.
+    const { vector: tfidfVector, coverage: featureCoverage } =
+      vectorizer.transformWithCoverage(text);
     const combinedVector = combineFeatures(tfidfVector, entry.feedId, feedIdMap, tfidfFeatureCount);
 
     const rawScore = regression.predictSingle(combinedVector);
 
-    // Compute confidence based on feature coverage
-    const featureCoverage = vectorizer.getFeatureCoverage(text);
     const feedKnown = feedIdMap.has(entry.feedId) ? 1.0 : 0.5;
     const confidence = featureCoverage * feedKnown;
 


### PR DESCRIPTION
## Summary

Closes #657

- **Eliminate double-tokenization during prediction**: Added `transformWithCoverage()` to `TfidfVectorizer` that computes the TF-IDF vector and feature coverage in a single tokenization pass, removing the overhead of tokenizing each entry's text twice per prediction
- **Eliminate double-tokenization during training**: Rewrote `fitTransform()` to cache extracted terms during the fit phase and reuse them for transform, instead of separately calling `fit()` (tokenizes all documents) then `transform()` (tokenizes all documents again)
- **Use `Float64Array` for numerical hot paths**: Replaced `number[]` with `Float64Array` in `computeFeatureMeans()` and `choleskySolve()` temporary vectors for better memory layout and V8 optimization in the linear algebra code
- **Remove dead code**: Removed unused `sparseToDense()` export from `tfidf.ts`

## Impact

These optimizations target the three main CPU-intensive phases of the scoring pipeline:

| Phase | Optimization | Effect |
|-------|-------------|--------|
| Training (`fitTransform`) | Cache tokenized terms | Eliminates ~10K redundant tokenizations per training run |
| Training (`choleskySolve`) | Float64Array temporaries | Better cache locality for 3500-dim linear algebra |
| Prediction (per entry) | `transformWithCoverage()` | Eliminates 1 tokenization per entry (up to 1000/batch) |

## Test plan

- [x] All 1633 unit tests pass
- [x] TypeScript type checking passes
- [x] Ridge regression tests verify numerical correctness is preserved
- [ ] Verify in production that scoring CPU usage is reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)