### PR TITLE
Show link to feed builder tool on discovery page

### DIFF
--- a/src/components/subscribe/SubscribeContent.tsx
+++ b/src/components/subscribe/SubscribeContent.tsx
@@ -17,7 +17,12 @@ import { clientPush } from "@/lib/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
-import { CheckCircleIcon, SpinnerIcon, ChevronRightIcon } from "@/components/ui/icon-button";
+import {
+  CheckCircleIcon,
+  SpinnerIcon,
+  ChevronRightIcon,
+  ExternalLinkIcon,
+} from "@/components/ui/icon-button";
 
 // ============================================================================
 // Types
@@ -43,6 +48,7 @@ export function SubscribeContent() {
   const [discoveredFeeds, setDiscoveredFeeds] = useState<DiscoveredFeed[]>([]);
   const [selectedFeedUrl, setSelectedFeedUrl] = useState<string | null>(null);
   const [discoveryError, setDiscoveryError] = useState<string | null>(null);
+  const [feedBuilderUrl, setFeedBuilderUrl] = useState<string | null>(null);
 
   const utils = trpc.useUtils();
 
@@ -97,6 +103,13 @@ export function SubscribeContent() {
     return true;
   };
 
+  const resetDiscoveryState = useCallback(() => {
+    setSelectedFeedUrl(null);
+    setDiscoveredFeeds([]);
+    setDiscoveryError(null);
+    setFeedBuilderUrl(null);
+  }, []);
+
   /**
    * Checks if an error indicates we should try discovery
    */
@@ -115,9 +128,7 @@ export function SubscribeContent() {
     }
 
     // Reset state
-    setSelectedFeedUrl(null);
-    setDiscoveredFeeds([]);
-    setDiscoveryError(null);
+    resetDiscoveryState();
 
     // First, try to preview directly
     const result = await previewQuery.refetch();
@@ -136,6 +147,7 @@ export function SubscribeContent() {
       if (discoverResult.data && discoverResult.data.feeds.length > 0) {
         // Found feeds via discovery
         setDiscoveredFeeds(discoverResult.data.feeds);
+        setFeedBuilderUrl(discoverResult.data.feedBuilderUrl ?? null);
         setStep("discovery");
         return;
       }
@@ -172,9 +184,7 @@ export function SubscribeContent() {
     } else {
       // Go back to input
       setStep("input");
-      setSelectedFeedUrl(null);
-      setDiscoveredFeeds([]);
-      setDiscoveryError(null);
+      resetDiscoveryState();
     }
   };
 
@@ -325,6 +335,22 @@ export function SubscribeContent() {
                 </button>
               ))}
             </div>
+
+            {/* Feed builder link from plugin */}
+            {feedBuilderUrl && (
+              <p className="ui-text-sm mt-4 text-zinc-600 dark:text-zinc-400">
+                Looking for a custom feed?{" "}
+                <a
+                  href={feedBuilderUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-zinc-900 underline hover:text-zinc-700 dark:text-zinc-200 dark:hover:text-zinc-400"
+                >
+                  Build a custom feed URL
+                  <ExternalLinkIcon className="h-3.5 w-3.5" />
+                </a>
+              </p>
+            )}
           </div>
 
           {/* Back button */}

--- a/src/server/plugins/lesswrong.ts
+++ b/src/server/plugins/lesswrong.ts
@@ -25,6 +25,8 @@ export const lessWrongPlugin: UrlPlugin = {
     return /^\/(posts|users)\//.test(url.pathname) || url.searchParams.has("commentId");
   },
 
+  feedBuilderUrl: "https://brendanlong.github.io/lesswrong-rss-builder/",
+
   capabilities: {
     feed: {
       async transformToFeedUrl(url: URL): Promise<URL | null> {

--- a/src/server/plugins/registry.ts
+++ b/src/server/plugins/registry.ts
@@ -55,6 +55,16 @@ class PluginRegistry {
 
     return plugins.find((p) => p.matchUrl(url)) ?? null;
   }
+
+  /**
+   * Find the first plugin registered for a hostname.
+   * Unlike findAny, this only checks hostname, not matchUrl.
+   * Useful for site-level metadata like feedBuilderUrl.
+   */
+  findByHostname(hostname: string): UrlPlugin | null {
+    const plugins = this.hostIndex.get(hostname.toLowerCase());
+    return plugins?.[0] ?? null;
+  }
 }
 
 // Global singleton

--- a/src/server/plugins/types.ts
+++ b/src/server/plugins/types.ts
@@ -21,6 +21,13 @@ export interface UrlPlugin {
 
   /** Plugin capabilities */
   capabilities: PluginCapabilities;
+
+  /**
+   * Optional URL to an external tool for building custom feed URLs for this site.
+   * Shown on the feed discovery/disambiguation page when subscribing.
+   * E.g., a LessWrong RSS feed builder tool.
+   */
+  feedBuilderUrl?: string;
 }
 
 export interface PluginCapabilities {


### PR DESCRIPTION
## Summary

- Adds `feedBuilderUrl` optional property to the `UrlPlugin` interface, allowing plugins to link to external tools for building custom feed URLs
- Adds `findByHostname` method to `PluginRegistry` for hostname-only lookups (without requiring `matchUrl` to pass)
- Sets `feedBuilderUrl` on the LessWrong plugin pointing to https://brendanlong.github.io/lesswrong-rss-builder/
- Extends `feeds.discover` endpoint to return `feedBuilderUrl` when a plugin provides one for the input URL's hostname
- Shows the link on the feed discovery/disambiguation page in the subscribe flow

Closes #661

## Test plan

- [ ] Navigate to subscribe page, enter a LessWrong URL (e.g., \`https://lesswrong.com\`)
- [ ] Verify the discovery page shows the "Build a custom feed URL" link at the bottom of the feed list
- [ ] Verify the link opens https://brendanlong.github.io/lesswrong-rss-builder/ in a new tab
- [ ] Enter a non-LessWrong URL and verify no feed builder link appears
- [ ] Verify typecheck passes (\`pnpm typecheck\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)