### PR TITLE
Keep screen on during active narration

### DIFF
--- a/src/components/narration/useNarration.ts
+++ b/src/components/narration/useNarration.ts
@@ -56,6 +56,7 @@ import {
   splitIntoParagraphs,
   mapPlaybackStatus,
 } from "./useNarrationTypes";
+import { useWakeLock } from "@/lib/hooks/useWakeLock";
 
 // Re-export types for consumers
 export type { UseNarrationConfig, UseNarrationReturn };
@@ -80,6 +81,10 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
   const [state, setState] = useState<NarrationState>(DEFAULT_NARRATION_STATE);
   const [isLoading, setIsLoading] = useState(false);
   const [narrationText, setNarrationText] = useState<string | null>(null);
+
+  // Keep screen on while narration is actively playing or loading
+  useWakeLock(state.status === "playing" || state.status === "loading");
+
   // Defer browser support check until after hydration to avoid SSR mismatch
   // useSyncExternalStore ensures the check runs after hydration without cascading renders
   const isSupported = useSyncExternalStore(

--- a/src/lib/hooks/useWakeLock.ts
+++ b/src/lib/hooks/useWakeLock.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Requests a screen wake lock while `active` is true.
+ * Automatically releases when `active` becomes false or on unmount.
+ * Re-acquires the lock if the page regains visibility while still active.
+ */
+export function useWakeLock(active: boolean): void {
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+
+  useEffect(() => {
+    if (!active || typeof navigator === "undefined" || !("wakeLock" in navigator)) {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function acquire() {
+      if (wakeLockRef.current) {
+        return;
+      }
+
+      try {
+        const sentinel = await navigator.wakeLock.request("screen");
+        if (cancelled) {
+          await sentinel.release();
+          return;
+        }
+        wakeLockRef.current = sentinel;
+        sentinel.addEventListener("release", () => {
+          if (wakeLockRef.current === sentinel) {
+            wakeLockRef.current = null;
+          }
+        });
+      } catch {
+        // Wake lock request can fail (e.g. low battery, background tab)
+      }
+    }
+
+    acquire();
+
+    // Re-acquire when page becomes visible again (wake locks are released on visibility change)
+    function handleVisibilityChange() {
+      if (document.visibilityState === "visible" && !cancelled) {
+        acquire();
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      wakeLockRef.current?.release().catch(() => {});
+      wakeLockRef.current = null;
+    };
+  }, [active]);
+}


### PR DESCRIPTION
## Summary
- Adds a `useWakeLock` hook that uses the Screen Wake Lock API to prevent the screen from turning off
- Integrates it into `useNarration` so the wake lock is active when narration status is `"playing"` or `"loading"`
- Automatically releases the lock when narration is paused, stopped, or the component unmounts
- Re-acquires the lock when the page regains visibility (browsers release wake locks on tab switch)

Closes #760

## Test plan
- [ ] Start narration on a mobile device and verify the screen stays on
- [ ] Pause narration and verify the screen can turn off normally
- [ ] Stop narration and verify the screen can turn off normally
- [ ] Switch tabs during narration, switch back, and verify the wake lock re-acquires
- [ ] Verify no errors on browsers that don't support the Wake Lock API (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)