### PR TITLE
Add Chrome Web Store extension link

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -21,6 +21,11 @@ This extension uses Manifest V3 (WebExtensions API) and works on:
 
 ## Installation
 
+### From Store
+
+- **Chrome/Edge:** [Chrome Web Store](https://chromewebstore.google.com/detail/lion-reader/mpjddkjjkckmclaifjfokjppfoenmlpl)
+- **Firefox:** [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/lion-reader/)
+
 ### From Source (Development)
 
 **Chrome/Edge:**

--- a/src/app/demo/articles/browser-extension.ts
+++ b/src/app/demo/articles/browser-extension.ts
@@ -11,7 +11,7 @@ const article: DemoArticle = {
     "Save articles to Lion Reader with one click using the browser extension for Firefox and Chrome.",
   publishedAt: new Date("2026-01-10T12:00:00Z"),
   starred: false,
-  summaryHtml: `<p>The Lion Reader browser extension lets you save any web page for later reading with a single click, a keyboard shortcut, or the right-click context menu. Available for <strong>Firefox</strong> (published on AMO) and <strong>Chrome</strong> (coming soon), the extension automatically extracts article content using Mozilla Readability, stores an API token for future saves, and handles Google Docs with automatic OAuth.</p>`,
+  summaryHtml: `<p>The Lion Reader browser extension lets you save any web page for later reading with a single click, a keyboard shortcut, or the right-click context menu. Available for <strong>Firefox</strong> and <strong>Chrome</strong>, the extension automatically extracts article content using Mozilla Readability, stores an API token for future saves, and handles Google Docs with automatic OAuth.</p>`,
   contentHtml: `
     <h2>Save While You Browse</h2>
 
@@ -41,7 +41,7 @@ const article: DemoArticle = {
 
     <ul>
       <li><strong>Firefox</strong> &mdash; Install from <a href="https://addons.mozilla.org/en-US/firefox/addon/lion-reader/" target="_blank" rel="noopener noreferrer">Firefox Add-ons (AMO)</a></li>
-      <li><strong>Chrome</strong> &mdash; Coming soon to the Chrome Web Store. In the meantime, the extension can be loaded manually for development.</li>
+      <li><strong>Chrome</strong> &mdash; Install from the <a href="https://chromewebstore.google.com/detail/lion-reader/mpjddkjjkckmclaifjfokjppfoenmlpl" target="_blank" rel="noopener noreferrer">Chrome Web Store</a></li>
     </ul>
 
     <h3>Self-Hosted Instances</h3>

--- a/src/components/settings/BookmarkletSettings.tsx
+++ b/src/components/settings/BookmarkletSettings.tsx
@@ -2,7 +2,7 @@
  * BookmarkletSettings Component
  *
  * Settings section for saving articles to Lion Reader.
- * Includes the Firefox extension link and the bookmarklet for other browsers.
+ * Includes browser extension links (Chrome, Firefox) and the bookmarklet for other browsers.
  */
 
 "use client";
@@ -49,25 +49,38 @@ export function BookmarkletSettings() {
           section where you can read it later.
         </p>
 
-        {/* Firefox Extension */}
+        {/* Browser Extensions */}
         <div className="mt-6">
           <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-            Firefox Extension
+            Browser Extensions
           </h3>
           <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-            The easiest way to save articles in Firefox.
+            The easiest way to save articles from your browser.
           </p>
-          <a
-            href="https://addons.mozilla.org/en-US/firefox/addon/lion-reader/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="ui-text-sm mt-3 inline-flex items-center gap-2 rounded-lg border border-orange-300 bg-orange-50 px-4 py-2.5 font-medium text-orange-800 shadow-sm transition-all hover:border-orange-400 hover:bg-orange-100 hover:shadow dark:border-orange-700 dark:bg-orange-950 dark:text-orange-200 dark:hover:border-orange-600 dark:hover:bg-orange-900"
-          >
-            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M12.001 1.5c-.707 0-1.415.14-2.08.42L4.5 4.42A4.5 4.5 0 002 8.42v7.16a4.5 4.5 0 002.5 4l5.42 2.5c.665.28 1.373.42 2.08.42s1.415-.14 2.08-.42l5.42-2.5a4.5 4.5 0 002.5-4V8.42a4.5 4.5 0 00-2.5-4l-5.42-2.5A5.1 5.1 0 0012 1.5zm0 2c.45 0 .9.09 1.32.27l5.18 2.39c.96.44 1.5 1.38 1.5 2.42v6.84c0 1.04-.54 1.98-1.5 2.42l-5.18 2.39c-.42.18-.87.27-1.32.27s-.9-.09-1.32-.27l-5.18-2.39c-.96-.44-1.5-1.38-1.5-2.42V8.58c0-1.04.54-1.98 1.5-2.42l5.18-2.39c.42-.18.87-.27 1.32-.27z" />
-            </svg>
-            Install Firefox Extension
-          </a>
+          <div className="mt-3 flex flex-wrap gap-3">
+            <a
+              href="https://chromewebstore.google.com/detail/lion-reader/mpjddkjjkckmclaifjfokjppfoenmlpl"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-blue-300 bg-blue-50 px-4 py-2.5 font-medium text-blue-800 shadow-sm transition-all hover:border-blue-400 hover:bg-blue-100 hover:shadow dark:border-blue-700 dark:bg-blue-950 dark:text-blue-200 dark:hover:border-blue-600 dark:hover:bg-blue-900"
+            >
+              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1.39 14.74L5.09 7.2A7.96 7.96 0 0112 4c2.85 0 5.35 1.5 6.76 3.74h-5.82c-.78 0-1.49.35-1.97.91l-1.36 3.09zm1.39.26c-1.69 0-3-1.31-3-3s1.31-3 3-3 3 1.31 3 3-1.31 3-3 3zm5.91-2.2L12.4 4.54c3.66.49 6.56 3.39 7.05 7.05l-1.54 3.21z" />
+              </svg>
+              Install Chrome Extension
+            </a>
+            <a
+              href="https://addons.mozilla.org/en-US/firefox/addon/lion-reader/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-orange-300 bg-orange-50 px-4 py-2.5 font-medium text-orange-800 shadow-sm transition-all hover:border-orange-400 hover:bg-orange-100 hover:shadow dark:border-orange-700 dark:bg-orange-950 dark:text-orange-200 dark:hover:border-orange-600 dark:hover:bg-orange-900"
+            >
+              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12.001 1.5c-.707 0-1.415.14-2.08.42L4.5 4.42A4.5 4.5 0 002 8.42v7.16a4.5 4.5 0 002.5 4l5.42 2.5c.665.28 1.373.42 2.08.42s1.415-.14 2.08-.42l5.42-2.5a4.5 4.5 0 002.5-4V8.42a4.5 4.5 0 00-2.5-4l-5.42-2.5A5.1 5.1 0 0012 1.5zm0 2c.45 0 .9.09 1.32.27l5.18 2.39c.96.44 1.5 1.38 1.5 2.42v6.84c0 1.04-.54 1.98-1.5 2.42l-5.18 2.39c-.42.18-.87.27-1.32.27s-.9-.09-1.32-.27l-5.18-2.39c-.96-.44-1.5-1.38-1.5-2.42V8.58c0-1.04.54-1.98 1.5-2.42l5.18-2.39c.42-.18.87-.27 1.32-.27z" />
+              </svg>
+              Install Firefox Extension
+            </a>
+          </div>
         </div>
 
         {/* Bookmarklet Section */}
@@ -76,7 +89,7 @@ export function BookmarkletSettings() {
             Bookmarklet (Other Browsers)
           </h3>
           <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-            For Chrome, Safari, and other browsers, use the bookmarklet.
+            For Safari and other browsers, use the bookmarklet.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

- Added Chrome Web Store link to the settings integrations page alongside the existing Firefox extension link
- Updated the demo browser extension article to replace "coming soon" with the actual Chrome Web Store link
- Updated the bookmarklet section to say "Safari and other browsers" since Chrome now has a dedicated extension
- Added store install links (Chrome and Firefox) to the extension README

Closes #307

## Test plan

- [ ] Verify the Chrome Web Store link works: https://chromewebstore.google.com/detail/lion-reader/mpjddkjjkckmclaifjfokjppfoenmlpl
- [ ] Check Settings > Integrations page shows both Chrome and Firefox extension buttons
- [ ] Check the demo article for browser extension no longer says "coming soon"
- [ ] Verify bookmarklet section text updated to exclude Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)