### PR TITLE
Improve test quality: remove tautological tests and strengthen assertions

### DIFF
--- a/tests/integration/redirect-tracking.test.ts
+++ b/tests/integration/redirect-tracking.test.ts
@@ -184,7 +184,7 @@ describe("Redirect Tracking", () => {
       const timeSinceFirstSeen = Date.now() - feed.redirectFirstSeenAt!.getTime();
 
       // Should not have exceeded the 7-day wait period
-      expect(timeSinceFirstSeen < REDIRECT_WAIT_PERIOD_MS).toBe(true);
+      expect(timeSinceFirstSeen).toBeLessThan(REDIRECT_WAIT_PERIOD_MS);
     });
 
     it("identifies when wait period has passed", async () => {
@@ -204,7 +204,7 @@ describe("Redirect Tracking", () => {
       const timeSinceFirstSeen = Date.now() - feed.redirectFirstSeenAt!.getTime();
 
       // Should have exceeded the 7-day wait period
-      expect(timeSinceFirstSeen >= REDIRECT_WAIT_PERIOD_MS).toBe(true);
+      expect(timeSinceFirstSeen).toBeGreaterThanOrEqual(REDIRECT_WAIT_PERIOD_MS);
     });
   });
 
@@ -496,12 +496,6 @@ describe("Redirect Tracking", () => {
       // The timestamp should be reset (approximately now)
       const timeSinceFirstSeen = Date.now() - feed.redirectFirstSeenAt!.getTime();
       expect(timeSinceFirstSeen).toBeLessThan(1000); // Less than 1 second ago
-    });
-  });
-
-  describe("REDIRECT_WAIT_PERIOD_MS constant", () => {
-    it("is 7 days in milliseconds", () => {
-      expect(REDIRECT_WAIT_PERIOD_MS).toBe(7 * 24 * 60 * 60 * 1000);
     });
   });
 });

--- a/tests/unit/google-reader-id.test.ts
+++ b/tests/unit/google-reader-id.test.ts
@@ -21,12 +21,10 @@ import {
 } from "../../src/server/google-reader/streams";
 
 describe("uuidToInt64", () => {
-  it("produces a positive 63-bit integer", () => {
+  it("produces the expected 63-bit integer", () => {
     const uuid = "0191a2b3-c4d5-7e6f-8a9b-0c1d2e3f4a5b";
     const result = uuidToInt64(uuid);
-    expect(result).toBeGreaterThan(BigInt(0));
-    // 63-bit max is 2^63 - 1
-    expect(result).toBeLessThan(BigInt(2) ** BigInt(63));
+    expect(result).toBe(BigInt("56525179323085689"));
   });
 
   it("is deterministic — same UUID produces same int64", () => {
@@ -40,9 +38,8 @@ describe("uuidToInt64", () => {
     // These UUIDs differ in rand_a (byte 7) which is within the 15 extracted random bits
     const uuid1 = "0191a2b3-c4d5-7e6f-8a9b-0c1d2e3f4a5b";
     const uuid2 = "0191a2b3-c4d5-7e7f-8a9b-0c1d2e3f4a5b";
-    const result1 = uuidToInt64(uuid1);
-    const result2 = uuidToInt64(uuid2);
-    expect(result1).not.toBe(result2);
+    expect(uuidToInt64(uuid1)).toBe(BigInt("56525179323085689"));
+    expect(uuidToInt64(uuid2)).toBe(BigInt("56525179323085817"));
   });
 
   it("UUIDs differing only in non-extracted bits may collide (known limitation)", () => {
@@ -63,9 +60,8 @@ describe("uuidToInt64", () => {
     const uuid1 = "01000000-0000-7000-8000-000000000000";
     // UUID with later timestamp
     const uuid2 = "02000000-0000-7000-8000-000000000000";
-    const result1 = uuidToInt64(uuid1);
-    const result2 = uuidToInt64(uuid2);
-    expect(result2).toBeGreaterThan(result1);
+    expect(uuidToInt64(uuid1)).toBe(BigInt("36028797018963968"));
+    expect(uuidToInt64(uuid2)).toBe(BigInt("72057594037927936"));
   });
 });
 
@@ -150,10 +146,9 @@ describe("parseItemId", () => {
 
 describe("subscriptionToStreamId", () => {
   it("formats as feed/{int64}", () => {
-    // A UUID that converts to some int64
     const uuid = "0191a2b3-c4d5-7e6f-8a9b-0c1d2e3f4a5b";
     const result = subscriptionToStreamId(uuid);
-    expect(result).toMatch(/^feed\/\d+$/);
+    expect(result).toBe("feed/56525179323085689");
   });
 });
 

--- a/tests/unit/narration-highlight.test.ts
+++ b/tests/unit/narration-highlight.test.ts
@@ -83,16 +83,14 @@ describe("computeHighlightedParagraphs", () => {
 
   describe("realistic scenarios", () => {
     it("handles sequential playback through article", () => {
-      // Simulate playing through paragraphs 0-4
-      const playSequence = [0, 1, 2, 3, 4];
-
-      playSequence.forEach((index) => {
-        expect(computeHighlightedParagraphs(index, true)).toEqual(new Set([index]));
-      });
+      expect(computeHighlightedParagraphs(0, true)).toEqual(new Set([0]));
+      expect(computeHighlightedParagraphs(1, true)).toEqual(new Set([1]));
+      expect(computeHighlightedParagraphs(2, true)).toEqual(new Set([2]));
+      expect(computeHighlightedParagraphs(3, true)).toEqual(new Set([3]));
+      expect(computeHighlightedParagraphs(4, true)).toEqual(new Set([4]));
     });
 
     it("handles skipping to a later paragraph", () => {
-      // User skips from paragraph 0 to paragraph 10
       expect(computeHighlightedParagraphs(0, true)).toEqual(new Set([0]));
       expect(computeHighlightedParagraphs(10, true)).toEqual(new Set([10]));
     });

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -27,22 +27,6 @@ function createBucketState(overrides: Partial<BucketState> = {}): BucketState {
   };
 }
 
-describe("RATE_LIMIT_CONFIGS", () => {
-  it("has default config with 100 capacity and 10/sec refill", () => {
-    expect(RATE_LIMIT_CONFIGS.default).toEqual({
-      capacity: 100,
-      refillRate: 10,
-    });
-  });
-
-  it("has expensive config with 10 capacity and 1/sec refill", () => {
-    expect(RATE_LIMIT_CONFIGS.expensive).toEqual({
-      capacity: 10,
-      refillRate: 1,
-    });
-  });
-});
-
 describe("calculateTokensToAdd", () => {
   it("calculates correct tokens for 1 second", () => {
     expect(calculateTokensToAdd(1000, 10)).toBe(10);

--- a/tests/unit/redirect-tracking.test.ts
+++ b/tests/unit/redirect-tracking.test.ts
@@ -3,11 +3,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import {
-  findPermanentRedirectUrl,
-  isHttpToHttpsUpgrade,
-  REDIRECT_WAIT_PERIOD_MS,
-} from "@/server/feed/redirect-utils";
+import { findPermanentRedirectUrl, isHttpToHttpsUpgrade } from "@/server/feed/redirect-utils";
 import type { RedirectInfo } from "@/server/feed/fetcher";
 
 describe("findPermanentRedirectUrl", () => {
@@ -147,12 +143,5 @@ describe("isHttpToHttpsUpgrade", () => {
     expect(
       isHttpToHttpsUpgrade("http://www.example.com/feed.xml", "https://example.com/feed.xml")
     ).toBe(false);
-  });
-});
-
-describe("REDIRECT_WAIT_PERIOD_MS", () => {
-  it("equals 7 days in milliseconds", () => {
-    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
-    expect(REDIRECT_WAIT_PERIOD_MS).toBe(sevenDaysMs);
   });
 });

--- a/tests/unit/sentence-splitter.test.ts
+++ b/tests/unit/sentence-splitter.test.ts
@@ -39,11 +39,11 @@ describe("splitIntoSentences", () => {
     const text = 'He said "This is a pen. I like it." Then he left.';
     const sentences = splitIntoSentences(text);
 
-    // sentence-splitter may keep the entire text as one sentence when
-    // the closing quote comes at the end without a period after "left"
-    // This is acceptable behavior - the key is that it doesn't break
-    expect(sentences.length).toBeGreaterThanOrEqual(1);
-    expect(sentences[0]).toContain("He said");
+    // sentence-splitter may keep the entire quoted text as one sentence or split it.
+    // Verify that all the original text is preserved across the sentences.
+    const rejoined = sentences.join(" ");
+    expect(rejoined).toContain("He said");
+    expect(rejoined).toContain("Then he left.");
   });
 
   it("returns the original text for text without sentence-ending punctuation", () => {
@@ -63,8 +63,10 @@ describe("splitIntoSentences", () => {
     const text = "What?! Really?! Yes!!!";
     const sentences = splitIntoSentences(text);
 
-    expect(sentences.length).toBeGreaterThan(0);
-    // The exact splitting depends on the library's behavior
+    // Verify all text is preserved across sentences
+    const rejoined = sentences.join(" ");
+    expect(rejoined).toContain("What?!");
+    expect(rejoined).toContain("Yes!!!");
   });
 
   it("handles newlines within a paragraph", () => {

--- a/tests/unit/tts-provider-factory.test.ts
+++ b/tests/unit/tts-provider-factory.test.ts
@@ -114,7 +114,8 @@ describe("createTTSProvider", () => {
         settings: { provider: "browser" },
       });
 
-      expect(typeof result.primaryAvailable).toBe("boolean");
+      // Browser speechSynthesis is mocked as available in the test setup
+      expect(result.primaryAvailable).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Remove tests that just verify constants equal themselves (`RATE_LIMIT_CONFIGS`, `REDIRECT_WAIT_PERIOD_MS`) — these can never catch bugs
- Hardcode expected values in `uuidToInt64` tests instead of only checking value ranges, so conversion bugs would actually be caught
- Replace trivially-true assertions (`length >= 1`, `typeof x === "boolean"`) with meaningful checks
- Use proper matchers (`toBeLessThan`/`toBeGreaterThanOrEqual`) instead of `expect(boolExpr).toBe(true)` for better error messages
- Unroll loop-based assertions in narration-highlight that constructed expected values from the loop variable

## Test plan
- [x] All 257 affected unit tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)