### PR TITLE
Fix MCP auth discovery for claude.ai

### DIFF
--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -9,8 +9,10 @@
 
 import { NextResponse } from "next/server";
 import { getAuthorizationServerMetadata } from "@/server/oauth/config";
+import { logger } from "@/lib/logger";
 
 export async function GET() {
+  logger.info("OAuth authorization server metadata requested");
   const metadata = getAuthorizationServerMetadata();
 
   return NextResponse.json(metadata, {

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -9,8 +9,10 @@
 
 import { NextResponse } from "next/server";
 import { getProtectedResourceMetadata } from "@/server/oauth/config";
+import { logger } from "@/lib/logger";
 
 export async function GET() {
+  logger.info("OAuth protected resource metadata requested");
   const metadata = getProtectedResourceMetadata();
 
   return NextResponse.json(metadata, {

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -85,11 +85,12 @@ async function authenticateRequest(request: NextRequest): Promise<AuthResult> {
 
 /**
  * Builds WWW-Authenticate header for 401 responses.
- * Includes resource_metadata URL per MCP specification.
+ * Includes resource_metadata URL and scope per MCP specification (RFC 9728 / RFC 6750).
  */
 function buildWwwAuthenticateHeader(): string {
   const metadata = getProtectedResourceMetadata();
-  return `Bearer resource_metadata="${metadata.resource}/.well-known/oauth-protected-resource"`;
+  const scopes = Object.values(OAUTH_SCOPES);
+  return `Bearer resource_metadata="${metadata.resource}/.well-known/oauth-protected-resource", scope="${scopes.join(" ")}"`;
 }
 
 // ============================================================================
@@ -232,17 +233,31 @@ export async function POST(request: NextRequest) {
 /**
  * GET /api/mcp - SSE endpoint for server-initiated messages
  *
- * In stateless mode, returns 405 since there are no persistent sessions.
+ * Auth is checked first so unauthenticated clients receive 401 with
+ * WWW-Authenticate header for OAuth discovery (MCP spec requirement).
+ * In stateless mode, authenticated requests return 405 since there are
+ * no persistent sessions for SSE streaming.
  */
-export function GET() {
+export async function GET(request: NextRequest) {
+  const auth = await authenticateRequest(request);
+  if (!auth.success) {
+    return unauthorizedResponse(auth.reason);
+  }
   return new Response(null, { status: 405 });
 }
 
 /**
  * DELETE /api/mcp - Session termination
  *
- * In stateless mode, returns 405 since there are no sessions to terminate.
+ * Auth is checked first so unauthenticated clients receive 401 with
+ * WWW-Authenticate header for OAuth discovery (MCP spec requirement).
+ * In stateless mode, authenticated requests return 405 since there are
+ * no sessions to terminate.
  */
-export function DELETE() {
+export async function DELETE(request: NextRequest) {
+  const auth = await authenticateRequest(request);
+  if (!auth.success) {
+    return unauthorizedResponse(auth.reason);
+  }
   return new Response(null, { status: 405 });
 }

--- a/src/app/oauth/authorize/route.ts
+++ b/src/app/oauth/authorize/route.ts
@@ -25,6 +25,7 @@ import {
   createOAuthError,
 } from "@/server/oauth/utils";
 import { getIssuer } from "@/server/oauth/config";
+import { logger } from "@/lib/logger";
 
 /**
  * Extracts session token from cookies.
@@ -68,6 +69,7 @@ function buildSuccessRedirect(redirectUri: string, code: string, state?: string)
 }
 
 export async function GET(request: NextRequest) {
+  logger.info("OAuth authorize GET", { url: request.nextUrl.pathname + request.nextUrl.search });
   const searchParams = request.nextUrl.searchParams;
 
   // Extract required parameters

--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -9,11 +9,13 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { registerClient, type ClientRegistrationRequest } from "@/server/oauth/service";
+import { logger } from "@/lib/logger";
 
 /**
  * Register a new OAuth client
  */
 export async function POST(request: NextRequest) {
+  logger.info("OAuth client registration requested");
   // Parse JSON body
   const contentType = request.headers.get("content-type") ?? "";
   if (!contentType.includes("application/json")) {

--- a/src/app/oauth/token/route.ts
+++ b/src/app/oauth/token/route.ts
@@ -11,6 +11,7 @@
 
 import crypto from "node:crypto";
 import { type NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import {
   resolveClient,
   validateAndConsumeAuthCode,
@@ -29,6 +30,7 @@ import {
  * Token request via form data (standard OAuth)
  */
 export async function POST(request: NextRequest) {
+  logger.info("OAuth token request");
   // Parse form data or JSON body
   let body: Record<string, string>;
 


### PR DESCRIPTION
## Summary
- Fix GET/DELETE on `/api/mcp` to return 401 with `WWW-Authenticate` header before 405 — unauthenticated clients were getting a bare 405 with no auth discovery info
- Add `scope` parameter to `WWW-Authenticate` header per MCP spec (RFC 6750 Section 3)
- Add request logging to all OAuth discovery/registration/token endpoints to help debug auth flow issues

## Context
MCP auth was failing on claude.ai. The root cause: when a client sent a GET to `/api/mcp` (which some clients do for transport detection), it received a bare 405 with no body and no headers — no `WWW-Authenticate` header to discover the OAuth flow. Now all HTTP methods check auth first.

## Test plan
- [ ] Verify `curl https://lionreader.com/api/mcp` returns 401 with `WWW-Authenticate` header (not 405)
- [ ] Verify POST still returns 401 with `WWW-Authenticate` for unauthenticated requests
- [ ] Retry connecting from claude.ai and check logs for OAuth discovery/registration requests
- [ ] Verify authenticated POST still works (Claude Code MCP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)