### PR TITLE
Handle upstream 429 rate limiting separately from site blocking

### DIFF
--- a/src/server/feed/lesswrong.ts
+++ b/src/server/feed/lesswrong.ts
@@ -10,6 +10,7 @@
 import { z } from "zod";
 import { logger } from "@/lib/logger";
 import { USER_AGENT } from "@/server/http/user-agent";
+import { HttpFetchError } from "@/server/http/fetch";
 
 // ============================================================================
 // Constants
@@ -329,6 +330,11 @@ async function fetchLessWrongPost(postId: string): Promise<LessWrongPostContent 
         status: response.status,
         statusText: response.statusText,
       });
+      // Throw on rate limiting so callers can handle it specifically
+      // (returning null would cause a pointless fallback fetch to the same site)
+      if (response.status === 429) {
+        throw new HttpFetchError(response.status, response.statusText, LESSWRONG_GRAPHQL_ENDPOINT);
+      }
       return null;
     }
 
@@ -390,6 +396,10 @@ async function fetchLessWrongPost(postId: string): Promise<LessWrongPostContent 
       url: post.pageUrl,
     };
   } catch (error) {
+    // Let HttpFetchError propagate (e.g., 429 rate limiting)
+    if (error instanceof HttpFetchError) {
+      throw error;
+    }
     if (error instanceof Error && error.name === "AbortError") {
       logger.warn("LessWrong GraphQL request timed out", { postId });
     } else {
@@ -462,6 +472,9 @@ async function fetchLessWrongComment(commentId: string): Promise<LessWrongCommen
         status: response.status,
         statusText: response.statusText,
       });
+      if (response.status === 429) {
+        throw new HttpFetchError(response.status, response.statusText, LESSWRONG_GRAPHQL_ENDPOINT);
+      }
       return null;
     }
 
@@ -509,6 +522,10 @@ async function fetchLessWrongComment(commentId: string): Promise<LessWrongCommen
       url: comment.pageUrl,
     };
   } catch (error) {
+    // Let HttpFetchError propagate (e.g., 429 rate limiting)
+    if (error instanceof HttpFetchError) {
+      throw error;
+    }
     if (error instanceof Error && error.name === "AbortError") {
       logger.warn("LessWrong GraphQL comment request timed out", { commentId });
     } else {

--- a/src/server/http/fetch.ts
+++ b/src/server/http/fetch.ts
@@ -29,6 +29,13 @@ export class HttpFetchError extends Error {
   }
 
   /**
+   * Check if this error indicates the upstream server is rate limiting us.
+   */
+  isRateLimited(): boolean {
+    return this.status === 429;
+  }
+
+  /**
    * Check if this error indicates the site blocked the request.
    * This includes 403 Forbidden, 429 Too Many Requests, and 406 Not Acceptable.
    */

--- a/src/server/plugins/lesswrong.ts
+++ b/src/server/plugins/lesswrong.ts
@@ -17,6 +17,7 @@ import {
   LESSWRONG_SHORTFORM_FRONTPAGE_FEED_URL,
 } from "@/server/feed/lesswrong";
 import { cleanLessWrongContent } from "@/server/feed/content-cleaner";
+import { HttpFetchError } from "@/server/http/fetch";
 import { logger } from "@/lib/logger";
 
 /**
@@ -143,6 +144,11 @@ export const lessWrongPlugin: UrlPlugin = {
             canonicalUrl: content.url || url.href,
           };
         } catch (error) {
+          // Let rate limit errors propagate - falling back to a normal fetch
+          // would hit the same rate limit on the same site
+          if (error instanceof HttpFetchError && error.isRateLimited()) {
+            throw error;
+          }
           logger.warn("Failed to fetch LessWrong saved article content", {
             url: url.href,
             error: error instanceof Error ? error.message : String(error),

--- a/src/server/services/full-content.ts
+++ b/src/server/services/full-content.ts
@@ -325,6 +325,9 @@ export async function fetchAndStoreFullContent(
  */
 function getErrorMessage(error: unknown): string {
   if (error instanceof HttpFetchError) {
+    if (error.isRateLimited()) {
+      return "Site is temporarily rate limiting requests";
+    }
     if (error.isBlocked()) {
       return "Site blocked the request";
     }

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -527,6 +527,16 @@ async function acquireArticleContent(
       if (isContentTooLargeError(error)) {
         throw error;
       }
+      // Rate limit errors should not fall back to a normal fetch — the same
+      // site would rate limit us again.
+      if (error instanceof HttpFetchError && error.isRateLimited()) {
+        logger.warn("Plugin fetch rate limited", {
+          url: params.url,
+          plugin: plugin.name,
+          status: error.status,
+        });
+        throw errors.upstreamRateLimited(params.url);
+      }
       logger.warn("Plugin fetch failed, falling back to normal fetch", {
         url: params.url,
         plugin: plugin.name,
@@ -599,8 +609,13 @@ async function acquireArticleContent(
     if (error instanceof ContentTooLargeError) {
       throw errors.contentTooLarge("Article", maxSize);
     }
-    if (error instanceof HttpFetchError && error.isBlocked()) {
-      throw errors.siteBlocked(fetchUrl, error.status);
+    if (error instanceof HttpFetchError) {
+      if (error.isRateLimited()) {
+        throw errors.upstreamRateLimited(fetchUrl);
+      }
+      if (error.isBlocked()) {
+        throw errors.siteBlocked(fetchUrl, error.status);
+      }
     }
     throw errors.savedArticleFetchError(
       fetchUrl,

--- a/src/server/trpc/errors.ts
+++ b/src/server/trpc/errors.ts
@@ -70,6 +70,9 @@ const ErrorCodes = {
 
   // Bad gateway errors (502)
   SITE_BLOCKED: "SITE_BLOCKED",
+
+  // Upstream rate limiting (429 from the target site, not from us)
+  UPSTREAM_RATE_LIMITED: "UPSTREAM_RATE_LIMITED",
 } as const;
 
 type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];
@@ -129,6 +132,7 @@ const errorCodeToTRPCCode: Record<
   CONTENT_TOO_LARGE: "BAD_REQUEST",
   MAX_SUBSCRIPTIONS_REACHED: "BAD_REQUEST",
   SITE_BLOCKED: "BAD_GATEWAY",
+  UPSTREAM_RATE_LIMITED: "TOO_MANY_REQUESTS",
 };
 
 /**
@@ -267,6 +271,13 @@ export const errors = {
         url,
         status,
       }
+    ),
+
+  upstreamRateLimited: (url: string) =>
+    createError(
+      ErrorCodes.UPSTREAM_RATE_LIMITED,
+      "This website is temporarily rate limiting requests. Please try again later.",
+      { url }
     ),
 
   // Signup provider restriction errors


### PR DESCRIPTION
## Summary

- When saving an article from a rate-limited site (e.g. LessWrong), the error was showing as "HTTP 502" / "This website blocked the request" because 429 responses were mapped to `SITE_BLOCKED` → `BAD_GATEWAY`. Now it correctly shows as a 429 with the message "This website is temporarily rate limiting requests. Please try again later."
- LessWrong GraphQL functions now throw on 429 instead of returning `null`, which was causing a pointless fallback fetch to `fetchHtmlPage()` on the same rate-limited site (which would also get 429)
- Rate limit errors propagate through the plugin system instead of being silently caught

## Test plan

- [ ] Save a LessWrong article when LessWrong is rate limiting — should show "This website is temporarily rate limiting requests. Please try again later." instead of "HTTP 502"
- [ ] Save a LessWrong article when LessWrong is not rate limiting — should work as before
- [ ] Save a non-LessWrong article from a site that returns 403 — should still show "This website blocked the request" (unchanged)
- [ ] Save a normal article — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)