### PR TITLE
Fix link hover style applying to all links in entry

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -150,6 +150,16 @@ body {
 }
 
 /* =================================
+   Prose Link Hover
+   Element-level hover so only the hovered link changes color,
+   not all links in the entry.
+   ================================= */
+
+.prose a:hover {
+  color: var(--accent-hover);
+}
+
+/* =================================
    Narration Highlighting Styles
    ================================= */
 

--- a/src/components/entries/EntryContentRenderer.tsx
+++ b/src/components/entries/EntryContentRenderer.tsx
@@ -38,7 +38,7 @@ export const EntryContentRenderer = React.memo(function EntryContentRenderer({
     return (
       <div
         ref={contentRef}
-        className={`${textSizeClass} prose-headings:font-semibold prose-headings:text-zinc-900 dark:prose-headings:text-zinc-100 prose-a:text-accent prose-a:underline-offset-2 hover:prose-a:text-accent-hover prose-img:rounded-lg prose-img:shadow-md prose-pre:overflow-x-auto prose-pre:bg-zinc-100 dark:prose-pre:bg-zinc-800 prose-code:text-zinc-800 dark:prose-code:text-zinc-200 prose-code:before:content-none prose-code:after:content-none prose-blockquote:border-l-zinc-300 dark:prose-blockquote:border-l-zinc-600 prose-blockquote:text-zinc-600 dark:prose-blockquote:text-zinc-400 max-w-none`}
+        className={`${textSizeClass} prose-headings:font-semibold prose-headings:text-zinc-900 dark:prose-headings:text-zinc-100 prose-a:text-accent prose-a:underline-offset-2 prose-img:rounded-lg prose-img:shadow-md prose-pre:overflow-x-auto prose-pre:bg-zinc-100 dark:prose-pre:bg-zinc-800 prose-code:text-zinc-800 dark:prose-code:text-zinc-200 prose-code:before:content-none prose-code:after:content-none prose-blockquote:border-l-zinc-300 dark:prose-blockquote:border-l-zinc-600 prose-blockquote:text-zinc-600 dark:prose-blockquote:text-zinc-400 max-w-none`}
         style={textStyle}
         dangerouslySetInnerHTML={{ __html: sanitizedContent }}
       />


### PR DESCRIPTION
## Summary

- Fixes #685: Hovering over an entry was triggering hover CSS for **all** links, not just the hovered link
- Root cause: `hover:prose-a:text-accent-hover` is a container-level hover — when the entry `div` is hovered, all `a` tags inside get the hover color
- Fix: Removed the container-level Tailwind class and added a `.prose a:hover` CSS rule in `globals.css` that applies hover styling at the individual link level

## Test plan

- [ ] Hover over an entry containing multiple links
- [ ] Verify only the hovered link changes color, not all links in the entry
- [ ] Verify link hover color works in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)