### PR TITLE
Fix Google Reader API: add `it` parameter and `read` state support

### DIFF
--- a/src/app/api/greader.php/reader/api/0/stream/contents/[...streamId]/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/contents/[...streamId]/route.ts
@@ -107,8 +107,7 @@ async function handleStreamContents(
           listParams.starredOnly = true;
           break;
         case "read":
-          // Read entries — not directly supported by list params,
-          // but we can handle via exclude logic below
+          listParams.readOnly = true;
           break;
         default:
           return errorResponse(`Unsupported state: ${parsedStream.state}`, 400);


### PR DESCRIPTION
## Summary

Fixes #721

- **Parse the `it` (include tag) parameter** in `stream/items/ids` to filter by read or starred state. This fixes incorrect responses when clients like Read You request read item IDs via the FreshRSS sync protocol (e.g., `it=user/-/state/com.google/read`).
- **Add `read` state handling** in the `stream/items/ids` switch statement so `s=user/-/state/com.google/read` no longer returns a 400 error.
- **Set `readOnly` filter** in `stream/contents` for the `read` state, which previously had the case but didn't actually filter entries.

## Test plan

- [ ] Verify Read You sync correctly fetches read item IDs when configured as FreshRSS backend
- [ ] Test `stream/items/ids` with `s=user/-/state/com.google/read` returns only read entries
- [ ] Test `stream/items/ids` with `s=user/-/state/com.google/reading-list&it=user/-/state/com.google/read` returns only read entries
- [ ] Test `stream/contents` with `read` state returns only read entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)