### PR TITLE
Fix Google Reader API pagination limits and add timestamp filters

### DIFF
--- a/src/app/api/greader.php/reader/api/0/stream/contents/[...streamId]/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/contents/[...streamId]/route.ts
@@ -55,15 +55,34 @@ async function handleStreamContents(
   const continuation = searchParams.get("c") ?? undefined;
   const sortOrder = searchParams.get("r") === "o" ? "oldest" : "newest";
   const excludeTarget = searchParams.get("xt");
+  const olderThan = searchParams.get("ot");
+  const newerThan = searchParams.get("nt");
 
   // Build list entries params
   const listParams: entriesService.ListEntriesParams = {
     userId: session.user.id,
     limit: count,
+    maxLimit: 1000,
     cursor: continuation,
     sortOrder: sortOrder as "newest" | "oldest",
     showSpam: session.user.showSpam,
   };
+
+  // ot = "older than" timestamp — only return items newer than this (published after)
+  if (olderThan) {
+    const ts = parseInt(olderThan, 10);
+    if (!isNaN(ts)) {
+      listParams.publishedAfter = new Date(ts * 1000);
+    }
+  }
+
+  // nt = "newer than" timestamp — only return items older than this (published before)
+  if (newerThan) {
+    const ts = parseInt(newerThan, 10);
+    if (!isNaN(ts)) {
+      listParams.publishedBefore = new Date(ts * 1000);
+    }
+  }
 
   // Resolve stream ID to filter params
   switch (parsedStream.type) {

--- a/src/app/api/greader.php/reader/api/0/stream/items/ids/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/items/ids/route.ts
@@ -50,14 +50,33 @@ export async function GET(request: Request): Promise<Response> {
   const continuation = searchParams.get("c") ?? undefined;
   const sortOrder = searchParams.get("r") === "o" ? "oldest" : "newest";
   const excludeTarget = searchParams.get("xt");
+  const olderThan = searchParams.get("ot");
+  const newerThan = searchParams.get("nt");
 
   const listParams: entriesService.ListEntriesParams = {
     userId: session.user.id,
     limit: count,
+    maxLimit: 10000,
     cursor: continuation,
     sortOrder: sortOrder as "newest" | "oldest",
     showSpam: session.user.showSpam,
   };
+
+  // ot = "older than" timestamp — only return items newer than this (published after)
+  if (olderThan) {
+    const ts = parseInt(olderThan, 10);
+    if (!isNaN(ts)) {
+      listParams.publishedAfter = new Date(ts * 1000);
+    }
+  }
+
+  // nt = "newer than" timestamp — only return items older than this (published before)
+  if (newerThan) {
+    const ts = parseInt(newerThan, 10);
+    if (!isNaN(ts)) {
+      listParams.publishedBefore = new Date(ts * 1000);
+    }
+  }
 
   switch (parsedStream.type) {
     case "feed": {


### PR DESCRIPTION
## Summary

Fixes #660.

- **Removed silent result cap**: The entries service enforced `MAX_LIMIT=100`, but Google Reader API clients commonly request 1000–10000 items at once. Added `maxLimit` parameter to `ListEntriesParams` so the Google Reader API endpoints can override this (10000 for `stream/items/ids`, 1000 for `stream/contents`).
- **Added `ot`/`nt` timestamp filters**: Implemented the Google Reader API `ot` (older than — only items newer than timestamp) and `nt` (newer than — only items older than timestamp) parameters via new `publishedAfter`/`publishedBefore` fields in `ListEntriesParams`.

### Research

Web search confirmed that the Google Reader API default sort order is **newest-first** (descending), which our code already implements correctly. The `r=o` parameter switches to oldest-first, also already handled. The actual issue was likely the `MAX_LIMIT=100` cap silently truncating results for clients expecting larger batches (1000+ items).

Sources consulted:
- [Re-Implementing the Google Reader API in 2025 (davd.io)](https://www.davd.io/posts/2025-02-05-reimplementing-google-reader-api-in-2025/)
- [FreshRSS Google Reader API Implementation](https://github.com/FreshRSS/FreshRSS/blob/edge/p/api/greader.php) — confirms `r=d`/`r=n` = newest first (default), `r=o` = oldest first
- [The Old Reader API](https://github.com/theoldreader/api)
- [Inoreader Developer Docs](https://www.inoreader.com/developers/stream-contents)

## Test plan

- [ ] Verify `stream/items/ids` returns up to the requested `n=` count (not capped at 100)
- [ ] Verify `stream/contents` returns up to the requested `n=` count (not capped at 100)
- [ ] Verify `ot=` parameter filters to only items newer than the given timestamp
- [ ] Verify `nt=` parameter filters to only items older than the given timestamp
- [ ] Verify default sort order remains newest-first
- [ ] Verify `r=o` still returns oldest-first
- [ ] Test with a Google Reader client (FeedMe, Read You, etc.) to confirm improved sync behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)