### PR TITLE
Fix: sync.events uses GREATEST for entry queries to prevent missed updates

### DIFF
--- a/src/server/trpc/routers/sync.ts
+++ b/src/server/trpc/routers/sync.ts
@@ -826,7 +826,9 @@ export const syncRouter = createTRPCRouter({
           changedEntryResults.pop();
         }
 
-        // Differentiate event types based on which timestamps changed
+        // Differentiate event types based on which timestamps changed.
+        // Both metadata and state can change simultaneously, so emit separate
+        // events for each — the frontend handles them with different cache updates.
         for (const row of changedEntryResults) {
           const entryMetadataChanged = row.entryUpdatedAt > entriesCursorDate;
           const entryStateChanged = row.userEntryUpdatedAt > entriesCursorDate;
@@ -861,8 +863,11 @@ export const syncRouter = createTRPCRouter({
                 _sortTime: new Date(row.maxUpdatedAtRaw),
               });
             }
-          } else if (entryStateChanged) {
-            // Only user state changed (read/starred) - lightweight update
+          }
+
+          if (entryStateChanged) {
+            // User state changed (read/starred) - emit separately from metadata
+            // so the frontend updates both the entry content and read/starred state
             allEvents.push({
               type: "entry_state_changed" as const,
               entryId: row.id,


### PR DESCRIPTION
## Summary

- Fixes #738: `sync.events` ran two separate entry queries (`user_entries.updated_at > cursor` and `entries.updated_at > cursor`), but the frontend tracks a single `entries` cursor. When one timestamp advanced the cursor past the other, updates could be missed.
- Combined into a single query using `GREATEST(entries.updated_at, user_entries.updated_at) > cursor`, matching the approach already used by `sync.changes`.
- Event types (`new_entry`, `entry_updated`, `entry_state_changed`) are differentiated in application code based on which timestamps changed relative to the cursor.

## Test plan

- [ ] Verify typecheck passes (confirmed locally)
- [ ] Verify sync.events returns correct event types for entry metadata changes, state changes, and new entries
- [ ] Verify cursor advancement doesn't skip events when both timestamps change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Claude