### PR TITLE
Wrap <pre> elements in articles on mobile

### DIFF
--- a/src/components/entries/EntryContentRenderer.tsx
+++ b/src/components/entries/EntryContentRenderer.tsx
@@ -38,7 +38,7 @@ export const EntryContentRenderer = React.memo(function EntryContentRenderer({
     return (
       <div
         ref={contentRef}
-        className={`${textSizeClass} prose-headings:font-semibold prose-headings:text-zinc-900 dark:prose-headings:text-zinc-100 prose-a:text-accent prose-a:underline-offset-2 prose-img:rounded-lg prose-img:shadow-md prose-pre:overflow-x-auto prose-pre:bg-zinc-100 dark:prose-pre:bg-zinc-800 prose-code:text-zinc-800 dark:prose-code:text-zinc-200 prose-code:before:content-none prose-code:after:content-none prose-blockquote:border-l-zinc-300 dark:prose-blockquote:border-l-zinc-600 prose-blockquote:text-zinc-600 dark:prose-blockquote:text-zinc-400 max-w-none`}
+        className={`${textSizeClass} prose-headings:font-semibold prose-headings:text-zinc-900 dark:prose-headings:text-zinc-100 prose-a:text-accent prose-a:underline-offset-2 prose-img:rounded-lg prose-img:shadow-md prose-pre:overflow-x-auto prose-pre:whitespace-pre-wrap prose-pre:break-words prose-pre:bg-zinc-100 dark:prose-pre:bg-zinc-800 prose-code:text-zinc-800 dark:prose-code:text-zinc-200 prose-code:before:content-none prose-code:after:content-none prose-blockquote:border-l-zinc-300 dark:prose-blockquote:border-l-zinc-600 prose-blockquote:text-zinc-600 dark:prose-blockquote:text-zinc-400 max-w-none`}
         style={textStyle}
         dangerouslySetInnerHTML={{ __html: sanitizedContent }}
       />


### PR DESCRIPTION
## Summary
- Adds `whitespace-pre-wrap` and `break-words` to `<pre>` elements in article content so they wrap instead of overflowing off-screen on mobile devices

## Test plan
- [ ] View an article containing `<pre>` blocks on a narrow/mobile viewport
- [ ] Verify text wraps within the viewport instead of requiring horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)