### PR TITLE
Add Playwright e2e tests for the realtime SSE cache-update flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,7 @@ extension/*.zip
 # source maps
 *.js.map
 
+
+# Playwright
+test-results/
+playwright-report/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@ Read these if you need context on features or specific references.
 ## Commands
 
 - `pnpm typecheck` - Run before committing (no `any`, no `@ts-ignore`)
+- `pnpm test:unit` - Pure logic tests (fast, no DB)
+- `pnpm test:integration` - Backend tests against real Postgres/Redis (docker-compose)
+- `pnpm test:e2e` - Playwright browser tests against a real app server (docker-compose)
 
 ## Code Quality
 
@@ -28,6 +31,16 @@ Read these if you need context on features or specific references.
 - **DRY**: Deduplicate logic that must stay in sync; don't merge code that merely looks similar but serves independent purposes
 - Always write tests for the intended behavior of functions, not the actual behavior. If the actual behavior is wrong and the issue is pre-existing, write the test correctly, mark it skipped, and file a GitHub issue on brendanlong/clawed-burrow
 - Don't create barrel files, prefer direct imports within our code
+
+## Frontend Testing
+
+The realtime SSE/cache-update code is the hardest part of the app to verify by review — always test it instead:
+
+- **Cache logic** (`src/lib/cache/`): pure functions, unit-tested in `tests/unit/frontend/cache/` against real `QueryClient` instances using the factories in `tests/utils/cache-test-helpers.ts`. Add cases there when changing cache operations or event handling.
+- **SSE → cache → UI pipeline**: covered by `tests/e2e/` Playwright tests, which seed the test DB directly, publish real Redis pub/sub events, and assert the UI updates **without** refetching (`recordTrpcProcedures` in `tests/e2e/helpers.ts`). When changing the realtime flow, run `pnpm test:e2e` and add scenarios using those helpers.
+- **The minimal-request invariant**: SSE events must patch the React Query cache directly, never trigger `entries.*` refetches. `src/FRONTEND_STATE.md` is the contract for which queries get direct updates vs invalidation — read and update it when changing queries, mutations, or SSE handling.
+
+For manual verification, `pnpm test:e2e` starts the app server on port 4983 against the test database; you can also seed data with the helpers and inspect pages with Playwright directly.
 
 ## UI Components
 
@@ -63,6 +76,7 @@ src/components/  # React components
 src/app/         # Next.js routes
 tests/unit/      # Pure logic tests (no mocks, no DB)
 tests/integration/ # Real DB via docker-compose (no mocks)
+tests/e2e/       # Playwright browser tests (real server + DB + Redis)
 ```
 
 See docs/diagrams/ for more detail. These diagrams are very helpful for quickly understanding the codebase.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Read these if you need context on features or specific references.
 - **Queries**: Avoid N+1 queries; use joins or batch fetching
 - **UI**: Use optimistic updates for responsive UX
 - **DRY**: Deduplicate logic that must stay in sync; don't merge code that merely looks similar but serves independent purposes
-- Always write tests for the intended behavior of functions, not the actual behavior. If the actual behavior is wrong and the issue is pre-existing, write the test correctly, mark it skipped, and file a GitHub issue on brendanlong/clawed-burrow
+- Always write tests for the intended behavior of functions, not the actual behavior. If the actual behavior is wrong and the issue is pre-existing, write the test correctly, mark it skipped, and file a GitHub issue on brendanlong/lion-reader (labels: `bug`, `reported-by-claude`)
 - Don't create barrel files, prefer direct imports within our code
 
 ## Frontend Testing

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -563,13 +563,26 @@ Structure code so business logic is pure and can be unit tested without mocks. I
 
 ```
 tests/
-  unit/           # Fast, no I/O - pure logic tests
+  unit/           # Fast, no I/O - pure logic tests (frontend cache logic under unit/frontend/)
   integration/    # Requires Docker services - full flow tests
+  e2e/            # Playwright browser tests - real app server + Postgres + Redis
 ```
 
 ### Guidelines
 
-- **Unit tests**: Feed parsing, cache header interpretation, scheduling logic
+- **Unit tests**: Feed parsing, cache header interpretation, scheduling logic, React Query cache operations (against real `QueryClient` instances)
 - **Integration tests**: Auth flows, CRUD operations, full fetch cycles
+- **E2E tests**: Realtime SSE → cache → UI flows in a real browser
 - **No mocks of internal code**: Refactor if mocking is needed
 - **Real databases in integration tests**: Docker Compose provides Postgres and Redis
+
+### End-to-End Tests (Playwright)
+
+`pnpm test:e2e` runs Playwright tests (`tests/e2e/`) against a real app server started automatically on port 4983 (override with `E2E_PORT`) using the test database from `.env.test`. Requires the docker-compose Postgres and Redis services, like the integration tests.
+
+Key design points:
+
+- **No UI login flow**: tests seed users/feeds/entries directly in the database (`tests/e2e/helpers.ts`) and authenticate by inserting a session row and setting the `session` cookie.
+- **Real event pipeline**: tests publish events through the same `src/server/redis/pubsub.ts` functions the worker uses, exercising Redis → SSE endpoint → EventSource → `handleSyncEvent` → cache → UI. `waitForChannelSubscriber` polls `PUBSUB NUMSUB` to avoid publishing before the SSE handler is listening.
+- **Minimal-request assertions**: `recordTrpcProcedures(page)` records every tRPC procedure the page calls. Tests assert that SSE events update the UI with _zero_ `entries.*` refetches — this encodes the delta-update invariant documented in `src/FRONTEND_STATE.md` as a regression test instead of a code-review concern.
+- **Isolation**: each test creates its own user and feeds (unique IDs), so tests don't interfere with each other or with leftover data; the suite runs serially against one shared server.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test": "pnpm db:migrate:test && pnpm db:schema:test && dotenv -o -e .env.test -- vitest",
     "test:unit": "dotenv -o -e .env.test -- vitest run tests/unit",
     "test:integration": "pnpm db:migrate:test && pnpm db:schema:test && dotenv -o -e .env.test -- vitest run tests/integration",
+    "test:e2e": "pnpm db:migrate:test && dotenv -o -e .env.test -- playwright test",
     "worker": "tsx scripts/worker.ts",
     "mcp:serve": "dotenv -- tsx src/server/mcp/bin.ts",
     "discord-bot": "dotenv -- tsx scripts/discord-bot.ts"
@@ -94,6 +95,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tailwindcss/typography": "^0.5.19",
     "@testing-library/dom": "^10.4.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright E2E test configuration.
+ *
+ * Run with `pnpm test:e2e` so that .env.test is loaded (the tests and the app
+ * server both need the test database and Redis). Requires the docker-compose
+ * Postgres and Redis services to be running, like the integration tests.
+ *
+ * The web server is started automatically against the test database. Tests
+ * seed their own users/feeds directly in the database (see tests/e2e/helpers.ts)
+ * and inject a session cookie, so no UI login flow is needed.
+ */
+
+const PORT = process.env.E2E_PORT ? parseInt(process.env.E2E_PORT, 10) : 4983;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  // Tests share one database and one app server; run serially to avoid
+  // cross-test interference (matches vitest's fileParallelism: false).
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  // Generous timeouts: the Next.js dev server compiles routes on first request.
+  timeout: 120_000,
+  expect: { timeout: 15_000 },
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: BASE_URL,
+    navigationTimeout: 120_000,
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev:next",
+    url: `${BASE_URL}/api/health`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    env: {
+      PORT: String(PORT),
+      // .env.test sets NODE_ENV=test, but the app server should run in
+      // development mode (DATABASE_URL/REDIS_URL still come from .env.test
+      // via inherited process env, which Next.js never overrides).
+      NODE_ENV: "development",
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         version: 3.1026.0
       '@ducanh2912/next-pwa':
         specifier: ^10.2.9
-        version: 10.2.9(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0))
+        version: 10.2.9(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0))
       '@mintplex-labs/piper-tts-web':
         specifier: ^1.0.4
         version: 1.0.4(onnxruntime-web@1.24.1)
@@ -42,7 +42,7 @@ importers:
         version: 1.1.1
       '@sentry/nextjs':
         specifier: ^10.48.0
-        version: 10.48.0(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0))
+        version: 10.48.0(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0))
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
@@ -111,7 +111,7 @@ importers:
         version: 18.0.4
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -161,6 +161,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -2164,6 +2167,11 @@ packages:
   '@phc/format@1.0.0':
     resolution: {integrity: sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==}
     engines: {node: '>=10'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/instrumentation@7.6.0':
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
@@ -4483,6 +4491,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5559,6 +5572,16 @@ packages:
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -7997,10 +8020,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ducanh2912/next-pwa@10.2.9(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0))':
+  '@ducanh2912/next-pwa@10.2.9(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0))':
     dependencies:
       fast-glob: 3.3.2
-      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       semver: 7.6.3
       webpack: 5.104.1(esbuild@0.28.0)(lightningcss@1.32.0)
       workbox-build: 7.1.1
@@ -8897,6 +8920,10 @@ snapshots:
 
   '@phc/format@1.0.0': {}
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -9248,7 +9275,7 @@ snapshots:
 
   '@sentry/core@10.48.0': {}
 
-  '@sentry/nextjs@10.48.0(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0))':
+  '@sentry/nextjs@10.48.0(@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -9261,7 +9288,7 @@ snapshots:
       '@sentry/react': 10.48.0(react@19.2.4)
       '@sentry/vercel-edge': 10.48.0
       '@sentry/webpack-plugin': 5.2.0(webpack@5.104.1(esbuild@0.28.0)(lightningcss@1.32.0))
-      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rollup: 4.60.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -11412,6 +11439,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -12260,7 +12290,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -12280,6 +12310,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
       '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -12524,6 +12555,14 @@ snapshots:
   pkce-challenge@5.0.1: {}
 
   platform@1.3.6: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -103,25 +103,49 @@ export async function loginAs(
 export interface TestFeed {
   feedId: string;
   subscriptionId: string;
+  title: string;
 }
 
 /** Creates a web feed and an active subscription (with subscription_feeds row). */
 export async function createSubscribedFeed(db: TestDb, userId: string): Promise<TestFeed> {
   const feedId = generateUuidv7();
   const subscriptionId = generateUuidv7();
+  const title = `E2E Feed ${feedId.slice(-6)}`;
 
   await db.insert(schema.feeds).values({
     id: feedId,
     type: "web",
     url: `https://example.com/e2e/${feedId}/feed.xml`,
-    title: `E2E Feed ${feedId.slice(-6)}`,
+    title,
     siteUrl: `https://example.com/e2e/${feedId}`,
   });
   await db.insert(schema.subscriptions).values({ id: subscriptionId, userId, feedId });
   // visible_entries maps entries to subscriptions through subscription_feeds
   await db.insert(schema.subscriptionFeeds).values({ subscriptionId, feedId, userId });
 
-  return { feedId, subscriptionId };
+  return { feedId, subscriptionId, title };
+}
+
+/** Creates a tag and assigns it to a subscription. Returns the tag ID. */
+export async function createTagOnSubscription(
+  db: TestDb,
+  userId: string,
+  subscriptionId: string,
+  name: string
+): Promise<string> {
+  const tagId = generateUuidv7();
+  await db.insert(schema.tags).values({ id: tagId, userId, name });
+  await db.insert(schema.subscriptionTags).values({ subscriptionId, tagId });
+  return tagId;
+}
+
+/** Stars an entry directly in the database (keeps it unread). */
+export async function starEntry(db: TestDb, userId: string, entryId: string): Promise<void> {
+  const now = new Date();
+  await db
+    .update(schema.userEntries)
+    .set({ starred: true, hasStarred: true, starredChangedAt: now, updatedAt: now })
+    .where(and(eq(schema.userEntries.userId, userId), eq(schema.userEntries.entryId, entryId)));
 }
 
 export interface TestEntry {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,0 +1,224 @@
+/**
+ * E2E test helpers: direct database seeding and Redis utilities.
+ *
+ * Tests create their own isolated users/feeds/entries directly in the test
+ * database (no UI signup flow) and authenticate by inserting a session row
+ * and setting the `session` cookie on the browser context.
+ *
+ * Requires DATABASE_URL and REDIS_URL (loaded from .env.test via `pnpm test:e2e`).
+ */
+
+import crypto from "node:crypto";
+import { Pool } from "pg";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import { and, eq } from "drizzle-orm";
+import Redis from "ioredis";
+import type { BrowserContext, Page } from "@playwright/test";
+import * as schema from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+
+export type TestDb = NodePgDatabase<typeof schema>;
+
+let pool: Pool | undefined;
+let redis: Redis | undefined;
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `${name} is not set. Run e2e tests via "pnpm test:e2e" so .env.test is loaded.`
+    );
+  }
+  return value;
+}
+
+export function getDb(): TestDb {
+  pool ??= new Pool({ connectionString: requireEnv("DATABASE_URL"), max: 5 });
+  return drizzle(pool, { schema });
+}
+
+function getRedis(): Redis {
+  redis ??= new Redis(requireEnv("REDIS_URL"));
+  return redis;
+}
+
+/** Close shared connections so the Playwright worker can exit cleanly. */
+export async function closeTestConnections(): Promise<void> {
+  await pool?.end();
+  pool = undefined;
+  redis?.disconnect();
+  redis = undefined;
+}
+
+// ============================================================================
+// Seeding
+// ============================================================================
+
+export interface TestUser {
+  id: string;
+  email: string;
+  sessionToken: string;
+}
+
+/**
+ * Creates a user that passes both authentication and signup confirmation
+ * (TOS/privacy/not-EU agreements), plus a valid session.
+ */
+export async function createConfirmedUser(db: TestDb): Promise<TestUser> {
+  const now = new Date();
+  const id = generateUuidv7();
+  const email = `e2e-${id}@example.com`;
+
+  await db.insert(schema.users).values({
+    id,
+    email,
+    emailVerifiedAt: now,
+    tosAgreedAt: now,
+    privacyPolicyAgreedAt: now,
+    notEuAgreedAt: now,
+  });
+
+  // Mirrors createSession in src/server/auth/session.ts: raw token goes in the
+  // cookie, only the SHA-256 hash is stored.
+  const sessionToken = crypto.randomBytes(32).toString("base64url");
+  await db.insert(schema.sessions).values({
+    id: generateUuidv7(),
+    userId: id,
+    tokenHash: crypto.createHash("sha256").update(sessionToken).digest("hex"),
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+  });
+
+  return { id, email, sessionToken };
+}
+
+/** Sets the session cookie so the browser context is logged in as the user. */
+export async function loginAs(
+  context: BrowserContext,
+  user: TestUser,
+  baseURL: string
+): Promise<void> {
+  await context.addCookies([{ name: "session", value: user.sessionToken, url: baseURL }]);
+}
+
+export interface TestFeed {
+  feedId: string;
+  subscriptionId: string;
+}
+
+/** Creates a web feed and an active subscription (with subscription_feeds row). */
+export async function createSubscribedFeed(db: TestDb, userId: string): Promise<TestFeed> {
+  const feedId = generateUuidv7();
+  const subscriptionId = generateUuidv7();
+
+  await db.insert(schema.feeds).values({
+    id: feedId,
+    type: "web",
+    url: `https://example.com/e2e/${feedId}/feed.xml`,
+    title: `E2E Feed ${feedId.slice(-6)}`,
+    siteUrl: `https://example.com/e2e/${feedId}`,
+  });
+  await db.insert(schema.subscriptions).values({ id: subscriptionId, userId, feedId });
+  // visible_entries maps entries to subscriptions through subscription_feeds
+  await db.insert(schema.subscriptionFeeds).values({ subscriptionId, feedId, userId });
+
+  return { feedId, subscriptionId };
+}
+
+export interface TestEntry {
+  id: string;
+  title: string;
+  updatedAt: Date;
+}
+
+/** Creates an entry plus the user_entries row that makes it visible (unread). */
+export async function createUnreadEntry(
+  db: TestDb,
+  params: { feedId: string; userId: string; title: string }
+): Promise<TestEntry> {
+  const { feedId, userId, title } = params;
+  const id = generateUuidv7();
+  const now = new Date();
+  const content = `<p>Content for ${title}</p>`;
+
+  const [entry] = await db
+    .insert(schema.entries)
+    .values({
+      id,
+      feedId,
+      type: "web",
+      guid: `e2e-${id}`,
+      url: `https://example.com/e2e/posts/${id}`,
+      title,
+      contentOriginal: content,
+      summary: `Summary for ${title}`,
+      publishedAt: now,
+      fetchedAt: now,
+      lastSeenAt: now, // required for web entries (entries_last_seen_only_fetched)
+      contentHash: crypto.createHash("sha256").update(content).digest("hex"),
+    })
+    .returning();
+
+  await db.insert(schema.userEntries).values({
+    userId,
+    entryId: id,
+    publishedOrFetchedAt: now,
+  });
+
+  return { id, title, updatedAt: entry.updatedAt };
+}
+
+/** Marks an entry read directly in the database, returning the update timestamp. */
+export async function markEntryRead(db: TestDb, userId: string, entryId: string): Promise<Date> {
+  const now = new Date();
+  await db
+    .update(schema.userEntries)
+    .set({ read: true, readChangedAt: now, updatedAt: now })
+    .where(and(eq(schema.userEntries.userId, userId), eq(schema.userEntries.entryId, entryId)));
+  return now;
+}
+
+// ============================================================================
+// SSE / Redis synchronization
+// ============================================================================
+
+/**
+ * Waits until the app server's SSE handler has subscribed to a Redis channel.
+ *
+ * The SSE endpoint subscribes asynchronously after the response starts
+ * streaming, so publishing immediately after the SSE response arrives can
+ * drop the event. Polling PUBSUB NUMSUB removes that race: tests create
+ * unique users/feeds, so each channel has exactly one possible subscriber.
+ */
+export async function waitForChannelSubscriber(channel: string, timeoutMs = 15_000): Promise<void> {
+  const client = getRedis();
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = (await client.call("pubsub", "numsub", channel)) as [string, number | string];
+    if (Number(result[1]) >= 1) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`No SSE subscriber on Redis channel ${channel} after ${timeoutMs}ms`);
+}
+
+// ============================================================================
+// Request tracking
+// ============================================================================
+
+/**
+ * Records the tRPC procedure names of every request the page makes.
+ *
+ * Returns a live array; clear it (`calls.length = 0`) after initial page load,
+ * then assert on what fired afterwards. Batched requests like
+ * `/api/trpc/entries.list,entries.count?batch=1` are split into individual
+ * procedure names.
+ */
+export function recordTrpcProcedures(page: Page): string[] {
+  const calls: string[] = [];
+  page.on("request", (request) => {
+    const match = request.url().match(/\/api\/trpc\/([^?]+)/);
+    if (match) {
+      calls.push(...decodeURIComponent(match[1]).split(","));
+    }
+  });
+  return calls;
+}

--- a/tests/e2e/realtime.spec.ts
+++ b/tests/e2e/realtime.spec.ts
@@ -2,10 +2,15 @@
  * E2E tests for the realtime SSE → cache update flow.
  *
  * These tests verify the core "minimal-request" invariant: SSE events patch
- * the React Query cache directly, they do NOT trigger refetches of entries
- * queries. Events are published through the same Redis pub/sub functions the
- * worker uses, so the full pipeline is exercised: Redis → SSE endpoint →
- * EventSource → handleSyncEvent → cache operations → UI.
+ * the React Query cache directly, they do NOT trigger refetches of entries,
+ * tags, or subscriptions queries. Events are published through the same Redis
+ * pub/sub functions the worker uses, so the full pipeline is exercised:
+ * Redis → SSE endpoint → EventSource → handleSyncEvent → cache → UI.
+ *
+ * Each test seeds a tagged feed and an untagged feed so it can assert that
+ * counts update correctly across every sidebar list (All Items, Starred,
+ * tag, subscription row, Uncategorized) — including that unaffected lists
+ * keep their counts.
  */
 
 import { test, expect, type Page } from "@playwright/test";
@@ -19,7 +24,9 @@ import {
   getDb,
   createConfirmedUser,
   createSubscribedFeed,
+  createTagOnSubscription,
   createUnreadEntry,
+  starEntry,
   markEntryRead,
   loginAs,
   waitForChannelSubscriber,
@@ -36,28 +43,55 @@ test.afterAll(async () => {
 
 interface RealtimeSetup {
   user: TestUser;
-  feed: TestFeed;
-  entries: TestEntry[];
+  taggedFeed: TestFeed;
+  tagId: string;
+  taggedEntries: TestEntry[];
   trpcCalls: string[];
-  allItemsLink: ReturnType<Page["getByRole"]>;
 }
 
 /**
- * Seeds a user with one feed and two unread entries, logs in, opens /all,
- * and waits for the SSE connection plus its Redis channel subscriptions.
+ * Seeds a user with:
+ * - a feed tagged "News" with two unread entries (optionally starring "Second post")
+ * - an untagged feed with one unread entry (exercises the Uncategorized list)
+ *
+ * Then logs in, opens /all, waits for the SSE connection plus its Redis
+ * channel subscriptions, and expands the News tag so the per-subscription
+ * unread count is visible (and the subscription is in cache, which the
+ * delta-based tag count updates rely on).
  */
-async function openAllWithSse(
+async function seedAndOpenAll(
   page: Page,
   baseURL: string,
-  channelForSetup: (setup: { user: TestUser; feed: TestFeed }) => string
+  channelFor: (setup: { user: TestUser; taggedFeed: TestFeed }) => string,
+  options: { starSecondPost?: boolean } = {}
 ): Promise<RealtimeSetup> {
   const db = getDb();
   const user = await createConfirmedUser(db);
-  const feed = await createSubscribedFeed(db, user.id);
-  const entries = [
-    await createUnreadEntry(db, { feedId: feed.feedId, userId: user.id, title: "First post" }),
-    await createUnreadEntry(db, { feedId: feed.feedId, userId: user.id, title: "Second post" }),
+
+  const taggedFeed = await createSubscribedFeed(db, user.id);
+  const tagId = await createTagOnSubscription(db, user.id, taggedFeed.subscriptionId, "News");
+  const taggedEntries = [
+    await createUnreadEntry(db, {
+      feedId: taggedFeed.feedId,
+      userId: user.id,
+      title: "First post",
+    }),
+    await createUnreadEntry(db, {
+      feedId: taggedFeed.feedId,
+      userId: user.id,
+      title: "Second post",
+    }),
   ];
+  if (options.starSecondPost) {
+    await starEntry(db, user.id, taggedEntries[1].id);
+  }
+
+  const untaggedFeed = await createSubscribedFeed(db, user.id);
+  await createUnreadEntry(db, {
+    feedId: untaggedFeed.feedId,
+    userId: user.id,
+    title: "Untagged post",
+  });
 
   await loginAs(page.context(), user, baseURL);
   const trpcCalls = recordTrpcProcedures(page);
@@ -65,86 +99,132 @@ async function openAllWithSse(
   // Resolves when the SSE response headers arrive (connection established)
   const sseResponse = page.waitForResponse(
     (response) => response.url().includes("/api/v1/events"),
-    {
-      timeout: 90_000,
-    }
+    { timeout: 90_000 }
   );
 
   await page.goto("/all");
-
-  const allItemsLink = page.getByRole("link", { name: /All Items/ });
-  await expect(allItemsLink).toContainText("(2)");
   await expect(page.locator('[aria-label*="article: First post"]')).toBeVisible();
+
+  // Expand the News tag so the subscription row (and its unread count) renders
+  await page
+    .getByRole("listitem")
+    .filter({ has: page.getByRole("link", { name: /News/ }) })
+    .getByRole("button", { name: "Expand" })
+    .click();
+  await expect(page.getByRole("link", { name: new RegExp(taggedFeed.title) })).toBeVisible();
 
   await sseResponse;
   // The SSE handler subscribes to Redis channels asynchronously after the
   // response starts; wait until it's actually listening before publishing.
-  await waitForChannelSubscriber(channelForSetup({ user, feed }));
+  await waitForChannelSubscriber(channelFor({ user, taggedFeed }));
 
-  return { user, feed, entries, trpcCalls, allItemsLink };
+  return { user, taggedFeed, tagId, taggedEntries, trpcCalls };
 }
 
-function entriesProcedures(trpcCalls: string[]): string[] {
-  return trpcCalls.filter((procedure) => procedure.startsWith("entries."));
+function sidebarLinks(page: Page, taggedFeed: TestFeed) {
+  return {
+    allItems: page.getByRole("link", { name: /All Items/ }),
+    starred: page.getByRole("link", { name: /^Starred/ }),
+    newsTag: page.getByRole("link", { name: /News/ }),
+    subscriptionRow: page.getByRole("link", { name: new RegExp(taggedFeed.title) }),
+    uncategorized: page.getByRole("link", { name: /Uncategorized/ }),
+  };
 }
 
-test("new_entry event updates unread counts without refetching entries", async ({
+/**
+ * Procedures that must never fire in response to a sync event — counts and
+ * entry state are patched directly into the cache (the delta-update invariant
+ * from src/FRONTEND_STATE.md).
+ */
+function refetchProcedures(trpcCalls: string[]): string[] {
+  return trpcCalls.filter(
+    (procedure) =>
+      procedure.startsWith("entries.") ||
+      procedure.startsWith("tags.") ||
+      procedure.startsWith("subscriptions.")
+  );
+}
+
+test("new_entry event updates unread counts in all affected lists without refetching", async ({
   page,
   baseURL,
 }) => {
-  const { user, feed, trpcCalls, allItemsLink } = await openAllWithSse(page, baseURL!, ({ feed }) =>
-    getFeedEventsChannel(feed.feedId)
+  const { user, taggedFeed, trpcCalls } = await seedAndOpenAll(page, baseURL!, ({ taggedFeed }) =>
+    getFeedEventsChannel(taggedFeed.feedId)
   );
+  const links = sidebarLinks(page, taggedFeed);
+
+  await expect(links.allItems).toContainText("(3)");
+  await expect(links.newsTag).toContainText("(2)");
+  await expect(links.subscriptionRow).toContainText("(2)");
+  await expect(links.uncategorized).toContainText("(1)");
 
   // Everything from here on must happen via the SSE event, not refetches
   trpcCalls.length = 0;
 
   const db = getDb();
   const entry = await createUnreadEntry(db, {
-    feedId: feed.feedId,
+    feedId: taggedFeed.feedId,
     userId: user.id,
     title: "Realtime post",
   });
-  await publishNewEntry(feed.feedId, entry.id, entry.updatedAt, "web");
+  await publishNewEntry(taggedFeed.feedId, entry.id, entry.updatedAt, "web");
 
-  // Unread count updates from the SSE event (delta applied client-side)
-  await expect(allItemsLink).toContainText("(3)");
+  // Affected lists increment (delta applied client-side)...
+  await expect(links.allItems).toContainText("(4)");
+  await expect(links.newsTag).toContainText("(3)");
+  await expect(links.subscriptionRow).toContainText("(3)");
+  // ...while unaffected lists keep their counts
+  await expect(links.uncategorized).toContainText("(1)");
 
-  // The minimal-request invariant: no entries.list / entries.count refetches
-  expect(entriesProcedures(trpcCalls)).toEqual([]);
+  expect(refetchProcedures(trpcCalls)).toEqual([]);
 });
 
-test("entry_state_changed event syncs read state and counts without refetching", async ({
+test("entry_state_changed event syncs read state and counts across lists without refetching", async ({
   page,
   baseURL,
 }) => {
-  const { user, feed, entries, trpcCalls, allItemsLink } = await openAllWithSse(
+  // "Second post" is starred (still unread) so the Starred count is visible
+  // and we can verify it's unaffected by marking a different entry read.
+  const { user, taggedFeed, tagId, taggedEntries, trpcCalls } = await seedAndOpenAll(
     page,
     baseURL!,
-    ({ user }) => getUserEventsChannel(user.id)
+    ({ user }) => getUserEventsChannel(user.id),
+    { starSecondPost: true }
   );
+  const links = sidebarLinks(page, taggedFeed);
+  const [firstPost] = taggedEntries;
 
-  const firstPost = page.locator('[aria-label*="article: First post"]');
-  await expect(firstPost).toHaveAttribute("aria-label", /^Unread/);
+  const db = getDb();
+  const firstPostItem = page.locator('[aria-label*="article: First post"]');
+  await expect(firstPostItem).toHaveAttribute("aria-label", /^Unread/);
+  await expect(links.allItems).toContainText("(3)");
+  await expect(links.starred).toContainText("(1)");
+  await expect(links.newsTag).toContainText("(2)");
+  await expect(links.subscriptionRow).toContainText("(2)");
+  await expect(links.uncategorized).toContainText("(1)");
 
   trpcCalls.length = 0;
 
-  // Simulate another device marking the entry read (as entries.markRead does):
-  // update the database, then publish the state change with absolute counts.
-  const db = getDb();
-  const entry = entries[0];
-  const updatedAt = await markEntryRead(db, user.id, entry.id);
-  await publishEntryStateChanged(user.id, entry.id, true, false, updatedAt, {
-    all: { unread: 1 },
-    starred: { unread: 0 },
-    subscriptions: [{ id: feed.subscriptionId, unread: 1 }],
-    tags: [],
+  // Simulate another device marking "First post" read (as entries.markRead
+  // does): update the database, then publish the change with absolute counts.
+  const updatedAt = await markEntryRead(db, user.id, firstPost.id);
+  await publishEntryStateChanged(user.id, firstPost.id, true, false, updatedAt, {
+    all: { unread: 2 },
+    starred: { unread: 1 },
+    subscriptions: [{ id: taggedFeed.subscriptionId, unread: 1 }],
+    tags: [{ id: tagId, unread: 1 }],
     uncategorized: { unread: 1 },
   });
 
-  // Read state and counts update from the SSE event's absolute values
-  await expect(firstPost).toHaveAttribute("aria-label", /^Read/);
-  await expect(allItemsLink).toContainText("(1)");
+  // Read state and affected counts update from the event's absolute values...
+  await expect(firstPostItem).toHaveAttribute("aria-label", /^Read/);
+  await expect(links.allItems).toContainText("(2)");
+  await expect(links.newsTag).toContainText("(1)");
+  await expect(links.subscriptionRow).toContainText("(1)");
+  // ...while unaffected lists keep their counts
+  await expect(links.starred).toContainText("(1)");
+  await expect(links.uncategorized).toContainText("(1)");
 
-  expect(entriesProcedures(trpcCalls)).toEqual([]);
+  expect(refetchProcedures(trpcCalls)).toEqual([]);
 });

--- a/tests/e2e/realtime.spec.ts
+++ b/tests/e2e/realtime.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * E2E tests for the realtime SSE → cache update flow.
+ *
+ * These tests verify the core "minimal-request" invariant: SSE events patch
+ * the React Query cache directly, they do NOT trigger refetches of entries
+ * queries. Events are published through the same Redis pub/sub functions the
+ * worker uses, so the full pipeline is exercised: Redis → SSE endpoint →
+ * EventSource → handleSyncEvent → cache operations → UI.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import {
+  publishNewEntry,
+  publishEntryStateChanged,
+  getFeedEventsChannel,
+  getUserEventsChannel,
+} from "../../src/server/redis/pubsub";
+import {
+  getDb,
+  createConfirmedUser,
+  createSubscribedFeed,
+  createUnreadEntry,
+  markEntryRead,
+  loginAs,
+  waitForChannelSubscriber,
+  recordTrpcProcedures,
+  closeTestConnections,
+  type TestUser,
+  type TestFeed,
+  type TestEntry,
+} from "./helpers";
+
+test.afterAll(async () => {
+  await closeTestConnections();
+});
+
+interface RealtimeSetup {
+  user: TestUser;
+  feed: TestFeed;
+  entries: TestEntry[];
+  trpcCalls: string[];
+  allItemsLink: ReturnType<Page["getByRole"]>;
+}
+
+/**
+ * Seeds a user with one feed and two unread entries, logs in, opens /all,
+ * and waits for the SSE connection plus its Redis channel subscriptions.
+ */
+async function openAllWithSse(
+  page: Page,
+  baseURL: string,
+  channelForSetup: (setup: { user: TestUser; feed: TestFeed }) => string
+): Promise<RealtimeSetup> {
+  const db = getDb();
+  const user = await createConfirmedUser(db);
+  const feed = await createSubscribedFeed(db, user.id);
+  const entries = [
+    await createUnreadEntry(db, { feedId: feed.feedId, userId: user.id, title: "First post" }),
+    await createUnreadEntry(db, { feedId: feed.feedId, userId: user.id, title: "Second post" }),
+  ];
+
+  await loginAs(page.context(), user, baseURL);
+  const trpcCalls = recordTrpcProcedures(page);
+
+  // Resolves when the SSE response headers arrive (connection established)
+  const sseResponse = page.waitForResponse(
+    (response) => response.url().includes("/api/v1/events"),
+    {
+      timeout: 90_000,
+    }
+  );
+
+  await page.goto("/all");
+
+  const allItemsLink = page.getByRole("link", { name: /All Items/ });
+  await expect(allItemsLink).toContainText("(2)");
+  await expect(page.locator('[aria-label*="article: First post"]')).toBeVisible();
+
+  await sseResponse;
+  // The SSE handler subscribes to Redis channels asynchronously after the
+  // response starts; wait until it's actually listening before publishing.
+  await waitForChannelSubscriber(channelForSetup({ user, feed }));
+
+  return { user, feed, entries, trpcCalls, allItemsLink };
+}
+
+function entriesProcedures(trpcCalls: string[]): string[] {
+  return trpcCalls.filter((procedure) => procedure.startsWith("entries."));
+}
+
+test("new_entry event updates unread counts without refetching entries", async ({
+  page,
+  baseURL,
+}) => {
+  const { user, feed, trpcCalls, allItemsLink } = await openAllWithSse(page, baseURL!, ({ feed }) =>
+    getFeedEventsChannel(feed.feedId)
+  );
+
+  // Everything from here on must happen via the SSE event, not refetches
+  trpcCalls.length = 0;
+
+  const db = getDb();
+  const entry = await createUnreadEntry(db, {
+    feedId: feed.feedId,
+    userId: user.id,
+    title: "Realtime post",
+  });
+  await publishNewEntry(feed.feedId, entry.id, entry.updatedAt, "web");
+
+  // Unread count updates from the SSE event (delta applied client-side)
+  await expect(allItemsLink).toContainText("(3)");
+
+  // The minimal-request invariant: no entries.list / entries.count refetches
+  expect(entriesProcedures(trpcCalls)).toEqual([]);
+});
+
+test("entry_state_changed event syncs read state and counts without refetching", async ({
+  page,
+  baseURL,
+}) => {
+  const { user, feed, entries, trpcCalls, allItemsLink } = await openAllWithSse(
+    page,
+    baseURL!,
+    ({ user }) => getUserEventsChannel(user.id)
+  );
+
+  const firstPost = page.locator('[aria-label*="article: First post"]');
+  await expect(firstPost).toHaveAttribute("aria-label", /^Unread/);
+
+  trpcCalls.length = 0;
+
+  // Simulate another device marking the entry read (as entries.markRead does):
+  // update the database, then publish the state change with absolute counts.
+  const db = getDb();
+  const entry = entries[0];
+  const updatedAt = await markEntryRead(db, user.id, entry.id);
+  await publishEntryStateChanged(user.id, entry.id, true, false, updatedAt, {
+    all: { unread: 1 },
+    starred: { unread: 0 },
+    subscriptions: [{ id: feed.subscriptionId, unread: 1 }],
+    tags: [],
+    uncategorized: { unread: 1 },
+  });
+
+  // Read state and counts update from the SSE event's absolute values
+  await expect(firstPost).toHaveAttribute("aria-label", /^Read/);
+  await expect(allItemsLink).toContainText("(1)");
+
+  expect(entriesProcedures(trpcCalls)).toEqual([]);
+});

--- a/tests/e2e/realtime.spec.ts
+++ b/tests/e2e/realtime.spec.ts
@@ -63,7 +63,7 @@ async function seedAndOpenAll(
   page: Page,
   baseURL: string,
   channelFor: (setup: { user: TestUser; taggedFeed: TestFeed }) => string,
-  options: { starSecondPost?: boolean } = {}
+  options: { starSecondPost?: boolean; expandTag?: boolean } = {}
 ): Promise<RealtimeSetup> {
   const db = getDb();
   const user = await createConfirmedUser(db);
@@ -105,13 +105,17 @@ async function seedAndOpenAll(
   await page.goto("/all");
   await expect(page.locator('[aria-label*="article: First post"]')).toBeVisible();
 
-  // Expand the News tag so the subscription row (and its unread count) renders
-  await page
-    .getByRole("listitem")
-    .filter({ has: page.getByRole("link", { name: /News/ }) })
-    .getByRole("button", { name: "Expand" })
-    .click();
-  await expect(page.getByRole("link", { name: new RegExp(taggedFeed.title) })).toBeVisible();
+  // Expand the News tag so the subscription row (and its unread count) renders.
+  // This also puts the subscription in the subscriptions.list cache, which the
+  // delta-based tag count updates rely on (see #892 for the collapsed case).
+  if (options.expandTag !== false) {
+    await page
+      .getByRole("listitem")
+      .filter({ has: page.getByRole("link", { name: /News/ }) })
+      .getByRole("button", { name: "Expand" })
+      .click();
+    await expect(page.getByRole("link", { name: new RegExp(taggedFeed.title) })).toBeVisible();
+  }
 
   await sseResponse;
   // The SSE handler subscribes to Redis channels asynchronously after the
@@ -176,6 +180,40 @@ test("new_entry event updates unread counts in all affected lists without refetc
   await expect(links.subscriptionRow).toContainText("(3)");
   // ...while unaffected lists keep their counts
   await expect(links.uncategorized).toContainText("(1)");
+
+  expect(refetchProcedures(trpcCalls)).toEqual([]);
+});
+
+// Skipped: known bug (#892). Tag deltas for new_entry are derived from cached
+// subscriptions.list data, which only exists once the tag has been expanded.
+// While the tag is collapsed (the default), the delta is silently skipped and
+// nothing invalidates tags.list, so the badge stays stale until an unrelated
+// refetch. This test encodes the intended behavior; unskip when #892 is fixed.
+test.skip("new_entry event updates a collapsed tag's unread count", async ({ page, baseURL }) => {
+  const { user, taggedFeed, trpcCalls } = await seedAndOpenAll(
+    page,
+    baseURL!,
+    ({ taggedFeed }) => getFeedEventsChannel(taggedFeed.feedId),
+    { expandTag: false }
+  );
+  const links = sidebarLinks(page, taggedFeed);
+
+  await expect(links.allItems).toContainText("(3)");
+  await expect(links.newsTag).toContainText("(2)");
+
+  trpcCalls.length = 0;
+
+  const db = getDb();
+  const entry = await createUnreadEntry(db, {
+    feedId: taggedFeed.feedId,
+    userId: user.id,
+    title: "Realtime post",
+  });
+  await publishNewEntry(taggedFeed.feedId, entry.id, entry.updatedAt, "web");
+
+  await expect(links.allItems).toContainText("(4)");
+  // Intended behavior: the collapsed tag's badge should update too
+  await expect(links.newsTag).toContainText("(3)");
 
   expect(refetchProcedures(trpcCalls)).toEqual([]);
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
@@ -8,6 +8,8 @@ export default defineConfig({
     },
   },
   test: {
+    // Playwright e2e tests are run separately via `pnpm test:e2e`
+    exclude: [...configDefaults.exclude, "tests/e2e/**"],
     // Use threads for faster parallel test execution
     pool: "threads",
     // Disable file parallelism for integration tests that share database state.


### PR DESCRIPTION
## Summary

- Adds a Playwright e2e harness (`pnpm test:e2e`) that starts the real app server against the test database (port 4983), seeds users/feeds/entries directly in Postgres, and logs in by injecting a session cookie — no UI signup flow needed.
- Adds `tests/e2e/realtime.spec.ts` covering the previously-untestable SSE pipeline: events are published through the same `src/server/redis/pubsub.ts` functions the worker uses, exercising Redis → SSE endpoint → EventSource → `handleSyncEvent` → cache → UI in a real browser.
- Encodes the **minimal-request invariant** as a regression test: `recordTrpcProcedures` records every tRPC call the page makes, and the tests assert SSE events update unread counts and read state with *zero* `entries.*` refetches.
- `waitForChannelSubscriber` polls `PUBSUB NUMSUB` so tests never publish before the SSE handler's Redis subscription is live (the main flake hazard in this design).
- Documents the frontend testing workflow in CLAUDE.md (new "Frontend Testing" section) and DESIGN.md (e2e section under Testing Strategy), so agents test realtime/cache changes instead of skipping browser verification.

Filed #890 for the follow-up `useRealtimeUpdates` refactor (extract the connection state machine into pure, unit-testable functions).

## Test plan

- [x] `pnpm test:e2e` — 2 passed (new_entry count update; entry_state_changed read-state + counts sync; both with zero `entries.*` refetches)
- [x] `pnpm test:unit` — 1714 passed (verifies the new vitest `tests/e2e/**` exclude)
- [x] `pnpm typecheck`, `pnpm lint` — clean
- [ ] CI note: e2e tests are not wired into CI yet; happy to add a workflow job (needs `playwright install chromium` + docker-compose services) as a follow-up if wanted

🤖 Generated with [Claude Code](https://claude.com/claude-code)