### PR TITLE
Add subscription_updated SSE event for tag and title changes

### DIFF
--- a/src/lib/events/schemas.ts
+++ b/src/lib/events/schemas.ts
@@ -130,6 +130,15 @@ export const subscriptionDeletedEventSchema = z.object({
   updatedAt: z.string(),
 });
 
+export const subscriptionUpdatedEventSchema = z.object({
+  type: z.literal("subscription_updated"),
+  subscriptionId: z.string(),
+  tags: z.array(syncTagSchema),
+  customTitle: z.string().nullable(),
+  timestamp: timestampWithDefault,
+  updatedAt: z.string(),
+});
+
 export const tagCreatedEventSchema = z.object({
   type: z.literal("tag_created"),
   tag: syncTagSchema,
@@ -202,6 +211,7 @@ const coreEventSchema = z.discriminatedUnion("type", [
   entryStateChangedEventSchema,
   subscriptionCreatedEventSchema,
   subscriptionDeletedEventSchema,
+  subscriptionUpdatedEventSchema,
   tagCreatedEventSchema,
   tagUpdatedEventSchema,
   tagDeletedEventSchema,
@@ -237,6 +247,7 @@ export const serverSyncEventSchema = z.discriminatedUnion("type", [
   entryStateChangedEventSchema.extend(strictTimestamp),
   subscriptionCreatedEventSchema.extend(strictTimestamp),
   subscriptionDeletedEventSchema.extend(strictTimestamp),
+  subscriptionUpdatedEventSchema.extend(strictTimestamp),
   tagCreatedEventSchema.extend(strictTimestamp),
   tagUpdatedEventSchema.extend(strictTimestamp),
   tagDeletedEventSchema.extend(strictTimestamp),

--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -207,7 +207,11 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
       event.type === "entry_state_changed"
     ) {
       cursorType = "entries";
-    } else if (event.type === "subscription_created" || event.type === "subscription_deleted") {
+    } else if (
+      event.type === "subscription_created" ||
+      event.type === "subscription_updated" ||
+      event.type === "subscription_deleted"
+    ) {
       cursorType = "subscriptions";
     } else if (
       event.type === "tag_created" ||
@@ -448,6 +452,7 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
         eventSource.addEventListener("entry_updated", handleEvent);
         eventSource.addEventListener("entry_state_changed", handleEvent);
         eventSource.addEventListener("subscription_created", handleEvent);
+        eventSource.addEventListener("subscription_updated", handleEvent);
         eventSource.addEventListener("subscription_deleted", handleEvent);
         eventSource.addEventListener("tag_created", handleEvent);
         eventSource.addEventListener("tag_updated", handleEvent);


### PR DESCRIPTION
## Summary

Fixes #704

- Adds a `subscription_updated` SSE event that fires when subscription tags or custom title change
- The `setTags` mutation now updates `subscriptions.updated_at` for sync cursor tracking and publishes the event
- The `update` mutation (custom title/fetchFullContent changes) now also publishes the event
- Frontend handles the event by updating the subscription cache and invalidating tag-related queries
- The `sync.events` endpoint now distinguishes between new subscriptions (`subscription_created`) and updated ones (`subscription_updated`)

## Changes across the stack

| Layer | File | Change |
|-------|------|--------|
| Schema | `src/lib/events/schemas.ts` | New `subscriptionUpdatedEventSchema` Zod schema |
| Pub/Sub | `src/server/redis/pubsub.ts` | New `SubscriptionUpdatedEvent` interface, `publishSubscriptionUpdated()`, and `parseUserEvent()` support |
| API | `src/server/trpc/routers/subscriptions.ts` | `setTags` updates `updated_at` and publishes event; `update` publishes event |
| SSE Route | `src/app/api/v1/events/route.ts` | Forwards `subscription_updated` events to clients |
| Sync | `src/server/trpc/routers/sync.ts` | Emits `subscription_updated` for existing subscriptions (vs `subscription_created` for new ones) |
| Cache | `src/lib/cache/count-cache.ts` | New `updateSubscriptionInCache()` helper |
| Cache | `src/lib/cache/event-handlers.ts` | Handles `subscription_updated` by updating cache and invalidating tag queries |
| Hook | `src/lib/hooks/useRealtimeUpdates.ts` | Listens for `subscription_updated` events and tracks cursor |

## Test plan

- [ ] Change tags on a subscription in one tab, verify other tabs update
- [ ] Change custom title on a subscription, verify other tabs update
- [ ] Remove all tags from a subscription, verify other tabs update
- [ ] Verify typecheck passes (`pnpm typecheck`)
- [ ] Verify lint passes (`pnpm lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)