### PR TITLE
Disable Piscina thread pool in standalone worker, fix metrics error handler

### DIFF
--- a/src/server/email/process-inbound.ts
+++ b/src/server/email/process-inbound.ts
@@ -9,7 +9,7 @@ import { createHash } from "crypto";
 import { eq, and, isNotNull } from "drizzle-orm";
 import { db } from "../db";
 import { generateSummary } from "../html/strip-html";
-import { cleanContentInWorker } from "@/server/worker-thread/pool";
+import { cleanContent } from "@/server/feed/content-cleaner";
 import { extractEmailUrl, extractUnsubscribeUrl } from "./extract-url";
 import {
   feeds,
@@ -398,7 +398,7 @@ export async function processInboundEmail(email: InboundEmail): Promise<ProcessE
   // Set to null if cleaning fails - UI only shows toggle when both versions exist.
   let contentCleaned: string | null = null;
   if (email.html) {
-    const cleaned = await cleanContentInWorker(email.html, {
+    const cleaned = cleanContent(email.html, {
       minContentLength: 50,
       minCleanedLength: 20,
     });

--- a/src/server/file/process-upload.ts
+++ b/src/server/file/process-upload.ts
@@ -9,7 +9,7 @@
  */
 
 import * as mammoth from "mammoth";
-import { cleanContentInWorker } from "@/server/worker-thread/pool";
+import { cleanContent } from "@/server/feed/content-cleaner";
 import { generateSummary } from "@/server/html/strip-html";
 import { logger } from "@/lib/logger";
 import { processMarkdown as convertMarkdown } from "@/server/markdown";
@@ -110,7 +110,7 @@ async function processDocx(buffer: Buffer, filename: string): Promise<ProcessedF
   const fullHtml = `<!DOCTYPE html><html><body>${rawHtml}</body></html>`;
 
   // Clean with Readability
-  const cleaned = await cleanContentInWorker(fullHtml, { minCleanedLength: 10 });
+  const cleaned = cleanContent(fullHtml, { minCleanedLength: 10 });
 
   // Use cleaned content if available, otherwise use raw mammoth output
   const contentCleaned = cleaned?.content ?? rawHtml;
@@ -130,7 +130,7 @@ async function processDocx(buffer: Buffer, filename: string): Promise<ProcessedF
  */
 async function processHtml(content: string, filename: string): Promise<ProcessedFile> {
   // Clean with Readability
-  const cleaned = await cleanContentInWorker(content, { minCleanedLength: 10 });
+  const cleaned = cleanContent(content, { minCleanedLength: 10 });
 
   if (cleaned) {
     return {

--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -24,8 +24,7 @@ import {
 import { fetchFullContent } from "../services/full-content";
 import { fetchFeed, type FetchFeedResult, type RedirectInfo } from "../feed/fetcher";
 import type { WebSubLinkHeaders } from "../feed/link-header";
-import { parseFeedInWorker } from "@/server/worker-thread/pool";
-import type { ParsedFeed } from "@/server/feed/types";
+import { parseFeed } from "../feed/parser";
 import { processEntries } from "../feed/entry-processor";
 import { calculateNextFetch } from "../feed/scheduling";
 import {
@@ -318,9 +317,9 @@ async function processSuccessfulFetch(
   const bodyText = body.toString("utf-8");
 
   // Parse the feed content
-  let parsedFeed: ParsedFeed;
+  let parsedFeed;
   try {
-    parsedFeed = await parseFeedInWorker(bodyText);
+    parsedFeed = parseFeed(bodyText);
   } catch (error) {
     // Parsing failed - treat as error
     // Also clear any redirect tracking since the destination doesn't have a valid feed

--- a/src/server/services/full-content.ts
+++ b/src/server/services/full-content.ts
@@ -7,8 +7,7 @@
  */
 
 import { fetchHtmlPage, HttpFetchError } from "@/server/http/fetch";
-import { absolutizeUrls } from "@/server/feed/content-cleaner";
-import { cleanContentInWorker } from "@/server/worker-thread/pool";
+import { cleanContent, absolutizeUrls } from "@/server/feed/content-cleaner";
 import { pluginRegistry } from "@/server/plugins";
 import { logger } from "@/lib/logger";
 import { processMarkdown } from "@/server/markdown";
@@ -74,7 +73,7 @@ export async function fetchFullContent(url: string): Promise<FetchFullContentRes
           }
 
           // Run Readability on plugin content
-          const cleaned = await cleanContentInWorker(html, { url: resolveUrl });
+          const cleaned = cleanContent(html, { url: resolveUrl });
 
           return {
             success: true,
@@ -118,7 +117,7 @@ export async function fetchFullContent(url: string): Promise<FetchFullContentRes
     const contentOriginal = absolutizeUrls(html, resolveUrl);
 
     // Clean the content using Readability
-    const cleaned = await cleanContentInWorker(html, { url: resolveUrl });
+    const cleaned = cleanContent(html, { url: resolveUrl });
 
     if (!cleaned) {
       return {

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -16,7 +16,7 @@ import { fetchHtmlPage, HttpFetchError, ContentTooLargeError } from "@/server/ht
 import { processMarkdown } from "@/server/markdown";
 import { usageLimitsConfig } from "@/server/config/env";
 import { wrapHtmlFragment } from "@/server/http/html";
-import { cleanContentInWorker } from "@/server/worker-thread/pool";
+import { cleanContent } from "@/server/feed/content-cleaner";
 import { getOrCreateSavedFeed } from "@/server/feed/saved-feed";
 import { generateSummary } from "@/server/html/strip-html";
 import { logger } from "@/lib/logger";
@@ -419,9 +419,7 @@ export async function saveArticle(
 
   // Run Readability for clean content (skip for plugins that request it, or for Markdown)
   const shouldSkipReadability = pluginContent?.skipReadability || markdownResult !== null;
-  const cleaned = shouldSkipReadability
-    ? null
-    : await cleanContentInWorker(html!, { url: contentUrl });
+  const cleaned = shouldSkipReadability ? null : cleanContent(html!, { url: contentUrl });
 
   // Generate excerpt - prefer frontmatter summary for Markdown content
   let excerpt: string | null = null;


### PR DESCRIPTION
## Summary
- Reverted worker-bundled code (job handlers, services, email processing, file upload) to use sync `cleanContent`/`parseFeed` directly instead of the Piscina pool wrappers
- App-server-only call sites (tRPC routers, webhook routes) continue using `cleanContentInWorker`/`parseFeedInWorker` for non-blocking async execution
- Removed the `WORKER_THREAD_POOL_SIZE=0` env var hack and `threadCount <= 0` pool bypass
- Removed the metrics server EADDRINUSE error handler (errors should surface, not be hidden)

## Root cause
The standalone worker process was loading the Piscina thread pool via transitive imports (handlers → `parseFeedInWorker`, services → `cleanContentInWorker`). When the pool spawned threads, they caused EADDRINUSE errors on the metrics port (9092).

## Fix
Invert the dependency: services stay pure/sync and call `cleanContent`/`parseFeed` directly. Only app-server call sites opt into the async pool wrappers (`cleanContentInWorker`/`parseFeedInWorker`). This keeps the standalone worker completely free of Piscina overhead.

## Test plan
- [x] `pnpm typecheck` passes
- [ ] Deploy and verify no EADDRINUSE errors on worker
- [ ] Verify feed fetching still works (uses sync `parseFeed`)
- [ ] Verify saved articles still work (uses sync `cleanContent`)
- [ ] Verify app server still uses thread pool for feed parsing and content cleaning

🤖 Generated with [Claude Code](https://claude.com/claude-code)