### PR TITLE
Docs: correct entry-visibility rule to match visible_entries view (#868)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ See docs/diagrams/ for more detail. These diagrams are very helpful for quickly 
 Use the database views for frontend queries instead of manual joins:
 
 - **`user_feeds`**: Active subscriptions with feed data merged. Use for `subscriptions.list/get/export`. Already filters out unsubscribed entries and resolves title (custom or original).
-- **`visible_entries`**: Entries with visibility rules applied. Use for `entries.list/get/count`. Includes read/starred state and subscription_id. An entry is visible if it's from an active subscription OR is starred.
+- **`visible_entries`**: Entries with visibility rules applied. Use for `entries.list/get/count`. Includes read/starred state and subscription_id. An entry is visible if a `user_entries` row exists for the `(user, entry)` pair AND (the entry is from an active subscription OR is starred). Privacy gating happens when `user_entries` rows are inserted (subscribe-time / fetch-time), not in the view; the old `fetched_at >= subscribed_at` rule was only a one-time backfill (migration 0007). See "Entry Visibility" in docs/DESIGN.md.
 
 These views are defined in `migrations/0035_subscription_views.sql` and have Drizzle schemas in `src/server/db/schema.ts`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ See docs/diagrams/ for more detail. These diagrams are very helpful for quickly 
 Use the database views for frontend queries instead of manual joins:
 
 - **`user_feeds`**: Active subscriptions with feed data merged. Use for `subscriptions.list/get/export`. Already filters out unsubscribed entries and resolves title (custom or original).
-- **`visible_entries`**: Entries with visibility rules applied. Use for `entries.list/get/count`. Includes read/starred state and subscription_id. An entry is visible if a `user_entries` row exists for the `(user, entry)` pair AND (the entry is from an active subscription OR is starred). Privacy gating happens when `user_entries` rows are inserted (subscribe-time / fetch-time), not in the view; the old `fetched_at >= subscribed_at` rule was only a one-time backfill (migration 0007). See "Entry Visibility" in docs/DESIGN.md.
+- **`visible_entries`**: Entries with visibility rules applied. Use for `entries.list/get/count`. Includes read/starred state and subscription_id. An entry is visible if a `user_entries` row exists for the `(user, entry)` pair AND (the entry is from an active subscription OR is starred). Privacy gating happens when `user_entries` rows are inserted (subscribe-time / fetch-time), not in the view. See "Entry Visibility" in docs/DESIGN.md.
 
 These views are defined in `migrations/0035_subscription_views.sql` and have Drizzle schemas in `src/server/db/schema.ts`.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -146,7 +146,14 @@ See `docs/features/subscription-centric-api.md` for design details.
 
 ### Key Design Decisions
 
-**Entry Visibility**: Users only see entries where `entry.fetched_at >= subscription.subscribed_at`. This prevents information leakage when users subscribe to feeds that may have been private before.
+**Entry Visibility**: Visibility is enforced at query time by the `visible_entries` view, which requires a `user_entries` row to exist for the `(user, entry)` pair AND that the entry is either from an active subscription (`subscription.unsubscribed_at IS NULL`) or is starred. The existence of the `user_entries` row is the durable record of visibility.
+
+The `user_entries` rows are created outside the view at:
+
+- **Subscribe time**: rows are inserted for entries present in the feed's most recent fetch (`entries.last_seen_at = feeds.last_entries_updated_at`), so a new subscriber sees current feed contents but not arbitrarily old entries. See `createSubscription` in `src/server/services/subscriptions.ts`.
+- **Fetch time**: when a feed fetch produces new entries, rows are created for that feed's active subscribers. See `createUserEntriesForFeed` in `src/server/feed/entry-processor.ts`.
+
+The older `entry.fetched_at >= subscription.subscribed_at` rule was a one-time backfill applied in migration `0007_user_entries_visibility.sql`; it is **not** enforced by the view. This insert-time gating is what prevents information leakage when users subscribe to feeds that may have contained private content before they subscribed.
 
 **Soft Deletes**: Subscriptions use `unsubscribed_at` for soft delete, allowing users to resubscribe and maintain their read state.
 


### PR DESCRIPTION
## Summary
- Fixes #868. The documented privacy invariant `entry.fetched_at >= subscription.subscribed_at` was never enforced by the `visible_entries` view.
- The view actually requires a `user_entries` row to exist for the `(user, entry)` pair **AND** (the subscription is active OR the entry is starred).
- Updated `docs/DESIGN.md` ("Entry Visibility") and `CLAUDE.md` (`visible_entries` description) to describe the actual query-time rule, and clarified that the `fetched_at >= subscribed_at` gating applies only when `user_entries` rows are inserted (the old rule being a one-time backfill in migration `0007`).

## Verification
- Confirmed against the live view in `migrations/schema.sql`: `WHERE ((s.unsubscribed_at IS NULL) OR (ue.starred = true))` over a JOIN on `user_entries`.
- Confirmed insert-time mechanisms: `createSubscription` (subscribe-time, uses `last_seen_at = last_entries_updated_at`) and `createUserEntriesForFeed` (fetch-time).

## Test plan
- [ ] Docs-only change; no code behavior affected. Review wording for accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude