### PR TITLE
Auto-subscribe new users to announcement feed

### DIFF
--- a/scripts/backfill-announcement-subscriptions.ts
+++ b/scripts/backfill-announcement-subscriptions.ts
@@ -11,14 +11,15 @@
  */
 
 import { drizzle } from "drizzle-orm/node-postgres";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { Pool } from "pg";
 
 import * as schema from "../src/server/db/schema";
+import { announcementFeedConfig } from "../src/server/config/env";
 import { createSubscription } from "../src/server/services/subscriptions";
 
-const ANNOUNCEMENT_FEED_URL =
-  process.env.ANNOUNCEMENT_FEED_URL || "https://announcements.lionreader.com/feed.xml";
+const ANNOUNCEMENT_FEED_URL = announcementFeedConfig.url;
+const BATCH_CONCURRENCY = 10;
 
 const connectionString = process.env.DATABASE_URL;
 if (!connectionString) {
@@ -32,73 +33,72 @@ const db = drizzle(pool, { schema });
 async function main() {
   if (!ANNOUNCEMENT_FEED_URL) {
     console.log("ANNOUNCEMENT_FEED_URL is empty, skipping backfill");
-    process.exit(0);
+    return;
   }
 
   console.log(`Backfilling announcement feed subscriptions for: ${ANNOUNCEMENT_FEED_URL}`);
 
-  // Find the feed record (if it exists)
-  const feedRecord = await db
+  // Find users who have never had a subscription to the announcement feed
+  // (no active subscription AND no unsubscribed record). This query runs
+  // entirely in the database to avoid loading all user IDs into memory.
+  const feedSubquery = db
     .select({ id: schema.feeds.id })
     .from(schema.feeds)
     .where(eq(schema.feeds.url, ANNOUNCEMENT_FEED_URL))
     .limit(1);
 
-  // Get all user IDs
-  const allUsers = await db.select({ id: schema.users.id }).from(schema.users);
-  console.log(`Found ${allUsers.length} total users`);
-
-  // If the feed already exists, find users who have ever had a subscription to it
-  // (active or unsubscribed) so we can skip them
-  const usersWithExistingSubscription = new Set<string>();
-  if (feedRecord.length > 0) {
-    const feedId = feedRecord[0].id;
-
-    // Check subscriptions table directly — includes both active and unsubscribed
-    const existing = await db
-      .select({ userId: schema.subscriptions.userId })
-      .from(schema.subscriptions)
-      .innerJoin(
-        schema.subscriptionFeeds,
-        eq(schema.subscriptionFeeds.subscriptionId, schema.subscriptions.id)
-      )
-      .where(eq(schema.subscriptionFeeds.feedId, feedId));
-
-    for (const row of existing) {
-      usersWithExistingSubscription.add(row.userId);
-    }
-    console.log(
-      `Found ${usersWithExistingSubscription.size} users with existing subscription (active or unsubscribed)`
+  const usersToSubscribe = await db
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(
+      sql`NOT EXISTS (
+        SELECT 1 FROM ${schema.subscriptions}
+        INNER JOIN ${schema.subscriptionFeeds}
+          ON ${schema.subscriptionFeeds.subscriptionId} = ${schema.subscriptions.id}
+        WHERE ${schema.subscriptions.userId} = ${schema.users.id}
+          AND ${schema.subscriptionFeeds.feedId} IN (${feedSubquery})
+      )`
     );
-  }
 
-  // Subscribe users who don't have any subscription record
-  const usersToSubscribe = allUsers.filter((u) => !usersWithExistingSubscription.has(u.id));
-  console.log(`Subscribing ${usersToSubscribe.length} users...`);
+  console.log(`Found ${usersToSubscribe.length} users to subscribe`);
 
   let succeeded = 0;
   let failed = 0;
 
-  for (const user of usersToSubscribe) {
-    try {
-      await createSubscription(db as typeof import("../src/server/db").db, user.id, {
-        url: ANNOUNCEMENT_FEED_URL,
-      });
-      succeeded++;
-      if (succeeded % 100 === 0) {
-        console.log(`  Progress: ${succeeded}/${usersToSubscribe.length}`);
+  // Process in parallel batches for performance
+  for (let i = 0; i < usersToSubscribe.length; i += BATCH_CONCURRENCY) {
+    const batch = usersToSubscribe.slice(i, i + BATCH_CONCURRENCY);
+    const results = await Promise.allSettled(
+      batch.map((user) =>
+        createSubscription(db as typeof import("../src/server/db").db, user.id, {
+          url: ANNOUNCEMENT_FEED_URL,
+        })
+      )
+    );
+
+    for (let j = 0; j < results.length; j++) {
+      const result = results[j];
+      if (result.status === "fulfilled") {
+        succeeded++;
+      } else {
+        failed++;
+        console.error(`  Failed for user ${batch[j].id}:`, result.reason);
       }
-    } catch (err) {
-      failed++;
-      console.error(`  Failed for user ${user.id}:`, err);
+    }
+
+    if ((i + BATCH_CONCURRENCY) % 100 < BATCH_CONCURRENCY) {
+      console.log(
+        `  Progress: ${Math.min(i + BATCH_CONCURRENCY, usersToSubscribe.length)}/${usersToSubscribe.length}`
+      );
     }
   }
 
   console.log(`Done! Succeeded: ${succeeded}, Failed: ${failed}`);
-  await pool.end();
 }
 
-main().catch((err) => {
-  console.error("Backfill failed:", err);
-  process.exit(1);
-});
+main()
+  .catch((err) => {
+    console.error("Backfill failed:", err);
+    process.exit(1);
+  })
+  .finally(() => pool.end());

--- a/src/server/auth/oauth/callback-helpers.ts
+++ b/src/server/auth/oauth/callback-helpers.ts
@@ -11,7 +11,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createSession } from "@/server/auth/session";
 import { db } from "@/server/db";
-import { subscribeToAnnouncementFeed } from "@/server/auth/signup";
 
 // ============================================================================
 // Types
@@ -134,11 +133,6 @@ export async function createSessionResponse(
     userAgent,
     ipAddress,
   });
-
-  // Auto-subscribe new users to announcement feed (fire-and-forget)
-  if (options?.isNewUser) {
-    void subscribeToAnnouncementFeed(db, userId);
-  }
 
   // New users need to complete signup confirmation first
   const redirectTo = options?.isNewUser ? "/complete-signup" : "/all";

--- a/src/server/auth/oauth/callback.ts
+++ b/src/server/auth/oauth/callback.ts
@@ -15,7 +15,7 @@ import { eq, and } from "drizzle-orm";
 import { db, type Database } from "@/server/db";
 import { users, oauthAccounts } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
-import { createUser } from "@/server/auth/signup";
+import { createUser, subscribeToAnnouncementFeed } from "@/server/auth/signup";
 
 /**
  * OAuth provider type
@@ -212,6 +212,9 @@ export async function processOAuthCallback(
 
     return user;
   });
+
+  // Auto-subscribe new OAuth users to announcement feed (fire-and-forget)
+  void subscribeToAnnouncementFeed(db, newUser.userId);
 
   return {
     userId: newUser.userId,

--- a/src/server/config/env.ts
+++ b/src/server/config/env.ts
@@ -151,7 +151,7 @@ export const githubConfig = {
  */
 export const announcementFeedConfig = {
   /** URL of the announcement feed. Set to empty string to disable. */
-  url: process.env.ANNOUNCEMENT_FEED_URL || "https://announcements.lionreader.com/feed.xml",
+  url: process.env.ANNOUNCEMENT_FEED_URL ?? "https://announcements.lionreader.com/feed.xml",
 };
 
 /**

--- a/src/server/trpc/routers/auth.ts
+++ b/src/server/trpc/routers/auth.ts
@@ -17,7 +17,6 @@ import {
   expensiveProtectedProcedure,
 } from "../trpc";
 import { errors } from "../errors";
-import type { Database } from "@/server/db";
 import { users, oauthAccounts } from "@/server/db/schema";
 import { signupConfig, ALL_SIGNUP_PROVIDERS } from "@/server/config/env";
 import { generateUuidv7 } from "@/lib/uuidv7";
@@ -149,11 +148,6 @@ async function handleOAuthCallback(
     userAgent,
     ipAddress,
   });
-
-  // Auto-subscribe new OAuth users to announcement feed (fire-and-forget)
-  if (oauthResult.isNewUser) {
-    void subscribeToAnnouncementFeed(db as Database, oauthResult.userId);
-  }
 
   return {
     user: {


### PR DESCRIPTION
## Summary

Closes #758

- Auto-subscribes every new user to a configurable announcement feed (`ANNOUNCEMENT_FEED_URL`, defaults to `https://announcements.lionreader.com/feed.xml`)
- Runs async (fire-and-forget) during signup — errors are caught, logged, and sent to Sentry without interfering with the signup flow
- Hooks into all signup paths: email/password registration, tRPC OAuth callbacks, and route-handler OAuth callbacks
- Includes a backfill script (`scripts/backfill-announcement-subscriptions.ts`) that subscribes existing users while respecting prior unsubscribes

## Changes

- `src/server/config/env.ts` — New `announcementFeedConfig` with `ANNOUNCEMENT_FEED_URL` env var
- `src/server/auth/signup.ts` — New `subscribeToAnnouncementFeed()` helper (async, error-safe)
- `src/server/trpc/routers/auth.ts` — Call on email registration + OAuth via `handleOAuthCallback`
- `src/server/auth/oauth/callback-helpers.ts` — Call on route-handler OAuth via `createSessionResponse`
- `scripts/backfill-announcement-subscriptions.ts` — Backfill script for existing users

## Test plan

- [ ] Register a new user via email/password — verify announcement feed subscription appears
- [ ] Register a new user via OAuth — verify announcement feed subscription appears
- [ ] Set `ANNOUNCEMENT_FEED_URL=""` — verify no subscription is created
- [ ] Run backfill script — verify all users get subscribed
- [ ] Unsubscribe a user, run backfill again — verify they are NOT re-subscribed
- [ ] Verify signup still succeeds if announcement feed URL is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)