### PR TITLE
Fix bugs found in multi-pass code review

### DIFF
--- a/src/app/extension/save/page.tsx
+++ b/src/app/extension/save/page.tsx
@@ -135,7 +135,7 @@ export default async function ExtensionSavePage({ searchParams }: PageProps) {
   }
 
   // Create an API token for the extension
-  const token = await createApiToken(
+  const { token } = await createApiToken(
     session.user.id,
     [API_TOKEN_SCOPES.SAVED_WRITE],
     "Browser Extension"

--- a/src/components/entries/StickyEntryControls.tsx
+++ b/src/components/entries/StickyEntryControls.tsx
@@ -67,7 +67,7 @@ export function StickyEntryControls({
         {/* Star button */}
         <button
           onClick={onToggleStar}
-          className={`flex min-h-[36px] min-w-[36px] items-center justify-center rounded-full transition-colors ${
+          className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full transition-colors ${
             starred
               ? "text-amber-500 hover:bg-amber-50 dark:hover:bg-amber-950"
               : "text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
@@ -83,7 +83,7 @@ export function StickyEntryControls({
         {/* Read/unread button */}
         <button
           onClick={onToggleRead}
-          className={`flex min-h-[36px] min-w-[36px] items-center justify-center rounded-full transition-colors ${
+          className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full transition-colors ${
             !read
               ? "text-accent hover:bg-accent-subtle"
               : "text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -73,6 +73,40 @@ export function Dialog({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
 
+  // Focus trap: keep focus within the dialog
+  useEffect(() => {
+    if (!isOpen) return;
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const focusableSelector =
+      'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+    // Focus the first focusable element on open
+    const focusableElements = dialog.querySelectorAll<HTMLElement>(focusableSelector);
+    focusableElements[0]?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const currentFocusable = dialog.querySelectorAll<HTMLElement>(focusableSelector);
+      if (currentFocusable.length === 0) return;
+
+      const first = currentFocusable[0];
+      const last = currentFocusable[currentFocusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
   // Prevent body scroll when dialog is open
   useEffect(() => {
     if (isOpen) {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -73,11 +73,13 @@ export function Dialog({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
 
-  // Focus trap: keep focus within the dialog
+  // Focus trap: keep focus within the dialog, restore focus on close
   useEffect(() => {
     if (!isOpen) return;
     const dialog = dialogRef.current;
     if (!dialog) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
 
     const focusableSelector =
       'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -104,7 +106,10 @@ export function Dialog({
     };
 
     document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocused?.focus();
+    };
   }, [isOpen]);
 
   // Prevent body scroll when dialog is open

--- a/src/server/auth/api-token.ts
+++ b/src/server/auth/api-token.ts
@@ -87,11 +87,12 @@ export async function createApiToken(
   scopes: ApiTokenScope[],
   name?: string,
   expiresAt?: Date
-): Promise<string> {
+): Promise<{ token: string; id: string }> {
   const { token, tokenHash } = generateApiToken();
+  const id = generateUuidv7();
 
   await db.insert(apiTokens).values({
-    id: generateUuidv7(),
+    id,
     userId,
     tokenHash,
     scopes,
@@ -99,7 +100,7 @@ export async function createApiToken(
     expiresAt,
   });
 
-  return token;
+  return { token, id };
 }
 
 // ============================================================================

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -64,7 +64,7 @@ interface CachedSession {
   userCreatedAt: string;
   userUpdatedAt: string;
   userEmailVerifiedAt: string | null;
-  userPasswordHash: string | null;
+  userPasswordHash?: string | null; // deprecated: no longer cached but kept for compat with old cache entries
   userInviteId: string | null;
   userShowSpam: boolean;
   userAlgorithmicFeedEnabled: boolean;
@@ -209,7 +209,6 @@ function serializeForCache(data: SessionData): string {
     userCreatedAt: data.user.createdAt.toISOString(),
     userUpdatedAt: data.user.updatedAt.toISOString(),
     userEmailVerifiedAt: data.user.emailVerifiedAt?.toISOString() ?? null,
-    userPasswordHash: data.user.passwordHash,
     userInviteId: data.user.inviteId ?? null,
     userShowSpam: data.user.showSpam,
     userAlgorithmicFeedEnabled: data.user.algorithmicFeedEnabled,
@@ -250,7 +249,7 @@ function deserializeFromCache(data: string): SessionData {
       createdAt: new Date(cached.userCreatedAt),
       updatedAt: new Date(cached.userUpdatedAt),
       emailVerifiedAt: cached.userEmailVerifiedAt ? new Date(cached.userEmailVerifiedAt) : null,
-      passwordHash: cached.userPasswordHash,
+      passwordHash: null, // Not cached in Redis for security; query DB when needed
       inviteId: cached.userInviteId ?? null,
       showSpam: cached.userShowSpam ?? false,
       algorithmicFeedEnabled: cached.userAlgorithmicFeedEnabled ?? true,

--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -134,11 +134,17 @@ async function fetchFullContentForNewEntries(
       const now = new Date();
 
       if (result.success) {
+        const fullContentForHash = result.contentCleaned ?? result.contentOriginal ?? "";
+        const fullContentHash = fullContentForHash
+          ? createHash("sha256").update(fullContentForHash, "utf8").digest("hex")
+          : null;
+
         await db
           .update(entries)
           .set({
             fullContentOriginal: result.contentOriginal ?? null,
             fullContentCleaned: result.contentCleaned ?? null,
+            fullContentHash,
             fullContentFetchedAt: now,
             fullContentError: null,
             updatedAt: now,

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -10,7 +10,6 @@ import {
   desc,
   asc,
   inArray,
-  notInArray,
   sql,
   isNull,
   isNotNull,
@@ -953,21 +952,18 @@ export async function markAllEntriesRead(
     conditions.push(inArray(userEntries.entryId, taggedEntryIdsSubquery));
   }
 
-  // Filter by uncategorized (no tags)
+  // Filter by uncategorized (no tags) - use LEFT JOIN anti-join to avoid scanning all subscription_tags
   if (params.uncategorized) {
-    const taggedSubscriptionIdsSubquery = db
-      .select({ subscriptionId: subscriptionTags.subscriptionId })
-      .from(subscriptionTags);
-
     const uncategorizedFeedIdsSubquery = db
       .select({ feedId: subscriptionFeeds.feedId })
       .from(subscriptions)
       .innerJoin(subscriptionFeeds, eq(subscriptionFeeds.subscriptionId, subscriptions.id))
+      .leftJoin(subscriptionTags, eq(subscriptionTags.subscriptionId, subscriptions.id))
       .where(
         and(
           eq(subscriptions.userId, params.userId),
           isNull(subscriptions.unsubscribedAt),
-          notInArray(subscriptions.id, taggedSubscriptionIdsSubquery)
+          isNull(subscriptionTags.subscriptionId)
         )
       );
 

--- a/src/server/trpc/routers/api-tokens.ts
+++ b/src/server/trpc/routers/api-tokens.ts
@@ -100,7 +100,7 @@ export const apiTokensRouter = createTRPCRouter({
         : undefined;
 
       // Create the token
-      const token = await createApiToken(
+      const { token, id: tokenId } = await createApiToken(
         ctx.session.user.id,
         scopes as ApiTokenScope[],
         name,
@@ -111,8 +111,7 @@ export const apiTokensRouter = createTRPCRouter({
       const tokenInfo = await ctx.db
         .select(apiTokenSelectFields)
         .from(apiTokens)
-        .where(and(eq(apiTokens.userId, ctx.session.user.id), isNull(apiTokens.revokedAt)))
-        .orderBy(desc(apiTokens.createdAt))
+        .where(eq(apiTokens.id, tokenId))
         .limit(1);
 
       if (!tokenInfo[0]) {

--- a/src/server/trpc/routers/blockedSenders.ts
+++ b/src/server/trpc/routers/blockedSenders.ts
@@ -58,19 +58,17 @@ export const blockedSendersRouter = createTRPCRouter({
 
       // Get all blocked senders for the user
       const senders = await ctx.db
-        .select()
+        .select({
+          id: blockedSenders.id,
+          senderEmail: blockedSenders.senderEmail,
+          blockedAt: blockedSenders.blockedAt,
+          unsubscribeSentAt: blockedSenders.unsubscribeSentAt,
+        })
         .from(blockedSenders)
         .where(eq(blockedSenders.userId, userId))
         .orderBy(sql`${blockedSenders.blockedAt} DESC`);
 
-      return {
-        items: senders.map((sender) => ({
-          id: sender.id,
-          senderEmail: sender.senderEmail,
-          blockedAt: sender.blockedAt,
-          unsubscribeSentAt: sender.unsubscribeSentAt,
-        })),
-      };
+      return { items: senders };
     }),
 
   /**

--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -19,13 +19,12 @@ import { fetchUrl, isHtmlContent } from "@/server/http/fetch";
 import {
   feeds,
   subscriptions,
-  entries,
-  userEntries,
   tags,
   subscriptionTags,
   blockedSenders,
   opmlImports,
   userFeeds,
+  visibleEntries,
   type OpmlImportFeedData,
 } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
@@ -387,17 +386,18 @@ export const subscriptionsRouter = createTRPCRouter({
           .innerJoin(tags, eq(tags.id, subscriptionTags.tagId))
           .where(eq(subscriptionTags.subscriptionId, subscription.id)),
 
-        // Unread count
+        // Unread count (use visibleEntries view to include entries from redirected feeds)
         ctx.db
           .select({
-            count: sql<number>`COUNT(*) FILTER (WHERE ${userEntries.read} = false)::int`,
+            count: sql<number>`COUNT(*) FILTER (WHERE ${visibleEntries.read} = false)::int`,
           })
-          .from(entries)
-          .innerJoin(
-            userEntries,
-            and(eq(userEntries.entryId, entries.id), eq(userEntries.userId, userId))
-          )
-          .where(eq(entries.feedId, subscription.feedId)),
+          .from(visibleEntries)
+          .where(
+            and(
+              eq(visibleEntries.userId, userId),
+              eq(visibleEntries.subscriptionId, subscription.id)
+            )
+          ),
       ]);
 
       const result = feedResult[0];


### PR DESCRIPTION
## Summary

Ran 5 sequential code review passes (bug hunting, security, frontend/a11y, performance/queries, final verification) and fixed the issues found:

### Bug fixes
- **API token creation race**: `createApiToken` now returns the token ID so the router queries by exact ID instead of "most recent token", which could return wrong results under concurrent creation
- **Missing fullContentHash**: Background full-content fetcher now computes `fullContentHash` (matching the on-demand path), fixing a bug where entries fetched by the background job couldn't be summarized
- **Subscription unread count**: Update mutation now uses `visibleEntries` view instead of raw `entries` join, correctly counting entries from redirected feeds via `subscription_feeds`

### Security
- **Password hash no longer cached in Redis**: The argon2 password hash was stored in the session cache despite no code path reading it. All password verification queries the DB directly.

### Accessibility
- **Dialog focus trap**: Implemented proper focus trap so keyboard users can't Tab out of open modals. Also restores focus to the triggering element on close.
- **Touch targets**: Increased sticky entry controls from 36px to 44px per WCAG 2.5.8

### Performance
- **blockedSenders.list**: Select only needed columns instead of `SELECT *`
- **markAllEntriesRead uncategorized filter**: Replaced unscoped `NOT IN (SELECT FROM subscription_tags)` with user-scoped `LEFT JOIN ... IS NULL` anti-join pattern

## Test plan
- [x] `pnpm typecheck` passes
- [ ] Manual testing of dialog focus trap (Tab cycling, Escape, focus restore)
- [ ] Verify subscription unread counts after feed redirect
- [ ] Verify summarization works for background-fetched full content

🤖 Generated with [Claude Code](https://claude.com/claude-code)