### PR TITLE
Replace localStorage admin token with httpOnly cookie session

### DIFF
--- a/src/app/api/admin/session/route.ts
+++ b/src/app/api/admin/session/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  ADMIN_COOKIE_NAME,
+  ADMIN_SESSION_TTL_SECONDS,
+  createAdminSessionToken,
+  validateAdminSecret,
+  validateAdminSessionToken,
+} from "@/server/auth/admin-session";
+import { signupConfig } from "@/server/config/env";
+import {
+  checkRateLimit,
+  getClientIdentifier,
+  getRateLimitHeaders,
+  RATE_LIMIT_CONFIGS,
+} from "@/server/rate-limit";
+
+/**
+ * POST /api/admin/session - Exchange admin secret for an httpOnly session cookie.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!signupConfig.allowlistSecret) {
+    return NextResponse.json({ error: "Admin not configured" }, { status: 404 });
+  }
+
+  // Rate limit by IP using the "expensive" tier (same as login/register)
+  const identifier = getClientIdentifier(null, request.headers);
+  const rateLimitResult = await checkRateLimit(identifier, "expensive");
+  if (!rateLimitResult.allowed) {
+    return NextResponse.json(
+      { error: "Too many attempts, please try again later" },
+      { status: 429, headers: getRateLimitHeaders(rateLimitResult, RATE_LIMIT_CONFIGS.expensive) }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object" || !("secret" in body) || typeof body.secret !== "string") {
+    return NextResponse.json({ error: "Missing secret" }, { status: 400 });
+  }
+
+  if (!validateAdminSecret(body.secret)) {
+    return NextResponse.json({ error: "Invalid admin secret" }, { status: 401 });
+  }
+
+  const token = createAdminSessionToken();
+  const isProduction = process.env.NODE_ENV === "production";
+
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(ADMIN_COOKIE_NAME, token, {
+    path: "/",
+    maxAge: ADMIN_SESSION_TTL_SECONDS,
+    sameSite: "lax",
+    httpOnly: true,
+    secure: isProduction,
+  });
+
+  return response;
+}
+
+/**
+ * DELETE /api/admin/session - Clear admin session cookie.
+ */
+export async function DELETE(): Promise<NextResponse> {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(ADMIN_COOKIE_NAME, "", {
+    path: "/",
+    maxAge: 0,
+    httpOnly: true,
+  });
+  return response;
+}
+
+/**
+ * GET /api/admin/session - Check if current admin session is valid.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const token = request.cookies.get(ADMIN_COOKIE_NAME)?.value;
+  if (token && validateAdminSessionToken(token)) {
+    return NextResponse.json({ authenticated: true });
+  }
+  return NextResponse.json({ authenticated: false }, { status: 401 });
+}

--- a/src/components/admin/AdminApp.tsx
+++ b/src/components/admin/AdminApp.tsx
@@ -2,8 +2,8 @@
  * AdminApp Component
  *
  * Main admin application component that handles:
- * - Admin token authentication via localStorage
- * - Login form when no token is present
+ * - Admin authentication via httpOnly cookie session
+ * - Login form when no session is present
  * - Tab navigation between admin sections (Invites, Feed Health, Users)
  * - Wrapping authenticated content in AdminTRPCProvider
  *
@@ -25,8 +25,6 @@ import AdminInvitesContent from "@/components/admin/AdminInvitesContent";
 import AdminFeedsContent from "@/components/admin/AdminFeedsContent";
 import AdminUsersContent from "@/components/admin/AdminUsersContent";
 
-const ADMIN_TOKEN_KEY = "lion-reader-admin-token";
-
 const adminTabs = [
   { href: "/admin/overview", label: "Overview" },
   { href: "/admin/invites", label: "Invites" },
@@ -34,35 +32,11 @@ const adminTabs = [
   { href: "/admin/users", label: "Users" },
 ];
 
-function getStoredToken(): string | null {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem(ADMIN_TOKEN_KEY);
-}
-
-/**
- * Validates an admin token by making a lightweight API call.
- * Returns true if the token is valid, false otherwise.
- */
-async function validateAdminToken(token: string): Promise<boolean> {
-  try {
-    const res = await fetch(
-      "/api/trpc/admin.listInvites?input=" +
-        encodeURIComponent(JSON.stringify({ json: { limit: 1 } })),
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      }
-    );
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Login form for admin authentication.
- * Validates the token against the server before accepting it.
+ * Exchanges the admin secret for an httpOnly session cookie via the server.
  */
-function AdminLoginForm({ onLogin }: { onLogin: (token: string) => void }) {
+function AdminLoginForm({ onLogin }: { onLogin: () => void }) {
   const [secret, setSecret] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isValidating, setIsValidating] = useState(false);
@@ -78,16 +52,24 @@ function AdminLoginForm({ onLogin }: { onLogin: (token: string) => void }) {
       setError(null);
       setIsValidating(true);
 
-      const valid = await validateAdminToken(trimmed);
-      setIsValidating(false);
+      try {
+        const res = await fetch("/api/admin/session", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ secret: trimmed }),
+        });
 
-      if (!valid) {
-        setError("Invalid admin secret");
-        return;
+        if (!res.ok) {
+          setError("Invalid admin secret");
+          return;
+        }
+
+        onLogin();
+      } catch {
+        setError("Failed to connect to server");
+      } finally {
+        setIsValidating(false);
       }
-
-      localStorage.setItem(ADMIN_TOKEN_KEY, trimmed);
-      onLogin(trimmed);
     },
     [secret, onLogin]
   );
@@ -205,34 +187,29 @@ interface AdminAppProps {
  * with header, tab navigation, and tRPC provider.
  */
 export function AdminApp({ children }: AdminAppProps) {
-  const [token, setToken] = useState<string | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
-  // Check localStorage and validate stored token on mount.
-  // Start in loading state on both server and client to avoid hydration mismatch,
-  // since localStorage is only available on the client.
+  // Check if there's a valid admin session cookie on mount.
   useEffect(() => {
     void (async () => {
-      const storedToken = getStoredToken();
-      if (storedToken) {
-        const valid = await validateAdminToken(storedToken);
-        if (valid) {
-          setToken(storedToken);
-        } else {
-          localStorage.removeItem(ADMIN_TOKEN_KEY);
-        }
+      try {
+        const res = await fetch("/api/admin/session");
+        setIsAuthenticated(res.ok);
+      } catch {
+        setIsAuthenticated(false);
       }
       setIsLoading(false);
     })();
   }, []);
 
-  const handleLogin = useCallback((newToken: string) => {
-    setToken(newToken);
+  const handleLogin = useCallback(() => {
+    setIsAuthenticated(true);
   }, []);
 
-  const handleLogout = useCallback(() => {
-    localStorage.removeItem(ADMIN_TOKEN_KEY);
-    setToken(null);
+  const handleLogout = useCallback(async () => {
+    await fetch("/api/admin/session", { method: "DELETE" });
+    setIsAuthenticated(false);
   }, []);
 
   if (isLoading) {
@@ -243,12 +220,12 @@ export function AdminApp({ children }: AdminAppProps) {
     );
   }
 
-  if (!token) {
+  if (!isAuthenticated) {
     return <AdminLoginForm onLogin={handleLogin} />;
   }
 
   return (
-    <AdminTRPCProvider token={token}>
+    <AdminTRPCProvider>
       <AdminShell onLogout={handleLogout}>{children}</AdminShell>
     </AdminTRPCProvider>
   );

--- a/src/components/admin/AdminTRPCProvider.tsx
+++ b/src/components/admin/AdminTRPCProvider.tsx
@@ -14,15 +14,14 @@ function getBaseUrl() {
 }
 
 interface AdminTRPCProviderProps {
-  token: string;
   children: ReactNode;
 }
 
 /**
  * tRPC provider for admin pages.
- * Uses Bearer token auth instead of cookie-based session auth.
+ * Uses httpOnly cookie auth (set by /api/admin/session) — cookies are sent automatically.
  */
-export function AdminTRPCProvider({ token, children }: AdminTRPCProviderProps) {
+export function AdminTRPCProvider({ children }: AdminTRPCProviderProps) {
   const [queryClient] = useState(() => new QueryClient());
 
   const [trpcClient] = useState(() =>
@@ -31,11 +30,6 @@ export function AdminTRPCProvider({ token, children }: AdminTRPCProviderProps) {
         httpBatchLink({
           url: `${getBaseUrl()}/api/trpc`,
           transformer: superjson,
-          headers() {
-            return {
-              Authorization: `Bearer ${token}`,
-            };
-          },
         }),
       ],
     })

--- a/src/server/auth/admin-session.ts
+++ b/src/server/auth/admin-session.ts
@@ -1,0 +1,66 @@
+import { createHmac, timingSafeEqual, randomBytes } from "crypto";
+import { signupConfig } from "@/server/config/env";
+
+export const ADMIN_COOKIE_NAME = "admin_session";
+export const ADMIN_SESSION_TTL_SECONDS = 24 * 60 * 60; // 24 hours
+
+/**
+ * Creates a signed admin session token.
+ * Format: `<nonce>.<timestamp>.<hmac>` where HMAC signs `<nonce>.<timestamp>`.
+ */
+export function createAdminSessionToken(): string {
+  const secret = signupConfig.allowlistSecret;
+  if (!secret) throw new Error("ALLOWLIST_SECRET not configured");
+
+  const nonce = randomBytes(16).toString("hex");
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const payload = `${nonce}.${timestamp}`;
+  const hmac = createHmac("sha256", secret).update(payload).digest("hex");
+  return `${payload}.${hmac}`;
+}
+
+/**
+ * Validates a signed admin session token.
+ * Checks HMAC signature and TTL.
+ */
+export function validateAdminSessionToken(token: string): boolean {
+  const secret = signupConfig.allowlistSecret;
+  if (!secret) return false;
+
+  const parts = token.split(".");
+  if (parts.length !== 3) return false;
+
+  const [nonce, timestampStr, signature] = parts;
+  if (!nonce || !timestampStr || !signature) return false;
+
+  // Verify HMAC using fixed-length hash comparison
+  const payload = `${nonce}.${timestampStr}`;
+  const expected = createHmac("sha256", secret).update(payload).digest("hex");
+  const expectedHash = createHmac("sha256", "token-validate").update(expected).digest();
+  const signatureHash = createHmac("sha256", "token-validate").update(signature).digest();
+
+  if (!timingSafeEqual(expectedHash, signatureHash)) {
+    return false;
+  }
+
+  // Check TTL (reject future timestamps and expired tokens)
+  const timestamp = parseInt(timestampStr, 10);
+  if (isNaN(timestamp)) return false;
+
+  const now = Math.floor(Date.now() / 1000);
+  const age = now - timestamp;
+  return age >= 0 && age < ADMIN_SESSION_TTL_SECONDS;
+}
+
+/**
+ * Validates the raw admin secret using timing-safe comparison.
+ * Compares HMAC digests to ensure constant-length buffers regardless of input length.
+ */
+export function validateAdminSecret(input: string): boolean {
+  const secret = signupConfig.allowlistSecret;
+  if (!secret) return false;
+
+  const inputHash = createHmac("sha256", "admin-validate").update(input).digest();
+  const secretHash = createHmac("sha256", "admin-validate").update(secret).digest();
+  return timingSafeEqual(inputHash, secretHash);
+}

--- a/src/server/trpc/trpc.ts
+++ b/src/server/trpc/trpc.ts
@@ -18,6 +18,13 @@ import {
   RATE_LIMIT_CONFIGS,
   type RateLimitType,
 } from "@/server/rate-limit";
+import { signupConfig } from "@/server/config/env";
+import { errors } from "./errors";
+import {
+  ADMIN_COOKIE_NAME,
+  validateAdminSessionToken,
+  validateAdminSecret,
+} from "@/server/auth/admin-session";
 import { logger } from "@/lib/logger";
 import * as Sentry from "@sentry/nextjs";
 
@@ -354,43 +361,46 @@ export const expensiveConfirmedProtectedProcedure = t.procedure
 // Admin Procedures (protected by ALLOWLIST_SECRET)
 // ============================================================================
 
-import { signupConfig } from "@/server/config/env";
-import { errors } from "./errors";
-
 /**
- * Middleware that enforces admin authentication via Bearer token.
- * Checks Authorization header against ALLOWLIST_SECRET env var.
+ * Middleware that enforces admin authentication.
+ * Accepts either:
+ * 1. An httpOnly `admin_session` cookie (signed HMAC token from /api/admin/session)
+ * 2. A Bearer token matching ALLOWLIST_SECRET (for programmatic API access)
  */
 const adminMiddleware = t.middleware(({ ctx, next }) => {
-  // Check if admin secret is configured
   if (!signupConfig.allowlistSecret) {
     throw errors.adminSecretNotConfigured();
   }
 
-  // Get Authorization header
+  // Check for admin session cookie
+  const cookieHeader = ctx.headers.get("cookie");
+  if (cookieHeader) {
+    const cookies = Object.fromEntries(
+      cookieHeader.split(/;\s*/).map((c) => {
+        const [key, ...value] = c.split("=");
+        return [key, value.join("=")];
+      })
+    );
+    const sessionToken = cookies[ADMIN_COOKIE_NAME];
+    if (sessionToken && validateAdminSessionToken(sessionToken)) {
+      return next({ ctx });
+    }
+  }
+
+  // Fallback: check Bearer token (for programmatic access)
   const authHeader = ctx.headers.get("authorization");
-  if (!authHeader) {
-    throw errors.adminUnauthorized();
+  if (authHeader) {
+    const match = authHeader.match(/^Bearer\s+(.+)$/i);
+    if (match?.[1] && validateAdminSecret(match[1])) {
+      return next({ ctx });
+    }
   }
 
-  // Parse Bearer token
-  const match = authHeader.match(/^Bearer\s+(.+)$/i);
-  if (!match) {
-    throw errors.adminUnauthorized();
-  }
-
-  const token = match[1];
-
-  // Validate token against secret
-  if (token !== signupConfig.allowlistSecret) {
-    throw errors.adminUnauthorized();
-  }
-
-  return next({ ctx });
+  throw errors.adminUnauthorized();
 });
 
 /**
- * Admin procedure - requires ALLOWLIST_SECRET Bearer token.
+ * Admin procedure - requires admin_session cookie or ALLOWLIST_SECRET Bearer token.
  * Used for managing invites and other admin operations.
  */
 export const adminProcedure = t.procedure.use(timingMiddleware).use(adminMiddleware);


### PR DESCRIPTION
## Summary

- Fixes [code scanning alert #12](https://github.com/brendanlong/lion-reader/security/code-scanning/12) (clear text storage of sensitive information)
- The admin panel previously stored the raw `ALLOWLIST_SECRET` in `localStorage`, which is accessible to any JS on the page and persists indefinitely
- Replaced with server-issued httpOnly session cookies: the admin secret is exchanged for an HMAC-signed token via `POST /api/admin/session`, stored in an httpOnly cookie with a 24-hour TTL
- Bearer token auth is preserved in the tRPC middleware for programmatic API access

## Changes

- **New**: `src/server/auth/admin-session.ts` — HMAC token creation/validation utilities with timing-safe comparisons
- **New**: `src/app/api/admin/session/route.ts` — POST (login), DELETE (logout), GET (check session) endpoints
- **Modified**: `src/server/trpc/trpc.ts` — `adminMiddleware` now accepts both cookie auth and Bearer token
- **Modified**: `src/components/admin/AdminApp.tsx` — removed all `localStorage` usage, uses fetch-based auth
- **Modified**: `src/components/admin/AdminTRPCProvider.tsx` — removed `token` prop, relies on cookies sent automatically

## Test plan

- [ ] Admin login flow: enter secret, verify cookie is set (httpOnly, not visible in JS), admin panel loads
- [ ] Admin logout: click logout, verify cookie is cleared, redirected to login form
- [ ] Page refresh: verify session persists across refreshes (cookie sent automatically)
- [ ] Cookie expiry: verify session expires after 24 hours
- [ ] Bearer token: verify programmatic access with `Authorization: Bearer <ALLOWLIST_SECRET>` still works
- [ ] Invalid secret: verify login form shows error, no cookie is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)