### PR TITLE
Add rate limiting to GReader, Wallabag, and OAuth token endpoints

### DIFF
--- a/src/app/api/admin/session/route.ts
+++ b/src/app/api/admin/session/route.ts
@@ -7,30 +7,19 @@ import {
   validateAdminSessionToken,
 } from "@/server/auth/admin-session";
 import { signupConfig } from "@/server/config/env";
-import {
-  checkRateLimit,
-  getClientIdentifier,
-  getRateLimitHeaders,
-  RATE_LIMIT_CONFIGS,
-} from "@/server/rate-limit";
+import { checkRouteRateLimit } from "@/server/rate-limit";
 
 /**
  * POST /api/admin/session - Exchange admin secret for an httpOnly session cookie.
  */
-export async function POST(request: NextRequest): Promise<NextResponse> {
+export async function POST(request: NextRequest): Promise<Response> {
   if (!signupConfig.allowlistSecret) {
     return NextResponse.json({ error: "Admin not configured" }, { status: 404 });
   }
 
   // Rate limit by IP using the "expensive" tier (same as login/register)
-  const identifier = getClientIdentifier(null, request.headers);
-  const rateLimitResult = await checkRateLimit(identifier, "expensive");
-  if (!rateLimitResult.allowed) {
-    return NextResponse.json(
-      { error: "Too many attempts, please try again later" },
-      { status: 429, headers: getRateLimitHeaders(rateLimitResult, RATE_LIMIT_CONFIGS.expensive) }
-    );
-  }
+  const rateLimitResponse = await checkRouteRateLimit(request, "expensive", { json: true });
+  if (rateLimitResponse) return rateLimitResponse;
 
   let body: unknown;
   try {

--- a/src/app/api/greader.php/accounts/ClientLogin/route.ts
+++ b/src/app/api/greader.php/accounts/ClientLogin/route.ts
@@ -17,10 +17,14 @@
 
 import { clientLogin } from "@/server/google-reader/auth";
 import { parseFormData, errorResponse } from "@/server/google-reader/parse";
+import { checkRouteRateLimit } from "@/server/rate-limit";
 
 export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
+  const rateLimitResponse = await checkRouteRateLimit(request, "expensive");
+  if (rateLimitResponse) return rateLimitResponse;
+
   const params = await parseFormData(request);
   const email = params.get("Email");
   const password = params.get("Passwd");

--- a/src/app/api/wallabag/oauth/v2/token/route.ts
+++ b/src/app/api/wallabag/oauth/v2/token/route.ts
@@ -24,10 +24,14 @@
 import { passwordGrant, refreshTokenGrant } from "@/server/wallabag/auth";
 import { parseBody } from "@/server/wallabag/parse";
 import { jsonResponse, errorResponse } from "@/server/wallabag/parse";
+import { checkRouteRateLimit } from "@/server/rate-limit";
 
 export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
+  const rateLimitResponse = await checkRouteRateLimit(request, "expensive", { json: true });
+  if (rateLimitResponse) return rateLimitResponse;
+
   const body = await parseBody(request);
 
   const grantType = body.grant_type;

--- a/src/app/oauth/token/route.ts
+++ b/src/app/oauth/token/route.ts
@@ -25,11 +25,15 @@ import {
   OAUTH_ERRORS,
   createOAuthError,
 } from "@/server/oauth/utils";
+import { checkRouteRateLimit } from "@/server/rate-limit";
 
 /**
  * Token request via form data (standard OAuth)
  */
 export async function POST(request: NextRequest) {
+  const rateLimitResponse = await checkRouteRateLimit(request, "expensive", { json: true });
+  if (rateLimitResponse) return rateLimitResponse;
+
   logger.info("OAuth token request");
   // Parse form data or JSON body
   let body: Record<string, string>;

--- a/src/server/rate-limit/index.ts
+++ b/src/server/rate-limit/index.ts
@@ -188,3 +188,38 @@ export function getClientIdentifier(userId: string | null, headers: Headers): st
   // Fallback for local development
   return "ip:unknown";
 }
+
+/**
+ * Checks rate limit for a route handler request and returns a 429 Response if exceeded.
+ * Returns null if the request is allowed.
+ *
+ * @param request - The incoming request
+ * @param type - Type of rate limit to apply
+ * @param options - Options for the response format
+ * @returns A 429 Response if rate limited, or null if allowed
+ */
+export async function checkRouteRateLimit(
+  request: Request,
+  type: RateLimitType = "default",
+  options: { json?: boolean } = {}
+): Promise<Response | null> {
+  const identifier = getClientIdentifier(null, request.headers);
+  const config = RATE_LIMIT_CONFIGS[type];
+  const result = await checkRateLimit(identifier, type);
+
+  if (!result.allowed) {
+    const rateLimitHeaders = getRateLimitHeaders(result, config);
+    const body = options.json
+      ? JSON.stringify({ error: "rate_limit_exceeded", error_description: "Rate limit exceeded" })
+      : "Rate limit exceeded";
+    return new Response(body, {
+      status: 429,
+      headers: {
+        ...rateLimitHeaders,
+        "Content-Type": options.json ? "application/json" : "text/plain",
+      },
+    });
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary\n\nFixes #827\n\n- Added `checkRouteRateLimit` helper to `src/server/rate-limit/index.ts` for use in Next.js route handlers\n- Applied \"expensive\" rate limiting (10 burst / 1 per second refill) to:\n  - **GReader ClientLogin** (`POST /api/greader.php/accounts/ClientLogin`) — password auth\n  - **Wallabag OAuth token** (`POST /api/wallabag/oauth/v2/token`) — password grant + refresh token\n  - **OAuth 2.1 token** (`POST /oauth/token`) — authorization code + refresh token exchange\n\nThese endpoints now share the same rate limit tier as the tRPC `auth.login` endpoint, preventing password brute-forcing via alternative auth paths.\n\n## Test plan\n\n- [ ] Verify rate limiting activates after 10 rapid requests to each endpoint\n- [ ] Verify normal usage is unaffected (requests succeed within rate limits)\n- [ ] Verify 429 responses include proper `Retry-After` and `X-RateLimit-*` headers\n- [ ] Verify Redis unavailability falls back to permissive mode (no broken endpoints)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"