### PR TITLE
Fix router/service duplication for markRead and setStarred (#869)

### DIFF
--- a/docs/features/entry-scoring.md
+++ b/docs/features/entry-scoring.md
@@ -83,13 +83,14 @@ export function computeImplicitScore(
 
 ### Setting Implicit Flags
 
-Flags are set in the relevant mutations:
+Flags are set in the shared service functions (`src/server/services/entries.ts`),
+so every API surface (tRPC, MCP, Google Reader, Wallabag) records the same signals:
 
-- **`has_starred`**: Set in `entries.star` mutation when starring
-- **`has_marked_unread`**: Set in `entries.markRead` when `read = false`
-- **`has_marked_read_on_list`**: Set in `entries.markRead` when `read = true` AND `fromList = true`
+- **`has_starred`**: Set in `updateEntryStarred` when starring
+- **`has_marked_unread`**: Set in `markEntriesRead` when `read = false`
+- **`has_marked_read_on_list`**: Set in `markEntriesRead` when `read = true` AND `fromList = true`
 
-The `fromList` parameter is passed by the frontend when the mark-read action originates from the entry list (not from within the entry view).
+The `fromList` parameter is passed by the frontend when the mark-read action originates from the entry list (not from within the entry view). Other API surfaces don't have a list view, so they never set `has_marked_read_on_list`.
 
 ## UI Components
 

--- a/src/app/api/greader.php/reader/api/0/edit-tag/route.ts
+++ b/src/app/api/greader.php/reader/api/0/edit-tag/route.ts
@@ -64,10 +64,11 @@ export async function POST(request: Request): Promise<Response> {
   const addRead = addTags.some((t) => isState(t, "read"));
   const removeRead = removeTags.some((t) => isState(t, "read"));
 
+  const entriesToMark = entryUuids.map((id) => ({ id }));
   if (addRead) {
-    await entriesService.markEntriesRead(db, session.user.id, entryUuids, true);
+    await entriesService.markEntriesRead(db, session.user.id, entriesToMark, true);
   } else if (removeRead) {
-    await entriesService.markEntriesRead(db, session.user.id, entryUuids, false);
+    await entriesService.markEntriesRead(db, session.user.id, entriesToMark, false);
   }
 
   // Process starred state changes

--- a/src/app/api/wallabag/api/entries/[entry]/route.ts
+++ b/src/app/api/wallabag/api/entries/[entry]/route.ts
@@ -69,7 +69,7 @@ export async function PATCH(
   // Handle archive (read) state
   if (body.archive !== undefined) {
     const read = body.archive === "1";
-    await entriesService.markEntriesRead(db, auth.userId, [entryId], read);
+    await entriesService.markEntriesRead(db, auth.userId, [{ id: entryId }], read);
   }
 
   // Handle starred state

--- a/src/app/api/wallabag/api/entries/route.ts
+++ b/src/app/api/wallabag/api/entries/route.ts
@@ -144,7 +144,7 @@ export async function POST(request: Request): Promise<Response> {
 
   // Handle archive/starred flags if provided
   if (body.archive === "1" && !article.read) {
-    await entriesService.markEntriesRead(db, auth.userId, [article.id], true);
+    await entriesService.markEntriesRead(db, auth.userId, [{ id: article.id }], true);
   }
   if (body.starred === "1" && !article.starred) {
     await entriesService.updateEntryStarred(db, auth.userId, article.id, true);

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -7,6 +7,7 @@
 
 import type { db as dbType } from "@/server/db";
 import * as entriesService from "@/server/services/entries";
+import * as countsService from "@/server/services/counts";
 import * as subscriptionsService from "@/server/services/subscriptions";
 import * as savedService from "@/server/services/saved";
 import * as tagsService from "@/server/services/tags";
@@ -117,7 +118,14 @@ export function registerTools(): Tool[] {
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       handler: async (db, args: any) => {
-        return entriesService.markEntriesRead(db, args.userId, args.entryIds, args.read);
+        const entries = await entriesService.markEntriesRead(
+          db,
+          args.userId,
+          (args.entryIds as string[]).map((id) => ({ id })),
+          args.read
+        );
+        const counts = await countsService.getBulkEntryRelatedCounts(db, args.userId, entries);
+        return { entries, counts };
       },
     },
 

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -121,22 +121,29 @@ export interface EntryState {
   id: string;
   read: boolean;
   starred: boolean;
+  updatedAt: Date;
 }
 
-export interface SubscriptionUnreadCount {
-  subscriptionId: string;
-  unreadCount: number;
+/**
+ * A single entry to mark read/unread, with an optional per-entry timestamp for
+ * offline sync scenarios where entries were marked at different times.
+ */
+export interface MarkReadEntry {
+  id: string;
+  changedAt?: Date;
 }
 
-export interface TagUnreadCount {
-  tagId: string;
-  unreadCount: number;
-}
-
-export interface MarkReadResult {
-  entries: EntryState[];
-  subscriptionUnreadCounts: SubscriptionUnreadCount[];
-  tagUnreadCounts: TagUnreadCount[];
+/**
+ * Final entry state returned after marking read, including the context fields
+ * needed for cache updates, count queries, and SSE publishing.
+ */
+export interface MarkReadEntryState {
+  id: string;
+  subscriptionId: string | null;
+  read: boolean;
+  starred: boolean;
+  type: "web" | "email" | "saved";
+  updatedAt: Date;
 }
 
 // ============================================================================
@@ -572,119 +579,92 @@ export async function getEntries(
  * Marks entries as read or unread.
  *
  * Uses idempotent updates: only applies if changedAt is newer than the stored
- * read_changed_at timestamp. This prevents stale updates from overwriting newer state.
+ * read_changed_at timestamp. This prevents stale updates from overwriting newer
+ * state. Supports per-entry timestamps for offline sync.
  *
- * @param changedAt - When the user initiated the action. Defaults to now.
+ * Sets the implicit score signal flags (see docs/features/entry-scoring.md):
+ * - `has_marked_unread` whenever marking unread
+ * - `has_marked_read_on_list` when marking read with `fromList`
+ *
+ * Returns the final state for all requested entries with the context fields
+ * needed for cache updates, count queries, and SSE publishing.
+ *
+ * @param options.fromList - Whether the mark-read originated from the entry list
+ *   (weak negative signal). Only meaningful when marking read.
  */
 export async function markEntriesRead(
   db: typeof dbType,
   userId: string,
-  entryIds: string[],
+  entriesToMark: MarkReadEntry[],
   read: boolean,
-  changedAt: Date = new Date()
-): Promise<MarkReadResult> {
-  if (entryIds.length === 0) {
-    return { entries: [], subscriptionUnreadCounts: [], tagUnreadCounts: [] };
+  options: { fromList?: boolean } = {}
+): Promise<MarkReadEntryState[]> {
+  if (entriesToMark.length === 0) {
+    return [];
   }
 
-  if (entryIds.length > 1000) {
+  if (entriesToMark.length > 1000) {
     throw errors.validation("Maximum 1000 entries per request");
   }
 
-  // Conditional update: only apply if incoming timestamp is newer or equal
-  await db
-    .update(userEntries)
-    .set({
-      read,
-      readChangedAt: changedAt,
-      updatedAt: new Date(),
-    })
-    .where(
-      and(
-        eq(userEntries.userId, userId),
-        inArray(userEntries.entryId, entryIds),
-        or(isNull(userEntries.readChangedAt), lte(userEntries.readChangedAt, changedAt))
-      )
-    );
+  const now = new Date();
 
-  // Always return final state for all requested entries
-  const finalEntries = await db
+  // Build the SET clause, including implicit score signal flags
+  const setClause: Record<string, unknown> = {
+    read,
+    updatedAt: now,
+  };
+  if (read && options.fromList) {
+    // Marking read from the entry list → implicit -1
+    setClause.hasMarkedReadOnList = true;
+  } else if (!read) {
+    // Marking unread from anywhere → implicit 0 (overrides read-on-list penalty)
+    setClause.hasMarkedUnread = true;
+  }
+
+  // Group entries by timestamp for efficient batch updates. Most interactive
+  // cases share a single timestamp; per-entry timestamps come from offline sync.
+  const entriesByTimestamp = new Map<string, string[]>();
+  for (const entry of entriesToMark) {
+    const ts = (entry.changedAt ?? now).toISOString();
+    const existing = entriesByTimestamp.get(ts) ?? [];
+    existing.push(entry.id);
+    entriesByTimestamp.set(ts, existing);
+  }
+
+  // Conditional update per timestamp group: only apply if incoming timestamp is
+  // newer or equal than the stored read_changed_at (or it is NULL).
+  for (const [tsIso, entryIds] of entriesByTimestamp) {
+    const changedAt = new Date(tsIso);
+    await db
+      .update(userEntries)
+      .set({
+        ...setClause,
+        readChangedAt: changedAt,
+      })
+      .where(
+        and(
+          eq(userEntries.userId, userId),
+          inArray(userEntries.entryId, entryIds),
+          or(isNull(userEntries.readChangedAt), lte(userEntries.readChangedAt, changedAt))
+        )
+      );
+  }
+
+  // Always return final state for all requested entries, including the context
+  // fields callers need for cache updates and count queries.
+  const allEntryIds = entriesToMark.map((e) => e.id);
+  return db
     .select({
-      id: userEntries.entryId,
-      read: userEntries.read,
-      starred: userEntries.starred,
+      id: visibleEntries.id,
+      subscriptionId: visibleEntries.subscriptionId,
+      read: visibleEntries.read,
+      starred: visibleEntries.starred,
+      type: visibleEntries.type,
+      updatedAt: visibleEntries.updatedAt,
     })
-    .from(userEntries)
-    .where(and(eq(userEntries.userId, userId), inArray(userEntries.entryId, entryIds)));
-
-  // Get affected feed IDs
-  const affectedFeedsSubquery = db
-    .selectDistinct({ feedId: entries.feedId })
-    .from(entries)
-    .where(inArray(entries.id, entryIds))
-    .as("affected_feeds");
-
-  // Find subscriptions containing the affected feeds via subscription_feeds junction table
-  const affectedSubscriptionsSubquery = db
-    .selectDistinct({ subscriptionId: subscriptions.id })
-    .from(subscriptions)
-    .innerJoin(subscriptionFeeds, eq(subscriptionFeeds.subscriptionId, subscriptions.id))
-    .where(
-      and(
-        eq(subscriptions.userId, userId),
-        isNull(subscriptions.unsubscribedAt),
-        inArray(subscriptionFeeds.feedId, sql`(SELECT feed_id FROM ${affectedFeedsSubquery})`)
-      )
-    )
-    .as("affected_subscriptions");
-
-  const subscriptionUnreadCounts = await db
-    .select({
-      subscriptionId: affectedSubscriptionsSubquery.subscriptionId,
-      unreadCount: sql<number>`COALESCE(COUNT(*) FILTER (WHERE ${userEntries.read} = false), 0)::int`,
-    })
-    .from(affectedSubscriptionsSubquery)
-    .leftJoin(
-      subscriptionFeeds,
-      eq(subscriptionFeeds.subscriptionId, affectedSubscriptionsSubquery.subscriptionId)
-    )
-    .leftJoin(entries, eq(entries.feedId, subscriptionFeeds.feedId))
-    .leftJoin(userEntries, and(eq(userEntries.entryId, entries.id), eq(userEntries.userId, userId)))
-    .groupBy(affectedSubscriptionsSubquery.subscriptionId);
-
-  // Get tag unread counts for tags associated with affected subscriptions
-  const affectedTagsSubquery = db
-    .selectDistinct({ tagId: subscriptionTags.tagId })
-    .from(subscriptionTags)
-    .where(
-      inArray(
-        subscriptionTags.subscriptionId,
-        sql`(SELECT subscription_id FROM ${affectedSubscriptionsSubquery})`
-      )
-    )
-    .as("affected_tags");
-
-  const tagUnreadCounts = await db
-    .select({
-      tagId: affectedTagsSubquery.tagId,
-      unreadCount: sql<number>`COALESCE(COUNT(*) FILTER (WHERE ${userEntries.read} = false), 0)::int`,
-    })
-    .from(affectedTagsSubquery)
-    .leftJoin(subscriptionTags, eq(subscriptionTags.tagId, affectedTagsSubquery.tagId))
-    .leftJoin(
-      subscriptions,
-      and(
-        eq(subscriptionTags.subscriptionId, subscriptions.id),
-        eq(subscriptions.userId, userId),
-        isNull(subscriptions.unsubscribedAt)
-      )
-    )
-    .leftJoin(subscriptionFeeds, eq(subscriptionFeeds.subscriptionId, subscriptions.id))
-    .leftJoin(entries, eq(entries.feedId, subscriptionFeeds.feedId))
-    .leftJoin(userEntries, and(eq(userEntries.entryId, entries.id), eq(userEntries.userId, userId)))
-    .groupBy(affectedTagsSubquery.tagId);
-
-  return { entries: finalEntries, subscriptionUnreadCounts, tagUnreadCounts };
+    .from(visibleEntries)
+    .where(and(eq(visibleEntries.userId, userId), inArray(visibleEntries.id, allEntryIds)));
 }
 
 /**
@@ -843,6 +823,9 @@ export async function markAllEntriesRead(
  * Uses idempotent updates: only applies if changedAt is newer than the stored
  * starred_changed_at timestamp. This prevents stale updates from overwriting newer state.
  *
+ * Sets the `has_starred` implicit score signal flag when starring (see
+ * docs/features/entry-scoring.md).
+ *
  * @param changedAt - When the user initiated the action. Defaults to now.
  */
 export async function updateEntryStarred(
@@ -852,14 +835,20 @@ export async function updateEntryStarred(
   starred: boolean,
   changedAt: Date = new Date()
 ): Promise<EntryState> {
+  // Build the SET clause, setting the implicit signal flag when starring
+  const setClause: Record<string, unknown> = {
+    starred,
+    starredChangedAt: changedAt,
+    updatedAt: new Date(),
+  };
+  if (starred) {
+    setClause.hasStarred = true;
+  }
+
   // Conditional update: only apply if incoming timestamp is newer or equal
   await db
     .update(userEntries)
-    .set({
-      starred,
-      starredChangedAt: changedAt,
-      updatedAt: new Date(),
-    })
+    .set(setClause)
     .where(
       and(
         eq(userEntries.userId, userId),
@@ -868,15 +857,16 @@ export async function updateEntryStarred(
       )
     );
 
-  // Always return final state
+  // Always return final state from visibleEntries (includes computed updatedAt)
   const result = await db
     .select({
-      id: userEntries.entryId,
-      read: userEntries.read,
-      starred: userEntries.starred,
+      id: visibleEntries.id,
+      read: visibleEntries.read,
+      starred: visibleEntries.starred,
+      updatedAt: visibleEntries.updatedAt,
     })
-    .from(userEntries)
-    .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, entryId)));
+    .from(visibleEntries)
+    .where(and(eq(visibleEntries.userId, userId), eq(visibleEntries.id, entryId)));
 
   if (result.length === 0) {
     throw errors.entryNotFound();

--- a/src/server/services/entry-filters.ts
+++ b/src/server/services/entry-filters.ts
@@ -62,8 +62,10 @@ export interface EntryFilterResult {
 
 /**
  * Gets feed IDs for a subscription from the subscription_feeds junction table.
+ * Validates subscription ownership via the user_feeds view. Returns null if the
+ * subscription doesn't exist or doesn't belong to the user.
  */
-async function getSubscriptionFeedIds(
+export async function getSubscriptionFeedIds(
   db: typeof dbType,
   subscriptionId: string,
   userId: string

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -10,7 +10,7 @@
  */
 
 import { z } from "zod";
-import { eq, and, lte, inArray, or, isNull } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { createHash } from "crypto";
 
 import { createTRPCRouter, confirmedProtectedProcedure as protectedProcedure } from "../trpc";
@@ -19,17 +19,15 @@ import { uuidSchema } from "../validation";
 import {
   entries,
   feeds,
-  subscriptionFeeds,
-  userEntries,
   subscriptions,
   tags,
   visibleEntries,
-  userFeeds,
   narrationContent,
 } from "@/server/db/schema";
 import { fetchFullContent as fetchFullContentFromUrl } from "@/server/services/full-content";
 import * as entriesService from "@/server/services/entries";
 import * as countsService from "@/server/services/counts";
+import { getSubscriptionFeedIds } from "@/server/services/entry-filters";
 import { publishEntryStateChanged } from "@/server/redis/pubsub";
 import { logger } from "@/lib/logger";
 
@@ -210,51 +208,6 @@ const setStarredOutputSchema = z.object({
 });
 
 // ============================================================================
-// Helper Functions
-// ============================================================================
-
-/**
- * Database context type for helper functions.
- */
-type DbContext = {
-  db: typeof import("@/server/db").db;
-};
-
-/**
- * Looks up the feed IDs for a subscription.
- * Returns all feed IDs from the subscription_feeds junction table (current feed + previous feeds from redirects).
- * Validates subscription ownership via user_feeds view.
- *
- * @param db - Database instance
- * @param subscriptionId - The subscription ID to look up
- * @param userId - The user ID (for access control)
- * @returns Array of feed IDs, or null if subscription not found
- */
-async function getSubscriptionFeedIds(
-  db: typeof import("@/server/db").db,
-  subscriptionId: string,
-  userId: string
-): Promise<string[] | null> {
-  // Verify subscription exists and belongs to user
-  const subExists = await db
-    .select({ id: userFeeds.id })
-    .from(userFeeds)
-    .where(and(eq(userFeeds.id, subscriptionId), eq(userFeeds.userId, userId)))
-    .limit(1);
-
-  if (subExists.length === 0) {
-    return null;
-  }
-
-  const result = await db
-    .select({ feedId: subscriptionFeeds.feedId })
-    .from(subscriptionFeeds)
-    .where(eq(subscriptionFeeds.subscriptionId, subscriptionId));
-
-  return result.map((r) => r.feedId);
-}
-
-// ============================================================================
 // Shared Select Fields
 // ============================================================================
 
@@ -324,82 +277,6 @@ function toFullEntry(row: NonNullable<Awaited<ReturnType<typeof selectFullEntry>
   return {
     ...rest,
     fetchFullContent: row.fetchFullContent ?? false,
-  };
-}
-
-// ============================================================================
-// Mutation Helpers
-// ============================================================================
-
-/**
- * Updates the starred status of an entry for a user.
- * Uses idempotent conditional updates: only applies if changedAt is newer than stored timestamp.
- *
- * @param ctx - Database context
- * @param userId - The user ID
- * @param entryId - The entry ID
- * @param starred - Whether to star (true) or unstar (false)
- * @param changedAt - When the user initiated the action. Defaults to now.
- * @returns The final entry state (may differ from requested if a newer change exists)
- * @throws entryNotFound if entry doesn't exist or user doesn't have access
- */
-async function updateEntryStarred(
-  ctx: DbContext,
-  userId: string,
-  entryId: string,
-  starred: boolean,
-  changedAt: Date = new Date()
-): Promise<{
-  id: string;
-  read: boolean;
-  starred: boolean;
-  updatedAt: Date;
-}> {
-  // Build SET clause, including hasStarred flag when starring
-  const setClause: Record<string, unknown> = {
-    starred,
-    starredChangedAt: changedAt,
-    updatedAt: new Date(),
-  };
-
-  // Set implicit signal flag when starring (not when unstarring)
-  if (starred) {
-    setClause.hasStarred = true;
-  }
-
-  // Conditional update: only apply if incoming timestamp is newer
-  await ctx.db
-    .update(userEntries)
-    .set(setClause)
-    .where(
-      and(
-        eq(userEntries.userId, userId),
-        eq(userEntries.entryId, entryId),
-        lte(userEntries.starredChangedAt, changedAt)
-      )
-    );
-
-  // Always return final state from visibleEntries (includes computed updatedAt)
-  const result = await ctx.db
-    .select({
-      id: visibleEntries.id,
-      read: visibleEntries.read,
-      starred: visibleEntries.starred,
-      updatedAt: visibleEntries.updatedAt,
-    })
-    .from(visibleEntries)
-    .where(and(eq(visibleEntries.userId, userId), eq(visibleEntries.id, entryId)));
-
-  if (result.length === 0) {
-    throw errors.entryNotFound();
-  }
-
-  const row = result[0];
-  return {
-    id: row.id,
-    read: row.read,
-    starred: row.starred,
-    updatedAt: row.updatedAt,
   };
 }
 
@@ -573,73 +450,14 @@ export const entriesRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
-      const now = new Date();
 
-      // Build the SET clause, optionally including implicit signal flags
-      const setClause: Record<string, unknown> = {
-        read: input.read,
-        updatedAt: now,
-      };
-
-      // Set implicit score signals based on the action and source
-      if (input.read && input.fromList) {
-        // Marking read from the entry list → implicit -1
-        setClause.hasMarkedReadOnList = true;
-      } else if (!input.read) {
-        // Marking unread from anywhere → implicit +1
-        setClause.hasMarkedUnread = true;
-      }
-
-      // Group entries by timestamp for efficient batch updates
-      // Most cases (interactive use) will have all entries with same/no timestamp
-      const entriesByTimestamp = new Map<string, string[]>();
-      for (const entry of input.entries) {
-        const ts = (entry.changedAt ?? now).toISOString();
-        const existing = entriesByTimestamp.get(ts) ?? [];
-        existing.push(entry.id);
-        entriesByTimestamp.set(ts, existing);
-      }
-
-      // Batch update for each timestamp group
-      for (const [tsIso, entryIds] of entriesByTimestamp) {
-        const changedAt = new Date(tsIso);
-        await ctx.db
-          .update(userEntries)
-          .set({
-            ...setClause,
-            readChangedAt: changedAt,
-          })
-          .where(
-            and(
-              eq(userEntries.userId, userId),
-              inArray(userEntries.entryId, entryIds),
-              or(isNull(userEntries.readChangedAt), lte(userEntries.readChangedAt, changedAt))
-            )
-          );
-      }
-
-      // Always return final state for all requested entries
-      const allEntryIds = input.entries.map((e) => e.id);
-      const entrySubscriptions = await ctx.db
-        .select({
-          id: visibleEntries.id,
-          subscriptionId: visibleEntries.subscriptionId,
-          read: visibleEntries.read,
-          starred: visibleEntries.starred,
-          type: visibleEntries.type,
-          updatedAt: visibleEntries.updatedAt,
-        })
-        .from(visibleEntries)
-        .where(and(eq(visibleEntries.userId, userId), inArray(visibleEntries.id, allEntryIds)));
-
-      const entriesResult = entrySubscriptions.map((e) => ({
-        id: e.id,
-        subscriptionId: e.subscriptionId,
-        read: e.read,
-        starred: e.starred,
-        type: e.type,
-        updatedAt: e.updatedAt,
-      }));
+      const entriesResult = await entriesService.markEntriesRead(
+        ctx.db,
+        userId,
+        input.entries,
+        input.read,
+        { fromList: input.fromList }
+      );
 
       // Get absolute counts for all affected lists
       const counts = await countsService.getBulkEntryRelatedCounts(ctx.db, userId, entriesResult);
@@ -662,7 +480,7 @@ export const entriesRouter = createTRPCRouter({
 
       return {
         success: true,
-        count: entrySubscriptions.length,
+        count: entriesResult.length,
         entries: entriesResult,
         counts,
       };
@@ -764,8 +582,8 @@ export const entriesRouter = createTRPCRouter({
     .output(setStarredOutputSchema)
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
-      const entry = await updateEntryStarred(
-        ctx,
+      const entry = await entriesService.updateEntryStarred(
+        ctx.db,
         userId,
         input.id,
         input.starred,


### PR DESCRIPTION
## Summary

Fixes #869. Several entry write operations were reimplemented inline in the tRPC `entries` router instead of calling the shared service functions, and the copies had drifted. Because MCP / Google Reader / Wallabag call the **services** while the web app called the **router**, the same logical operation set implicit score signals on some surfaces but not others.

This moves the router-only behavior (the implicit score signal flags) into the service layer so every API surface behaves identically.

- **`markEntriesRead`** (service) now owns the grouped conditional write, per-entry timestamps, and the `has_marked_unread` / `has_marked_read_on_list` signals. It returns the rich entry state (`subscriptionId`, `type`, `updatedAt`, …) the router needs for counts and SSE publishing. The router's hand-written copy is gone; `markRead` just calls the service, then `getBulkEntryRelatedCounts`, then publishes.
- **`updateEntryStarred`** (service) now sets the `has_starred` signal when starring and returns `updatedAt` from `visible_entries`. The router's near-duplicate is deleted; `setStarred` calls the service.
- **`getSubscriptionFeedIds`** is now exported from `entry-filters.ts` and the router's duplicate copy is deleted.
- MCP's `mark_entries_read` now computes counts via `getBulkEntryRelatedCounts`, returning the same `{ entries, counts }` shape as the web app.
- Google Reader / Wallabag callers updated to the new `markEntriesRead` signature (`{ id }[]`).

Net: ~180 fewer lines, single source of truth for each operation.

## Behavior notes

- `has_starred` and `has_marked_unread` are surface-independent signals ("from anywhere" per `docs/features/entry-scoring.md`), so they are now correctly recorded on MCP / Google Reader / Wallabag too. `has_marked_read_on_list` stays gated behind `fromList`, which only the web list view passes.
- `updateEntryStarred` now reads final state from `visible_entries` (to get the computed `updatedAt`) on all surfaces, matching the prior web behavior.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:unit` (1703 passed)
- [ ] Integration tests (no local DB/Docker in this environment — `tests/integration/entries.test.ts` and `entries-perf.test.ts` exercise these paths through the tRPC caller and should run in CI)
- [ ] Manual: star/unstar and mark read/unread from web, MCP, Google Reader, and Wallabag still behave correctly and set the expected implicit signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)