### PR TITLE
Enforce API token scopes in tRPC + OAuth audience binding (#870)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -199,6 +199,30 @@ Each provider is enabled by setting its environment variables (client ID and sec
 
 Session tokens are 32 random bytes, base64url encoded. We store SHA-256 hash in database (never the raw token).
 
+### Token Scopes & Authorization
+
+Authorization is **fail-closed** for tokens. There are three credential types:
+
+- **Browser sessions**: full access. Scopes do not apply (`scopes` is a token-only concept).
+- **API tokens** (`api_tokens`, used by extensions/integrations and the legacy MCP path): restricted to their granted scopes.
+- **OAuth 2.1 access tokens**: audience-bound to the MCP endpoint only (see below).
+
+Available scopes (`API_TOKEN_SCOPES` / `OAUTH_SCOPES`):
+
+| Scope         | Grants                                                                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `mcp`         | The MCP tool surface: entries list/get/mark-read/star/count, subscriptions list/get, tag CRUD, saved delete/upload |
+| `saved:write` | Saving articles (`saved.save`) only                                                                                |
+
+Enforcement (`src/server/trpc/trpc.ts`):
+
+- `protectedProcedure` / `confirmedProtectedProcedure` (and their `expensive*` variants) are **session-only** — token auth is rejected with `FORBIDDEN`. This protects account-management and other non-MCP endpoints (sessions, password, preferences, ingest addresses, blocked senders, OPML import, narration, summarization, feed stats, broken feeds, subscription create/update/delete/import/export, `entries.markAllRead`, `entries.fetchFullContent`) by default.
+- `scopedProtectedProcedure(scope | scope[])` opts an endpoint into token access; a token must hold at least one of the listed scopes (sessions bypass). The `mcp`-scoped endpoints mirror the MCP tools exactly; `saved.save` accepts `saved:write` or `mcp`.
+
+Because the default is session-only, **new endpoints are token-inaccessible until they explicitly opt in**.
+
+OAuth access tokens are validated only at `POST /api/mcp` (not in the main tRPC/REST context), where the `mcp` scope and the RFC 8707 `resource`/audience binding are both enforced — a token minted for a different resource is rejected. Dynamic Client Registration (`/oauth/register`) is open per RFC 7591 but rate-limited; it stores only the supported subset of requested scopes and rejects registration if none are recognized (it never falls back to "all scopes").
+
 ---
 
 ## Feed Processing

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -221,7 +221,14 @@ Enforcement (`src/server/trpc/trpc.ts`):
 
 Because the default is session-only, **new endpoints are token-inaccessible until they explicitly opt in**.
 
-OAuth access tokens are validated only at `POST /api/mcp` (not in the main tRPC/REST context), where the `mcp` scope and the RFC 8707 `resource`/audience binding are both enforced — a token minted for a different resource is rejected. Dynamic Client Registration (`/oauth/register`) is open per RFC 7591 but rate-limited; it stores only the supported subset of requested scopes and rejects registration if none are recognized (it never falls back to "all scopes").
+OAuth access tokens are validated only at `POST /api/mcp` (not in the main tRPC/REST context), where the `mcp` scope and the RFC 8707 `resource`/audience binding are both enforced — a token minted for a different resource is rejected.
+
+The audience binding is enforced on both sides:
+
+- **Mint time** (`/oauth/authorize`): the requested `resource` is validated against this server's canonical resource identifier (`getProtectedResourceMetadata().resource`); a mismatch is rejected with `invalid_target`. When `resource` is omitted, it defaults to the canonical identifier so every issued token is audience-bound. Comparison (`isResourceForThisServer`) ignores trailing slashes and is case-insensitive for scheme/host.
+- **Use time** (`/api/mcp`): the token's stored `resource` must match the canonical identifier. Only legacy tokens issued before audience binding may have a null `resource`, which is still accepted (they expire within an hour).
+
+Dynamic Client Registration (`/oauth/register`) is open per RFC 7591 but rate-limited; it stores only the supported subset of requested scopes and rejects registration if none are recognized (it never falls back to "all scopes").
 
 ---
 

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -24,7 +24,7 @@ import { db } from "@/server/db";
 import { registerTools } from "@/server/mcp/tools";
 import { validateApiToken, API_TOKEN_SCOPES } from "@/server/auth/api-token";
 import { validateAccessToken } from "@/server/oauth/service";
-import { OAUTH_SCOPES } from "@/server/oauth/utils";
+import { OAUTH_SCOPES, isResourceForThisServer } from "@/server/oauth/utils";
 import { getProtectedResourceMetadata } from "@/server/oauth/config";
 import { logger } from "@/lib/logger";
 
@@ -64,13 +64,15 @@ async function authenticateRequest(request: NextRequest): Promise<AuthResult> {
       return { success: false, reason: "oauth_token_missing_mcp_scope" };
     }
     // Enforce RFC 8707 audience binding: a token minted for a different resource
-    // must not be accepted here. We only validate when a resource was recorded
-    // (tokens issued without a resource indicator are not audience-restricted).
-    if (oauthToken.resource && oauthToken.resource !== getProtectedResourceMetadata().resource) {
+    // must not be accepted here. Newly issued tokens always carry a resource
+    // (bound at authorization time); only legacy tokens issued before audience
+    // binding may have a null resource, which we still accept.
+    const expectedResource = getProtectedResourceMetadata().resource;
+    if (oauthToken.resource && !isResourceForThisServer(oauthToken.resource, expectedResource)) {
       logger.warn("MCP auth: OAuth token resource/audience mismatch", {
         userId: oauthToken.userId,
         tokenResource: oauthToken.resource,
-        expectedResource: getProtectedResourceMetadata().resource,
+        expectedResource,
       });
       return { success: false, reason: "oauth_token_audience_mismatch" };
     }

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -63,6 +63,17 @@ async function authenticateRequest(request: NextRequest): Promise<AuthResult> {
       });
       return { success: false, reason: "oauth_token_missing_mcp_scope" };
     }
+    // Enforce RFC 8707 audience binding: a token minted for a different resource
+    // must not be accepted here. We only validate when a resource was recorded
+    // (tokens issued without a resource indicator are not audience-restricted).
+    if (oauthToken.resource && oauthToken.resource !== getProtectedResourceMetadata().resource) {
+      logger.warn("MCP auth: OAuth token resource/audience mismatch", {
+        userId: oauthToken.userId,
+        tokenResource: oauthToken.resource,
+        expectedResource: getProtectedResourceMetadata().resource,
+      });
+      return { success: false, reason: "oauth_token_audience_mismatch" };
+    }
     return { success: true, userId: oauthToken.userId };
   }
 

--- a/src/app/oauth/authorize/route.ts
+++ b/src/app/oauth/authorize/route.ts
@@ -19,12 +19,13 @@ import {
   isValidCodeChallenge,
   validateRedirectUri,
   isValidRedirectUriFormat,
+  isResourceForThisServer,
   parseScopes,
   validateScopes,
   OAUTH_ERRORS,
   createOAuthError,
 } from "@/server/oauth/utils";
-import { getIssuer } from "@/server/oauth/config";
+import { getIssuer, getProtectedResourceMetadata } from "@/server/oauth/config";
 import { logger } from "@/lib/logger";
 
 /**
@@ -177,6 +178,21 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  // Validate the RFC 8707 resource indicator (server-side audience binding).
+  // A token issued here is only ever valid for this server's MCP endpoint, so a
+  // client requesting a different resource is rejected. When omitted, we bind to
+  // our canonical resource so every token is audience-restricted.
+  const canonicalResource = getProtectedResourceMetadata().resource;
+  if (resource !== undefined && !isResourceForThisServer(resource, canonicalResource)) {
+    return buildErrorRedirect(
+      redirectUri,
+      OAUTH_ERRORS.INVALID_TARGET,
+      "The requested resource is not served by this authorization server",
+      state
+    );
+  }
+  const effectiveResource = resource ?? canonicalResource;
+
   // Check if user is authenticated
   const sessionToken = getSessionToken(request);
   if (!sessionToken) {
@@ -210,9 +226,7 @@ export async function GET(request: NextRequest) {
     if (state) {
       consentUrl.searchParams.set("state", state);
     }
-    if (resource) {
-      consentUrl.searchParams.set("resource", resource);
-    }
+    consentUrl.searchParams.set("resource", effectiveResource);
     return NextResponse.redirect(consentUrl.toString());
   }
 
@@ -223,7 +237,7 @@ export async function GET(request: NextRequest) {
     redirectUri,
     scopes: validScopes,
     codeChallenge,
-    resource,
+    resource: effectiveResource,
     state,
   });
 
@@ -286,6 +300,18 @@ export async function POST(request: NextRequest) {
   const userId = session.user.id;
   const scopes = scope ? scope.split(" ") : ["mcp"];
 
+  // Validate / bind the RFC 8707 resource indicator (see GET handler).
+  const canonicalResource = getProtectedResourceMetadata().resource;
+  if (resource !== undefined && !isResourceForThisServer(resource, canonicalResource)) {
+    return buildErrorRedirect(
+      redirectUri,
+      OAUTH_ERRORS.INVALID_TARGET,
+      "The requested resource is not served by this authorization server",
+      state
+    );
+  }
+  const effectiveResource = resource ?? canonicalResource;
+
   // Handle user decision
   if (action === "deny") {
     return buildErrorRedirect(
@@ -307,7 +333,7 @@ export async function POST(request: NextRequest) {
       redirectUri,
       scopes,
       codeChallenge,
-      resource,
+      resource: effectiveResource,
       state,
     });
 

--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { registerClient, type ClientRegistrationRequest } from "@/server/oauth/service";
+import { checkRouteRateLimit } from "@/server/rate-limit";
 import { logger } from "@/lib/logger";
 
 /**
@@ -16,6 +17,14 @@ import { logger } from "@/lib/logger";
  */
 export async function POST(request: NextRequest) {
   logger.info("OAuth client registration requested");
+
+  // Dynamic Client Registration is open (no auth) per RFC 7591, so rate-limit by
+  // IP to prevent anonymous client-spam. Uses the strict "expensive" bucket.
+  const rateLimited = await checkRouteRateLimit(request, "expensive", { json: true });
+  if (rateLimited) {
+    return rateLimited;
+  }
+
   // Parse JSON body
   const contentType = request.headers.get("content-type") ?? "";
   if (!contentType.includes("application/json")) {

--- a/src/server/oauth/service.ts
+++ b/src/server/oauth/service.ts
@@ -660,17 +660,29 @@ export async function registerClient(
     responseTypes.push("code");
   }
 
-  // Validate scope
+  // Validate scope. A client that requests scopes gets exactly the supported
+  // subset of those scopes. If none of the requested scopes are recognized we
+  // reject the registration rather than silently broadening to "all scopes"
+  // (defaulting unknown scopes to null/all is a privilege-escalation footgun).
+  // When no scope is requested, scopes stays null (client may later request any
+  // supported scope at authorization time, subject to user consent).
   const supportedScopes = Object.values(OAUTH_SCOPES);
   let scopes: string[] | null = null;
   if (request.scope) {
     const requestedScopes = request.scope.split(" ");
-    scopes = requestedScopes.filter((s) =>
+    const validScopes = requestedScopes.filter((s) =>
       supportedScopes.includes(s as (typeof supportedScopes)[number])
     );
-    if (scopes.length === 0) {
-      scopes = null; // Allow all scopes if none of the requested scopes are valid
+    if (validScopes.length === 0) {
+      return {
+        success: false,
+        error: {
+          error: "invalid_client_metadata",
+          error_description: `None of the requested scopes are supported. Supported scopes: ${supportedScopes.join(", ")}`,
+        },
+      };
     }
+    scopes = validScopes;
   }
 
   // Generate client ID

--- a/src/server/oauth/service.ts
+++ b/src/server/oauth/service.ts
@@ -670,8 +670,12 @@ export async function registerClient(
   let scopes: string[] | null = null;
   if (request.scope) {
     const requestedScopes = request.scope.split(" ");
-    const validScopes = requestedScopes.filter((s) =>
-      supportedScopes.includes(s as (typeof supportedScopes)[number])
+    const validScopes = Array.from(
+      new Set(
+        requestedScopes.filter((s) =>
+          supportedScopes.includes(s as (typeof supportedScopes)[number])
+        )
+      )
     );
     if (validScopes.length === 0) {
       return {

--- a/src/server/oauth/utils.ts
+++ b/src/server/oauth/utils.ts
@@ -188,6 +188,41 @@ export function validateScopes(
 }
 
 // ============================================================================
+// Resource Indicator Validation (RFC 8707)
+// ============================================================================
+
+/**
+ * Normalizes a resource indicator for comparison: absolute URI, no fragment,
+ * trailing slashes on the path removed. Scheme and host are already
+ * lowercased by the URL parser. Returns null if the value is not a valid
+ * absolute URI or contains a fragment (RFC 8707 §2 forbids fragments).
+ */
+function normalizeResource(value: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (url.hash) {
+    return null;
+  }
+  const path = url.pathname.replace(/\/+$/, "");
+  return `${url.protocol}//${url.host}${path}${url.search}`;
+}
+
+/**
+ * Checks whether an RFC 8707 resource indicator refers to this server's
+ * canonical resource identifier. Comparison ignores trailing slashes and is
+ * case-insensitive for scheme/host. Returns false for malformed resources.
+ */
+export function isResourceForThisServer(resource: string, canonical: string): boolean {
+  const a = normalizeResource(resource);
+  const b = normalizeResource(canonical);
+  return a !== null && b !== null && a === b;
+}
+
+// ============================================================================
 // Expiry Calculation
 // ============================================================================
 
@@ -241,6 +276,8 @@ export const OAUTH_ERRORS = {
   INVALID_CLIENT_METADATA: "invalid_client_metadata",
   INVALID_SOFTWARE_STATEMENT: "invalid_software_statement",
   UNAPPROVED_SOFTWARE_STATEMENT: "unapproved_software_statement",
+  // RFC 8707 Resource Indicators
+  INVALID_TARGET: "invalid_target",
 } as const;
 
 export type OAuthError = (typeof OAUTH_ERRORS)[keyof typeof OAUTH_ERRORS];

--- a/src/server/trpc/context.ts
+++ b/src/server/trpc/context.ts
@@ -127,10 +127,18 @@ export async function createContext(opts: FetchCreateContextFnOptions): Promise<
     };
   }
 
-  // Try API token validation
+  // Try API token validation.
+  //
+  // Note: OAuth 2.1 access tokens are intentionally NOT accepted here. They are
+  // audience-bound to the MCP endpoint (`/api/mcp`, see validateAccessToken +
+  // the RFC 8707 resource check there). The main tRPC/REST API is reachable only
+  // via browser sessions and legacy API tokens.
   const apiTokenData = await validateApiToken(token);
   if (apiTokenData) {
-    // Create a synthetic session for compatibility with existing code
+    // Build a synthetic session so downstream code can read user data uniformly.
+    // This does NOT grant full access: token requests carry the token's scopes
+    // (below) and every protected procedure is either session-only or enforces a
+    // scope via `scopedProtectedProcedure`. See src/server/trpc/trpc.ts.
     const syntheticSession: SessionData = {
       session: {
         id: apiTokenData.token.id,

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -13,8 +13,16 @@ import { z } from "zod";
 import { eq, and } from "drizzle-orm";
 import { createHash } from "crypto";
 
-import { createTRPCRouter, confirmedProtectedProcedure as protectedProcedure } from "../trpc";
+import {
+  createTRPCRouter,
+  confirmedProtectedProcedure as protectedProcedure,
+  scopedProtectedProcedure,
+} from "../trpc";
+import { API_TOKEN_SCOPES } from "@/server/auth/api-token";
 import { errors } from "../errors";
+
+// Endpoints exposed via the MCP tool surface; accessible to tokens with the `mcp` scope.
+const mcpProcedure = scopedProtectedProcedure(API_TOKEN_SCOPES.MCP);
 import { uuidSchema } from "../validation";
 import {
   entries,
@@ -305,7 +313,7 @@ export const entriesRouter = createTRPCRouter({
    * @param limit - Optional number of entries per page (default: 50, max: 100)
    * @returns Paginated list of entries
    */
-  list: protectedProcedure
+  list: mcpProcedure
     .meta({
       openapi: {
         method: "GET",
@@ -365,7 +373,7 @@ export const entriesRouter = createTRPCRouter({
    * @param id - The entry ID
    * @returns The full entry with content and subscription data
    */
-  get: protectedProcedure
+  get: mcpProcedure
     .meta({
       openapi: {
         method: "GET",
@@ -404,7 +412,7 @@ export const entriesRouter = createTRPCRouter({
    * @param read - Whether to mark as read (true) or unread (false)
    * @returns The updated entries with subscription context for cache updates
    */
-  markRead: protectedProcedure
+  markRead: mcpProcedure
     .meta({
       openapi: {
         method: "POST",
@@ -563,7 +571,7 @@ export const entriesRouter = createTRPCRouter({
    * @param starred - Whether to star (true) or unstar (false)
    * @returns The updated entry with current state
    */
-  setStarred: protectedProcedure
+  setStarred: mcpProcedure
     .meta({
       openapi: {
         method: "POST",
@@ -623,7 +631,7 @@ export const entriesRouter = createTRPCRouter({
    * @param starredOnly - Optional filter to count only starred entries
    * @returns Count of total and unread entries
    */
-  count: protectedProcedure
+  count: mcpProcedure
     .meta({
       openapi: {
         method: "GET",

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -20,9 +20,6 @@ import {
 } from "../trpc";
 import { API_TOKEN_SCOPES } from "@/server/auth/api-token";
 import { errors } from "../errors";
-
-// Endpoints exposed via the MCP tool surface; accessible to tokens with the `mcp` scope.
-const mcpProcedure = scopedProtectedProcedure(API_TOKEN_SCOPES.MCP);
 import { uuidSchema } from "../validation";
 import {
   entries,
@@ -38,6 +35,9 @@ import * as countsService from "@/server/services/counts";
 import { getSubscriptionFeedIds } from "@/server/services/entry-filters";
 import { publishEntryStateChanged } from "@/server/redis/pubsub";
 import { logger } from "@/lib/logger";
+
+// Endpoints exposed via the MCP tool surface; accessible to tokens with the `mcp` scope.
+const mcpProcedure = scopedProtectedProcedure(API_TOKEN_SCOPES.MCP);
 
 // ============================================================================
 // Constants

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -22,12 +22,11 @@ import { eq, and } from "drizzle-orm";
 import { Parser } from "htmlparser2";
 import { TRPCError } from "@trpc/server";
 
-import {
-  createTRPCRouter,
-  confirmedProtectedProcedure as protectedProcedure,
-  scopedProtectedProcedure,
-} from "../trpc";
+import { createTRPCRouter, scopedProtectedProcedure } from "../trpc";
 import { API_TOKEN_SCOPES } from "@/server/auth/api-token";
+
+// Saved-article reads/management are part of the MCP tool surface (`mcp` scope).
+const mcpProcedure = scopedProtectedProcedure(API_TOKEN_SCOPES.MCP);
 import { errors } from "../errors";
 import { uuidSchema } from "../validation";
 import { fetchHtmlPage, HttpFetchError } from "@/server/http/fetch";
@@ -220,7 +219,7 @@ export const savedRouter = createTRPCRouter({
    * @param title - Optional title hint (from bookmarklet's document.title)
    * @returns The saved article
    */
-  save: scopedProtectedProcedure(API_TOKEN_SCOPES.SAVED_WRITE)
+  save: scopedProtectedProcedure([API_TOKEN_SCOPES.SAVED_WRITE, API_TOKEN_SCOPES.MCP])
     .meta({
       openapi: {
         method: "POST",
@@ -794,7 +793,7 @@ export const savedRouter = createTRPCRouter({
    * @param id - The saved article ID to delete
    * @returns Empty object on success
    */
-  delete: protectedProcedure
+  delete: mcpProcedure
     .meta({
       openapi: {
         method: "DELETE",
@@ -853,7 +852,7 @@ export const savedRouter = createTRPCRouter({
    * @param title - Optional title override
    * @returns The saved article
    */
-  uploadFile: protectedProcedure
+  uploadFile: mcpProcedure
     .meta({
       openapi: {
         method: "POST",

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -24,9 +24,6 @@ import { TRPCError } from "@trpc/server";
 
 import { createTRPCRouter, scopedProtectedProcedure } from "../trpc";
 import { API_TOKEN_SCOPES } from "@/server/auth/api-token";
-
-// Saved-article reads/management are part of the MCP tool surface (`mcp` scope).
-const mcpProcedure = scopedProtectedProcedure(API_TOKEN_SCOPES.MCP);
 import { errors } from "../errors";
 import { uuidSchema } from "../validation";
 import { fetchHtmlPage, HttpFetchError } from "@/server/http/fetch";
@@ -61,6 +58,9 @@ import {
 } from "@/server/file/process-upload";
 import { pluginRegistry } from "@/server/plugins";
 import { generateContentHash, createUploadedArticle } from "@/server/services/saved";
+
+// Saved-article reads/management are part of the MCP tool surface (`mcp` scope).
+const mcpProcedure = scopedProtectedProcedure(API_TOKEN_SCOPES.MCP);
 
 // ============================================================================
 // Validation Schemas

--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -16,9 +16,6 @@ import {
 } from "../trpc";
 import { API_TOKEN_SCOPES } from "@/server/auth/api-token";
 import { errors } from "../errors";
-
-// Endpoints exposed via the MCP tool surface; accessible to tokens with the `mcp` scope.
-const mcpProcedure = scopedProtectedProcedure(API_TOKEN_SCOPES.MCP);
 import { feedUrlSchema, uuidSchema } from "../validation";
 import { fetchUrl, isHtmlContent } from "@/server/http/fetch";
 import {
@@ -43,6 +40,9 @@ import { publishSubscriptionDeleted, publishSubscriptionUpdated } from "@/server
 import { attemptUnsubscribe, getLatestUnsubscribeMailto } from "@/server/email/unsubscribe";
 import { logger } from "@/lib/logger";
 import * as subscriptionsService from "@/server/services/subscriptions";
+
+// Endpoints exposed via the MCP tool surface; accessible to tokens with the `mcp` scope.
+const mcpProcedure = scopedProtectedProcedure(API_TOKEN_SCOPES.MCP);
 
 // ============================================================================
 // Validation Schemas

--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -12,8 +12,13 @@ import {
   createTRPCRouter,
   confirmedProtectedProcedure as protectedProcedure,
   expensiveConfirmedProtectedProcedure as expensiveProtectedProcedure,
+  scopedProtectedProcedure,
 } from "../trpc";
+import { API_TOKEN_SCOPES } from "@/server/auth/api-token";
 import { errors } from "../errors";
+
+// Endpoints exposed via the MCP tool surface; accessible to tokens with the `mcp` scope.
+const mcpProcedure = scopedProtectedProcedure(API_TOKEN_SCOPES.MCP);
 import { feedUrlSchema, uuidSchema } from "../validation";
 import { fetchUrl, isHtmlContent } from "@/server/http/fetch";
 import {
@@ -229,7 +234,7 @@ export const subscriptionsRouter = createTRPCRouter({
    *
    * Returns subscriptions with their associated feed information and unread counts.
    */
-  list: protectedProcedure
+  list: mcpProcedure
     .meta({
       openapi: {
         method: "GET",
@@ -270,7 +275,7 @@ export const subscriptionsRouter = createTRPCRouter({
    *
    * Returns the subscription with its associated feed information and unread count.
    */
-  get: protectedProcedure
+  get: mcpProcedure
     .meta({
       openapi: {
         method: "GET",

--- a/src/server/trpc/routers/tags.ts
+++ b/src/server/trpc/routers/tags.ts
@@ -8,9 +8,13 @@
 
 import { z } from "zod";
 
-import { createTRPCRouter, confirmedProtectedProcedure as protectedProcedure } from "../trpc";
+import { createTRPCRouter, scopedProtectedProcedure } from "../trpc";
+import { API_TOKEN_SCOPES } from "@/server/auth/api-token";
 import { uuidSchema } from "../validation";
 import * as tagsService from "@/server/services/tags";
+
+// All tag operations are part of the MCP tool surface; accessible to tokens with the `mcp` scope.
+const protectedProcedure = scopedProtectedProcedure(API_TOKEN_SCOPES.MCP);
 
 // ============================================================================
 // Validation Schemas

--- a/src/server/trpc/trpc.ts
+++ b/src/server/trpc/trpc.ts
@@ -148,12 +148,42 @@ const authMiddleware = t.middleware(({ ctx, next }) => {
 });
 
 /**
- * Protected procedure - requires authentication.
+ * Middleware that rejects API token / OAuth token auth, allowing only browser
+ * sessions. This makes scope enforcement fail-closed: any endpoint that does not
+ * explicitly opt into a token scope (via `scopedProtectedProcedure`) is
+ * session-only, so tokens cannot reach account-management or other sensitive
+ * operations even though they produce a synthetic session in the context.
+ *
+ * Must be chained after authMiddleware.
+ */
+const sessionOnlyMiddleware = t.middleware(({ ctx, next }) => {
+  if (ctx.authType !== "session") {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "API tokens cannot access this endpoint; it requires a logged-in session",
+    });
+  }
+  // session/sessionToken are guaranteed non-null for session auth (authMiddleware
+  // ran first); re-pass them so downstream procedures keep the narrowed types.
+  return next({
+    ctx: {
+      ...ctx,
+      session: ctx.session!,
+      sessionToken: ctx.sessionToken!,
+    },
+  });
+});
+
+/**
+ * Protected procedure - requires a browser session (not an API token).
  * The session is guaranteed to be non-null in the handler.
  * Does NOT require signup confirmation — use for auth management endpoints
  * (auth.me, auth.confirmSignup, auth.logout, etc.)
  */
-export const protectedProcedure = t.procedure.use(timingMiddleware).use(authMiddleware);
+export const protectedProcedure = t.procedure
+  .use(timingMiddleware)
+  .use(authMiddleware)
+  .use(sessionOnlyMiddleware);
 
 /**
  * Middleware that enforces signup confirmation.
@@ -187,6 +217,7 @@ const confirmedMiddleware = t.middleware(({ ctx, next }) => {
 export const confirmedProtectedProcedure = t.procedure
   .use(timingMiddleware)
   .use(authMiddleware)
+  .use(sessionOnlyMiddleware)
   .use(confirmedMiddleware);
 
 // ============================================================================
@@ -194,24 +225,27 @@ export const confirmedProtectedProcedure = t.procedure
 // ============================================================================
 
 /**
- * Creates a middleware that enforces a specific API token scope.
- * Session-based auth (browser) has full access; API tokens must have the scope.
+ * Creates a middleware that enforces API token scopes.
+ * Session-based auth (browser) has full access; tokens must hold at least one
+ * of the required scopes (any-of).
  *
  * Must be chained after authMiddleware to receive narrowed types.
  */
-function createScopeMiddleware(requiredScope: ApiTokenScope) {
+function createScopeMiddleware(requiredScopes: ApiTokenScope[]) {
   return t.middleware(({ ctx, next }) => {
     // Session and sessionToken are guaranteed non-null after authMiddleware
     const session = ctx.session!;
     const sessionToken = ctx.sessionToken!;
 
-    // API token auth - must have the required scope
-    // Session auth (browser) has full access - no scope restrictions
-    if (ctx.authType === "api_token") {
-      if (!ctx.scopes.includes(requiredScope)) {
+    // Token auth (API token / OAuth) must hold one of the required scopes.
+    // Session auth (browser) has full access - no scope restrictions.
+    if (ctx.authType !== "session") {
+      const hasScope = requiredScopes.some((scope) => ctx.scopes.includes(scope));
+      if (!hasScope) {
+        const list = requiredScopes.map((s) => `'${s}'`).join(" or ");
         throw new TRPCError({
           code: "FORBIDDEN",
-          message: `This operation requires the '${requiredScope}' scope`,
+          message: `This operation requires the ${list} scope`,
         });
       }
     }
@@ -228,18 +262,19 @@ function createScopeMiddleware(requiredScope: ApiTokenScope) {
 }
 
 /**
- * Creates a protected procedure that requires a specific API token scope.
- * Session-based auth has full access; API tokens must have the specified scope.
- * Also requires signup confirmation.
+ * Creates a protected procedure that requires an API token scope.
+ * Session-based auth has full access; tokens must hold at least one of the
+ * specified scopes. Also requires signup confirmation.
  *
- * @param scope - The required scope for API token access
+ * @param scopes - The required scope(s) for token access (any-of)
  */
-export function scopedProtectedProcedure(scope: ApiTokenScope) {
+export function scopedProtectedProcedure(scopes: ApiTokenScope | ApiTokenScope[]) {
+  const requiredScopes = Array.isArray(scopes) ? scopes : [scopes];
   return t.procedure
     .use(timingMiddleware)
     .use(authMiddleware)
     .use(confirmedMiddleware)
-    .use(createScopeMiddleware(scope));
+    .use(createScopeMiddleware(requiredScopes));
 }
 
 // ============================================================================
@@ -344,6 +379,7 @@ export const expensivePublicProcedure = t.procedure
 export const expensiveProtectedProcedure = t.procedure
   .use(timingMiddleware)
   .use(authMiddleware)
+  .use(sessionOnlyMiddleware)
   .use(createAuthenticatedRateLimitMiddleware("expensive"));
 
 /**
@@ -354,6 +390,7 @@ export const expensiveProtectedProcedure = t.procedure
 export const expensiveConfirmedProtectedProcedure = t.procedure
   .use(timingMiddleware)
   .use(authMiddleware)
+  .use(sessionOnlyMiddleware)
   .use(confirmedMiddleware)
   .use(createAuthenticatedRateLimitMiddleware("expensive"));
 

--- a/tests/integration/oauth-register.test.ts
+++ b/tests/integration/oauth-register.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Integration tests for OAuth Dynamic Client Registration (RFC 7591) scope handling.
+ *
+ * See issue #870: registration previously fell back to `scopes = null` ("allow
+ * all") when none of the requested scopes were recognized. It must instead
+ * reject the registration, and only ever store the supported subset.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { inArray } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { oauthClients } from "../../src/server/db/schema";
+import { registerClient } from "../../src/server/oauth/service";
+
+const registeredClientIds: string[] = [];
+
+async function register(scope: string | undefined) {
+  const result = await registerClient({
+    redirect_uris: ["https://example.com/callback"],
+    client_name: "Test Client",
+    scope,
+  });
+  if (result.success) {
+    registeredClientIds.push(result.data.client_id);
+  }
+  return result;
+}
+
+afterAll(async () => {
+  if (registeredClientIds.length > 0) {
+    await db.delete(oauthClients).where(inArray(oauthClients.clientId, registeredClientIds));
+  }
+});
+
+describe("OAuth Dynamic Client Registration scope handling", () => {
+  it("rejects registration when no requested scope is recognized", async () => {
+    const result = await register("totally-made-up another-bogus-scope");
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.error).toBe("invalid_client_metadata");
+    }
+  });
+
+  it("stores only the supported subset of requested scopes", async () => {
+    const result = await register("mcp bogus-scope");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.scope).toBe("mcp");
+    }
+  });
+
+  it("accepts a single valid scope", async () => {
+    const result = await register("saved:write");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.scope).toBe("saved:write");
+    }
+  });
+});

--- a/tests/integration/token-scopes.test.ts
+++ b/tests/integration/token-scopes.test.ts
@@ -107,6 +107,16 @@ async function expectForbidden(promise: Promise<unknown>): Promise<void> {
   });
 }
 
+/**
+ * Asserts the promise rejects with a non-FORBIDDEN TRPCError code, which proves
+ * the scope gate let the request through (it failed later, e.g. on input
+ * validation or a missing record, not on authorization).
+ */
+async function expectPassedScopeGate(promise: Promise<unknown>, code: string): Promise<void> {
+  await expect(promise).rejects.toMatchObject({ code });
+  expect(code).not.toBe("FORBIDDEN");
+}
+
 afterAll(async () => {
   for (const userId of createdUserIds) {
     await db.delete(users).where(eq(users.id, userId));
@@ -148,6 +158,40 @@ describe("API token scope enforcement", () => {
       const caller = createCaller(createTokenContext(userId, []));
 
       await expectForbidden(caller.entries.list({}));
+    });
+  });
+
+  describe("saved-article endpoints (any-of scope behavior)", () => {
+    // saved.save accepts saved:write OR mcp. We use an invalid URL so the call
+    // fails input validation (BAD_REQUEST) *after* the scope gate, proving the
+    // gate allowed the request without performing a real network fetch.
+    it("saved.save accepts both saved:write and mcp tokens", async () => {
+      const writeUser = await createTestUser();
+      const mcpUser = await createTestUser();
+      const writeCaller = createCaller(createTokenContext(writeUser, ["saved:write"]));
+      const mcpCaller = createCaller(createTokenContext(mcpUser, ["mcp"]));
+
+      await expectPassedScopeGate(writeCaller.saved.save({ url: "not-a-url" }), "BAD_REQUEST");
+      await expectPassedScopeGate(mcpCaller.saved.save({ url: "not-a-url" }), "BAD_REQUEST");
+    });
+
+    it("saved.save rejects a token with no scopes", async () => {
+      const userId = await createTestUser();
+      const caller = createCaller(createTokenContext(userId, []));
+
+      await expectForbidden(caller.saved.save({ url: "not-a-url" }));
+    });
+
+    // saved.delete requires the mcp scope. A non-existent id yields NOT_FOUND for
+    // an mcp token (gate passed) but FORBIDDEN for a saved:write-only token.
+    it("saved.delete requires mcp; saved:write is rejected", async () => {
+      const mcpUser = await createTestUser();
+      const writeUser = await createTestUser();
+      const mcpCaller = createCaller(createTokenContext(mcpUser, ["mcp"]));
+      const writeCaller = createCaller(createTokenContext(writeUser, ["saved:write"]));
+
+      await expectPassedScopeGate(mcpCaller.saved.delete({ id: generateUuidv7() }), "NOT_FOUND");
+      await expectForbidden(writeCaller.saved.delete({ id: generateUuidv7() }));
     });
   });
 

--- a/tests/integration/token-scopes.test.ts
+++ b/tests/integration/token-scopes.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Integration tests for API token scope enforcement in tRPC.
+ *
+ * Verifies that scoped API tokens are restricted to the endpoints their scope
+ * grants (the MCP tool surface for `mcp`, saving for `saved:write`), while
+ * account-management / non-MCP endpoints are session-only. Browser sessions
+ * retain full access.
+ *
+ * See issue #870: scoped tokens previously got a full-access synthetic session.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createCaller } from "../../src/server/trpc/root";
+import type { Context } from "../../src/server/trpc/context";
+import type { ApiTokenScope } from "../../src/server/auth/api-token";
+import { TRPCError } from "@trpc/server";
+
+const createdUserIds: string[] = [];
+
+async function createTestUser(): Promise<string> {
+  const userId = generateUuidv7();
+  await db.insert(users).values({
+    id: userId,
+    email: `scope-${userId}@test.com`,
+    passwordHash: "test-hash",
+    tosAgreedAt: new Date(),
+    privacyPolicyAgreedAt: new Date(),
+    notEuAgreedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  createdUserIds.push(userId);
+  return userId;
+}
+
+function buildSession(userId: string): NonNullable<Context["session"]> {
+  const now = new Date();
+  return {
+    session: {
+      id: generateUuidv7(),
+      userId,
+      tokenHash: "test-hash",
+      userAgent: null,
+      ipAddress: null,
+      createdAt: now,
+      expiresAt: new Date(Date.now() + 3600000),
+      revokedAt: null,
+      lastActiveAt: now,
+    },
+    user: {
+      id: userId,
+      email: `${userId}@test.com`,
+      emailVerifiedAt: null,
+      tosAgreedAt: now,
+      privacyPolicyAgreedAt: now,
+      notEuAgreedAt: now,
+      passwordHash: "test-hash",
+      inviteId: null,
+      showSpam: false,
+      groqApiKey: null,
+      anthropicApiKey: null,
+      summarizationModel: null,
+      summarizationMaxWords: null,
+      summarizationPrompt: null,
+      createdAt: now,
+      updatedAt: now,
+    },
+    hasGroqApiKey: false,
+    hasAnthropicApiKey: false,
+  };
+}
+
+function createSessionContext(userId: string): Context {
+  return {
+    db,
+    session: buildSession(userId),
+    apiToken: null,
+    authType: "session",
+    scopes: [],
+    sessionToken: "test-token",
+    headers: new Headers(),
+  };
+}
+
+function createTokenContext(userId: string, scopes: ApiTokenScope[]): Context {
+  return {
+    db,
+    // Synthetic session (matches what createContext builds for API tokens).
+    session: buildSession(userId),
+    apiToken: null,
+    authType: "api_token",
+    scopes,
+    sessionToken: "test-token",
+    headers: new Headers(),
+  };
+}
+
+async function expectForbidden(promise: Promise<unknown>): Promise<void> {
+  await expect(promise).rejects.toMatchObject({ code: "FORBIDDEN" });
+  // Sanity-check it's actually a TRPCError, not some other rejection.
+  await promise.catch((err) => {
+    expect(err).toBeInstanceOf(TRPCError);
+  });
+}
+
+afterAll(async () => {
+  for (const userId of createdUserIds) {
+    await db.delete(users).where(eq(users.id, userId));
+  }
+});
+
+describe("API token scope enforcement", () => {
+  describe("mcp-scoped token", () => {
+    it("can access MCP-surface endpoints (entries.list, tags.list)", async () => {
+      const userId = await createTestUser();
+      const caller = createCaller(createTokenContext(userId, ["mcp"]));
+
+      await expect(caller.entries.list({})).resolves.toBeDefined();
+      await expect(caller.tags.list()).resolves.toBeDefined();
+    });
+
+    it("cannot access session-only endpoints (sessions, narration)", async () => {
+      const userId = await createTestUser();
+      const caller = createCaller(createTokenContext(userId, ["mcp"]));
+
+      await expectForbidden(caller.users["me.sessions"]());
+      await expectForbidden(caller.narration.isAiTextProcessingAvailable());
+    });
+  });
+
+  describe("saved:write-only token", () => {
+    it("cannot access mcp-scoped endpoints", async () => {
+      const userId = await createTestUser();
+      const caller = createCaller(createTokenContext(userId, ["saved:write"]));
+
+      await expectForbidden(caller.entries.list({}));
+      await expectForbidden(caller.tags.list());
+    });
+  });
+
+  describe("token with no scopes", () => {
+    it("cannot access mcp-scoped endpoints", async () => {
+      const userId = await createTestUser();
+      const caller = createCaller(createTokenContext(userId, []));
+
+      await expectForbidden(caller.entries.list({}));
+    });
+  });
+
+  describe("browser session", () => {
+    it("retains full access to both mcp-surface and session-only endpoints", async () => {
+      const userId = await createTestUser();
+      const caller = createCaller(createSessionContext(userId));
+
+      await expect(caller.entries.list({})).resolves.toBeDefined();
+      await expect(caller.users["me.sessions"]()).resolves.toBeDefined();
+      await expect(caller.narration.isAiTextProcessingAvailable()).resolves.toBeDefined();
+    });
+  });
+});

--- a/tests/unit/oauth-resource.test.ts
+++ b/tests/unit/oauth-resource.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for RFC 8707 resource indicator matching.
+ *
+ * See issue #870: OAuth tokens are audience-bound to this server's MCP
+ * endpoint; the resource indicator is validated server-side at authorization
+ * time and again at /api/mcp.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isResourceForThisServer } from "../../src/server/oauth/utils";
+
+const CANONICAL = "https://reader.example.com";
+
+describe("isResourceForThisServer", () => {
+  it("matches the exact canonical resource", () => {
+    expect(isResourceForThisServer(CANONICAL, CANONICAL)).toBe(true);
+  });
+
+  it("ignores a trailing slash difference", () => {
+    expect(isResourceForThisServer("https://reader.example.com/", CANONICAL)).toBe(true);
+    expect(isResourceForThisServer(CANONICAL, "https://reader.example.com/")).toBe(true);
+  });
+
+  it("is case-insensitive for scheme and host", () => {
+    expect(isResourceForThisServer("HTTPS://Reader.Example.com", CANONICAL)).toBe(true);
+  });
+
+  it("matches when both include the same path", () => {
+    expect(
+      isResourceForThisServer(
+        "https://reader.example.com/api/mcp",
+        "https://reader.example.com/api/mcp"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects a different host", () => {
+    expect(isResourceForThisServer("https://evil.example.com", CANONICAL)).toBe(false);
+  });
+
+  it("rejects a different scheme", () => {
+    expect(isResourceForThisServer("http://reader.example.com", CANONICAL)).toBe(false);
+  });
+
+  it("rejects a different port", () => {
+    expect(isResourceForThisServer("https://reader.example.com:8443", CANONICAL)).toBe(false);
+  });
+
+  it("rejects a different path", () => {
+    expect(isResourceForThisServer("https://reader.example.com/other", CANONICAL)).toBe(false);
+  });
+
+  it("rejects a resource with a fragment (RFC 8707 forbids fragments)", () => {
+    expect(isResourceForThisServer("https://reader.example.com/#frag", CANONICAL)).toBe(false);
+  });
+
+  it("rejects malformed / non-absolute resources", () => {
+    expect(isResourceForThisServer("not-a-url", CANONICAL)).toBe(false);
+    expect(isResourceForThisServer("", CANONICAL)).toBe(false);
+    expect(isResourceForThisServer("/relative/path", CANONICAL)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #870. API tokens previously produced a **full-access synthetic session**, so a token issued with only `saved:write` or `mcp` scope could reach every endpoint (read all entries, list/revoke sessions, change password, manage tags, etc.). Authorization is now **fail-closed**.

### #1 — Scope enforcement in tRPC/REST (high severity)
- Default protected procedures (`protectedProcedure`, `confirmedProtectedProcedure`, `expensive*`) are now **session-only**: API/OAuth token auth is rejected with `FORBIDDEN`. New endpoints are token-inaccessible until they explicitly opt in.
- `scopedProtectedProcedure` now accepts **multiple scopes (any-of)**.
- The `mcp` scope is mapped to exactly the **MCP tool surface**: `entries.list/get/markRead/setStarred/count`, `subscriptions.list/get`, `tags.list/create/update/delete`, `saved.delete/uploadFile`. `saved.save` accepts `saved:write` **or** `mcp`.
- Everything else (sessions, password, preferences, ingest addresses, blocked senders, OPML import, narration, summarization, feed/broken stats, subscription writes, `entries.markAllRead`, `entries.fetchFullContent`) is session-only — tokens get `403`.

### #2 — OAuth token reach
Decision: keep OAuth access tokens **MCP-only** (they aren't validated in the main tRPC/REST context), since OAuth login is only intended for MCP. Documented with a comment in `context.ts`. This preserves audience separation alongside #3.

### #3 — RFC 8707 audience binding at `/api/mcp`
An OAuth token whose `resource` doesn't match this server's protected-resource identifier is now rejected (previously the `resource` was stored but never checked). Tokens issued without a resource indicator remain accepted.

### #4 — Dynamic Client Registration
- No longer falls back to `scopes = null` ("allow all") when requested scopes are unrecognized — it stores only the supported subset and rejects registration if none are recognized.
- Added IP-based rate limiting (strict "expensive" bucket) to `/oauth/register`.

## ⚠️ Behavioral change
The public `/api/v1` REST API now returns `403` for tokens hitting account-management / non-MCP endpoints. This is the intended least-privilege fix. The browser extension (only calls `/api/v1/saved`) and the Discord bot (uses the service layer directly) are unaffected.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:unit` (1704 passing)
- [ ] `pnpm test:integration` — new `tests/integration/token-scopes.test.ts` and `oauth-register.test.ts` (could not run locally; no Docker in this environment — needs CI)
- [ ] Manually verify a scoped token gets `403` on a session-only endpoint and `200` on its MCP-surface endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)