### PR TITLE
Add scoring model trained-at date to admin users page

### DIFF
--- a/src/components/admin/AdminUsersContent.tsx
+++ b/src/components/admin/AdminUsersContent.tsx
@@ -84,6 +84,7 @@ interface User {
   entryCount: number;
   scoringModelSize: number | null;
   scoringModelMemoryEstimate: number | null;
+  scoringModelTrainedAt: Date | null;
 }
 
 function UserRow({ user }: { user: User }) {
@@ -127,6 +128,9 @@ function UserRow({ user }: { user: User }) {
           Scoring model: {formatBytes(user.scoringModelSize)}
           {user.scoringModelMemoryEstimate != null && (
             <span> (est. memory: {formatBytes(user.scoringModelMemoryEstimate)})</span>
+          )}
+          {user.scoringModelTrainedAt != null && (
+            <span> · trained {formatDate(user.scoringModelTrainedAt)}</span>
           )}
         </div>
       )}

--- a/src/server/trpc/routers/admin.ts
+++ b/src/server/trpc/routers/admin.ts
@@ -531,6 +531,7 @@ const userEndpoints = {
             entryCount: z.number(),
             scoringModelSize: z.number().nullable(),
             scoringModelMemoryEstimate: z.number().nullable(),
+            scoringModelTrainedAt: z.date().nullable(),
           })
         ),
         nextCursor: z.string().optional(),
@@ -583,6 +584,13 @@ const userEndpoints = {
          WHERE ${userScoreModels.userId} = ${users.id})
       `;
 
+      // Subquery: scoring model trained_at timestamp
+      const scoringModelTrainedAtSq = sql<Date | null>`
+        (SELECT ${userScoreModels.trainedAt}
+         FROM ${userScoreModels}
+         WHERE ${userScoreModels.userId} = ${users.id})
+      `;
+
       const conditions = [];
 
       // Cursor-based pagination: id < cursor (order by id DESC, since UUIDv7 is time-ordered)
@@ -609,6 +617,7 @@ const userEndpoints = {
           scoringModelMemoryEstimate: scoringModelMemoryEstimateSq.as(
             "scoring_model_memory_estimate"
           ),
+          scoringModelTrainedAt: scoringModelTrainedAtSq.as("scoring_model_trained_at"),
         })
         .from(users)
         .where(whereClause)
@@ -630,6 +639,9 @@ const userEndpoints = {
           scoringModelSize: row.scoringModelSize != null ? Number(row.scoringModelSize) : null,
           scoringModelMemoryEstimate:
             row.scoringModelMemoryEstimate != null ? Number(row.scoringModelMemoryEstimate) : null,
+          scoringModelTrainedAt: row.scoringModelTrainedAt
+            ? new Date(row.scoringModelTrainedAt)
+            : null,
         })),
         nextCursor,
       };


### PR DESCRIPTION
## Summary
- Adds the `trained_at` timestamp from `user_score_models` to the admin users list API and UI
- Displays as "trained Mar 9, 2026" alongside the existing model size/memory info

## Test plan
- [ ] Visit /admin/users and verify the trained date appears for users with scoring models
- [ ] Verify users without scoring models show no scoring model info (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)