### PR TITLE
Prevent worker from silently hanging

### DIFF
--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -15,12 +15,19 @@
  */
 
 import { startWorkerWithSignalHandling } from "../src/server/jobs/worker";
-import { startMetricsServer } from "../src/server/metrics/server";
+import { startMetricsServer, setHealthChecker } from "../src/server/metrics/server";
 import { notifyWorkerStarted } from "../src/server/notifications/discord-webhook";
 import { logger } from "../src/lib/logger";
 
 const pollIntervalMs = parseInt(process.env.WORKER_POLL_INTERVAL_MS ?? "5000", 10);
 const concurrency = parseInt(process.env.WORKER_CONCURRENCY ?? "3", 10);
+
+/**
+ * How long the worker loop can be inactive before the health check reports unhealthy.
+ * This should be longer than the job timeout (5 min) to avoid false positives.
+ * Set to 10 minutes: enough time for a job to time out + cleanup.
+ */
+const LIVENESS_THRESHOLD_MS = 10 * 60 * 1000;
 
 logger.info("Starting standalone worker", {
   pollIntervalMs,
@@ -41,8 +48,37 @@ startWorkerWithSignalHandling({
   pollIntervalMs,
   concurrency,
 })
-  .then(() => {
+  .then((worker) => {
     logger.info("Worker started successfully");
+
+    // Register liveness health checker now that the worker is running.
+    // Fly.io will restart the machine if /health returns 503.
+    setHealthChecker(() => {
+      const stats = worker.getStats();
+      const staleDurationMs = Date.now() - stats.lastActivityAt.getTime();
+
+      if (staleDurationMs > LIVENESS_THRESHOLD_MS) {
+        return {
+          status: "unhealthy",
+          details: {
+            reason: "worker_loop_stale",
+            lastActivityAt: stats.lastActivityAt.toISOString(),
+            staleDurationMs,
+            thresholdMs: LIVENESS_THRESHOLD_MS,
+            activeJobs: stats.activeJobs,
+          },
+        };
+      }
+
+      return {
+        status: "healthy",
+        details: {
+          activeJobs: stats.activeJobs,
+          totalProcessed: stats.totalProcessed,
+          lastActivityAt: stats.lastActivityAt.toISOString(),
+        },
+      };
+    });
   })
   .catch((error) => {
     logger.error("Failed to start worker", { error });

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -34,6 +34,31 @@ pool.on("error", (err) => {
   });
 });
 
+// Log warnings when pool has waiting requests, indicating connection pressure.
+// Check every 10 seconds to avoid log spam while still catching issues.
+const POOL_MONITOR_INTERVAL_MS = 10_000;
+let poolMonitorTimer: ReturnType<typeof setInterval> | null = null;
+
+function startPoolMonitor(): void {
+  if (poolMonitorTimer) return;
+
+  poolMonitorTimer = setInterval(() => {
+    if (pool.waitingCount > 0) {
+      logger.warn("Database pool has waiting requests", {
+        waitingCount: pool.waitingCount,
+        totalCount: pool.totalCount,
+        idleCount: pool.idleCount,
+        maxConnections: pool.options.max,
+      });
+    }
+  }, POOL_MONITOR_INTERVAL_MS);
+
+  // Don't prevent process exit
+  poolMonitorTimer.unref();
+}
+
+startPoolMonitor();
+
 export const db = drizzle(pool, {
   schema,
   logger: {

--- a/src/server/jobs/worker-core.ts
+++ b/src/server/jobs/worker-core.ts
@@ -29,6 +29,8 @@ export interface WorkerConfig {
   pollIntervalMs?: number;
   /** Maximum concurrent jobs to process (default: 5) */
   concurrency?: number;
+  /** Maximum time a single job can run before being timed out (default: no timeout) */
+  jobTimeoutMs?: number;
   /** Job types to process (default: all types) */
   jobTypes?: string[];
   /** Logger function for worker events */
@@ -113,6 +115,21 @@ export interface WorkerStats {
   totalSucceeded: number;
   /** Total jobs that failed */
   totalFailed: number;
+  /** Timestamp of last worker loop activity (job completed, polled, or claimed) */
+  lastActivityAt: Date;
+}
+
+/**
+ * Error thrown when a job exceeds its timeout.
+ */
+export class JobTimeoutError extends Error {
+  constructor(
+    public readonly jobId: string,
+    public readonly timeoutMs: number
+  ) {
+    super(`Job ${jobId} timed out after ${timeoutMs}ms`);
+    this.name = "JobTimeoutError";
+  }
 }
 
 /**
@@ -121,6 +138,7 @@ export interface WorkerStats {
 interface InternalWorkerConfig {
   pollIntervalMs: number;
   concurrency: number;
+  jobTimeoutMs?: number;
   jobTypes?: string[];
   logger: WorkerLogger;
   claimJob: ClaimJobFn;
@@ -135,8 +153,16 @@ interface InternalWorkerConfig {
  * @returns Worker instance
  */
 export function createWorkerCore(config: InternalWorkerConfig): Worker {
-  const { pollIntervalMs, concurrency, jobTypes, logger, claimJob, processJob, onJobError } =
-    config;
+  const {
+    pollIntervalMs,
+    concurrency,
+    jobTimeoutMs,
+    jobTypes,
+    logger,
+    claimJob,
+    processJob,
+    onJobError,
+  } = config;
 
   // Worker state
   const state: WorkerState = {
@@ -150,6 +176,35 @@ export function createWorkerCore(config: InternalWorkerConfig): Worker {
   let totalProcessed = 0;
   let totalSucceeded = 0;
   let totalFailed = 0;
+  let lastActivityAt = new Date();
+
+  /**
+   * Update the last activity timestamp to track worker liveness.
+   */
+  function touchActivity(): void {
+    lastActivityAt = new Date();
+  }
+
+  /**
+   * Wraps processJob with an optional timeout. If the job doesn't complete
+   * within jobTimeoutMs, the promise rejects with a JobTimeoutError.
+   * The underlying job may still be running, but the worker loop moves on.
+   */
+  function processJobWithTimeout(job: Job): Promise<void> {
+    if (!jobTimeoutMs) {
+      return processJob(job);
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        reject(new JobTimeoutError(job.id, jobTimeoutMs));
+      }, jobTimeoutMs);
+
+      processJob(job)
+        .then(resolve, reject)
+        .finally(() => clearTimeout(timeoutId));
+    });
+  }
 
   /**
    * Main run loop - claims and processes jobs continuously.
@@ -159,28 +214,38 @@ export function createWorkerCore(config: InternalWorkerConfig): Worker {
       // Fill up to capacity
       while (state.currentlyExecuting.size < concurrency && !state.shuttingDown) {
         const job = await claimJob({ types: jobTypes });
+        touchActivity();
         if (job === null) break;
 
         // Wrap processJob with .catch() to ensure no unhandled rejections escape
         // into Promise.race()/Promise.all(). The error is already logged and
         // reported to Sentry inside processJob, so we just need to prevent
         // the rejection from propagating.
-        const promise = processJob(job)
+        const promise = processJobWithTimeout(job)
           .then(() => {
             totalSucceeded++;
           })
           .catch((error) => {
             totalFailed++;
-            // This should rarely happen since processJob has its own try/catch,
-            // but handle it defensively
-            logger.error("Unexpected error in job execution", {
-              jobId: job.id,
-              error: error instanceof Error ? error.message : "Unknown error",
-            });
+            if (error instanceof JobTimeoutError) {
+              logger.error("Job timed out", {
+                jobId: job.id,
+                type: job.type,
+                timeoutMs: jobTimeoutMs,
+              });
+            } else {
+              // This should rarely happen since processJob has its own try/catch,
+              // but handle it defensively
+              logger.error("Unexpected error in job execution", {
+                jobId: job.id,
+                error: error instanceof Error ? error.message : "Unknown error",
+              });
+            }
             onJobError?.(job, error);
           })
           .finally(() => {
             totalProcessed++;
+            touchActivity();
             state.currentlyExecuting.delete(promise);
           });
         state.currentlyExecuting.add(promise);
@@ -200,6 +265,8 @@ export function createWorkerCore(config: InternalWorkerConfig): Worker {
         // No jobs at all — poll after delay
         await sleep(pollIntervalMs);
       }
+
+      touchActivity();
     }
 
     // Graceful shutdown: wait for in-flight jobs
@@ -279,6 +346,7 @@ export function createWorkerCore(config: InternalWorkerConfig): Worker {
       totalProcessed,
       totalSucceeded,
       totalFailed,
+      lastActivityAt,
     };
   }
 

--- a/src/server/jobs/worker.ts
+++ b/src/server/jobs/worker.ts
@@ -38,6 +38,13 @@ import { createWorkerCore, type WorkerLogger, type Worker } from "./worker-core"
 export type { WorkerLogger, Worker, WorkerStats } from "./worker-core";
 
 /**
+ * Default job timeout: 5 minutes.
+ * Prevents a hung job (e.g., stuck DB query, pathological XML parsing)
+ * from blocking the worker loop forever.
+ */
+const DEFAULT_JOB_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
  * Worker configuration options.
  */
 export interface WorkerConfig {
@@ -45,6 +52,8 @@ export interface WorkerConfig {
   pollIntervalMs?: number;
   /** Maximum concurrent jobs to process (default: 5) */
   concurrency?: number;
+  /** Maximum time a single job can run before being timed out (default: 5 minutes) */
+  jobTimeoutMs?: number;
   /** Job types to process (default: all types) */
   jobTypes?: JobType[];
   /** Logger function for worker events */
@@ -81,6 +90,7 @@ function createWorker(config: WorkerConfig = {}): Worker {
   const {
     pollIntervalMs = 5000,
     concurrency = 5,
+    jobTimeoutMs = DEFAULT_JOB_TIMEOUT_MS,
     jobTypes,
     logger = defaultLogger,
     _claimJob: claimJobOverride,
@@ -93,6 +103,7 @@ function createWorker(config: WorkerConfig = {}): Worker {
     return createWorkerCore({
       pollIntervalMs,
       concurrency,
+      jobTimeoutMs,
       jobTypes,
       logger,
       claimJob,
@@ -274,6 +285,7 @@ function createWorker(config: WorkerConfig = {}): Worker {
   return createWorkerCore({
     pollIntervalMs,
     concurrency,
+    jobTimeoutMs,
     jobTypes,
     logger,
     claimJob,

--- a/src/server/metrics/collect.ts
+++ b/src/server/metrics/collect.ts
@@ -6,9 +6,14 @@
  */
 
 import { sql } from "drizzle-orm";
-import { db } from "../db";
+import { db, pool } from "../db";
 import { users, subscriptions, entries, feeds, jobs } from "../db/schema";
-import { metricsEnabled, updateBusinessMetrics, updateJobQueueMetrics } from "./metrics";
+import {
+  metricsEnabled,
+  updateBusinessMetrics,
+  updateJobQueueMetrics,
+  updateDbPoolMetrics,
+} from "./metrics";
 
 /**
  * Collects and updates all business metrics from the database.
@@ -91,11 +96,26 @@ async function collectJobQueueMetrics(): Promise<void> {
 }
 
 /**
+ * Collects database connection pool metrics.
+ * These are synchronous reads from the pg Pool object.
+ */
+function collectPoolMetrics(): void {
+  if (!metricsEnabled) return;
+
+  updateDbPoolMetrics({
+    totalCount: pool.totalCount,
+    idleCount: pool.idleCount,
+    waitingCount: pool.waitingCount,
+  });
+}
+
+/**
  * Collects all metrics before returning them.
  * Called by the /api/metrics endpoint to ensure metrics are up-to-date.
  */
 export async function collectAllMetrics(): Promise<void> {
   if (!metricsEnabled) return;
 
+  collectPoolMetrics();
   await Promise.all([collectBusinessMetrics(), collectJobQueueMetrics()]);
 }

--- a/src/server/metrics/metrics.ts
+++ b/src/server/metrics/metrics.ts
@@ -325,6 +325,59 @@ export function trackSSEEventSent(eventType: string): void {
 }
 
 // ============================================================================
+// Database Pool Metrics
+// ============================================================================
+
+/**
+ * Gauge for database connection pool total connections.
+ */
+const dbPoolTotalConnections = metricsEnabled
+  ? new Gauge({
+      name: "db_pool_total_connections",
+      help: "Total connections in the database pool",
+      registers: [registry],
+    })
+  : null;
+
+/**
+ * Gauge for database connection pool idle connections.
+ */
+const dbPoolIdleConnections = metricsEnabled
+  ? new Gauge({
+      name: "db_pool_idle_connections",
+      help: "Idle connections in the database pool",
+      registers: [registry],
+    })
+  : null;
+
+/**
+ * Gauge for database connection pool waiting requests.
+ */
+const dbPoolWaitingRequests = metricsEnabled
+  ? new Gauge({
+      name: "db_pool_waiting_requests",
+      help: "Requests waiting for a database connection",
+      registers: [registry],
+    })
+  : null;
+
+/**
+ * Updates database pool metrics from pg Pool stats.
+ * This function has zero overhead when metrics are disabled.
+ */
+export function updateDbPoolMetrics(stats: {
+  totalCount: number;
+  idleCount: number;
+  waitingCount: number;
+}): void {
+  if (!metricsEnabled) return;
+
+  dbPoolTotalConnections?.set(stats.totalCount);
+  dbPoolIdleConnections?.set(stats.idleCount);
+  dbPoolWaitingRequests?.set(stats.waitingCount);
+}
+
+// ============================================================================
 // Business Metrics
 // ============================================================================
 

--- a/src/server/metrics/server.ts
+++ b/src/server/metrics/server.ts
@@ -14,6 +14,30 @@ import { logger } from "@/lib/logger";
 let server: Server | null = null;
 
 /**
+ * Health check response from a liveness checker.
+ */
+export interface HealthCheckResult {
+  status: "healthy" | "unhealthy";
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Function that checks whether the process is healthy beyond just being alive.
+ * Used by the worker to report whether the job loop is making progress.
+ */
+export type HealthChecker = () => HealthCheckResult;
+
+let healthChecker: HealthChecker | null = null;
+
+/**
+ * Registers a health checker function that the /health endpoint will use.
+ * When set, /health returns 503 if the checker reports unhealthy.
+ */
+export function setHealthChecker(checker: HealthChecker): void {
+  healthChecker = checker;
+}
+
+/**
  * Starts the internal metrics HTTP server.
  *
  * The server responds to GET /metrics with Prometheus-formatted metrics.
@@ -50,9 +74,17 @@ export function startMetricsServer(port = 9091): Server | null {
         res.end("Internal Server Error");
       }
     } else if (req.method === "GET" && req.url === "/health") {
-      // Simple health check for Fly.io - just confirms the process is running
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ status: "healthy" }));
+      // Health check for Fly.io - checks process liveness and worker progress
+      if (healthChecker) {
+        const result = healthChecker();
+        const statusCode = result.status === "healthy" ? 200 : 503;
+        res.writeHead(statusCode, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(result));
+      } else {
+        // Fallback: just confirm the process is running
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "healthy" }));
+      }
     } else {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not Found");

--- a/tests/unit/worker.test.ts
+++ b/tests/unit/worker.test.ts
@@ -543,4 +543,159 @@ describe("Worker", () => {
       expect(warnCalls).toContain("Worker is not running");
     });
   });
+
+  describe("job timeout", () => {
+    it("times out a job that takes too long", async () => {
+      const errors: string[] = [];
+      let jobsClaimed = 0;
+      const testLogger: WorkerLogger = {
+        info: () => {},
+        warn: () => {},
+        error: (msg) => errors.push(msg),
+      };
+
+      const worker = createWorker({
+        concurrency: 1,
+        pollIntervalMs: 10,
+        jobTimeoutMs: 50, // Very short timeout for testing
+        logger: testLogger,
+        claimJob: async () => {
+          if (jobsClaimed === 0) {
+            jobsClaimed++;
+            return createMockJob("slow-job");
+          }
+          return null;
+        },
+        processJob: async () => {
+          // This job will never complete on its own
+          await new Promise(() => {});
+        },
+      });
+
+      await worker.start();
+
+      // Wait for the timeout to fire
+      await tick(200);
+
+      expect(errors).toContain("Job timed out");
+      expect(worker.getStats().totalFailed).toBe(1);
+
+      await worker.stop();
+    });
+
+    it("does not time out jobs that complete in time", async () => {
+      let jobsClaimed = 0;
+
+      const worker = createWorker({
+        concurrency: 1,
+        pollIntervalMs: 10,
+        jobTimeoutMs: 500, // Generous timeout
+        logger: silentLogger,
+        claimJob: async () => {
+          if (jobsClaimed === 0) {
+            jobsClaimed++;
+            return createMockJob("fast-job");
+          }
+          return null;
+        },
+        processJob: async () => {
+          await tick(10); // Quick job
+        },
+      });
+
+      await worker.start();
+      await tick(100);
+
+      expect(worker.getStats().totalSucceeded).toBe(1);
+      expect(worker.getStats().totalFailed).toBe(0);
+
+      await worker.stop();
+    });
+
+    it("continues processing after a timed-out job", async () => {
+      let jobsClaimed = 0;
+
+      const worker = createWorker({
+        concurrency: 1,
+        pollIntervalMs: 10,
+        jobTimeoutMs: 50,
+        logger: silentLogger,
+        claimJob: async () => {
+          jobsClaimed++;
+          if (jobsClaimed === 1) {
+            return createMockJob("slow-job"); // Will timeout
+          }
+          if (jobsClaimed === 2) {
+            return createMockJob("fast-job"); // Should succeed
+          }
+          return null;
+        },
+        processJob: async (job) => {
+          if (job.id === "slow-job") {
+            await new Promise(() => {}); // Never completes
+          }
+          // fast-job completes immediately
+        },
+      });
+
+      await worker.start();
+      await tick(200);
+
+      // Slow job timed out, fast job succeeded
+      expect(worker.getStats().totalFailed).toBe(1);
+      expect(worker.getStats().totalSucceeded).toBe(1);
+
+      await worker.stop();
+    });
+  });
+
+  describe("liveness tracking", () => {
+    it("updates lastActivityAt when polling", async () => {
+      const worker = createWorker({
+        concurrency: 1,
+        pollIntervalMs: 10,
+        logger: silentLogger,
+        claimJob: async () => null,
+        processJob: async () => {},
+      });
+
+      const beforeStart = new Date();
+      await worker.start();
+      await tick(50);
+
+      const stats = worker.getStats();
+      expect(stats.lastActivityAt.getTime()).toBeGreaterThanOrEqual(beforeStart.getTime());
+
+      await worker.stop();
+    });
+
+    it("updates lastActivityAt when jobs complete", async () => {
+      let jobsClaimed = 0;
+
+      const worker = createWorker({
+        concurrency: 1,
+        pollIntervalMs: 10,
+        logger: silentLogger,
+        claimJob: async () => {
+          if (jobsClaimed === 0) {
+            jobsClaimed++;
+            return createMockJob("1");
+          }
+          return null;
+        },
+        processJob: async () => {
+          await tick(20);
+        },
+      });
+
+      await worker.start();
+      await tick(100);
+
+      const stats = worker.getStats();
+      // lastActivityAt should be very recent (after job completed)
+      expect(Date.now() - stats.lastActivityAt.getTime()).toBeLessThan(200);
+
+      await worker.stop();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The worker process silently stopped on March 6 — the process was still running (health check passed), but the job processing loop hung indefinitely. No crash, no error, no Fly.io event. Investigation found:

1. **No job timeout**: If a job hung (stuck DB query, pathological feed XML), its promise never settled, blocking `Promise.race()` in the worker loop forever
2. **Health check was process-level only**: `/health` just confirmed the HTTP server was alive, not that jobs were being processed
3. **No DB pool visibility**: Connection pool exhaustion would be invisible

## Changes

### Per-job timeout (5 min default)
- Wraps each `processJob()` call in `Promise.race` with a configurable timeout
- Timed-out jobs are logged as errors and counted as failures
- The worker loop moves on to process the next job
- New `JobTimeoutError` class for clear error identification

### Liveness health check
- Worker loop now tracks `lastActivityAt` (updated on job completion, polling, and claim attempts)
- `/health` endpoint returns **503** if the loop has been inactive for >10 minutes
- Fly.io will auto-restart the machine when health check fails
- Health response includes diagnostic details (activeJobs, totalProcessed, lastActivityAt)

### DB pool monitoring
- New Prometheus gauges: `db_pool_total_connections`, `db_pool_idle_connections`, `db_pool_waiting_requests`
- Periodic warning logs when requests are waiting for connections (every 10s)
- Pool metrics collected on `/metrics` scrape

## Test plan
- [x] All 16 worker unit tests pass (5 new tests for timeout and liveness)
- [x] Typecheck passes
- [ ] Deploy and verify health check returns diagnostic details
- [ ] Verify Prometheus metrics include new `db_pool_*` gauges

🤖 Generated with [Claude Code](https://claude.com/claude-code)