### PR TITLE
SSR demo entry lists for SEO crawlability

### DIFF
--- a/src/app/demo/DemoEntryListSSR.tsx
+++ b/src/app/demo/DemoEntryListSSR.tsx
@@ -1,0 +1,70 @@
+/**
+ * DemoEntryListSSR Component
+ *
+ * Server component that renders a static entry list with crawlable <a> links
+ * for SEO. Shown during SSR when no ?entry= parameter is present.
+ * After hydration, DemoLayoutContent switches to DemoRouter which replaces
+ * this with the interactive client-side entry list.
+ */
+
+import { formatRelativeTime } from "@/lib/format";
+import { type DemoEntry } from "./data";
+
+interface DemoEntryListSSRProps {
+  entries: DemoEntry[];
+  backHref: string;
+  title: string;
+}
+
+export function DemoEntryListSSR({ entries, backHref, title }: DemoEntryListSSRProps) {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
+      <div className="mb-4 flex items-center justify-between sm:mb-6">
+        <h1 className="ui-text-xl sm:ui-text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+          {title}
+        </h1>
+      </div>
+      <div className="space-y-3">
+        {entries.map((entry) => {
+          const displayTitle = entry.title ?? "Untitled";
+          const source = entry.feedTitle ?? "Lion Reader";
+          const date = entry.publishedAt ?? entry.fetchedAt;
+
+          return (
+            <a
+              key={entry.id}
+              href={`${backHref}?entry=${entry.id}`}
+              className="group relative block cursor-pointer rounded-lg border border-zinc-300 bg-zinc-50 p-3 transition-colors hover:bg-zinc-100 active:bg-zinc-200 sm:p-4 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:bg-zinc-700/50 dark:active:bg-zinc-700"
+            >
+              <div className="flex items-start gap-3">
+                <div className="mt-1.5 shrink-0">
+                  <span
+                    className="bg-accent-muted dark:bg-accent block h-2.5 w-2.5 rounded-full"
+                    aria-hidden="true"
+                  />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <h3 className="ui-text-sm line-clamp-2 font-medium text-zinc-900 dark:text-zinc-100">
+                    {displayTitle}
+                  </h3>
+                  <div className="ui-text-xs mt-1 flex items-center gap-2 text-zinc-500 dark:text-zinc-400">
+                    <span className="truncate">{source}</span>
+                    <span aria-hidden="true">&middot;</span>
+                    <time dateTime={date.toISOString()} className="shrink-0">
+                      {formatRelativeTime(date)}
+                    </time>
+                  </div>
+                  {entry.summary && (
+                    <p className="ui-text-sm mt-2 line-clamp-2 text-zinc-600 dark:text-zinc-400">
+                      {entry.summary}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/demo/all/page.tsx
+++ b/src/app/demo/all/page.tsx
@@ -2,14 +2,16 @@
  * /demo/all — All features demo page
  *
  * Server component that renders EntryArticle with static demo data when
- * ?entry= is present, enabling SSR of entry content for SEO. After
- * hydration, DemoLayoutContent switches to DemoRouter for interactivity.
+ * ?entry= is present, or a static entry list with crawlable links when
+ * no entry is selected. After hydration, DemoLayoutContent switches to
+ * DemoRouter for full client-side interactivity.
  */
 
 import { type Metadata } from "next";
 import { EntryArticle } from "@/components/entries/EntryArticle";
 import { defaultOpenGraph } from "@/lib/metadata";
-import { getDemoEntry, getDemoEntryArticleProps } from "../data";
+import { getDemoEntry, getDemoEntryArticleProps, DEMO_ENTRIES, sortNewestFirst } from "../data";
+import { DemoEntryListSSR } from "../DemoEntryListSSR";
 
 interface Props {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -36,7 +38,15 @@ export default async function DemoAllPage({ searchParams }: Props) {
   const entryId = typeof sp.entry === "string" ? sp.entry : undefined;
   const entry = entryId ? getDemoEntry(entryId) : undefined;
 
-  if (!entry) return null;
+  if (entry) {
+    return <EntryArticle {...getDemoEntryArticleProps(entry)} />;
+  }
 
-  return <EntryArticle {...getDemoEntryArticleProps(entry)} />;
+  return (
+    <DemoEntryListSSR
+      entries={sortNewestFirst([...DEMO_ENTRIES])}
+      backHref="/demo/all"
+      title="All Features"
+    />
+  );
 }

--- a/src/app/demo/data.ts
+++ b/src/app/demo/data.ts
@@ -142,7 +142,7 @@ export const DEMO_ENTRIES: DemoEntry[] = DEMO_ARTICLES.map(articleToEntry);
 // ============================================================================
 
 /** Sort entries newest-first by publishedAt date */
-function sortNewestFirst(entries: DemoEntry[]): DemoEntry[] {
+export function sortNewestFirst(entries: DemoEntry[]): DemoEntry[] {
   return [...entries].sort(
     (a, b) => (b.publishedAt?.getTime() ?? 0) - (a.publishedAt?.getTime() ?? 0)
   );

--- a/src/app/demo/highlights/page.tsx
+++ b/src/app/demo/highlights/page.tsx
@@ -2,14 +2,16 @@
  * /demo/highlights — Highlights demo page
  *
  * Server component that renders EntryArticle with static demo data when
- * ?entry= is present, enabling SSR of entry content for SEO. After
- * hydration, DemoLayoutContent switches to DemoRouter for interactivity.
+ * ?entry= is present, or a static list of initially-starred entries
+ * with crawlable links when no entry is selected. After hydration,
+ * DemoLayoutContent switches to DemoRouter for full client-side interactivity.
  */
 
 import { type Metadata } from "next";
 import { EntryArticle } from "@/components/entries/EntryArticle";
 import { defaultOpenGraph } from "@/lib/metadata";
-import { getDemoEntry, getDemoEntryArticleProps } from "../data";
+import { getDemoEntry, getDemoEntryArticleProps, DEMO_ENTRIES, sortNewestFirst } from "../data";
+import { DemoEntryListSSR } from "../DemoEntryListSSR";
 
 interface Props {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -34,7 +36,12 @@ export default async function DemoHighlightsPage({ searchParams }: Props) {
   const entryId = typeof sp.entry === "string" ? sp.entry : undefined;
   const entry = entryId ? getDemoEntry(entryId) : undefined;
 
-  if (!entry) return null;
+  if (entry) {
+    return <EntryArticle {...getDemoEntryArticleProps(entry)} />;
+  }
 
-  return <EntryArticle {...getDemoEntryArticleProps(entry)} />;
+  const starredEntries = sortNewestFirst(DEMO_ENTRIES.filter((e) => e.starred));
+  return (
+    <DemoEntryListSSR entries={starredEntries} backHref="/demo/highlights" title="Highlights" />
+  );
 }

--- a/src/app/demo/subscription/[id]/page.tsx
+++ b/src/app/demo/subscription/[id]/page.tsx
@@ -2,14 +2,21 @@
  * /demo/subscription/[id] — Subscription demo page
  *
  * Server component that renders EntryArticle with static demo data when
- * ?entry= is present, enabling SSR of entry content for SEO. After
- * hydration, DemoLayoutContent switches to DemoRouter for interactivity.
+ * ?entry= is present, or a static entry list with crawlable links when
+ * no entry is selected. After hydration, DemoLayoutContent switches to
+ * DemoRouter for full client-side interactivity.
  */
 
 import { type Metadata } from "next";
 import { EntryArticle } from "@/components/entries/EntryArticle";
 import { defaultOpenGraph } from "@/lib/metadata";
-import { getDemoEntry, getDemoEntryArticleProps, getDemoSubscription } from "../../data";
+import {
+  getDemoEntry,
+  getDemoEntryArticleProps,
+  getDemoSubscription,
+  getDemoEntriesForSubscription,
+} from "../../data";
+import { DemoEntryListSSR } from "../../DemoEntryListSSR";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -34,12 +41,22 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   };
 }
 
-export default async function DemoSubscriptionPage({ searchParams }: Props) {
+export default async function DemoSubscriptionPage({ params, searchParams }: Props) {
+  const { id } = await params;
   const sp = await searchParams;
   const entryId = typeof sp.entry === "string" ? sp.entry : undefined;
   const entry = entryId ? getDemoEntry(entryId) : undefined;
 
-  if (!entry) return null;
+  if (entry) {
+    return <EntryArticle {...getDemoEntryArticleProps(entry)} />;
+  }
 
-  return <EntryArticle {...getDemoEntryArticleProps(entry)} />;
+  const subscription = getDemoSubscription(id);
+  return (
+    <DemoEntryListSSR
+      entries={getDemoEntriesForSubscription(id)}
+      backHref={`/demo/subscription/${id}`}
+      title={subscription?.title ?? "Subscription"}
+    />
+  );
 }

--- a/src/app/demo/tag/[id]/page.tsx
+++ b/src/app/demo/tag/[id]/page.tsx
@@ -2,14 +2,21 @@
  * /demo/tag/[id] — Tag demo page
  *
  * Server component that renders EntryArticle with static demo data when
- * ?entry= is present, enabling SSR of entry content for SEO. After
- * hydration, DemoLayoutContent switches to DemoRouter for interactivity.
+ * ?entry= is present, or a static entry list with crawlable links when
+ * no entry is selected. After hydration, DemoLayoutContent switches to
+ * DemoRouter for full client-side interactivity.
  */
 
 import { type Metadata } from "next";
 import { EntryArticle } from "@/components/entries/EntryArticle";
 import { defaultOpenGraph } from "@/lib/metadata";
-import { getDemoEntry, getDemoEntryArticleProps, getDemoTag } from "../../data";
+import {
+  getDemoEntry,
+  getDemoEntryArticleProps,
+  getDemoTag,
+  getDemoEntriesForTag,
+} from "../../data";
+import { DemoEntryListSSR } from "../../DemoEntryListSSR";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -34,12 +41,22 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   };
 }
 
-export default async function DemoTagPage({ searchParams }: Props) {
+export default async function DemoTagPage({ params, searchParams }: Props) {
+  const { id } = await params;
   const sp = await searchParams;
   const entryId = typeof sp.entry === "string" ? sp.entry : undefined;
   const entry = entryId ? getDemoEntry(entryId) : undefined;
 
-  if (!entry) return null;
+  if (entry) {
+    return <EntryArticle {...getDemoEntryArticleProps(entry)} />;
+  }
 
-  return <EntryArticle {...getDemoEntryArticleProps(entry)} />;
+  const tag = getDemoTag(id);
+  return (
+    <DemoEntryListSSR
+      entries={getDemoEntriesForTag(id)}
+      backHref={`/demo/tag/${id}`}
+      title={tag?.name ?? "Tag"}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- Demo pages previously returned `null` when no `?entry=` param was present, showing only a loading skeleton — crawlers couldn't discover any inter-page links
- Added `DemoEntryListSSR` server component that renders a static entry list with `<a>` links pointing to each entry's detail page
- Updated all four demo page routes (`/demo/all`, `/demo/highlights`, `/demo/subscription/[id]`, `/demo/tag/[id]`) to render this SSR entry list when no entry is selected
- The sidebar was already SSR'd correctly (client components still SSR in Next.js, and `NavLink`/`ClientLink` render proper `<a href="...">` tags)
- After hydration, `DemoLayoutContent` switches to `DemoRouter` which replaces the static list with the full interactive version

## Test plan
- [ ] Visit `/demo/all` — should see a rendered list of entry links (not a skeleton)
- [ ] View page source on `/demo/all` — verify `<a href="/demo/all?entry=...">` links are present in HTML
- [ ] View page source on `/demo/subscription/feed-types` — verify filtered entry links
- [ ] View page source on `/demo/tag/features` — verify filtered entry links
- [ ] View page source sidebar — verify navigation links to tags, subscriptions are present
- [ ] Click entries in the list — verify interactive demo still works after hydration
- [ ] Test keyboard navigation (j/k), read/star toggles still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)