### PR TITLE
Fix markdown frontmatter not parsed when values contain colons

### DIFF
--- a/src/server/markdown/index.ts
+++ b/src/server/markdown/index.ts
@@ -53,38 +53,86 @@ export function extractFrontmatter(markdown: string): FrontmatterResult {
   const yamlContent = match[1];
   const contentWithoutFrontmatter = markdown.slice(match[0].length);
 
+  // Try strict YAML parsing first
   try {
     const parsed = parseYaml(yamlContent);
 
     // Ensure we got an object
-    if (typeof parsed !== "object" || parsed === null) {
-      return { frontmatter: null, content: markdown };
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return {
+        frontmatter: buildFrontmatter(parsed as Record<string, unknown>),
+        content: contentWithoutFrontmatter,
+      };
     }
-
-    const frontmatter: Frontmatter = {
-      raw: parsed as Record<string, unknown>,
-    };
-
-    // Extract title if present and is a string
-    if (typeof parsed.title === "string" && parsed.title.trim()) {
-      frontmatter.title = parsed.title.trim();
-    }
-
-    // Extract description if present and is a string
-    if (typeof parsed.description === "string" && parsed.description.trim()) {
-      frontmatter.description = parsed.description.trim();
-    }
-
-    // Extract author if present and is a string
-    if (typeof parsed.author === "string" && parsed.author.trim()) {
-      frontmatter.author = parsed.author.trim();
-    }
-
-    return { frontmatter, content: contentWithoutFrontmatter };
   } catch {
-    // YAML parsing failed, treat as no frontmatter
-    return { frontmatter: null, content: markdown };
+    // Strict YAML failed (e.g. unquoted colons in values), try lenient parsing
   }
+
+  // Lenient fallback: parse simple "key: value" lines.
+  // Handles common frontmatter that isn't strictly valid YAML,
+  // e.g. "title: Parcae: Doing more..." where the colon in the value
+  // causes a YAML nested mapping error.
+  const lenient = parseFrontmatterLenient(yamlContent);
+  if (lenient) {
+    return { frontmatter: buildFrontmatter(lenient), content: contentWithoutFrontmatter };
+  }
+
+  // Even if we can't parse the frontmatter, still strip it from content
+  return { frontmatter: null, content: contentWithoutFrontmatter };
+}
+
+/**
+ * Builds a Frontmatter object from a parsed key-value record.
+ */
+function buildFrontmatter(raw: Record<string, unknown>): Frontmatter {
+  const frontmatter: Frontmatter = { raw };
+
+  if (typeof raw.title === "string" && raw.title.trim()) {
+    frontmatter.title = raw.title.trim();
+  }
+
+  if (typeof raw.description === "string" && raw.description.trim()) {
+    frontmatter.description = raw.description.trim();
+  }
+
+  if (typeof raw.author === "string" && raw.author.trim()) {
+    frontmatter.author = raw.author.trim();
+  }
+
+  return frontmatter;
+}
+
+/**
+ * Lenient frontmatter parser for when strict YAML parsing fails.
+ *
+ * Parses simple single-line "key: value" pairs, taking everything after
+ * the first colon as the value. This handles common cases like unquoted
+ * colons in values (e.g. "title: Parcae: Doing more...").
+ *
+ * Does not handle multi-line values, nested objects, or arrays.
+ */
+function parseFrontmatterLenient(yaml: string): Record<string, string> | null {
+  const result: Record<string, string> = {};
+
+  for (const line of yaml.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const colonIndex = trimmed.indexOf(":");
+    if (colonIndex <= 0) return null; // Not a key: value line
+
+    const key = trimmed.slice(0, colonIndex).trim();
+    const value = trimmed.slice(colonIndex + 1).trim();
+
+    // Keys must be simple identifiers
+    if (!/^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(key)) return null;
+
+    if (key && value) {
+      result[key] = value;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
 }
 
 /**

--- a/tests/unit/markdown.test.ts
+++ b/tests/unit/markdown.test.ts
@@ -116,20 +116,58 @@ A serverless platform for building, deploying, and scaling apps.`;
     );
   });
 
-  it("ignores invalid YAML in frontmatter", () => {
+  it("handles unquoted colons in values via lenient fallback", () => {
     const markdown = `---
-title: [invalid yaml
-description: missing closing bracket
+description: A model that does X
+title: Parcae: Doing more with fewer parameters
+image: https://example.com/image.jpg
+---
+
+Content here.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.title).toBe("Parcae: Doing more with fewer parameters");
+    expect(result.frontmatter?.description).toBe("A model that does X");
+    expect(result.content).toBe("\nContent here.");
+  });
+
+  it("handles unquoted colons with CRLF line endings via lenient fallback", () => {
+    const markdown =
+      "---\r\ntitle: Parcae: Doing more\r\ndescription: A summary\r\n---\r\n\r\nContent.";
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.title).toBe("Parcae: Doing more");
+    expect(result.frontmatter?.description).toBe("A summary");
+  });
+
+  it("strips YAML array frontmatter from content", () => {
+    const markdown = `---
+- item1
+- item2
 ---
 
 Content here.`;
 
     const result = extractFrontmatter(markdown);
     expect(result.frontmatter).toBeNull();
-    expect(result.content).toBe(markdown);
+    expect(result.content).toBe("\nContent here.");
   });
 
-  it("ignores non-object YAML frontmatter", () => {
+  it("strips frontmatter from content even when YAML is completely invalid", () => {
+    const markdown = `---
+not: valid: yaml: here
+also not valid
+---
+
+Content here.`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter).toBeNull();
+    // Frontmatter block is still stripped from content
+    expect(result.content).toBe("\nContent here.");
+  });
+
+  it("strips frontmatter from content for non-object YAML", () => {
     const markdown = `---
 just a string value
 ---
@@ -138,7 +176,8 @@ Content here.`;
 
     const result = extractFrontmatter(markdown);
     expect(result.frontmatter).toBeNull();
-    expect(result.content).toBe(markdown);
+    // Frontmatter block is still stripped
+    expect(result.content).toBe("\nContent here.");
   });
 
   it("requires frontmatter at document start", () => {
@@ -344,5 +383,22 @@ The full content of the article.`;
     expect(result.summary).toBe("A brief summary.");
     expect(result.author).toBe("Jane Smith");
     expect(result.html).toContain("full content");
+  });
+
+  it("handles frontmatter with unquoted colons in values (#818)", async () => {
+    const markdown = `---
+description: A model that matches quality
+title: Parcae: Doing more with fewer parameters
+image: https://example.com/image.jpg
+---
+
+This paper introduces Parcae.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.title).toBe("Parcae: Doing more with fewer parameters");
+    expect(result.summary).toBe("A model that matches quality");
+    expect(result.html).not.toContain("description:");
+    expect(result.html).not.toContain("image:");
+    expect(result.html).toContain("Parcae");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #818.

- When a server returns `text/markdown` with YAML frontmatter containing unquoted colons in values (e.g. `title: Parcae: Doing more with fewer parameters`), the YAML parser throws a "nested mapping" error
- Previously this caused the entire frontmatter block (including `---` delimiters) to remain in the content, rendering as visible text like `description: ...`, `title: ...`, `image: ...`
- Added a lenient fallback parser that handles simple `key: value` lines by splitting on the first colon
- Also changed behavior to always strip the frontmatter block from content even when parsing completely fails (previously the raw frontmatter was left in)

## Root cause

The Together.ai blog supports content negotiation — when Lion Reader sends `Accept: text/markdown` (which it prefers), the server returns markdown with YAML frontmatter. The `title` field contains an unquoted colon (`Parcae: Doing more...`), which is invalid YAML. The strict YAML parser threw an error, and the catch block returned the original markdown with frontmatter still included.

## Test plan

- [x] Added unit test for unquoted colons in frontmatter values
- [x] Added unit test for completely invalid YAML (frontmatter still stripped from content)
- [x] Updated existing tests for the new "always strip frontmatter" behavior
- [x] All 29 markdown tests pass
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)