### PR TITLE
Replace feed_ids array with subscription_feeds junction table (10-47x faster counts)

### DIFF
--- a/migrations/0060_subscription_feeds.sql
+++ b/migrations/0060_subscription_feeds.sql
@@ -1,0 +1,114 @@
+-- Migration: Replace feed_ids array column with subscription_feeds junction table
+--
+-- Background: The subscriptions.feed_ids column (a generated array combining feed_id
+-- and previous_feed_ids) was used in the visible_entries view join:
+--   LEFT JOIN subscriptions s ON s.feed_ids @> ARRAY[e.feed_id]
+-- This array containment join creates O(entries × subscriptions) intermediate rows
+-- because PostgreSQL's GIN index cannot be used in this join direction, causing
+-- 10-50x slower queries than necessary.
+--
+-- Solution: A junction table subscription_feeds(subscription_id, feed_id) with scalar
+-- equality joins enables hash joins and btree index usage.
+--
+-- This migration is atomic: it creates the new table, populates it, updates both
+-- views, and drops the old columns in a single transaction.
+
+-- Step 1: Create subscription_feeds junction table
+CREATE TABLE public.subscription_feeds (
+    subscription_id uuid NOT NULL REFERENCES public.subscriptions(id) ON DELETE CASCADE,
+    feed_id uuid NOT NULL REFERENCES public.feeds(id) ON DELETE CASCADE,
+    user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    PRIMARY KEY (subscription_id, feed_id)
+);
+
+-- Step 2: Populate from existing data (all subscriptions, active and unsubscribed)
+-- ON CONFLICT handles potential duplicate feed_ids from redirect chains
+INSERT INTO public.subscription_feeds (subscription_id, feed_id, user_id)
+SELECT s.id, unnest(s.feed_ids), s.user_id
+FROM public.subscriptions s
+ON CONFLICT DO NOTHING;
+
+-- Step 3: Create indexes for efficient joins
+CREATE INDEX idx_subscription_feeds_user_feed ON public.subscription_feeds (user_id, feed_id);
+CREATE INDEX idx_subscription_feeds_feed ON public.subscription_feeds (feed_id);
+
+-- Step 4: Replace visible_entries view to use junction table
+CREATE OR REPLACE VIEW public.visible_entries AS
+SELECT ue.user_id,
+    e.id,
+    e.feed_id,
+    e.type,
+    e.guid,
+    e.url,
+    e.title,
+    e.author,
+    e.content_original,
+    e.content_cleaned,
+    e.summary,
+    e.site_name,
+    e.image_url,
+    e.published_at,
+    e.fetched_at,
+    e.last_seen_at,
+    e.content_hash,
+    e.full_content_hash,
+    e.spam_score,
+    e.is_spam,
+    e.list_unsubscribe_mailto,
+    e.list_unsubscribe_https,
+    e.list_unsubscribe_post,
+    e.created_at,
+    GREATEST(e.updated_at, ue.updated_at) AS updated_at,
+    e.full_content_original,
+    e.full_content_cleaned,
+    e.full_content_fetched_at,
+    e.full_content_error,
+    ue.read,
+    ue.starred,
+    ue.score,
+    ue.has_marked_read_on_list,
+    ue.has_marked_unread,
+    ue.has_starred,
+    s.id AS subscription_id,
+    esp.predicted_score,
+    esp.confidence AS prediction_confidence,
+    e.unsubscribe_url,
+    ue.read_changed_at,
+    e.wallabag_id
+FROM public.user_entries ue
+    JOIN public.entries e ON e.id = ue.entry_id
+    LEFT JOIN public.subscription_feeds sf ON sf.user_id = ue.user_id AND sf.feed_id = e.feed_id
+    LEFT JOIN public.subscriptions s ON s.id = sf.subscription_id
+    LEFT JOIN public.entry_score_predictions esp ON esp.user_id = ue.user_id AND esp.entry_id = e.id
+WHERE s.unsubscribed_at IS NULL OR ue.starred = true;
+
+-- Step 5: Drop and recreate user_feeds view to remove feed_ids column
+-- (CREATE OR REPLACE can't remove columns, so we must DROP first)
+DROP VIEW IF EXISTS public.user_feeds;
+CREATE VIEW public.user_feeds AS
+SELECT s.id,
+    s.user_id,
+    s.subscribed_at,
+    s.created_at,
+    s.feed_id,
+    s.custom_title,
+    s.fetch_full_content,
+    f.type,
+    COALESCE(s.custom_title, f.title) AS title,
+    f.title AS original_title,
+    f.url,
+    f.site_url,
+    f.description
+FROM public.subscriptions s
+    JOIN public.feeds f ON f.id = s.feed_id
+WHERE s.unsubscribed_at IS NULL;
+
+-- Step 6: Drop old columns and indexes
+-- Drop generated column first (depends on previous_feed_ids)
+ALTER TABLE public.subscriptions DROP COLUMN feed_ids;
+ALTER TABLE public.subscriptions DROP COLUMN previous_feed_ids;
+
+-- Drop the now-unused GIN indexes (they were on the dropped columns)
+-- These are automatically dropped when the columns are dropped, but be explicit
+DROP INDEX IF EXISTS public.idx_subscriptions_feed_ids;
+DROP INDEX IF EXISTS public.idx_subscriptions_previous_feed_ids;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -414,6 +414,20 @@
       "when": 1770598800000,
       "tag": "0058_wallabag_id",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1770608800000,
+      "tag": "0059_visible_entries_gin_operator",
+      "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1770618800000,
+      "tag": "0060_subscription_feeds",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/greader.php/reader/api/0/subscription/quickadd/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/quickadd/route.ts
@@ -15,7 +15,7 @@ import { uuidToInt64 } from "@/server/google-reader/id";
 import * as subscriptionsService from "@/server/services/subscriptions";
 import { db } from "@/server/db";
 import { eq, isNull, and } from "drizzle-orm";
-import { feeds, subscriptions } from "@/server/db/schema";
+import { feeds, subscriptions, subscriptionFeeds } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
 
 export const dynamic = "force-dynamic";
@@ -98,6 +98,12 @@ export async function POST(request: Request): Promise<Response> {
       createdAt: now,
       updatedAt: now,
     });
+
+    // Add the feed to the subscription_feeds junction table
+    await db
+      .insert(subscriptionFeeds)
+      .values({ subscriptionId, feedId, userId: session.user.id })
+      .onConflictDoNothing();
 
     return jsonResponse({
       query: feedUrl,

--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -15,6 +15,7 @@ import { fetchUrl, isHtmlContent } from "@/server/http/fetch";
 import {
   feeds,
   subscriptions,
+  subscriptionFeeds,
   entries,
   userEntries,
   tags,
@@ -197,6 +198,12 @@ export async function createOrReactivateSubscription(
       createdAt: subscribedAt,
       updatedAt: subscribedAt,
     });
+
+    // Add the feed to the subscription_feeds junction table
+    await db
+      .insert(subscriptionFeeds)
+      .values({ subscriptionId, feedId, userId })
+      .onConflictDoNothing();
   }
 
   // Populate user_entries for initial unread entries

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -7,7 +7,14 @@
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { eq } from "drizzle-orm";
 import { db } from "../../src/server/db";
-import { users, feeds, entries, subscriptions, userEntries } from "../../src/server/db/schema";
+import {
+  users,
+  feeds,
+  entries,
+  subscriptions,
+  subscriptionFeeds,
+  userEntries,
+} from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
@@ -109,6 +116,10 @@ async function createTestSubscription(userId: string, feedId: string): Promise<s
     createdAt: new Date(),
     updatedAt: new Date(),
   });
+  await db
+    .insert(subscriptionFeeds)
+    .values({ subscriptionId, feedId, userId })
+    .onConflictDoNothing();
   return subscriptionId;
 }
 

--- a/tests/integration/tags.test.ts
+++ b/tests/integration/tags.test.ts
@@ -12,6 +12,7 @@ import {
   users,
   tags,
   subscriptions,
+  subscriptionFeeds,
   subscriptionTags,
   feeds,
   entries,
@@ -128,6 +129,10 @@ async function createTestSubscription(userId: string, feedId: string): Promise<s
     createdAt: new Date(),
     updatedAt: new Date(),
   });
+  await db
+    .insert(subscriptionFeeds)
+    .values({ subscriptionId, feedId, userId })
+    .onConflictDoNothing();
   return subscriptionId;
 }
 


### PR DESCRIPTION
## Summary

- Performance profiling revealed count queries through `visible_entries` view are the primary bottleneck (~90% of `markRead`/`setStarred` latency)
- Root cause: `subscriptions.feed_ids @> ARRAY[e.feed_id]` array containment join creates O(entries × subscriptions) intermediate rows because PostgreSQL's GIN index cannot be used in this join direction
- Replace with `subscription_feeds(subscription_id, feed_id)` junction table that enables hash joins with scalar equality
- **Measured speedups at 5K entries**: global count 10x, subscription count 47x, tag count 47x, uncategorized count 46x

## Changes

1. **New migration** (`0059_subscription_feeds.sql`): Creates junction table, populates from existing data, updates both views, drops old columns - all atomic
2. **Drizzle schema**: Added `subscriptionFeeds` table, removed `previousFeedIds`/`feedIds` columns from `subscriptions`, removed `feedIds` from `userFeeds` view
3. **All query updates**: Replaced `feed_ids @>` array containment joins with `subscription_feeds` equi-joins across:
   - `visible_entries` view (the core fix)
   - Services: `entry-filters.ts`, `tags.ts`, `entries.ts`
   - Routers: `entries.ts`, `sync.ts`, `subscriptions.ts`
   - GReader API: `mark-all-as-read`, `quickadd`
   - Feed redirect handler and entry processor dedup
4. **Subscription creation**: All subscription creation points now also insert into `subscription_feeds`
5. **Tests updated**: All integration tests updated to insert `subscription_feeds` rows alongside subscriptions

## Test plan

- [x] `pnpm typecheck` passes
- [x] All 1942 tests pass (80 test files)
- [x] Feed redirect tests pass (subscription migration to junction table)
- [x] Saved articles tests pass (visibility preserved for feeds without subscriptions)
- [x] Entry listing/marking/starring tests pass
- [x] Tag filtering tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)