### PR TITLE
Fix Recently Read to only show actually-read articles

### DIFF
--- a/migrations/0064_nullable_read_changed_at.sql
+++ b/migrations/0064_nullable_read_changed_at.sql
@@ -1,0 +1,100 @@
+-- Make read_changed_at nullable on user_entries so it only has a value when
+-- the user has explicitly changed the read state. Previously it defaulted to
+-- NOW() on row creation, causing the "Recently Read" list to include entries
+-- the user had never actually read.
+--
+-- Also adds a created_at column to user_entries for general housekeeping.
+
+-- Step 1: Add created_at column (nullable initially for backfill)
+ALTER TABLE user_entries ADD COLUMN created_at timestamptz;
+
+-- Step 2: Backfill created_at from the later of entries.created_at and
+-- subscriptions.created_at (whichever event triggered the row).
+-- GREATEST in Postgres ignores NULLs, so orphaned starred entries
+-- (no subscription) just get entries.created_at.
+-- Note: In UPDATE...FROM, the target table can't be referenced in JOIN
+-- conditions, so we use a subquery to compute the value.
+UPDATE user_entries ue
+SET created_at = sub.computed_created_at
+FROM (
+    SELECT ue2.user_id, ue2.entry_id,
+           GREATEST(e.created_at, s.created_at) AS computed_created_at
+    FROM user_entries ue2
+    JOIN entries e ON e.id = ue2.entry_id
+    LEFT JOIN subscription_feeds sf ON sf.user_id = ue2.user_id AND sf.feed_id = e.feed_id
+    LEFT JOIN subscriptions s ON s.id = sf.subscription_id
+) sub
+WHERE ue.user_id = sub.user_id AND ue.entry_id = sub.entry_id;
+
+-- Step 3: Any remaining NULLs (shouldn't happen, but be safe) get NOW()
+UPDATE user_entries SET created_at = NOW() WHERE created_at IS NULL;
+
+-- Step 4: Make NOT NULL with default
+ALTER TABLE user_entries ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE user_entries ALTER COLUMN created_at SET DEFAULT NOW();
+
+-- Step 5: Make read_changed_at nullable and change default to NULL
+ALTER TABLE user_entries ALTER COLUMN read_changed_at DROP NOT NULL;
+ALTER TABLE user_entries ALTER COLUMN read_changed_at SET DEFAULT NULL;
+
+-- Step 6: Set read_changed_at to NULL for entries that were never explicitly
+-- read-state-changed by the user. If read is false and none of the interaction
+-- flags are set, the timestamp is just the row-creation default.
+UPDATE user_entries
+SET read_changed_at = NULL
+WHERE read = false
+  AND has_marked_read_on_list = false
+  AND has_marked_unread = false;
+
+-- Step 7: Recreate visible_entries view (CREATE OR REPLACE can't change column
+-- types, but the column is still projected the same way — it's just nullable now).
+-- We need to DROP and recreate because the underlying column type changed.
+DROP VIEW IF EXISTS public.visible_entries;
+CREATE VIEW public.visible_entries AS
+SELECT ue.user_id,
+    e.id,
+    e.feed_id,
+    e.type,
+    e.guid,
+    e.url,
+    e.title,
+    e.author,
+    e.content_original,
+    e.content_cleaned,
+    e.summary,
+    e.site_name,
+    e.image_url,
+    e.published_at,
+    e.fetched_at,
+    e.last_seen_at,
+    e.content_hash,
+    e.full_content_hash,
+    e.spam_score,
+    e.is_spam,
+    e.list_unsubscribe_mailto,
+    e.list_unsubscribe_https,
+    e.list_unsubscribe_post,
+    e.created_at,
+    GREATEST(e.updated_at, ue.updated_at) AS updated_at,
+    e.full_content_original,
+    e.full_content_cleaned,
+    e.full_content_fetched_at,
+    e.full_content_error,
+    ue.read,
+    ue.starred,
+    ue.score,
+    ue.has_marked_read_on_list,
+    ue.has_marked_unread,
+    ue.has_starred,
+    s.id AS subscription_id,
+    esp.predicted_score,
+    esp.confidence AS prediction_confidence,
+    e.unsubscribe_url,
+    ue.read_changed_at,
+    e.wallabag_id
+FROM public.user_entries ue
+    JOIN public.entries e ON e.id = ue.entry_id
+    LEFT JOIN public.subscription_feeds sf ON sf.user_id = ue.user_id AND sf.feed_id = e.feed_id
+    LEFT JOIN public.subscriptions s ON s.id = sf.subscription_id
+    LEFT JOIN public.entry_score_predictions esp ON esp.user_id = ue.user_id AND esp.entry_id = e.id
+WHERE s.unsubscribed_at IS NULL OR ue.starred = true;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1770638800000,
       "tag": "0063_refresh_token_resource",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1770648800000,
+      "tag": "0064_nullable_read_changed_at",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -318,13 +318,14 @@ CREATE TABLE public.user_entries (
     read boolean DEFAULT false NOT NULL,
     starred boolean DEFAULT false NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    read_changed_at timestamp with time zone DEFAULT now() NOT NULL,
+    read_changed_at timestamp with time zone,
     starred_changed_at timestamp with time zone DEFAULT now() NOT NULL,
     score smallint,
     score_changed_at timestamp with time zone,
     has_marked_read_on_list boolean DEFAULT false NOT NULL,
     has_marked_unread boolean DEFAULT false NOT NULL,
     has_starred boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
     CONSTRAINT user_entries_score_range CHECK (((score >= '-2'::integer) AND (score <= 2)))
 );
 

--- a/src/app/api/greader.php/reader/api/0/mark-all-as-read/route.ts
+++ b/src/app/api/greader.php/reader/api/0/mark-all-as-read/route.ts
@@ -15,15 +15,8 @@ import { parseFormData, textResponse, errorResponse } from "@/server/google-read
 import { parseStreamId } from "@/server/google-reader/streams";
 import { feedStreamIdToSubscriptionUuid } from "@/server/google-reader/id";
 import { resolveTagByName } from "@/server/google-reader/tags";
-import { eq, and, isNull, lte, inArray, type SQL } from "drizzle-orm";
 import { db } from "@/server/db";
-import {
-  userEntries,
-  entries,
-  subscriptionFeeds,
-  subscriptions,
-  subscriptionTags,
-} from "@/server/db/schema";
+import { markAllEntriesRead } from "@/server/services/entries";
 
 export const dynamic = "force-dynamic";
 
@@ -49,26 +42,7 @@ export async function POST(request: Request): Promise<Response> {
   const tsStr = params.get("ts");
   const beforeDate = tsStr ? new Date(parseInt(tsStr, 10) / 1000) : undefined;
 
-  const now = new Date();
-
-  // Build conditions for the update
-  const conditions: SQL[] = [
-    eq(userEntries.userId, userId),
-    eq(userEntries.read, false),
-    lte(userEntries.readChangedAt, now),
-  ];
-
-  // Add timestamp filter if provided
-  if (beforeDate) {
-    const beforeEntryIdsSubquery = db
-      .select({ id: entries.id })
-      .from(entries)
-      .where(lte(entries.fetchedAt, beforeDate));
-
-    conditions.push(inArray(userEntries.entryId, beforeEntryIdsSubquery));
-  }
-
-  // Filter by stream
+  // Translate GReader stream into shared service params
   switch (parsedStream.type) {
     case "feed": {
       const subscriptionId = await feedStreamIdToSubscriptionUuid(
@@ -80,41 +54,27 @@ export async function POST(request: Request): Promise<Response> {
         return textResponse("OK");
       }
 
-      // Look up feed IDs for this subscription via subscription_feeds junction table
-      const feedIdsResult = await db
-        .select({ feedId: subscriptionFeeds.feedId })
-        .from(subscriptionFeeds)
-        .innerJoin(
-          subscriptions,
-          and(
-            eq(subscriptions.id, subscriptionFeeds.subscriptionId),
-            eq(subscriptions.userId, userId),
-            isNull(subscriptions.unsubscribedAt)
-          )
-        )
-        .where(eq(subscriptionFeeds.subscriptionId, subscriptionId));
-
-      if (feedIdsResult.length === 0) {
-        return textResponse("OK");
-      }
-
-      const feedIds = feedIdsResult.map((r) => r.feedId);
-
-      const entryIdsSubquery = db
-        .select({ id: entries.id })
-        .from(entries)
-        .where(inArray(entries.feedId, feedIds));
-
-      conditions.push(inArray(userEntries.entryId, entryIdsSubquery));
+      await markAllEntriesRead(db, {
+        userId,
+        subscriptionId,
+        before: beforeDate,
+      });
       break;
     }
     case "state": {
       switch (parsedStream.state) {
         case "reading-list":
-          // All entries — no additional filter
+          await markAllEntriesRead(db, {
+            userId,
+            before: beforeDate,
+          });
           break;
         case "starred":
-          conditions.push(eq(userEntries.starred, true));
+          await markAllEntriesRead(db, {
+            userId,
+            starredOnly: true,
+            before: beforeDate,
+          });
           break;
         default:
           return errorResponse(
@@ -130,37 +90,14 @@ export async function POST(request: Request): Promise<Response> {
         return textResponse("OK");
       }
 
-      // Subquery for feed IDs from subscriptions with this tag via subscription_feeds
-      const taggedFeedIdsSubquery = db
-        .select({
-          feedId: subscriptionFeeds.feedId,
-        })
-        .from(subscriptionTags)
-        .innerJoin(
-          subscriptionFeeds,
-          eq(subscriptionTags.subscriptionId, subscriptionFeeds.subscriptionId)
-        )
-        .where(eq(subscriptionTags.tagId, tag.id));
-
-      const taggedEntryIdsSubquery = db
-        .select({ id: entries.id })
-        .from(entries)
-        .where(inArray(entries.feedId, taggedFeedIdsSubquery));
-
-      conditions.push(inArray(userEntries.entryId, taggedEntryIdsSubquery));
+      await markAllEntriesRead(db, {
+        userId,
+        tagId: tag.id,
+        before: beforeDate,
+      });
       break;
     }
   }
-
-  // Execute the update
-  await db
-    .update(userEntries)
-    .set({
-      read: true,
-      readChangedAt: now,
-      updatedAt: now,
-    })
-    .where(and(...conditions));
 
   return textResponse("OK");
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -649,13 +649,15 @@ export const userEntries = pgTable(
 
     // Timestamps for idempotent updates - tracks when each field was last set
     // Used for conditional updates: only apply if incoming timestamp is newer
-    readChangedAt: timestamp("read_changed_at", { withTimezone: true }).notNull().defaultNow(),
+    // NULL means the user has never explicitly changed the read state
+    readChangedAt: timestamp("read_changed_at", { withTimezone: true }),
     starredChangedAt: timestamp("starred_changed_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
 
     // Timestamp for tracking state changes (for sync endpoint)
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
     primaryKey({ columns: [table.userId, table.entryId] }),
@@ -742,7 +744,7 @@ export const visibleEntries = pgView("visible_entries", {
   predictedScore: real("predicted_score"), // ML-predicted score, nullable
   predictionConfidence: real("prediction_confidence"), // confidence of prediction, nullable
   unsubscribeUrl: text("unsubscribe_url"), // extracted from email HTML body
-  readChangedAt: timestamp("read_changed_at", { withTimezone: true }).notNull(),
+  readChangedAt: timestamp("read_changed_at", { withTimezone: true }),
   wallabagId: integer("wallabag_id"), // Wallabag API integer ID (generated column from entries table)
 }).existing();
 

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -4,7 +4,20 @@
  * Business logic for entry operations. Used by both tRPC routers and MCP server.
  */
 
-import { eq, and, desc, asc, inArray, sql, isNull, lte } from "drizzle-orm";
+import {
+  eq,
+  and,
+  desc,
+  asc,
+  inArray,
+  notInArray,
+  sql,
+  isNull,
+  isNotNull,
+  lte,
+  or,
+  type SQL,
+} from "drizzle-orm";
 import type { db as dbType } from "@/server/db";
 import {
   entries,
@@ -417,6 +430,11 @@ export async function listEntries(
     return { items, nextCursor };
   }
 
+  // Recently Read: exclude entries that were never explicitly read-state-changed
+  if (params.sortBy === "readChanged") {
+    conditions.push(isNotNull(visibleEntries.readChangedAt));
+  }
+
   // Sort column - readChanged sorts by when read state was last changed
   const sortColumn =
     params.sortBy === "readChanged"
@@ -763,7 +781,7 @@ export async function markEntriesRead(
       and(
         eq(userEntries.userId, userId),
         inArray(userEntries.entryId, entryIds),
-        lte(userEntries.readChangedAt, changedAt)
+        or(isNull(userEntries.readChangedAt), lte(userEntries.readChangedAt, changedAt))
       )
     );
 
@@ -845,6 +863,159 @@ export async function markEntriesRead(
     .groupBy(affectedTagsSubquery.tagId);
 
   return { entries: finalEntries, subscriptionUnreadCounts, tagUnreadCounts };
+}
+
+/**
+ * Marks all unread entries matching the given filters as read.
+ *
+ * Shared implementation used by both the tRPC markAllRead mutation and the
+ * Google Reader API mark-all-as-read endpoint.
+ *
+ * Uses idempotent updates: only applies if changedAt is newer than the stored
+ * read_changed_at timestamp (or if read_changed_at is NULL).
+ *
+ * @returns The entry IDs that were marked as read.
+ */
+export async function markAllEntriesRead(
+  db: typeof dbType,
+  params: {
+    userId: string;
+    feedIds?: string[];
+    subscriptionId?: string;
+    tagId?: string;
+    uncategorized?: boolean;
+    starredOnly?: boolean;
+    type?: "web" | "email" | "saved";
+    before?: Date;
+    changedAt?: Date;
+  }
+): Promise<string[]> {
+  const changedAt = params.changedAt ?? new Date();
+
+  const conditions: SQL[] = [
+    eq(userEntries.userId, params.userId),
+    eq(userEntries.read, false),
+    or(isNull(userEntries.readChangedAt), lte(userEntries.readChangedAt, changedAt))!,
+  ];
+
+  // Filter by explicit feed IDs (used by GReader route after stream resolution)
+  if (params.feedIds) {
+    const entryIdsSubquery = db
+      .select({ id: entries.id })
+      .from(entries)
+      .where(inArray(entries.feedId, params.feedIds));
+
+    conditions.push(inArray(userEntries.entryId, entryIdsSubquery));
+  }
+
+  // Filter by subscriptionId (single subquery, no extra roundtrip)
+  if (params.subscriptionId) {
+    const entryIdsSubquery = db
+      .select({ id: entries.id })
+      .from(entries)
+      .where(
+        inArray(
+          entries.feedId,
+          db
+            .select({ feedId: subscriptionFeeds.feedId })
+            .from(subscriptionFeeds)
+            .innerJoin(
+              subscriptions,
+              and(
+                eq(subscriptions.id, subscriptionFeeds.subscriptionId),
+                eq(subscriptions.userId, params.userId),
+                isNull(subscriptions.unsubscribedAt)
+              )
+            )
+            .where(eq(subscriptionFeeds.subscriptionId, params.subscriptionId))
+        )
+      );
+
+    conditions.push(inArray(userEntries.entryId, entryIdsSubquery));
+  }
+
+  // Filter by tag (scoped to user via subscription_tags → subscription_feeds)
+  if (params.tagId) {
+    const taggedFeedIdsSubquery = db
+      .select({ feedId: subscriptionFeeds.feedId })
+      .from(subscriptionTags)
+      .innerJoin(
+        subscriptionFeeds,
+        eq(subscriptionTags.subscriptionId, subscriptionFeeds.subscriptionId)
+      )
+      .where(eq(subscriptionTags.tagId, params.tagId));
+
+    const taggedEntryIdsSubquery = db
+      .select({ id: entries.id })
+      .from(entries)
+      .where(inArray(entries.feedId, taggedFeedIdsSubquery));
+
+    conditions.push(inArray(userEntries.entryId, taggedEntryIdsSubquery));
+  }
+
+  // Filter by uncategorized (no tags)
+  if (params.uncategorized) {
+    const taggedSubscriptionIdsSubquery = db
+      .select({ subscriptionId: subscriptionTags.subscriptionId })
+      .from(subscriptionTags);
+
+    const uncategorizedFeedIdsSubquery = db
+      .select({ feedId: subscriptionFeeds.feedId })
+      .from(subscriptions)
+      .innerJoin(subscriptionFeeds, eq(subscriptionFeeds.subscriptionId, subscriptions.id))
+      .where(
+        and(
+          eq(subscriptions.userId, params.userId),
+          isNull(subscriptions.unsubscribedAt),
+          notInArray(subscriptions.id, taggedSubscriptionIdsSubquery)
+        )
+      );
+
+    const uncategorizedEntryIdsSubquery = db
+      .select({ id: entries.id })
+      .from(entries)
+      .where(inArray(entries.feedId, uncategorizedFeedIdsSubquery));
+
+    conditions.push(inArray(userEntries.entryId, uncategorizedEntryIdsSubquery));
+  }
+
+  // Filter by starred only
+  if (params.starredOnly) {
+    conditions.push(eq(userEntries.starred, true));
+  }
+
+  // Filter by feed type
+  if (params.type) {
+    const typeEntryIdsSubquery = db
+      .select({ id: entries.id })
+      .from(entries)
+      .innerJoin(feeds, eq(entries.feedId, feeds.id))
+      .where(eq(feeds.type, params.type));
+
+    conditions.push(inArray(userEntries.entryId, typeEntryIdsSubquery));
+  }
+
+  // Filter by before date
+  if (params.before) {
+    const beforeEntryIdsSubquery = db
+      .select({ id: entries.id })
+      .from(entries)
+      .where(lte(entries.fetchedAt, params.before));
+
+    conditions.push(inArray(userEntries.entryId, beforeEntryIdsSubquery));
+  }
+
+  const result = await db
+    .update(userEntries)
+    .set({
+      read: true,
+      readChangedAt: changedAt,
+      updatedAt: new Date(),
+    })
+    .where(and(...conditions))
+    .returning({ entryId: userEntries.entryId });
+
+  return result.map((r) => r.entryId);
 }
 
 /**

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -10,7 +10,7 @@
  */
 
 import { z } from "zod";
-import { eq, and, lte, inArray, notInArray, sql } from "drizzle-orm";
+import { eq, and, lte, inArray, sql, or, isNull } from "drizzle-orm";
 import { createHash } from "crypto";
 
 import { createTRPCRouter, confirmedProtectedProcedure as protectedProcedure } from "../trpc";
@@ -22,7 +22,6 @@ import {
   subscriptionFeeds,
   userEntries,
   subscriptions,
-  subscriptionTags,
   tags,
   visibleEntries,
   userFeeds,
@@ -647,7 +646,7 @@ export const entriesRouter = createTRPCRouter({
             and(
               eq(userEntries.userId, userId),
               inArray(userEntries.entryId, entryIds),
-              lte(userEntries.readChangedAt, changedAt)
+              or(isNull(userEntries.readChangedAt), lte(userEntries.readChangedAt, changedAt))
             )
           );
       }
@@ -743,35 +742,9 @@ export const entriesRouter = createTRPCRouter({
     .output(z.object({ count: z.number() }))
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
-      const changedAt = input.changedAt ?? new Date();
 
-      // Build conditions for the update using subqueries to avoid sequential queries
-      // Note: We also require readChangedAt <= changedAt for idempotency
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const conditions: any[] = [
-        eq(userEntries.userId, userId),
-        eq(userEntries.read, false),
-        lte(userEntries.readChangedAt, changedAt),
-      ];
-
-      // Filter by subscriptionId - need to look up feed IDs first for validation
-      if (input.subscriptionId) {
-        const subFeedIds = await getSubscriptionFeedIds(ctx.db, input.subscriptionId, userId);
-        if (subFeedIds === null) {
-          return { count: 0 };
-        }
-        // Use subquery to filter entries by feed IDs instead of fetching all IDs
-        const entryIdsSubquery = ctx.db
-          .select({ id: entries.id })
-          .from(entries)
-          .where(inArray(entries.feedId, subFeedIds));
-
-        conditions.push(inArray(userEntries.entryId, entryIdsSubquery));
-      }
-
-      // If tagId is provided, filter entries by feeds with this tag
+      // Validate tag belongs to user before passing to service
       if (input.tagId) {
-        // First verify the tag belongs to the user
         const tagExists = await ctx.db
           .select({ id: tags.id })
           .from(tags)
@@ -779,95 +752,30 @@ export const entriesRouter = createTRPCRouter({
           .limit(1);
 
         if (tagExists.length === 0) {
-          // Tag not found or doesn't belong to user
           return { count: 0 };
         }
-
-        // Subquery for feed IDs of subscriptions with this tag via subscription_feeds junction table
-        const taggedFeedIdsSubquery = ctx.db
-          .select({ feedId: subscriptionFeeds.feedId })
-          .from(subscriptionTags)
-          .innerJoin(
-            subscriptionFeeds,
-            eq(subscriptionTags.subscriptionId, subscriptionFeeds.subscriptionId)
-          )
-          .where(eq(subscriptionTags.tagId, input.tagId));
-
-        // Subquery for entry IDs from tagged feeds
-        const taggedEntryIdsSubquery = ctx.db
-          .select({ id: entries.id })
-          .from(entries)
-          .where(inArray(entries.feedId, taggedFeedIdsSubquery));
-
-        conditions.push(inArray(userEntries.entryId, taggedEntryIdsSubquery));
       }
 
-      // If uncategorized is true, filter entries by feeds with no tags
-      if (input.uncategorized) {
-        // Subquery for subscription IDs that have tags
-        const taggedSubscriptionIdsSubquery = ctx.db
-          .select({ subscriptionId: subscriptionTags.subscriptionId })
-          .from(subscriptionTags);
-
-        // Subquery for feed IDs from uncategorized subscriptions (no tags) via subscription_feeds
-        const uncategorizedFeedIdsSubquery = ctx.db
-          .select({ feedId: subscriptionFeeds.feedId })
-          .from(userFeeds)
-          .innerJoin(subscriptionFeeds, eq(subscriptionFeeds.subscriptionId, userFeeds.id))
-          .where(
-            and(
-              eq(userFeeds.userId, userId),
-              notInArray(userFeeds.id, taggedSubscriptionIdsSubquery)
-            )
-          );
-
-        // Subquery for entry IDs from uncategorized feeds
-        const uncategorizedEntryIdsSubquery = ctx.db
-          .select({ id: entries.id })
-          .from(entries)
-          .where(inArray(entries.feedId, uncategorizedFeedIdsSubquery));
-
-        conditions.push(inArray(userEntries.entryId, uncategorizedEntryIdsSubquery));
+      // Validate subscription belongs to user before passing to service
+      if (input.subscriptionId) {
+        const subFeedIds = await getSubscriptionFeedIds(ctx.db, input.subscriptionId, userId);
+        if (subFeedIds === null) {
+          return { count: 0 };
+        }
       }
 
-      // If starredOnly is true, filter to only starred entries
-      if (input.starredOnly) {
-        conditions.push(eq(userEntries.starred, true));
-      }
+      const entryIds = await entriesService.markAllEntriesRead(ctx.db, {
+        userId,
+        subscriptionId: input.subscriptionId,
+        tagId: input.tagId,
+        uncategorized: input.uncategorized,
+        starredOnly: input.starredOnly,
+        type: input.type,
+        before: input.before,
+        changedAt: input.changedAt,
+      });
 
-      // If type is provided, filter entries by feed type using subquery
-      if (input.type) {
-        const typeEntryIdsSubquery = ctx.db
-          .select({ id: entries.id })
-          .from(entries)
-          .innerJoin(feeds, eq(entries.feedId, feeds.id))
-          .where(eq(feeds.type, input.type));
-
-        conditions.push(inArray(userEntries.entryId, typeEntryIdsSubquery));
-      }
-
-      // If before date is provided, filter entries by fetchedAt using subquery
-      if (input.before) {
-        const beforeEntryIdsSubquery = ctx.db
-          .select({ id: entries.id })
-          .from(entries)
-          .where(lte(entries.fetchedAt, input.before));
-
-        conditions.push(inArray(userEntries.entryId, beforeEntryIdsSubquery));
-      }
-
-      // Use a single query with RETURNING to both update and count
-      const result = await ctx.db
-        .update(userEntries)
-        .set({
-          read: true,
-          readChangedAt: changedAt,
-          updatedAt: new Date(),
-        })
-        .where(and(...conditions))
-        .returning({ entryId: userEntries.entryId });
-
-      return { count: result.length };
+      return { count: entryIds.length };
     }),
 
   /**


### PR DESCRIPTION
## Summary

- **Make `read_changed_at` nullable** — defaults to NULL on new `user_entries` rows instead of NOW(). Only set when the user explicitly changes the read state. This fixes the Recently Read list showing brand-new unread articles.
- **Add `created_at` to `user_entries`** — backfilled from `GREATEST(entries.created_at, subscriptions.created_at)`. Addresses #747.
- **Filter Recently Read** — entries with NULL `read_changed_at` are excluded when `sortBy === "readChanged"`.
- **Extract shared `markAllEntriesRead` service** — consolidates duplicated mark-all-as-read logic from both the tRPC `markAllRead` mutation and the GReader `mark-all-as-read` route into a single service function.
- **Update idempotency guards** — all 4 locations now handle NULL `read_changed_at` with `IS NULL OR <= changedAt`.

## Migration details

The migration (`0064_nullable_read_changed_at.sql`):
1. Adds `created_at` column, backfills from parent tables
2. Makes `read_changed_at` nullable with NULL default
3. Sets `read_changed_at = NULL` for entries that were never explicitly read-state-changed (`read = false AND has_marked_read_on_list = false AND has_marked_unread = false`)
4. Recreates `visible_entries` view

## Related issues

- Filed #746: Score training excludes opened-and-read articles
- Filed #747: Tables missing `created_at`/`updated_at` columns

## Test plan

- [ ] Verify typecheck passes (confirmed locally)
- [ ] Run integration tests with DB
- [ ] Verify Recently Read page only shows articles that have been marked read
- [ ] Verify marking an article read moves it to top of Recently Read
- [ ] Verify starring doesn't affect Recently Read ordering
- [ ] Verify mark-all-as-read works from both web UI and GReader API
- [ ] Verify articles read then marked unread still appear in Recently Read

🤖 Generated with [Claude Code](https://claude.com/claude-code)