### PR TITLE
Fix OpenAPI build failure (externalize trpc-to-openapi)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -115,8 +115,12 @@ const nextConfig: NextConfig = {
     ];
   },
   // Packages that should be loaded from node_modules at runtime, not bundled
-  // html-rewriter-wasm contains a WASM file that can't be bundled by Next.js
-  serverExternalPackages: ["html-rewriter-wasm", "piscina"],
+  // - html-rewriter-wasm contains a WASM file that can't be bundled by Next.js
+  // - trpc-to-openapi must not be bundled: webpack tree-shakes zod's `coerce`
+  //   export (only referenced via `'coerce' in z`), which flips the library's
+  //   `zodSupportsCoerce` check to false and makes it reject numeric query
+  //   params (e.g. `limit`) when generating the OpenAPI document.
+  serverExternalPackages: ["html-rewriter-wasm", "piscina", "trpc-to-openapi"],
   // Handle piper-tts-web which has conditional Node.js code (require('fs'))
   // that the bundler tries to resolve even though it only runs in Node.js
   webpack: (config, { isServer }) => {


### PR DESCRIPTION
## Summary

The deploy build (`next build --webpack`) was failing with:

```
Error [TRPCError]: [query.admin.listInvites] - Input parser key: "limit" must be ZodString
Error: Failed to collect page data for /api/openapi
```

### Root cause

`/api/openapi` evaluates `generateOpenApiDocument(appRouter, …)` at module load. For GET endpoints, `trpc-to-openapi` validates each query-param schema: numeric params (like `limit: z.number()`) are only allowed when its `zodSupportsCoerce` check (`'coerce' in z`) is true.

When webpack bundles the route, it **tree-shakes zod's `coerce` export** because the library only references it via the `'coerce' in z` membership test (the actual coercion mutates `_def.coerce`, it never reads `z.coerce` as a value). With `coerce` removed from the bundled namespace, `zodSupportsCoerce` becomes `false`, so the library rejects every numeric query param and throws during build. At plain Node runtime `'coerce' in z` is `true`, which is why it only reproduces in the bundled build.

### Fix

Add `trpc-to-openapi` to `serverExternalPackages` so it's loaded from `node_modules` at runtime instead of being bundled. It then `require("zod")`s the full, un-tree-shaken package where `coerce` exists.

## Test plan

- [x] `pnpm build` fails on `master` with the OpenAPI error
- [x] `pnpm build` succeeds with this change; `/api/openapi` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)