### PR TITLE
Stop intercepting navigation requests in service worker

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -2,9 +2,7 @@
  * Lion Reader Custom Service Worker Extensions
  *
  * This file extends the auto-generated service worker from next-pwa.
- * It handles:
- * 1. Share Target API for URLs and files
- * 2. Offline fallback for navigation requests
+ * It handles the Share Target API for URLs and files.
  *
  * For URL shares, the service worker redirects to /save which handles
  * saving the article and auto-closes itself.
@@ -144,34 +142,9 @@ sw.addEventListener("fetch", ((event: SWFetchEvent) => {
     return; // Don't continue to other handlers
   }
 
-  // Only handle navigation requests (not API calls, assets, etc.)
-  // Assets are handled by Workbox's precaching and runtime caching
-  if (event.request.mode !== "navigate") {
-    return;
-  }
-
-  // For navigation requests, try network first, fall back to cached homepage
-  event.respondWith(
-    fetch(event.request).catch(async () => {
-      // If offline, try to serve cached homepage from Workbox precache
-      const cache = await caches.open("workbox-precache-v2");
-      const cachedResponse = await cache.match("/");
-      if (cachedResponse) {
-        return cachedResponse;
-      }
-      // Fallback to the offline page that Workbox may have cached
-      const offlineResponse = await caches.match("/~offline");
-      if (offlineResponse) {
-        return offlineResponse;
-      }
-      // Last resort: return a basic offline response
-      return new Response("You are offline", {
-        status: 503,
-        statusText: "Service Unavailable",
-        headers: { "Content-Type": "text/plain" },
-      });
-    })
-  );
+  // Navigation requests are NOT intercepted. Letting the browser handle them
+  // natively preserves streaming SSR without any service worker overhead.
+  // Non-navigation assets are handled by Workbox's precaching and runtime caching.
 }) as EventListener);
 
 export {};


### PR DESCRIPTION
## Summary

- Removes the navigation request handler from the service worker entirely — the browser now handles navigation natively, preserving streaming SSR with zero SW overhead
- Removes Navigation Preload setup (no longer needed since we don't intercept navigations)
- Share Target API handling (`/api/share` POST) is unchanged

Previously, the SW called `respondWith(fetch(req))` for every navigation, which put it in the critical path: the browser had to boot the SW before the network request could start. Since we don't support offline mode, there's no reason to intercept navigations at all.

## Test plan

- [ ] Verify streaming SSR pages load without SW-related delay
- [ ] Verify Share Target still works (share a URL from another app)
- [ ] Verify Workbox static asset caching (fonts, images) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)