### PR TITLE
Fix "0 years ago" display for posts near year boundary

### DIFF
--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -26,7 +26,7 @@ export function formatRelativeTime(date: Date): string {
     return `${diffDays} ${diffDays === 1 ? "day" : "days"} ago`;
   } else if (diffDays < 30) {
     return `${diffWeeks} ${diffWeeks === 1 ? "week" : "weeks"} ago`;
-  } else if (diffMonths < 12) {
+  } else if (diffYears < 1) {
     return `${diffMonths} ${diffMonths === 1 ? "month" : "months"} ago`;
   } else {
     return `${diffYears} ${diffYears === 1 ? "year" : "years"} ago`;

--- a/tests/unit/frontend/format.test.ts
+++ b/tests/unit/frontend/format.test.ts
@@ -91,6 +91,14 @@ describe("formatRelativeTime", () => {
     expect(formatRelativeTime(sixMonthsAgo)).toBe("6 months ago");
   });
 
+  it("returns months for times near the year boundary (360-364 days)", () => {
+    const now = new Date();
+
+    // 362 days: diffMonths=12 but diffYears=0, should show months not "0 years ago"
+    const almostOneYear = new Date(now.getTime() - 362 * 24 * 60 * 60 * 1000);
+    expect(formatRelativeTime(almostOneYear)).toBe("12 months ago");
+  });
+
   it("returns years for times 1+ years ago", () => {
     const now = new Date();
 


### PR DESCRIPTION
## Summary
- Fixed off-by-one gap in `formatRelativeTime()` where posts 360-364 days old showed "0 years ago"
- The months threshold (`diffDays/30 >= 12`) triggered at 360 days but years (`diffDays/365 >= 1`) didn't until 365, leaving a gap where `diffYears=0`
- Changed the months/years boundary from `diffMonths < 12` to `diffYears < 1` so those posts correctly show "12 months ago"

## Test plan
- [x] Added test for the 360-364 day edge case
- [x] All existing format tests pass
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)