### PR TITLE
Fix streamed 500 on entry pages by externalizing jsdom

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -123,7 +123,7 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ["html-rewriter-wasm", "piscina", "trpc-to-openapi"],
   // Handle piper-tts-web which has conditional Node.js code (require('fs'))
   // that the bundler tries to resolve even though it only runs in Node.js
-  webpack: (config, { isServer }) => {
+  webpack: (config, { isServer, nextRuntime }) => {
     if (!isServer) {
       // Stub out Node.js modules for client bundles
       config.resolve.fallback = {
@@ -131,6 +131,17 @@ const nextConfig: NextConfig = {
         fs: false,
         path: false,
       };
+    }
+    // isomorphic-dompurify pulls in jsdom during SSR of `"use client"` components
+    // (e.g. EntryContentBody). jsdom reads browser/default-stylesheet.css via
+    // `path.resolve(__dirname, ...)` at runtime; bundling breaks __dirname so the
+    // read resolves to a bogus path (e.g. /app/browser/default-stylesheet.css) and
+    // throws ENOENT mid-stream, producing a 500 status even though the shell already
+    // rendered. `serverExternalPackages` doesn't cover deps reached through the
+    // client-component SSR graph, so force-externalize jsdom on the Node server build
+    // to load it from node_modules where the __dirname-relative read resolves.
+    if (isServer && nextRuntime === "nodejs") {
+      config.externals.push({ jsdom: "commonjs jsdom" });
     }
     config.devtool = "source-map";
     return config;

--- a/next.config.ts
+++ b/next.config.ts
@@ -141,7 +141,10 @@ const nextConfig: NextConfig = {
     // client-component SSR graph, so force-externalize jsdom on the Node server build
     // to load it from node_modules where the __dirname-relative read resolves.
     if (isServer && nextRuntime === "nodejs") {
-      config.externals.push({ jsdom: "commonjs jsdom" });
+      // Bare string (not { jsdom: "commonjs jsdom" }) so webpack emits the external
+      // in whatever module format the server build uses, staying correct if Next
+      // ever switches the Node server output to ESM.
+      config.externals.push("jsdom");
     }
     config.devtool = "source-map";
     return config;


### PR DESCRIPTION
## Summary

Loading `/all` (and other entry pages) returned an HTTP **500** status even though the page content rendered normally. The error in production logs was:

```
Error: ENOENT: no such file or directory, open '/app/browser/default-stylesheet.css'
```

`default-stylesheet.css` is a **jsdom** internal file. The `EntryContentBody` `"use client"` component imports `isomorphic-dompurify`, which loads jsdom during SSR. jsdom reads that CSS file via `path.resolve(__dirname, "../../../browser/default-stylesheet.css")`. When webpack bundles jsdom into `.next/server/chunks`, `__dirname` collapses to `/app`, so the read resolves to the bogus `/app/browser/default-stylesheet.css` and throws `ENOENT` mid-stream. Because the SSR shell had already flushed, the page looked fine but the response status was 500.

`serverExternalPackages` does **not** cover dependencies reached through the client-component SSR graph (only Server Components / Route Handlers), so adding jsdom there had no effect. Instead this force-externalizes jsdom on the Node server webpack build, loading it from `node_modules` at runtime where the `__dirname`-relative read resolves correctly.

## Verification

- Clean `next build --webpack`: `default-stylesheet` no longer present in any `.next/server/chunks/*`; `require("jsdom")` now appears as an external runtime require in built pages including `.next/server/app/(app)/all/page.js`.
- `node -e "require('isomorphic-dompurify').sanitize(...)"` runs server-side without ENOENT.
- `pnpm typecheck` passes.

Dev mode uses turbopack (which externalizes node_modules differently and doesn't exhibit the bundled-`__dirname` problem), so this change targets the production webpack build where the 500 occurred.

## Test plan

- [ ] Deploy and confirm `GET /all` returns HTTP 200 (check the network tab / inspector status code).
- [ ] Confirm entry content (web/email/saved) still renders and is sanitized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)