### PR TITLE
Fix: saved article default score overridden by mark-unread

### DIFF
--- a/docs/features/entry-scoring.md
+++ b/docs/features/entry-scoring.md
@@ -23,11 +23,11 @@ Implicit scores are computed from user actions that indicate interest or disinte
 | Action                      | Flag                      | Implicit Score | Rationale                          |
 | --------------------------- | ------------------------- | -------------- | ---------------------------------- |
 | Star an entry               | `has_starred`             | +2             | Starring indicates strong interest |
-| Mark unread (from anywhere) | `has_marked_unread`       | +1             | User wants to revisit this content |
-| Mark read from entry list   | `has_marked_read_on_list` | -1             | Dismissed without opening          |
 | Save an article             | Entry type = `saved`      | +1             | User explicitly chose to save it   |
+| Mark unread (from anywhere) | `has_marked_unread`       | 0              | Overrides read-on-list penalty     |
+| Mark read from entry list   | `has_marked_read_on_list` | -1             | Dismissed without opening          |
 
-**Priority order**: starred (+2) > unread (+1) > read-on-list (-1) > saved default (+1) > default (0)
+**Priority order**: starred (+2) > saved (+1) > unread (0) > read-on-list (-1) > default (0)
 
 ### Display Score
 
@@ -71,9 +71,9 @@ export function computeImplicitScore(
   type?: "web" | "email" | "saved"
 ): number {
   if (hasStarred) return 2;
-  if (hasMarkedUnread) return 1;
-  if (hasMarkedReadOnList) return -1;
   if (type === "saved") return 1; // Saved articles default to +1
+  if (hasMarkedUnread) return 0;
+  if (hasMarkedReadOnList) return -1;
   return 0;
 }
 ```

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -142,11 +142,12 @@ export interface MarkReadResult {
 /**
  * Computes the implicit score from boolean signal flags and entry type.
  *
- * Priority: starred (+2) > unread (0) > read-on-list (-1) > saved default (+1) > default (0)
+ * Priority: starred (+2) > saved (+1) > unread (0) > read-on-list (-1) > default (0)
  *
- * Marking unread overrides read-on-list (returns 0 instead of -1) but doesn't
- * give a positive bonus. Saved articles default to +1 because the user explicitly
- * saved them, indicating interest.
+ * Saved articles default to +1 because the user explicitly saved them,
+ * indicating interest. This takes priority over mark-unread (0) and
+ * read-on-list (-1). Marking unread overrides read-on-list (returns 0
+ * instead of -1) but doesn't give a positive bonus.
  */
 export function computeImplicitScore(
   hasStarred: boolean,
@@ -155,10 +156,10 @@ export function computeImplicitScore(
   type?: "web" | "email" | "saved"
 ): number {
   if (hasStarred) return 2;
-  if (hasMarkedUnread) return 0;
-  if (hasMarkedReadOnList) return -1;
   // Saved articles default to +1 since user explicitly saved them
   if (type === "saved") return 1;
+  if (hasMarkedUnread) return 0;
+  if (hasMarkedReadOnList) return -1;
   return 0;
 }
 

--- a/src/server/services/score-prediction.ts
+++ b/src/server/services/score-prediction.ts
@@ -82,8 +82,8 @@ export interface ScorePrediction {
  *
  * Implicit score mapping:
  * - has_starred = +2
- * - has_marked_unread = 0 (overrides read-on-list but no positive bonus)
  * - type = 'saved' = +1
+ * - has_marked_unread = 0 (overrides read-on-list but no positive bonus)
  * - has_marked_read_on_list = -1
  * - default = 0
  */
@@ -101,8 +101,8 @@ function computeEffectiveScore(row: {
 
   // Implicit score based on user actions
   if (row.hasStarred) return 2;
-  if (row.hasMarkedUnread) return 0;
   if (row.type === "saved") return 1;
+  if (row.hasMarkedUnread) return 0;
   if (row.hasMarkedReadOnList) return -1;
 
   return 0;


### PR DESCRIPTION
## Summary

- Fixes #729: Reorders implicit score priority so saved articles keep their +1 default even when marked unread
- Previous order: starred (+2) > **unread (0)** > read-on-list (-1) > saved (+1) — mark-unread could override saved
- New order: starred (+2) > **saved (+1)** > unread (0) > read-on-list (-1) — saved article bonus is preserved
- Updates both `computeImplicitScore()` (entries service) and `computeEffectiveScore()` (score prediction training)

## Test plan

- [ ] Save an article, verify implicit score is +1
- [ ] Mark saved article as unread, verify implicit score stays +1 (not 0)
- [ ] Star a saved article, verify implicit score is +2
- [ ] Mark a regular web entry as unread, verify implicit score is 0
- [ ] Mark a regular web entry as read from list, verify implicit score is -1

🤖 Generated with [Claude Code](https://claude.com/claude-code)