### PR TITLE
Fix swipe gesture false positives with ratio-based check

### DIFF
--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/components/ui/icon-button";
 import { EntryArticle } from "@/components/entries/EntryArticle";
 import { SummaryCard } from "@/components/summarization/SummaryCard";
-import { SWIPE_CONFIG } from "@/components/entries/EntryContentHelpers";
+import { useSwipeGesture } from "@/lib/hooks/useSwipeGesture";
 import { SortToggle } from "@/components/entries/SortToggle";
 import { UnreadToggle } from "@/components/entries/UnreadToggle";
 import { MarkAllReadButton } from "@/components/entries/MarkAllReadButton";
@@ -208,38 +208,11 @@ function DemoRouterContent() {
     onNavigatePrevious: goToPreviousEntry,
   });
 
-  // Swipe gesture handlers for entry detail view
-  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
-
-  const handleTouchStart = useCallback(
-    (e: React.TouchEvent) => {
-      if (!entryId) return;
-      const touch = e.touches[0];
-      touchStartRef.current = { x: touch.clientX, y: touch.clientY };
-    },
-    [entryId]
-  );
-
-  const handleTouchEnd = useCallback(
-    (e: React.TouchEvent) => {
-      if (!touchStartRef.current) return;
-
-      const touch = e.changedTouches[0];
-      const deltaX = touch.clientX - touchStartRef.current.x;
-      const deltaY = touch.clientY - touchStartRef.current.y;
-      touchStartRef.current = null;
-
-      if (Math.abs(deltaY) > SWIPE_CONFIG.MAX_VERTICAL_DISTANCE) return;
-      if (Math.abs(deltaX) < SWIPE_CONFIG.SWIPE_THRESHOLD) return;
-
-      if (deltaX < 0 && nextEntryId) {
-        openEntry(nextEntryId);
-      } else if (deltaX > 0 && previousEntryId) {
-        openEntry(previousEntryId);
-      }
-    },
-    [nextEntryId, previousEntryId, openEntry]
-  );
+  const { onTouchStart: handleTouchStart, onTouchEnd: handleTouchEnd } = useSwipeGesture({
+    onSwipeLeft: nextEntryId ? () => openEntry(nextEntryId) : undefined,
+    onSwipeRight: previousEntryId ? () => openEntry(previousEntryId) : undefined,
+    enabled: Boolean(entryId),
+  });
 
   // Auto-mark entry as read when viewing it (like the real app)
   const hasSentMarkRead = useRef<string | null>(null);

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -7,7 +7,7 @@
 
 "use client";
 
-import { useEffect, useRef, useMemo, useCallback } from "react";
+import { useEffect, useRef, useMemo } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import DOMPurify from "isomorphic-dompurify";
 
@@ -51,7 +51,7 @@ import { processHtmlForHighlighting } from "@/lib/narration/client-paragraph-ids
 import { useNarrationSettings } from "@/lib/narration/settings";
 import { useEntryTextStyles } from "@/lib/appearance/AppearanceProvider";
 import { useImagePrefetch } from "@/lib/hooks/useImagePrefetch";
-import { SWIPE_CONFIG } from "./EntryContentHelpers";
+import { useSwipeGesture } from "@/lib/hooks/useSwipeGesture";
 import { EntryArticle } from "./EntryArticle";
 import { StickyEntryControls } from "./StickyEntryControls";
 import { VoteControls } from "./VoteControls";
@@ -206,7 +206,6 @@ export function EntryContentBody({
 }: EntryContentBodyProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const actionButtonsRef = useRef<HTMLDivElement>(null);
-  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
 
   // Determine if we're showing full content
   // Full content is shown if:
@@ -340,50 +339,11 @@ export function EntryContentBody({
     narration.state.status,
   ]);
 
-  // Swipe gesture handlers
-  const swipeEnabled = Boolean(onSwipeNext || onSwipePrevious);
-
-  const handleTouchStart = useCallback(
-    (e: React.TouchEvent) => {
-      if (!swipeEnabled) return;
-      const touch = e.touches[0];
-      touchStartRef.current = { x: touch.clientX, y: touch.clientY };
-    },
-    [swipeEnabled]
-  );
-
-  const handleTouchEnd = useCallback(
-    (e: React.TouchEvent) => {
-      if (!swipeEnabled || !touchStartRef.current) return;
-
-      const touch = e.changedTouches[0];
-      const deltaX = touch.clientX - touchStartRef.current.x;
-      const deltaY = touch.clientY - touchStartRef.current.y;
-
-      // Reset touch start
-      touchStartRef.current = null;
-
-      // Check if vertical movement is too large (user is scrolling, not swiping)
-      if (Math.abs(deltaY) > SWIPE_CONFIG.MAX_VERTICAL_DISTANCE) {
-        return;
-      }
-
-      // Check if horizontal movement meets threshold
-      if (Math.abs(deltaX) < SWIPE_CONFIG.SWIPE_THRESHOLD) {
-        return;
-      }
-
-      // Determine swipe direction
-      if (deltaX < 0 && onSwipeNext) {
-        // Swipe left -> next entry
-        onSwipeNext();
-      } else if (deltaX > 0 && onSwipePrevious) {
-        // Swipe right -> previous entry
-        onSwipePrevious();
-      }
-    },
-    [swipeEnabled, onSwipeNext, onSwipePrevious]
-  );
+  const { onTouchStart: handleTouchStart, onTouchEnd: handleTouchEnd } = useSwipeGesture({
+    onSwipeLeft: onSwipeNext,
+    onSwipeRight: onSwipePrevious,
+    enabled: Boolean(onSwipeNext || onSwipePrevious),
+  });
 
   // Keyboard shortcut: m to toggle read/unread
   useHotkeys(

--- a/src/components/entries/EntryContentHelpers.ts
+++ b/src/components/entries/EntryContentHelpers.ts
@@ -21,9 +21,29 @@ export function formatDate(date: Date): string {
 /**
  * Swipe gesture configuration constants.
  */
-export const SWIPE_CONFIG = {
+const SWIPE_CONFIG = {
   /** Minimum horizontal distance for swipe */
   SWIPE_THRESHOLD: 50,
-  /** Maximum vertical movement allowed */
-  MAX_VERTICAL_DISTANCE: 100,
+  /** Maximum ratio of vertical to horizontal movement (0.5 = require 2:1 horizontal-to-vertical) */
+  MAX_VERTICAL_RATIO: 0.5,
 } as const;
+
+/**
+ * Detect swipe direction from touch start/end coordinates.
+ * Returns "left", "right", or null if the gesture doesn't qualify as a swipe.
+ */
+export function detectSwipeDirection(
+  start: { x: number; y: number },
+  end: { x: number; y: number }
+): "left" | "right" | null {
+  const deltaX = end.x - start.x;
+  const deltaY = end.y - start.y;
+
+  if (Math.abs(deltaY) > Math.abs(deltaX) * SWIPE_CONFIG.MAX_VERTICAL_RATIO) {
+    return null;
+  }
+  if (Math.abs(deltaX) < SWIPE_CONFIG.SWIPE_THRESHOLD) {
+    return null;
+  }
+  return deltaX < 0 ? "left" : "right";
+}

--- a/src/lib/hooks/useSwipeGesture.ts
+++ b/src/lib/hooks/useSwipeGesture.ts
@@ -1,0 +1,47 @@
+import { useCallback, useRef } from "react";
+import { detectSwipeDirection } from "@/components/entries/EntryContentHelpers";
+
+export function useSwipeGesture({
+  onSwipeLeft,
+  onSwipeRight,
+  enabled = true,
+}: {
+  onSwipeLeft?: () => void;
+  onSwipeRight?: () => void;
+  enabled?: boolean;
+}) {
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (!enabled) return;
+      const touch = e.touches[0];
+      touchStartRef.current = { x: touch.clientX, y: touch.clientY };
+    },
+    [enabled]
+  );
+
+  const onTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (!enabled || !touchStartRef.current) return;
+
+      const touch = e.changedTouches[0];
+      const start = touchStartRef.current;
+      touchStartRef.current = null;
+
+      const direction = detectSwipeDirection(start, {
+        x: touch.clientX,
+        y: touch.clientY,
+      });
+
+      if (direction === "left") {
+        onSwipeLeft?.();
+      } else if (direction === "right") {
+        onSwipeRight?.();
+      }
+    },
+    [enabled, onSwipeLeft, onSwipeRight]
+  );
+
+  return { onTouchStart, onTouchEnd };
+}


### PR DESCRIPTION
## Summary
- Replace absolute `MAX_VERTICAL_DISTANCE` (100px) check with a ratio-based check requiring horizontal movement to be at least 2x vertical movement
- Prevents diagonal scrolling and small movements from triggering next/previous entry navigation
- Applied to both the main entry view and demo router

## Test plan
- [ ] On mobile, scroll vertically through an article — should not trigger swipe navigation
- [ ] On mobile, swipe horizontally — should navigate to next/previous entry
- [ ] Diagonal swipes (more vertical than horizontal) should be ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)