### PR TITLE
Add compound (feed_id, timestamp) index for per-feed entry queries

### DIFF
--- a/migrations/0061_entries_feed_published_sort_index.sql
+++ b/migrations/0061_entries_feed_published_sort_index.sql
@@ -1,0 +1,14 @@
+-- Compound index on entries for per-feed sorted queries.
+--
+-- When filtering entries by feed_id (single subscription view), the global
+-- expression index (idx_entries_published_coalesce) must scan entries across
+-- all feeds in sort order, filtering out non-matching feed_ids. This compound
+-- index lets the planner seek directly to the feed_id partition and scan in
+-- sort order within it.
+--
+-- The global index remains the better choice for "all entries" queries that
+-- don't filter by feed_id. Write overhead is minimal since entry inserts
+-- only happen in the background worker.
+
+CREATE INDEX CONCURRENTLY idx_entries_feed_published_coalesce
+ON entries (feed_id, (COALESCE(published_at, fetched_at)) DESC, id DESC);

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -582,6 +582,8 @@ CREATE INDEX idx_entries_feed ON public.entries USING btree (feed_id, id);
 
 CREATE INDEX idx_entries_feed_type ON public.entries USING btree (feed_id, type);
 
+CREATE INDEX idx_entries_feed_published_coalesce ON public.entries USING btree (feed_id, (COALESCE(published_at, fetched_at)) DESC, id DESC);
+
 CREATE INDEX idx_entries_published_coalesce ON public.entries USING btree ((COALESCE(published_at, fetched_at)) DESC, id DESC);
 
 CREATE INDEX idx_entries_fetched ON public.entries USING btree (feed_id, fetched_at);

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -471,9 +471,11 @@ export const entries = pgTable(
     index("idx_entries_spam").on(table.feedId, table.isSpam),
     // For filtering by entry type
     index("idx_entries_type").on(table.type),
-    // Expression index for the primary sort column (COALESCE(published_at, fetched_at) DESC, id DESC)
-    // Enables limit pushdown for entry list queries through the visible_entries view.
-    // Created via raw SQL in migration 0060 (Drizzle can't express expression indexes with DESC).
+    // Expression indexes for entry list sorting (Drizzle can't express these, created via raw SQL):
+    // - idx_entries_published_coalesce: (COALESCE(published_at, fetched_at) DESC, id DESC)
+    //   Enables limit pushdown for "all entries" queries. Migration 0060.
+    // - idx_entries_feed_published_coalesce: (feed_id, COALESCE(published_at, fetched_at) DESC, id DESC)
+    //   Enables seek + limit pushdown for per-feed/subscription queries. Migration 0061.
     //
     // Type-specific check constraints (created via raw SQL in migrations):
     // - entries_spam_only_email: spam fields only for email entries


### PR DESCRIPTION
## Summary

- Adds `idx_entries_feed_published_coalesce` index on `(feed_id, COALESCE(published_at, fetched_at) DESC, id DESC)`
- Complements the existing global `idx_entries_published_coalesce` which optimizes "all entries" queries
- For per-feed/subscription queries, the planner can now seek directly to the feed_id and scan in sort order, instead of scanning all entries and filtering by feed_id
- Write overhead is only in the background worker (entry inserts), not latency-sensitive

## Context

Follow-up to #674. The global expression index gives excellent limit pushdown for "all entries" but per-feed queries still scanned across all entries in sort order, filtering out non-matching feed_ids. With many feeds in production, this compound index gives a direct seek path.

## Test plan

- [ ] Migration creates index concurrently (no table lock)
- [ ] Verify EXPLAIN shows index scan on `idx_entries_feed_published_coalesce` for subscription-filtered entry queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)