### PR TITLE
Replace to_char with Temporal.Instant and helpers (#683)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "sentence-splitter": "^5.0.0",
     "sonner": "^2.0.7",
     "superjson": "^2.2.6",
+    "temporal-polyfill": "^0.3.0",
     "trpc-to-openapi": "^3.1.0",
     "tsx": "^4.21.0",
     "yaml": "^2.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       superjson:
         specifier: ^2.2.6
         version: 2.2.6
+      temporal-polyfill:
+        specifier: ^0.3.0
+        version: 0.3.0
       trpc-to-openapi:
         specifier: ^3.1.0
         version: 3.1.0(@trpc/server@11.10.0(typescript@5.9.3))(zod-openapi@5.4.5(zod@4.3.6))(zod@4.3.6)
@@ -6073,6 +6076,12 @@ packages:
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
+
+  temporal-polyfill@0.3.0:
+    resolution: {integrity: sha512-qNsTkX9K8hi+FHDfHmf22e/OGuXmfBm9RqNismxBrnSmZVJKegQ+HYYXT+R7Ha8F/YSm2Y34vmzD4cxMu2u95g==}
+
+  temporal-spec@0.3.0:
+    resolution: {integrity: sha512-n+noVpIqz4hYgFSMOSiINNOUOMFtV5cZQNCmmszA6GiVFVRt3G7AqVyhXjhCSmowvQn+NsGn+jMDMKJYHd3bSQ==}
 
   tempy@0.6.0:
     resolution: {integrity: sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==}
@@ -13150,6 +13159,12 @@ snapshots:
       bintrees: 1.0.2
 
   temp-dir@2.0.0: {}
+
+  temporal-polyfill@0.3.0:
+    dependencies:
+      temporal-spec: 0.3.0
+
+  temporal-spec@0.3.0: {}
 
   tempy@0.6.0:
     dependencies:

--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -16,6 +16,7 @@
 
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { Temporal } from "temporal-polyfill";
 import { trpc } from "@/lib/trpc/client";
 import { handleSyncEvent } from "@/lib/cache/event-handlers";
 import { syncEventSchema, type SyncEvent } from "@/lib/events/schemas";
@@ -223,7 +224,13 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
 
     if (cursorType) {
       const currentCursor = cursorsRef.current[cursorType];
-      if (!currentCursor || new Date(event.updatedAt) > new Date(currentCursor)) {
+      if (
+        !currentCursor ||
+        Temporal.Instant.compare(
+          Temporal.Instant.from(event.updatedAt),
+          Temporal.Instant.from(currentCursor)
+        ) > 0
+      ) {
         cursorsRef.current = {
           ...cursorsRef.current,
           [cursorType]: event.updatedAt,

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -1,9 +1,18 @@
 import { drizzle } from "drizzle-orm/node-postgres";
-import { Pool } from "pg";
+import { Pool, types } from "pg";
 import * as Sentry from "@sentry/nextjs";
 
 import { logger } from "@/lib/logger";
 import * as schema from "./schema";
+
+// Return raw strings for timestamptz instead of JavaScript Date objects.
+// Date only has millisecond precision, losing the microseconds that Postgres
+// stores. Raw strings preserve full precision for Temporal.Instant conversion
+// in the temporalTimestamp custom type. Drizzle's built-in timestamp() columns
+// still work because their mapFromDriverValue calls new Date(string).
+// See: https://github.com/brendanlong/lion-reader/issues/683
+types.setTypeParser(types.builtins.TIMESTAMPTZ, (val) => val);
+types.setTypeParser(types.builtins.TIMESTAMP, (val) => val);
 
 const connectionString = process.env.DATABASE_URL;
 

--- a/src/server/db/temporal.ts
+++ b/src/server/db/temporal.ts
@@ -1,0 +1,92 @@
+/**
+ * Temporal.Instant utilities for microsecond-precision timestamps.
+ *
+ * Provides a Drizzle `customType` that maps Postgres `timestamptz` to
+ * `Temporal.Instant`, preserving microsecond precision that JavaScript's
+ * `Date` loses (Date only supports milliseconds).
+ *
+ * Also provides a SQL helper `microsecondISO()` for extracting
+ * microsecond-precision ISO 8601 strings from timestamp columns without
+ * the verbose `to_char(... AT TIME ZONE 'UTC', '...')` boilerplate.
+ *
+ * @see https://github.com/brendanlong/lion-reader/issues/683
+ * @see https://github.com/brendanlong/lion-reader/issues/680
+ */
+
+import { Temporal } from "temporal-polyfill";
+import { customType } from "drizzle-orm/pg-core";
+import { sql, type SQL, type AnyColumn } from "drizzle-orm";
+
+/**
+ * Drizzle custom column type mapping Postgres `timestamptz` to `Temporal.Instant`.
+ *
+ * Preserves microsecond precision by receiving raw strings from node-postgres
+ * (requires `pg.types.setTypeParser(1184, val => val)` in db/index.ts)
+ * and converting them to `Temporal.Instant`.
+ *
+ * Usage in schema:
+ * ```typescript
+ * export const myTable = pgTable("my_table", {
+ *   createdAt: temporalTimestamp("created_at").notNull().defaultNow(),
+ * });
+ * ```
+ *
+ * Note: Currently not used for existing schema columns to avoid cascading
+ * type changes (Date → Temporal.Instant) across the entire codebase.
+ * Available for new columns or future migration.
+ */
+export const temporalTimestamp = customType<{
+  data: Temporal.Instant;
+  dpiData: string;
+}>({
+  dataType() {
+    return "timestamptz";
+  },
+  fromDriver(value: unknown): Temporal.Instant {
+    // With pg type parser returning raw strings, value is like:
+    // "2024-01-15 12:34:56.123456+00"
+    // Convert to ISO 8601 format for Temporal.Instant.from()
+    const str = String(value);
+    const iso = str.replace(" ", "T").replace(/\+00$/, "+00:00");
+    return Temporal.Instant.from(iso);
+  },
+  toDriver(value: Temporal.Instant): string {
+    // Temporal.Instant.toString() returns full-precision ISO 8601
+    // e.g., "2024-01-15T12:34:56.123456Z"
+    return value.toString();
+  },
+});
+
+/**
+ * SQL helper to extract a microsecond-precision ISO 8601 string from a
+ * timestamp column or expression.
+ *
+ * Replaces the verbose pattern:
+ * ```sql
+ * to_char(column AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')
+ * ```
+ *
+ * With:
+ * ```typescript
+ * microsecondISO(column)
+ * ```
+ *
+ * @param column - A Drizzle column reference or SQL expression
+ * @returns SQL expression that evaluates to an ISO 8601 string with microsecond precision
+ */
+export function microsecondISO(column: AnyColumn | SQL): SQL<string> {
+  return sql<string>`to_char(${column} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`;
+}
+
+/**
+ * Compare two ISO 8601 timestamp strings with microsecond precision.
+ *
+ * Uses `Temporal.Instant.compare()` instead of `new Date()` to avoid
+ * precision loss when comparing timestamps. JavaScript's `Date` truncates
+ * to milliseconds, which can cause cursor comparison bugs (#680).
+ *
+ * @returns negative if a < b, 0 if equal, positive if a > b
+ */
+export function compareTimestamps(a: string, b: string): number {
+  return Temporal.Instant.compare(Temporal.Instant.from(a), Temporal.Instant.from(b));
+}

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -17,6 +17,7 @@ import {
 } from "@/server/db/schema";
 import { errors } from "@/server/trpc/errors";
 import { buildEntryFeedFilter, buildEntryFilterConditions } from "./entry-filters";
+import { microsecondISO } from "@/server/db/temporal";
 
 // ============================================================================
 // Types
@@ -423,12 +424,12 @@ export async function listEntries(
       ? visibleEntries.readChangedAt
       : sql`COALESCE(${visibleEntries.publishedAt}, ${visibleEntries.fetchedAt})`;
 
-  // Raw ISO string version of sortColumn with microsecond precision.
-  // Used for cursor encoding to avoid JavaScript Date truncation.
+  // µs-precision ISO string version of sortColumn for cursor encoding.
+  // Uses microsecondISO() helper to avoid JavaScript Date truncation (#680).
   const sortTsRawExpr =
     params.sortBy === "readChanged"
-      ? sql<string>`to_char(${visibleEntries.readChangedAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`
-      : sql<string>`to_char(COALESCE(${visibleEntries.publishedAt}, ${visibleEntries.fetchedAt}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`;
+      ? microsecondISO(visibleEntries.readChangedAt)
+      : microsecondISO(sql`COALESCE(${visibleEntries.publishedAt}, ${visibleEntries.fetchedAt})`);
 
   // Cursor condition
   // Pass timestamp string directly to Postgres (::timestamptz) to preserve

--- a/src/server/trpc/routers/sync.ts
+++ b/src/server/trpc/routers/sync.ts
@@ -21,6 +21,7 @@ import {
 } from "@/server/db/schema";
 import { syncTagSchema, serverSyncEventSchema } from "@/lib/events/schemas";
 import type { Database } from "@/server/db";
+import { microsecondISO, compareTimestamps } from "@/server/db/temporal";
 
 // ============================================================================
 // Helpers
@@ -113,18 +114,15 @@ export const syncRouter = createTRPCRouter({
   cursors: protectedProcedure.output(syncCursorsSchema).query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 
-    // Run all max queries in parallel for efficiency
-    // Use to_char to format timestamps as ISO 8601 with microsecond precision.
-    // Avoids JavaScript Date truncation which loses microseconds and causes
-    // cursor comparison bugs (see #680).
+    // Run all max queries in parallel for efficiency.
+    // Uses microsecondISO() to format timestamps as ISO 8601 with µs precision,
+    // avoiding JavaScript Date truncation which causes cursor comparison bugs (#680).
     const [entriesResult, subscriptionsResult, tagsResult] = await Promise.all([
       // Entries: max of GREATEST(entries.updated_at, user_entries.updated_at)
       // This catches both entry metadata changes AND read/starred state changes
       ctx.db
         .select({
-          max: sql<
-            string | null
-          >`to_char(MAX(GREATEST(${entries.updatedAt}, ${userEntries.updatedAt})) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+          max: microsecondISO(sql`MAX(GREATEST(${entries.updatedAt}, ${userEntries.updatedAt}))`),
         })
         .from(userEntries)
         .innerJoin(entries, eq(entries.id, userEntries.entryId))
@@ -134,9 +132,7 @@ export const syncRouter = createTRPCRouter({
       // updated_at is set when unsubscribing, so this covers both cases
       ctx.db
         .select({
-          max: sql<
-            string | null
-          >`to_char(MAX(${subscriptions.updatedAt}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+          max: microsecondISO(sql`MAX(${subscriptions.updatedAt})`),
         })
         .from(subscriptions)
         .where(eq(subscriptions.userId, userId)),
@@ -144,9 +140,7 @@ export const syncRouter = createTRPCRouter({
       // Tags: max(updated_at) - captures creates, updates, and soft deletes
       ctx.db
         .select({
-          max: sql<
-            string | null
-          >`to_char(MAX(${tags.updatedAt}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+          max: microsecondISO(sql`MAX(${tags.updatedAt})`),
         })
         .from(tags)
         .where(eq(tags.userId, userId)),
@@ -192,8 +186,6 @@ export const syncRouter = createTRPCRouter({
       const entriesCursor = input.cursors?.entries ?? null;
       const subscriptionsCursor = input.cursors?.subscriptions ?? null;
       const tagsCursor = input.cursors?.tags ?? null;
-      // Date versions for JavaScript comparisons (categorization, sorting)
-      const tagsCursorDate = tagsCursor ? new Date(tagsCursor) : null;
 
       // If no cursors provided, return empty events (initial cursor establishment
       // is handled by sync.cursors endpoint)
@@ -205,7 +197,7 @@ export const syncRouter = createTRPCRouter({
       }
 
       // Collect all events with their timestamps for sorting
-      const allEvents: Array<z.infer<typeof serverSyncEventSchema> & { _sortTime: Date }> = [];
+      const allEvents: Array<z.infer<typeof serverSyncEventSchema> & { _sortTime: string }> = [];
 
       // Track if we hit any limits
       let hasMore = false;
@@ -217,7 +209,6 @@ export const syncRouter = createTRPCRouter({
       // when one timestamp advances past the other (see #738).
       // ========================================================================
       if (entriesCursor) {
-        const entriesCursorDate = new Date(entriesCursor);
         const changedEntryResults = await ctx.db
           .select({
             id: entries.id,
@@ -233,8 +224,14 @@ export const syncRouter = createTRPCRouter({
             userEntryUpdatedAt: userEntries.updatedAt,
             subscriptionId: subscriptions.id,
             feedType: feeds.type,
-            // Raw ISO string with µs precision for cursor/timestamp output
-            maxUpdatedAtRaw: sql<string>`to_char(GREATEST(${entries.updatedAt}, ${userEntries.updatedAt}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+            // µs-precision ISO string for cursor/timestamp output
+            maxUpdatedAtRaw: microsecondISO(
+              sql`GREATEST(${entries.updatedAt}, ${userEntries.updatedAt})`
+            ),
+            // µs-precision ISO strings for individual timestamp comparisons
+            entryUpdatedAtRaw: microsecondISO(entries.updatedAt),
+            userEntryUpdatedAtRaw: microsecondISO(userEntries.updatedAt),
+            createdAtRaw: microsecondISO(entries.createdAt),
           })
           .from(userEntries)
           .innerJoin(entries, eq(entries.id, userEntries.entryId))
@@ -268,12 +265,13 @@ export const syncRouter = createTRPCRouter({
         // Differentiate event types based on which timestamps changed.
         // Both metadata and state can change simultaneously, so emit separate
         // events for each — the frontend handles them with different cache updates.
+        // Uses Temporal.Instant comparison to preserve µs precision (#680).
         for (const row of changedEntryResults) {
-          const entryMetadataChanged = row.entryUpdatedAt > entriesCursorDate;
-          const entryStateChanged = row.userEntryUpdatedAt > entriesCursorDate;
+          const entryMetadataChanged = compareTimestamps(row.entryUpdatedAtRaw, entriesCursor) > 0;
+          const entryStateChanged = compareTimestamps(row.userEntryUpdatedAtRaw, entriesCursor) > 0;
 
           if (entryMetadataChanged) {
-            if (row.createdAt > entriesCursorDate) {
+            if (compareTimestamps(row.createdAtRaw, entriesCursor) > 0) {
               // New entry created after cursor - emit new_entry for count updates
               allEvents.push({
                 type: "new_entry" as const,
@@ -282,7 +280,7 @@ export const syncRouter = createTRPCRouter({
                 timestamp: row.maxUpdatedAtRaw,
                 updatedAt: row.maxUpdatedAtRaw,
                 feedType: row.feedType,
-                _sortTime: new Date(row.maxUpdatedAtRaw),
+                _sortTime: row.maxUpdatedAtRaw,
               });
             } else {
               // Existing entry with metadata changes
@@ -299,7 +297,7 @@ export const syncRouter = createTRPCRouter({
                   url: row.url,
                   publishedAt: row.publishedAt?.toISOString() ?? null,
                 },
-                _sortTime: new Date(row.maxUpdatedAtRaw),
+                _sortTime: row.maxUpdatedAtRaw,
               });
             }
           }
@@ -314,7 +312,7 @@ export const syncRouter = createTRPCRouter({
               starred: row.starred,
               timestamp: row.maxUpdatedAtRaw,
               updatedAt: row.maxUpdatedAtRaw,
-              _sortTime: new Date(row.maxUpdatedAtRaw),
+              _sortTime: row.maxUpdatedAtRaw,
             });
           }
         }
@@ -328,7 +326,8 @@ export const syncRouter = createTRPCRouter({
           .select({
             subscription: subscriptions,
             feed: feeds,
-            updatedAtRaw: sql<string>`to_char(${subscriptions.updatedAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+            updatedAtRaw: microsecondISO(subscriptions.updatedAt),
+            subscribedAtRaw: microsecondISO(subscriptions.subscribedAt),
           })
           .from(subscriptions)
           .innerJoin(feeds, eq(subscriptions.feedId, feeds.id))
@@ -379,13 +378,13 @@ export const syncRouter = createTRPCRouter({
           }
         }
 
-        const subscriptionsCursorDate = new Date(subscriptionsCursor);
-        for (const { subscription, feed, updatedAtRaw } of subscriptionResults) {
+        for (const { subscription, feed, updatedAtRaw, subscribedAtRaw } of subscriptionResults) {
           if (subscription.unsubscribedAt === null) {
             // Distinguish new subscriptions from updated ones:
             // If subscribedAt is after the cursor, it's a new subscription.
             // Otherwise, it's an existing subscription whose properties changed.
-            const isNew = subscription.subscribedAt > subscriptionsCursorDate;
+            // Uses Temporal.Instant comparison to preserve µs precision (#680).
+            const isNew = compareTimestamps(subscribedAtRaw, subscriptionsCursor) > 0;
             if (isNew) {
               allEvents.push({
                 type: "subscription_created" as const,
@@ -397,7 +396,7 @@ export const syncRouter = createTRPCRouter({
                   id: subscription.id,
                   feedId: subscription.feedId,
                   customTitle: subscription.customTitle,
-                  subscribedAt: subscription.subscribedAt.toISOString(),
+                  subscribedAt: subscribedAtRaw,
                   unreadCount: unreadBySubscription.get(subscription.id) ?? 0,
                   tags: tagsBySubscription.get(subscription.id) ?? [],
                 },
@@ -409,7 +408,7 @@ export const syncRouter = createTRPCRouter({
                   description: feed.description,
                   siteUrl: feed.siteUrl,
                 },
-                _sortTime: subscription.updatedAt,
+                _sortTime: updatedAtRaw,
               });
             } else {
               allEvents.push({
@@ -419,7 +418,7 @@ export const syncRouter = createTRPCRouter({
                 customTitle: subscription.customTitle,
                 timestamp: updatedAtRaw,
                 updatedAt: updatedAtRaw,
-                _sortTime: subscription.updatedAt,
+                _sortTime: updatedAtRaw,
               });
             }
           } else {
@@ -428,7 +427,7 @@ export const syncRouter = createTRPCRouter({
               subscriptionId: subscription.id,
               timestamp: updatedAtRaw,
               updatedAt: updatedAtRaw,
-              _sortTime: subscription.updatedAt,
+              _sortTime: updatedAtRaw,
             });
           }
         }
@@ -443,10 +442,9 @@ export const syncRouter = createTRPCRouter({
             id: tags.id,
             name: tags.name,
             color: tags.color,
-            createdAt: tags.createdAt,
-            updatedAt: tags.updatedAt,
             deletedAt: tags.deletedAt,
-            updatedAtRaw: sql<string>`to_char(${tags.updatedAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+            updatedAtRaw: microsecondISO(tags.updatedAt),
+            createdAtRaw: microsecondISO(tags.createdAt),
           })
           .from(tags)
           .where(and(eq(tags.userId, userId), sql`${tags.updatedAt} > ${tagsCursor}::timestamptz`))
@@ -459,9 +457,9 @@ export const syncRouter = createTRPCRouter({
               tagId: row.id,
               timestamp: row.updatedAtRaw,
               updatedAt: row.updatedAtRaw,
-              _sortTime: row.updatedAt,
+              _sortTime: row.updatedAtRaw,
             });
-          } else if (tagsCursorDate && row.createdAt > tagsCursorDate) {
+          } else if (compareTimestamps(row.createdAtRaw, tagsCursor) > 0) {
             allEvents.push({
               type: "tag_created" as const,
               tag: {
@@ -471,7 +469,7 @@ export const syncRouter = createTRPCRouter({
               },
               timestamp: row.updatedAtRaw,
               updatedAt: row.updatedAtRaw,
-              _sortTime: row.updatedAt,
+              _sortTime: row.updatedAtRaw,
             });
           } else {
             allEvents.push({
@@ -483,14 +481,14 @@ export const syncRouter = createTRPCRouter({
               },
               timestamp: row.updatedAtRaw,
               updatedAt: row.updatedAtRaw,
-              _sortTime: row.updatedAt,
+              _sortTime: row.updatedAtRaw,
             });
           }
         }
       }
 
-      // Sort all events by timestamp
-      allEvents.sort((a, b) => a._sortTime.getTime() - b._sortTime.getTime());
+      // Sort all events by timestamp using Temporal.Instant for µs precision
+      allEvents.sort((a, b) => compareTimestamps(a._sortTime, b._sortTime));
 
       // Remove _sortTime from events before returning
       // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## Summary

Closes #683

- Add `temporal-polyfill` and create `src/server/db/temporal.ts` with a Drizzle `customType` (`temporalTimestamp`), a `microsecondISO()` SQL helper, and a `compareTimestamps()` utility
- Configure node-postgres to return raw strings for `timestamptz` columns, preserving microsecond precision for `Temporal.Instant` conversion
- Replace all verbose `to_char(... AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')` patterns in `sync.ts` and `entries.ts` with the `microsecondISO()` helper
- Replace `new Date()` comparisons with `Temporal.Instant.compare()` in `sync.ts` (server) and `useRealtimeUpdates.ts` (client) for µs-precision cursor tracking

## Test plan

- [x] `pnpm typecheck` passes
- [x] All 1953 unit tests pass
- [ ] Manual testing: verify sync cursors work correctly with real-time updates
- [ ] Verify entry list pagination cursors maintain microsecond precision

🤖 Generated with [Claude Code](https://claude.com/claude-code)