### PR TITLE
Fix: saved article +1 score no longer overridden by mark unread

### DIFF
--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -142,22 +142,16 @@ export interface MarkReadResult {
 /**
  * Computes the implicit score from boolean signal flags and entry type.
  *
- * Priority: starred (+2) > unread (0) > read-on-list (-1) > saved default (+1) > default (0)
+ * Priority: starred (+2) > saved (+1) > default (0)
  *
- * Marking unread overrides read-on-list (returns 0 instead of -1) but doesn't
- * give a positive bonus. Saved articles default to +1 because the user explicitly
- * saved them, indicating interest.
+ * Saved articles default to +1 because the user explicitly saved them,
+ * indicating interest.
  */
 export function computeImplicitScore(
   hasStarred: boolean,
-  hasMarkedUnread: boolean,
-  hasMarkedReadOnList: boolean,
   type?: "web" | "email" | "saved"
 ): number {
   if (hasStarred) return 2;
-  if (hasMarkedUnread) return 0;
-  if (hasMarkedReadOnList) return -1;
-  // Saved articles default to +1 since user explicitly saved them
   if (type === "saved") return 1;
   return 0;
 }
@@ -226,12 +220,7 @@ function toEntryListItem(row: EntryListRow): EntryListItem {
     feedTitle: row.feedTitle,
     siteName: row.siteName,
     score: row.score,
-    implicitScore: computeImplicitScore(
-      row.hasStarred,
-      row.hasMarkedUnread,
-      row.hasMarkedReadOnList,
-      row.type
-    ),
+    implicitScore: computeImplicitScore(row.hasStarred, row.type),
     predictedScore: row.predictedScore,
   };
 }
@@ -658,12 +647,7 @@ export async function getEntry(
   return {
     ...row,
     score: row.score,
-    implicitScore: computeImplicitScore(
-      row.hasStarred,
-      row.hasMarkedUnread,
-      row.hasMarkedReadOnList,
-      row.type
-    ),
+    implicitScore: computeImplicitScore(row.hasStarred, row.type),
   };
 }
 
@@ -715,12 +699,7 @@ export async function getEntries(
     resultMap.set(row.id, {
       ...row,
       score: row.score,
-      implicitScore: computeImplicitScore(
-        row.hasStarred,
-        row.hasMarkedUnread,
-        row.hasMarkedReadOnList,
-        row.type
-      ),
+      implicitScore: computeImplicitScore(row.hasStarred, row.type),
     });
   }
 
@@ -1076,11 +1055,6 @@ export async function setEntryScore(
     starred: row.starred,
     updatedAt: row.updatedAt,
     score: row.score,
-    implicitScore: computeImplicitScore(
-      row.hasStarred,
-      row.hasMarkedUnread,
-      row.hasMarkedReadOnList,
-      row.type
-    ),
+    implicitScore: computeImplicitScore(row.hasStarred, row.type),
   };
 }

--- a/src/server/services/score-prediction.ts
+++ b/src/server/services/score-prediction.ts
@@ -78,20 +78,11 @@ export interface ScorePrediction {
 
 /**
  * Computes the effective score for an entry.
- * Priority: explicit score > implicit signals
- *
- * Implicit score mapping:
- * - has_starred = +2
- * - has_marked_unread = 0 (overrides read-on-list but no positive bonus)
- * - type = 'saved' = +1
- * - has_marked_read_on_list = -1
- * - default = 0
+ * Priority: explicit score > starred (+2) > saved (+1) > default (0)
  */
 function computeEffectiveScore(row: {
   score: number | null;
   hasStarred: boolean;
-  hasMarkedUnread: boolean;
-  hasMarkedReadOnList: boolean;
   type: "web" | "email" | "saved";
 }): number {
   // Explicit score takes priority
@@ -101,9 +92,7 @@ function computeEffectiveScore(row: {
 
   // Implicit score based on user actions
   if (row.hasStarred) return 2;
-  if (row.hasMarkedUnread) return 0;
   if (row.type === "saved") return 1;
-  if (row.hasMarkedReadOnList) return -1;
 
   return 0;
 }
@@ -157,8 +146,6 @@ async function getTrainingData(db: typeof dbType, userId: string): Promise<Train
       type: entries.type,
       score: userEntries.score,
       hasStarred: userEntries.hasStarred,
-      hasMarkedUnread: userEntries.hasMarkedUnread,
-      hasMarkedReadOnList: userEntries.hasMarkedReadOnList,
     })
     .from(userEntries)
     .innerJoin(entries, eq(entries.id, userEntries.entryId))

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -333,12 +333,7 @@ function toFullEntry(row: NonNullable<Awaited<ReturnType<typeof selectFullEntry>
   const { hasStarred, hasMarkedUnread, hasMarkedReadOnList, contentHash, ...rest } = row;
   return {
     ...rest,
-    implicitScore: entriesService.computeImplicitScore(
-      hasStarred,
-      hasMarkedUnread,
-      hasMarkedReadOnList,
-      row.type
-    ),
+    implicitScore: entriesService.computeImplicitScore(hasStarred, row.type),
     fetchFullContent: row.fetchFullContent ?? false,
   };
 }
@@ -424,12 +419,7 @@ async function updateEntryStarred(
     starred: row.starred,
     updatedAt: row.updatedAt,
     score: row.score,
-    implicitScore: entriesService.computeImplicitScore(
-      row.hasStarred,
-      row.hasMarkedUnread,
-      row.hasMarkedReadOnList,
-      row.type
-    ),
+    implicitScore: entriesService.computeImplicitScore(row.hasStarred, row.type),
   };
 }
 
@@ -678,12 +668,7 @@ export const entriesRouter = createTRPCRouter({
         type: e.type,
         updatedAt: e.updatedAt,
         score: e.score,
-        implicitScore: entriesService.computeImplicitScore(
-          e.hasStarred,
-          e.hasMarkedUnread,
-          e.hasMarkedReadOnList,
-          e.type
-        ),
+        implicitScore: entriesService.computeImplicitScore(e.hasStarred, e.type),
       }));
 
       // Get absolute counts for all affected lists


### PR DESCRIPTION
## Summary

Fixes #729

- Simplified implicit scoring priority to: explicit vote > starred (+2) > saved (+1) > default (0)
- Removed `hasMarkedUnread` (was overriding saved +1 with 0) and `hasMarkedReadOnList` (was -1) from score computation
- The `hasMarkedUnread` and `hasMarkedReadOnList` flags are still set in the database and used as "user interacted" signals for training data filtering

## Test plan

- [x] TypeScript typecheck passes
- [x] All 1653 unit tests pass
- [ ] Verify saved articles retain +1 implicit score after marking unread
- [ ] Verify starred articles retain +2 implicit score after any action
- [ ] Verify model training still uses articles with user interaction signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)