### PR TITLE
Remove unnecessary total counts from count queries

### DIFF
--- a/src/app/api/wallabag/api/entries/route.ts
+++ b/src/app/api/wallabag/api/entries/route.ts
@@ -72,8 +72,8 @@ export async function GET(request: Request): Promise<Response> {
     baseParams.unstarredOnly = true;
   }
 
-  // Get total count for pagination metadata
-  const counts = await entriesService.countEntries(db, auth.userId, {
+  // Get total count for pagination metadata (Wallabag API needs total for offset pagination)
+  const total = await entriesService.countTotalEntries(db, auth.userId, {
     type: "saved",
     unreadOnly: params.archive === false ? true : undefined,
     readOnly: params.archive === true ? true : undefined,
@@ -94,9 +94,7 @@ export async function GET(request: Request): Promise<Response> {
     if (!cursor) {
       // Requested page is beyond available data
       const baseUrl = `${url.origin}/api/wallabag/api/entries`;
-      return jsonResponse(
-        createPaginatedResponse([], params.page, params.perPage, counts.total, baseUrl)
-      );
+      return jsonResponse(createPaginatedResponse([], params.page, params.perPage, total, baseUrl));
     }
   }
 
@@ -125,7 +123,7 @@ export async function GET(request: Request): Promise<Response> {
 
   const baseUrl = `${url.origin}/api/wallabag/api/entries`;
   return jsonResponse(
-    createPaginatedResponse(formattedItems, params.page, params.perPage, counts.total, baseUrl)
+    createPaginatedResponse(formattedItems, params.page, params.perPage, total, baseUrl)
   );
 }
 

--- a/src/lib/cache/count-cache.ts
+++ b/src/lib/cache/count-cache.ts
@@ -273,18 +273,15 @@ export function adjustTagUnreadCounts(
  * @param utils - tRPC utils for cache access
  * @param filters - The filter params to target (e.g., { starredOnly: true })
  * @param unreadDelta - Change to unread count
- * @param totalDelta - Change to total count (default: 0)
  */
 export function adjustEntriesCount(
   utils: TRPCClientUtils,
   filters: Parameters<typeof utils.entries.count.setData>[0],
-  unreadDelta: number,
-  totalDelta: number = 0
+  unreadDelta: number
 ): void {
   utils.entries.count.setData(filters, (oldData) => {
     if (!oldData) return oldData;
     return {
-      total: Math.max(0, oldData.total + totalDelta),
       unread: Math.max(0, oldData.unread + unreadDelta),
     };
   });

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -177,11 +177,11 @@ const entryMutationResultSchema = z.object({
  */
 const unreadCountsSchema = z.object({
   // Always present
-  all: z.object({ total: z.number(), unread: z.number() }),
-  starred: z.object({ total: z.number(), unread: z.number() }),
+  all: z.object({ unread: z.number() }),
+  starred: z.object({ unread: z.number() }),
 
   // Only for saved articles
-  saved: z.object({ total: z.number(), unread: z.number() }).optional(),
+  saved: z.object({ unread: z.number() }).optional(),
 
   // Only for web/email entries (have subscriptions)
   subscription: z.object({ id: z.string(), unread: z.number() }).optional(),
@@ -195,9 +195,9 @@ const unreadCountsSchema = z.object({
  */
 const bulkUnreadCountsSchema = z.object({
   // Always present
-  all: z.object({ total: z.number(), unread: z.number() }),
-  starred: z.object({ total: z.number(), unread: z.number() }),
-  saved: z.object({ total: z.number(), unread: z.number() }),
+  all: z.object({ unread: z.number() }),
+  starred: z.object({ unread: z.number() }),
+  saved: z.object({ unread: z.number() }),
 
   // Per-subscription counts (only subscriptions that were affected)
   subscriptions: z.array(z.object({ id: z.string(), unread: z.number() })),
@@ -999,7 +999,6 @@ export const entriesRouter = createTRPCRouter({
     )
     .output(
       z.object({
-        total: z.number(),
         unread: z.number(),
       })
     )

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -95,9 +95,9 @@ const savedArticleFullSchema = z.object({
  * Saved articles only affect all, starred, and saved counts (no subscription/tags).
  */
 const savedUnreadCountsSchema = z.object({
-  all: z.object({ total: z.number(), unread: z.number() }),
-  starred: z.object({ total: z.number(), unread: z.number() }),
-  saved: z.object({ total: z.number(), unread: z.number() }),
+  all: z.object({ unread: z.number() }),
+  starred: z.object({ unread: z.number() }),
+  saved: z.object({ unread: z.number() }),
 });
 
 // ============================================================================

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -634,7 +634,6 @@ describe("Entries", () => {
 
       const result = await caller.entries.count({});
 
-      expect(result.total).toBe(3);
       expect(result.unread).toBe(2);
     });
 
@@ -656,7 +655,6 @@ describe("Entries", () => {
 
       const result = await caller.entries.count({ unreadOnly: true });
 
-      expect(result.total).toBe(2);
       expect(result.unread).toBe(2);
     });
   });


### PR DESCRIPTION
## Summary

Fixes #713

- Remove `total` from all count interfaces (`GlobalCounts`, `SavedCounts`, `UnreadCounts`, `BulkUnreadCounts`) — only `unread` is kept
- Update `getEntryRelatedCounts`, `getBulkEntryRelatedCounts`, and `getNewEntryRelatedCounts` to skip `count(*)` (total) queries, only computing `count(*) FILTER (WHERE NOT read)` which can leverage the `idx_user_entries_unread` partial index
- Update `countEntries` to return `{ unread: number }` instead of `{ total: number; unread: number }`
- Add `countTotalEntries` for the Wallabag API which needs total for offset-based pagination metadata
- Update `entries.count` tRPC endpoint output schema and Zod validation schemas
- Update frontend cache types and `adjustEntriesCount` helper (removed `totalDelta` parameter)

## Test plan

- [ ] Verify sidebar unread counts display correctly
- [ ] Verify marking entries read/unread updates counts properly
- [ ] Verify starring/unstarring entries updates starred counts
- [ ] Verify Wallabag API pagination still returns correct total counts
- [ ] Verify typecheck passes (`pnpm typecheck` — confirmed clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)