### PR TITLE
Fix email subscriptions missing from subscription_feeds

### DIFF
--- a/migrations/0065_backfill_subscription_feeds.sql
+++ b/migrations/0065_backfill_subscription_feeds.sql
@@ -1,0 +1,14 @@
+-- Backfill missing subscription_feeds rows.
+--
+-- The email inbound processing (process-inbound.ts) created subscriptions
+-- without inserting into subscription_feeds. Entry queries join through
+-- subscription_feeds, so affected subscriptions showed unread counts in the
+-- sidebar but returned no entries when clicked.
+
+INSERT INTO public.subscription_feeds (subscription_id, feed_id, user_id)
+SELECT s.id, s.feed_id, s.user_id
+FROM public.subscriptions s
+LEFT JOIN public.subscription_feeds sf
+  ON sf.subscription_id = s.id AND sf.feed_id = s.feed_id
+WHERE sf.subscription_id IS NULL
+ON CONFLICT DO NOTHING;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1770648800000,
       "tag": "0064_nullable_read_changed_at",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1770658800000,
+      "tag": "0065_backfill_subscription_feeds",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/email/process-inbound.ts
+++ b/src/server/email/process-inbound.ts
@@ -15,6 +15,7 @@ import {
   feeds,
   entries,
   subscriptions,
+  subscriptionFeeds,
   userEntries,
   ingestAddresses,
   blockedSenders,
@@ -334,6 +335,17 @@ export async function processInboundEmail(email: InboundEmail): Promise<ProcessE
     .returning();
 
   if (upsertedSubscription) {
+    // Ensure subscription_feeds row exists so entry queries can find this
+    // subscription's entries (they join through subscription_feeds)
+    await db
+      .insert(subscriptionFeeds)
+      .values({
+        subscriptionId: upsertedSubscription.id,
+        feedId: feed.id,
+        userId,
+      })
+      .onConflictDoNothing();
+
     const isNewSubscription = upsertedSubscription.id === subscriptionId;
     logger.info(isNewSubscription ? "Created subscription" : "Reactivated subscription", {
       subscriptionId: upsertedSubscription.id,


### PR DESCRIPTION
Email inbound processing (process-inbound.ts) created subscriptions without inserting into subscription_feeds. Entry queries join through subscription_feeds to find feed IDs, so affected subscriptions showed unread counts in the sidebar but returned no entries when clicked.

Adds the missing insert and a backfill migration for existing data.