### PR TITLE
Add brotli to Accept-Encoding for outgoing HTTP requests

### DIFF
--- a/src/server/feed/fetcher.ts
+++ b/src/server/feed/fetcher.ts
@@ -6,7 +6,11 @@
 import { parseCacheHeaders, type ParsedCacheHeaders } from "./cache-headers";
 import { parseWebSubLinkHeaders, type WebSubLinkHeaders } from "./link-header";
 import { buildUserAgent } from "../http/user-agent";
-import { readResponseBufferWithSizeLimit, ContentTooLargeError } from "../http/fetch";
+import {
+  readResponseBufferWithSizeLimit,
+  ContentTooLargeError,
+  ACCEPT_ENCODING,
+} from "../http/fetch";
 import { usageLimitsConfig } from "../config/env";
 
 /**
@@ -346,6 +350,7 @@ export async function fetchFeed(
         subscriberCount,
       }),
     Accept: "application/rss+xml, application/atom+xml, application/xml, text/xml, */*",
+    "Accept-Encoding": ACCEPT_ENCODING,
   };
 
   if (etag) {

--- a/src/server/http/fetch.ts
+++ b/src/server/http/fetch.ts
@@ -127,6 +127,17 @@ async function readResponseWithSizeLimit(
 // ============================================================================
 
 /**
+ * Accept-Encoding header for outgoing requests.
+ *
+ * Node.js 20's native fetch only advertises "gzip, deflate" by default,
+ * but it can also decompress brotli. Explicitly including "br" lets servers
+ * send brotli-compressed responses, which are typically 15-20% smaller than gzip.
+ *
+ * zstd is not included because Node.js 20 doesn't support it (added in Node.js 22.15+).
+ */
+export const ACCEPT_ENCODING = "gzip, deflate, br";
+
+/**
  * Default timeout for feed fetch requests (10 seconds).
  */
 export const FEED_FETCH_TIMEOUT_MS = 10000;
@@ -206,6 +217,7 @@ export async function fetchUrl(url: string, options?: FetchUrlOptions): Promise<
       headers: {
         "User-Agent": userAgent,
         Accept: accept,
+        "Accept-Encoding": ACCEPT_ENCODING,
       },
       signal: controller.signal,
       redirect: "follow",
@@ -273,6 +285,7 @@ export async function fetchHtmlPage(
       headers: {
         "User-Agent": USER_AGENT,
         Accept: HTML_ACCEPT_HEADER,
+        "Accept-Encoding": ACCEPT_ENCODING,
       },
       redirect: "follow",
     });

--- a/src/server/trpc/routers/feeds.ts
+++ b/src/server/trpc/routers/feeds.ts
@@ -11,7 +11,12 @@ import { logger } from "@/lib/logger";
 import { createTRPCRouter, publicProcedure } from "../trpc";
 import { errors } from "../errors";
 import { feedUrlSchema } from "../validation";
-import { fetchUrl, isHtmlContent, FEED_FETCH_TIMEOUT_MS } from "@/server/http/fetch";
+import {
+  fetchUrl,
+  isHtmlContent,
+  FEED_FETCH_TIMEOUT_MS,
+  ACCEPT_ENCODING,
+} from "@/server/http/fetch";
 import { stripHtml } from "@/server/html/strip-html";
 import { USER_AGENT } from "@/server/http/user-agent";
 import { parseFeed, detectFeedType } from "@/server/feed/parser";
@@ -159,6 +164,7 @@ async function tryFetchAsFeed(
         "User-Agent": USER_AGENT,
         Accept:
           "application/rss+xml, application/atom+xml, application/feed+json, application/json, application/xml, text/xml, */*",
+        "Accept-Encoding": ACCEPT_ENCODING,
       },
       signal: controller.signal,
       redirect: "follow",


### PR DESCRIPTION
## Summary

Fixes #686

- Adds explicit `Accept-Encoding: gzip, deflate, br` header to all outgoing content-fetching HTTP requests (feed fetching, URL fetching, HTML page fetching, feed discovery)
- Node.js 20's native fetch only advertises `gzip, deflate` by default, but can decompress brotli — this change lets servers send brotli-compressed responses which are typically 15-20% smaller than gzip
- zstd is not included because Node.js 20 doesn't support it (decompression support was added in Node.js 22.15+); upgrading Node.js would enable zstd support in the future

## Test plan

- [ ] Verify feeds are still fetched and parsed correctly
- [ ] Check outgoing request headers include `Accept-Encoding: gzip, deflate, br`
- [ ] Confirm brotli-compressed responses are decompressed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)