### PR TITLE
Fix: pass next compression config directly to Next server in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,12 @@ COPY --from=builder /app/dist/discord-bot.js ./dist/discord-bot.js
 COPY --from=builder /app/scripts/start-all.sh ./scripts/start-all.sh
 RUN chmod +x scripts/start-all.sh
 
+# Generate minimal next.config.js for runtime.
+# The full next.config.ts requires TypeScript and build-time-only deps (next-pwa,
+# sentry). Only compress:false is needed at runtime — everything else (headers,
+# webpack, etc.) is baked into .next/ at build time.
+RUN echo 'module.exports = { compress: false };' > next.config.js
+
 # Switch to non-root user
 USER nextjs
 


### PR DESCRIPTION
## Summary

- The custom server's `next()` call loads config from disk, but `next.config.ts` isn't in the Docker runner stage (requires TypeScript and build-time deps like `next-pwa`)
- Without the config file, Next.js defaults to `compress: true` and applies gzip before our custom zstd/brotli middleware can act
- The `conf` API option on `next()` is ignored by Next.js, so we can't pass it programmatically
- Fix: generate a minimal `next.config.js` with `compress: false` in the Dockerfile runner stage — all other config (headers, webpack, etc.) is already baked into `.next/` at build time

## Test plan

- [ ] Deploy and verify `/all` responses use `Content-Encoding: zstd` (or `br`) instead of `gzip`
- [ ] Check `curl -H 'Accept-Encoding: zstd, br, gzip' -sI https://lionreader.com/all` for the Content-Encoding header

🤖 Generated with [Claude Code](https://claude.com/claude-code)