### PR TITLE
Fix: add jsdom to esbuild external list

### DIFF
--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -45,7 +45,9 @@ const buildOptions = {
   // - next: loaded from node_modules at runtime (needs .next build output)
   // - Native modules (argon2 uses node-gyp bindings)
   // - html-rewriter-wasm has WASM files and internal requires that break when bundled
-  external: ["next", "argon2", "html-rewriter-wasm"],
+  // - jsdom uses __dirname-relative fs.readFileSync for browser/default-stylesheet.css;
+  //   bundling breaks the path resolution (required at runtime by isomorphic-dompurify)
+  external: ["next", "argon2", "html-rewriter-wasm", "jsdom"],
 
   // Source maps for debugging production issues
   sourcemap: true,


### PR DESCRIPTION
## Summary

- Adds `jsdom` to the `external` list in `scripts/build-server.mjs` so esbuild doesn't bundle it

jsdom v29 uses `__dirname`-relative `fs.readFileSync` to load `browser/default-stylesheet.css`. When esbuild bundles jsdom into the server chunk, `__dirname` resolves to the bundle output directory (`/app/`) instead of the jsdom package directory, causing repeated `ENOENT` errors in production:

```
Error: ENOENT: no such file or directory, open '/app/browser/default-stylesheet.css'
```

jsdom is a runtime dependency because `isomorphic-dompurify` does `require("jsdom")` on the server side. Marking it as external (same treatment as `argon2` and `html-rewriter-wasm`) preserves correct `__dirname` resolution at runtime.

## Test plan

- [ ] Verify production deploy no longer shows the ENOENT error in logs
- [ ] Verify DOMPurify/content sanitization still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Claude