### PR TITLE
Broken feeds page: show all feeds with subscriber filter

### DIFF
--- a/src/components/admin/AdminFeedsContent.tsx
+++ b/src/components/admin/AdminFeedsContent.tsx
@@ -261,6 +261,7 @@ export default function AdminFeedsContent() {
   const [urlInput, setUrlInput] = useState("");
   const [emailInput, setEmailInput] = useState(initialEmail);
   const [brokenOnly, setBrokenOnly] = useState(false);
+  const [hasSubscribers, setHasSubscribers] = useState(true);
   const [debouncedUrl, setDebouncedUrl] = useState("");
   const [debouncedEmail, setDebouncedEmail] = useState(initialEmail);
   const [retryingId, setRetryingId] = useState<string | null>(null);
@@ -291,6 +292,7 @@ export default function AdminFeedsContent() {
       urlFilter: debouncedUrl || undefined,
       userEmail: debouncedEmail || undefined,
       brokenOnly: brokenOnly || undefined,
+      hasSubscribers: hasSubscribers || undefined,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -354,7 +356,8 @@ export default function AdminFeedsContent() {
     };
   }, [handleObserver]);
 
-  const hasFilters = debouncedUrl.length > 0 || debouncedEmail.length > 0 || brokenOnly;
+  const hasFilters =
+    debouncedUrl.length > 0 || debouncedEmail.length > 0 || brokenOnly || hasSubscribers;
 
   return (
     <div>
@@ -381,7 +384,16 @@ export default function AdminFeedsContent() {
             onChange={(e) => setEmailInput(e.target.value)}
           />
         </div>
-        <div className="shrink-0">
+        <div className="flex shrink-0 items-center gap-3">
+          <label className="ui-text-sm flex cursor-pointer items-center gap-2 text-zinc-600 dark:text-zinc-400">
+            <input
+              type="checkbox"
+              checked={hasSubscribers}
+              onChange={(e) => setHasSubscribers(e.target.checked)}
+              className="text-accent focus:ring-accent h-4 w-4 rounded border-zinc-300 dark:border-zinc-700 dark:bg-zinc-800"
+            />
+            Has subscribers
+          </label>
           <Button
             variant={brokenOnly ? "primary" : "secondary"}
             size="sm"

--- a/src/server/trpc/routers/admin.ts
+++ b/src/server/trpc/routers/admin.ts
@@ -272,6 +272,7 @@ const feedHealthEndpoints = {
           urlFilter: z.string().optional(),
           userEmail: z.string().optional(),
           brokenOnly: z.boolean().optional(),
+          hasSubscribers: z.boolean().optional(),
         })
         .optional()
     )
@@ -305,6 +306,7 @@ const feedHealthEndpoints = {
       const urlFilter = input?.urlFilter;
       const userEmail = input?.userEmail;
       const brokenOnly = input?.brokenOnly;
+      const hasSubscribers = input?.hasSubscribers;
 
       // Subscriber count subquery
       const subscriberCountSq = ctx.db
@@ -368,6 +370,11 @@ const feedHealthEndpoints = {
       // Broken only filter
       if (brokenOnly) {
         conditions.push(gt(feeds.consecutiveFailures, 0));
+      }
+
+      // Has subscribers filter: only feeds with active subscribers
+      if (hasSubscribers) {
+        conditions.push(sql`(${subscriberCountSq}) > 0`);
       }
 
       // User email filter: feeds that a specific user is subscribed to


### PR DESCRIPTION
## Summary

Fixes #666

- Added `hasSubscribers` filter parameter to `admin.listFeeds` backend endpoint
- Added a **"Has subscribers" checkbox** (checked by default) to the admin feeds page at `/admin/feeds`
- When checked, only feeds with >0 active subscribers are shown
- Unchecking reveals all feeds including those with no subscribers

## Test plan

- [ ] Verify the admin feeds page at `/admin/feeds` loads with the checkbox checked by default
- [ ] Verify that with the checkbox checked, only feeds with active subscribers are shown
- [ ] Verify unchecking the checkbox shows all feeds including those with 0 subscribers
- [ ] Verify the checkbox works in combination with other filters (URL filter, email filter, broken only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)