### PR TITLE
Update Node.js from v20 to v24 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install dependencies
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install dependencies
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install dependencies
@@ -123,7 +123,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # =============================================================================
 # Stage 1: Base image with pnpm (for building)
 # =============================================================================
-FROM node:20-alpine AS base
+FROM node:24-alpine AS base
 
 # Enable corepack and prepare the exact pnpm version from package.json
 RUN corepack enable && corepack prepare pnpm@10.26.2 --activate
@@ -67,7 +67,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # =============================================================================
 # Stage 4: Production runner (minimal image, no pnpm needed)
 # =============================================================================
-FROM node:20-alpine AS runner
+FROM node:24-alpine AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Update Docker base images (`node:20-alpine` → `node:24-alpine`) for both build and runner stages
- Update all GitHub Actions CI workflows to use Node.js 24

Closes #689

## Test plan
- [ ] CI passes with Node.js 24
- [ ] Docker build succeeds with `node:24-alpine`
- [ ] Application starts and runs correctly on Node.js 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)