### PR TITLE
Reduce SSE connection overhead: shared Redis subscriber + single client connection

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -268,19 +268,24 @@ Lion Reader respects server Cache-Control headers, Retry-After directives, and H
 2. Worker publishes to per-feed Redis channel: `PUBLISH feed:{feedId}:events {type, entryId, ...}`
 3. SSE connections subscribe only to channels for feeds their user cares about
 4. App server receives message, forwards to client
-5. Client receives event, invalidates React Query cache
+5. Client receives event, patches the React Query cache (see `src/FRONTEND_STATE.md`)
 6. UI updates automatically
 
 ### Channel Design
 
 Per-feed channels for scalability - servers only receive events they care about:
 
-| Channel Pattern        | Purpose                                |
-| ---------------------- | -------------------------------------- |
-| `feed:{feedId}:events` | Feed events (new_entry, entry_updated) |
-| `user:{userId}:events` | User events (subscription_created)     |
+| Channel Pattern        | Events                                                                                                                                                                            |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `feed:{feedId}:events` | `new_entry`, `entry_updated`                                                                                                                                                      |
+| `user:{userId}:events` | `subscription_created`, `subscription_updated`, `subscription_deleted`, `entry_state_changed`, `tag_created`, `tag_updated`, `tag_deleted`, `import_progress`, `import_completed` |
 
 When a user subscribes to a new feed, the SSE connection dynamically subscribes to that feed's channel.
+
+### Connection Efficiency
+
+- **Single client connection**: the browser opens the `/api/v1/events` EventSource directly (one connection per tab). SSE availability (e.g. Redis down) is detected via a lightweight `HEAD /api/v1/events` check only on the error path; a 503 switches the client to polling the sync endpoint.
+- **Shared Redis subscriber**: each app process holds a single Redis subscriber connection (`createPubSubSubscription` in `src/server/redis/pubsub.ts`). Channel subscriptions are reference-counted across SSE connections and messages are fanned out in-process, so Redis connections don't grow with the number of connected users.
 
 ---
 

--- a/docs/diagrams/sse-cache-updates.d2
+++ b/docs/diagrams/sse-cache-updates.d2
@@ -82,7 +82,10 @@ redis: Redis Pub/Sub {
 
       Events:
       - subscription_created (full subscription + feed data)
+      - subscription_updated (tags, customTitle)
       - subscription_deleted (subscriptionId)
+      - entry_state_changed (read/starred + unread counts)
+      - tag_created / tag_updated / tag_deleted
       - import_progress (per-feed progress)
       - import_completed (final counts)
     |
@@ -97,10 +100,14 @@ sse-endpoint: SSE Endpoint {
   style.fill: "#f0fdf4"
   tooltip: "src/app/api/v1/events/route.ts"
 
-  subscriber: Redis Subscriber {
+  subscriber: Shared Redis Subscriber {
     style.fill: "#bbf7d0"
 
     description: |
+      One Redis connection per process; channel
+      subscriptions are reference-counted and messages
+      fan out in-process to all SSE connections.
+
       On connection:
       1. Build feedId → {subscriptionId, tagIds} map
       2. Subscribe to user:{userId}:events

--- a/src/app/api/v1/events/route.ts
+++ b/src/app/api/v1/events/route.ts
@@ -25,12 +25,13 @@ import { subscriptions, subscriptionTags } from "@/server/db/schema";
 import { validateSession } from "@/server/auth/session";
 import { getSavedFeedId } from "@/server/feed/saved-feed";
 import {
-  createSubscriberClient,
+  createPubSubSubscription,
   getFeedEventsChannel,
   getUserEventsChannel,
   parseFeedEvent,
   parseUserEvent,
   checkRedisHealth,
+  type PubSubSubscription,
   type UserEvent,
 } from "@/server/redis/pubsub";
 import { eq, and, isNull } from "drizzle-orm";
@@ -220,7 +221,7 @@ export async function GET(req: Request): Promise<Response> {
   const stream = new ReadableStream({
     start(controller) {
       const encoder = new TextEncoder();
-      let subscriber: ReturnType<typeof createSubscriberClient> = null;
+      let subscription: PubSubSubscription | null = null;
       let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
       let isCleanedUp = false;
 
@@ -231,7 +232,7 @@ export async function GET(req: Request): Promise<Response> {
       const feedSubscriptionMap = new Map(feedToSubscriptionMap);
 
       /**
-       * Cleanup function to close Redis subscription and clear heartbeat
+       * Cleanup function to release Redis channel subscriptions and clear heartbeat
        */
       function cleanup(): void {
         if (isCleanedUp) return;
@@ -245,14 +246,9 @@ export async function GET(req: Request): Promise<Response> {
           heartbeatInterval = null;
         }
 
-        if (subscriber) {
-          subscriber.unsubscribe().catch(() => {
-            // Ignore unsubscribe errors during cleanup
-          });
-          subscriber.quit().catch(() => {
-            // Ignore quit errors during cleanup
-          });
-          subscriber = null;
+        if (subscription) {
+          subscription.close();
+          subscription = null;
         }
       }
 
@@ -273,14 +269,14 @@ export async function GET(req: Request): Promise<Response> {
        * Subscribes to a feed's event channel and tracks the subscription mapping
        */
       function subscribeToFeed(feedId: string, info: FeedSubscriptionInfo): void {
-        if (isCleanedUp || !subscriber) return;
+        if (isCleanedUp || !subscription) return;
 
         const channel = getFeedEventsChannel(feedId);
         if (subscribedFeedChannels.has(channel)) return;
 
         subscribedFeedChannels.add(channel);
         feedSubscriptionMap.set(feedId, info);
-        subscriber.subscribe(channel).catch((err) => {
+        subscription.subscribe(channel).catch((err) => {
           console.error(`Failed to subscribe to feed channel ${feedId}:`, err);
           subscribedFeedChannels.delete(channel);
           feedSubscriptionMap.delete(feedId);
@@ -291,16 +287,14 @@ export async function GET(req: Request): Promise<Response> {
        * Unsubscribes from a feed's event channel and removes the subscription mapping
        */
       function unsubscribeFromFeed(feedId: string): void {
-        if (isCleanedUp || !subscriber) return;
+        if (isCleanedUp || !subscription) return;
 
         const channel = getFeedEventsChannel(feedId);
         if (!subscribedFeedChannels.has(channel)) return;
 
         subscribedFeedChannels.delete(channel);
         feedSubscriptionMap.delete(feedId);
-        subscriber.unsubscribe(channel).catch((err) => {
-          console.error(`Failed to unsubscribe from feed channel ${feedId}:`, err);
-        });
+        subscription.unsubscribe(channel);
       }
 
       // Set up abort handler for client disconnection
@@ -313,13 +307,90 @@ export async function GET(req: Request): Promise<Response> {
         }
       });
 
-      // Create Redis subscriber
+      /**
+       * Handles messages from subscribed Redis channels (via the process-wide
+       * shared subscriber connection).
+       */
+      function handleMessage(channel: string, message: string): void {
+        // Handle user events (subscriptions, tags, imports, entry state)
+        if (channel === userEventsChannel) {
+          const event = parseUserEvent(message);
+          if (!event) return;
+
+          // Handle side effects for subscription/tag lifecycle events,
+          // keeping the per-connection feed -> subscription/tags mapping current
+          if (event.type === "subscription_created") {
+            subscribeToFeed(event.feedId, {
+              subscriptionId: event.subscriptionId,
+              tagIds: event.subscription.tags.map((tag) => tag.id),
+            });
+          } else if (event.type === "subscription_deleted") {
+            unsubscribeFromFeed(event.feedId);
+          } else if (event.type === "subscription_updated") {
+            for (const info of feedSubscriptionMap.values()) {
+              if (info.subscriptionId === event.subscriptionId) {
+                info.tagIds = event.tags.map((tag) => tag.id);
+              }
+            }
+          } else if (event.type === "tag_deleted") {
+            for (const info of feedSubscriptionMap.values()) {
+              info.tagIds = info.tagIds.filter((tagId) => tagId !== event.tagId);
+            }
+          }
+
+          // All user events are forwarded to the client
+          send(formatSSEUserEvent(event));
+          trackSSEEventSent(event.type);
+          return;
+        }
+
+        // Handle feed events (new_entry, entry_updated)
+        // Transform events to use subscriptionId instead of feedId for client
+        if (subscribedFeedChannels.has(channel)) {
+          const event = parseFeedEvent(message);
+          if (!event) return;
+
+          // Look up the subscription info for this feed
+          // For saved feeds, subscriptionId will be null (no subscription exists)
+          const subscriptionInfo = feedSubscriptionMap.get(event.feedId) ?? null;
+
+          // Transform event to use subscriptionId instead of feedId
+          // Include metadata for entry_updated events to enable direct cache updates
+          const clientEvent: Record<string, unknown> = {
+            type: event.type,
+            subscriptionId: subscriptionInfo?.subscriptionId ?? null,
+            entryId: event.entryId,
+            timestamp: event.timestamp,
+            updatedAt: event.updatedAt, // Database updated_at for cursor tracking
+            feedType: event.feedType,
+          };
+
+          // Include the subscription's tag IDs so the client can update tag
+          // unread counts without cached subscription data (#892)
+          if (event.type === "new_entry" && subscriptionInfo) {
+            clientEvent.tagIds = subscriptionInfo.tagIds;
+          }
+
+          // Include metadata for entry_updated events
+          if (event.type === "entry_updated") {
+            clientEvent.metadata = event.metadata;
+          }
+
+          const cursor = new Date().toISOString();
+          send(
+            `event: ${clientEvent.type}\nid: ${cursor}\ndata: ${JSON.stringify(clientEvent)}\n\n`
+          );
+          trackSSEEventSent(event.type);
+        }
+      }
+
+      // Set up the subscription on the shared Redis subscriber
       try {
-        subscriber = createSubscriberClient();
+        subscription = createPubSubSubscription(handleMessage);
 
         // This should never happen since we checked Redis health above,
         // but handle it gracefully just in case
-        if (!subscriber) {
+        if (!subscription) {
           controller.error(new Error("Redis subscriber unavailable"));
           return;
         }
@@ -345,96 +416,14 @@ export async function GET(req: Request): Promise<Response> {
         }
 
         // Subscribe to all channels
-        if (allChannels.length > 0) {
-          subscriber.subscribe(...allChannels).catch((err) => {
-            console.error("Failed to subscribe to channels:", err);
-            cleanup();
-            try {
-              controller.error(err);
-            } catch {
-              // Controller may already be closed
-            }
-          });
-        }
-
-        // Handle incoming messages
-        subscriber.on("message", (channel: string, message: string) => {
-          // Handle user events (subscriptions, tags, imports, entry state)
-          if (channel === userEventsChannel) {
-            const event = parseUserEvent(message);
-            if (!event) return;
-
-            // Handle side effects for subscription/tag lifecycle events,
-            // keeping the per-connection feed -> subscription/tags mapping current
-            if (event.type === "subscription_created") {
-              subscribeToFeed(event.feedId, {
-                subscriptionId: event.subscriptionId,
-                tagIds: event.subscription.tags.map((tag) => tag.id),
-              });
-            } else if (event.type === "subscription_deleted") {
-              unsubscribeFromFeed(event.feedId);
-            } else if (event.type === "subscription_updated") {
-              for (const info of feedSubscriptionMap.values()) {
-                if (info.subscriptionId === event.subscriptionId) {
-                  info.tagIds = event.tags.map((tag) => tag.id);
-                }
-              }
-            } else if (event.type === "tag_deleted") {
-              for (const info of feedSubscriptionMap.values()) {
-                info.tagIds = info.tagIds.filter((tagId) => tagId !== event.tagId);
-              }
-            }
-
-            // All user events are forwarded to the client
-            send(formatSSEUserEvent(event));
-            trackSSEEventSent(event.type);
-            return;
+        subscription.subscribe(...allChannels).catch((err) => {
+          console.error("Failed to subscribe to channels:", err);
+          cleanup();
+          try {
+            controller.error(err);
+          } catch {
+            // Controller may already be closed
           }
-
-          // Handle feed events (new_entry, entry_updated)
-          // Transform events to use subscriptionId instead of feedId for client
-          if (subscribedFeedChannels.has(channel)) {
-            const event = parseFeedEvent(message);
-            if (!event) return;
-
-            // Look up the subscription info for this feed
-            // For saved feeds, subscriptionId will be null (no subscription exists)
-            const subscriptionInfo = feedSubscriptionMap.get(event.feedId) ?? null;
-
-            // Transform event to use subscriptionId instead of feedId
-            // Include metadata for entry_updated events to enable direct cache updates
-            const clientEvent: Record<string, unknown> = {
-              type: event.type,
-              subscriptionId: subscriptionInfo?.subscriptionId ?? null,
-              entryId: event.entryId,
-              timestamp: event.timestamp,
-              updatedAt: event.updatedAt, // Database updated_at for cursor tracking
-              feedType: event.feedType,
-            };
-
-            // Include the subscription's tag IDs so the client can update tag
-            // unread counts without cached subscription data (#892)
-            if (event.type === "new_entry" && subscriptionInfo) {
-              clientEvent.tagIds = subscriptionInfo.tagIds;
-            }
-
-            // Include metadata for entry_updated events
-            if (event.type === "entry_updated") {
-              clientEvent.metadata = event.metadata;
-            }
-
-            const cursor = new Date().toISOString();
-            send(
-              `event: ${clientEvent.type}\nid: ${cursor}\ndata: ${JSON.stringify(clientEvent)}\n\n`
-            );
-            trackSSEEventSent(event.type);
-          }
-        });
-
-        // Handle Redis errors
-        subscriber.on("error", (err) => {
-          console.error("Redis subscriber error:", err);
-          // Don't cleanup on transient errors - ioredis handles reconnection
         });
 
         // Start heartbeat
@@ -477,4 +466,27 @@ export async function GET(req: Request): Promise<Response> {
       "X-Accel-Buffering": "no", // Disable nginx buffering
     },
   });
+}
+
+/**
+ * HEAD /api/v1/events
+ *
+ * Lightweight SSE availability check: reports whether real-time updates are
+ * available (Redis healthy) without the per-connection auth and subscription
+ * queries that GET performs. The client calls this only after an EventSource
+ * failure to decide between reconnecting (non-503) and falling back to
+ * polling (503), so the happy path uses a single connection.
+ */
+export async function HEAD(): Promise<Response> {
+  const redisHealthy = await checkRedisHealth();
+  if (!redisHealthy) {
+    return new Response(null, {
+      status: 503,
+      headers: {
+        "Retry-After": "30",
+        "X-Fallback-Sync": "true",
+      },
+    });
+  }
+  return new Response(null, { status: 200 });
 }

--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -386,25 +386,23 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
     cleanup();
     isManuallyClosedRef.current = false;
 
-    const createConnection = async () => {
+    /**
+     * Decides how to recover after the EventSource fails. A lightweight HEAD
+     * request (no auth/DB work server-side) distinguishes "SSE unavailable"
+     * (503, e.g. Redis down) — fall back to polling — from other failures,
+     * which get the normal reconnect backoff.
+     */
+    async function handleConnectionFailure(): Promise<void> {
       if (!shouldConnectRef.current || isManuallyClosedRef.current) {
         return;
       }
 
-      setConnectionStatus("connecting");
-
       try {
-        // First, try a fetch to check if SSE is available
-        // This handles the 503 case where Redis is down
         const response = await fetch("/api/v1/events", {
-          method: "GET",
+          method: "HEAD",
           credentials: "include",
-          headers: {
-            Accept: "text/event-stream",
-          },
         });
 
-        // If we get a 503, switch to polling mode
         if (response.status === 503) {
           console.log("SSE unavailable (503), switching to polling mode");
           startPolling();
@@ -419,80 +417,71 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
 
           return;
         }
+      } catch {
+        // Network error - fall through to the normal reconnect backoff
+      }
 
-        // If not OK, treat as error
-        if (!response.ok) {
-          throw new Error(`SSE request failed with status ${response.status}`);
+      scheduleReconnect(createConnection);
+    }
+
+    function createConnection(): void {
+      if (!shouldConnectRef.current || isManuallyClosedRef.current) {
+        return;
+      }
+
+      setConnectionStatus("connecting");
+
+      // Open the EventSource directly: a single connection per session.
+      // SSE availability (the 503 case) is only checked on the error path,
+      // so the happy path doesn't double the per-connect auth and DB work.
+      const eventSource = new EventSource("/api/v1/events", {
+        withCredentials: true,
+      });
+
+      eventSourceRef.current = eventSource;
+
+      eventSource.onopen = () => {
+        setConnectionStatus("connected");
+        reconnectDelayRef.current = INITIAL_RECONNECT_DELAY_MS;
+
+        // Stop polling if we were in polling mode
+        stopPolling();
+
+        // Clear SSE retry timeout
+        if (sseRetryTimeoutRef.current) {
+          clearTimeout(sseRetryTimeoutRef.current);
+          sseRetryTimeoutRef.current = null;
         }
 
-        // Close the fetch response since we'll use EventSource
-        // The fetch was just to check availability
-        response.body?.cancel();
+        // Perform a catch-up sync to get any changes we might have missed
+        // The cursorsRef is already initialized, so performSync will work correctly
+        performSync();
+      };
 
-        // Create EventSource connection
-        const eventSource = new EventSource("/api/v1/events", {
-          withCredentials: true,
-        });
+      // Handle named events
+      eventSource.addEventListener("connected", handleEvent); // Initial cursor from server
+      eventSource.addEventListener("new_entry", handleEvent);
+      eventSource.addEventListener("entry_updated", handleEvent);
+      eventSource.addEventListener("entry_state_changed", handleEvent);
+      eventSource.addEventListener("subscription_created", handleEvent);
+      eventSource.addEventListener("subscription_updated", handleEvent);
+      eventSource.addEventListener("subscription_deleted", handleEvent);
+      eventSource.addEventListener("tag_created", handleEvent);
+      eventSource.addEventListener("tag_updated", handleEvent);
+      eventSource.addEventListener("tag_deleted", handleEvent);
+      eventSource.addEventListener("import_progress", handleEvent);
+      eventSource.addEventListener("import_completed", handleEvent);
 
-        eventSourceRef.current = eventSource;
-
-        eventSource.onopen = () => {
-          setConnectionStatus("connected");
-          reconnectDelayRef.current = INITIAL_RECONNECT_DELAY_MS;
-
-          // Stop polling if we were in polling mode
-          stopPolling();
-
-          // Clear SSE retry timeout
-          if (sseRetryTimeoutRef.current) {
-            clearTimeout(sseRetryTimeoutRef.current);
-            sseRetryTimeoutRef.current = null;
-          }
-
-          // Perform a catch-up sync to get any changes we might have missed
-          // The cursorsRef is already initialized, so performSync will work correctly
-          performSync();
-        };
-
-        // Handle named events
-        eventSource.addEventListener("connected", handleEvent); // Initial cursor from server
-        eventSource.addEventListener("new_entry", handleEvent);
-        eventSource.addEventListener("entry_updated", handleEvent);
-        eventSource.addEventListener("entry_state_changed", handleEvent);
-        eventSource.addEventListener("subscription_created", handleEvent);
-        eventSource.addEventListener("subscription_updated", handleEvent);
-        eventSource.addEventListener("subscription_deleted", handleEvent);
-        eventSource.addEventListener("tag_created", handleEvent);
-        eventSource.addEventListener("tag_updated", handleEvent);
-        eventSource.addEventListener("tag_deleted", handleEvent);
-        eventSource.addEventListener("import_progress", handleEvent);
-        eventSource.addEventListener("import_completed", handleEvent);
-
-        eventSource.onerror = () => {
-          if (eventSourceRef.current?.readyState === EventSource.CLOSED) {
-            setConnectionStatus("error");
-            cleanup();
-            scheduleReconnect(createConnection);
-          } else {
-            setConnectionStatus("connecting");
-          }
-        };
-      } catch (error) {
-        console.error("Failed to create SSE connection:", error);
-        setConnectionStatus("error");
-
-        // On connection failure, try polling as fallback
-        startPolling();
-
-        // Schedule SSE retry
-        sseRetryTimeoutRef.current = setTimeout(() => {
-          if (shouldConnectRef.current && !isManuallyClosedRef.current) {
-            stopPolling();
-            createConnection();
-          }
-        }, SSE_RETRY_INTERVAL_MS);
-      }
-    };
+      eventSource.onerror = () => {
+        if (eventSourceRef.current?.readyState === EventSource.CLOSED) {
+          setConnectionStatus("error");
+          cleanup();
+          handleConnectionFailure();
+        } else {
+          setConnectionStatus("connecting");
+        }
+      };
+    }
 
     createConnection();
 

--- a/src/server/redis/pubsub.ts
+++ b/src/server/redis/pubsub.ts
@@ -1,10 +1,12 @@
 /**
- * Redis Pub/Sub module for real-time event publishing.
+ * Redis Pub/Sub module for real-time event publishing and subscribing.
  *
- * This module provides event publishing capabilities for the feed system.
- * Events are published when new entries are created or existing entries are updated.
+ * Publishing: events are published when entries are created/updated and when
+ * user-scoped state changes (subscriptions, tags, read/starred state, imports).
  *
- * The subscriber side (SSE endpoint) will be implemented in phase 6.2.
+ * Subscribing: the SSE endpoint consumes events via createPubSubSubscription,
+ * which multiplexes all subscriptions in this process over a single shared
+ * Redis connection with reference-counted channels and in-process fan-out.
  */
 
 import Redis from "ioredis";
@@ -631,14 +633,36 @@ export async function publishTagDeleted(
   return client.publish(channel, JSON.stringify(event));
 }
 
+// ============================================================================
+// Shared Subscriber (one Redis connection per process, in-process fan-out)
+// ============================================================================
+
+/** Callback invoked with every message received on a subscribed channel. */
+type ChannelMessageListener = (channel: string, message: string) => void;
+
+interface ChannelState {
+  listeners: Set<ChannelMessageListener>;
+  /** Resolves when the Redis-level SUBSCRIBE for this channel completes. */
+  ready: Promise<void>;
+}
+
+let sharedSubscriberClient: Redis | null = null;
+let sharedSubscriberInitialized = false;
+const channelStates = new Map<string, ChannelState>();
+
 /**
- * Creates a new Redis client for subscribing to feed events.
- * Each subscriber should use its own connection as Redis requires
- * dedicated connections for subscriptions.
- *
- * @returns A new Redis client configured for subscribing, or null if Redis is not configured
+ * Gets or creates the shared Redis subscriber connection for this process.
+ * Redis requires a dedicated connection for SUBSCRIBE mode, but one connection
+ * can hold any number of channel subscriptions, so all consumers in the
+ * process (e.g. every SSE connection) share this single client instead of
+ * opening one connection each.
  */
-export function createSubscriberClient(): Redis | null {
+function getSharedSubscriberClient(): Redis | null {
+  if (sharedSubscriberInitialized) {
+    return sharedSubscriberClient;
+  }
+
+  sharedSubscriberInitialized = true;
   const redisUrl = process.env.REDIS_URL;
   if (!redisUrl) {
     return null;
@@ -651,17 +675,153 @@ export function createSubscriberClient(): Redis | null {
     },
   });
 
-  if (process.env.NODE_ENV === "development") {
-    client.on("connect", () => {
-      console.log("Redis subscriber connected");
-    });
+  client.on("message", (channel: string, message: string) => {
+    const state = channelStates.get(channel);
+    if (!state) return;
+    for (const listener of state.listeners) {
+      try {
+        listener(channel, message);
+      } catch (err) {
+        console.error(`Pub/sub listener error on channel ${channel}:`, err);
+      }
+    }
+  });
 
-    client.on("error", (err) => {
-      console.error("Redis subscriber error:", err);
-    });
+  client.on("error", (err) => {
+    // ioredis reconnects automatically and re-subscribes to all channels
+    console.error("Redis shared subscriber error:", err);
+  });
+
+  sharedSubscriberClient = client;
+  return client;
+}
+
+/**
+ * Adds a listener for a channel, issuing the Redis-level SUBSCRIBE only for
+ * the first listener. Resolves once the channel subscription is active.
+ */
+async function addChannelListener(
+  client: Redis,
+  channel: string,
+  listener: ChannelMessageListener
+): Promise<void> {
+  const existing = channelStates.get(channel);
+  if (existing) {
+    existing.listeners.add(listener);
+    try {
+      await existing.ready;
+    } catch (err) {
+      existing.listeners.delete(listener);
+      throw err;
+    }
+    return;
   }
 
-  return client;
+  const state: ChannelState = {
+    listeners: new Set([listener]),
+    ready: client.subscribe(channel).then(() => undefined),
+  };
+  channelStates.set(channel, state);
+  try {
+    await state.ready;
+  } catch (err) {
+    // Drop the failed state so a later subscribe attempt retries the SUBSCRIBE
+    if (channelStates.get(channel) === state) {
+      channelStates.delete(channel);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Removes a listener for a channel, issuing the Redis-level UNSUBSCRIBE when
+ * the last listener is removed.
+ */
+function removeChannelListener(channel: string, listener: ChannelMessageListener): void {
+  const state = channelStates.get(channel);
+  if (!state) return;
+
+  state.listeners.delete(listener);
+  if (state.listeners.size === 0) {
+    channelStates.delete(channel);
+    sharedSubscriberClient?.unsubscribe(channel).catch((err) => {
+      console.error(`Failed to unsubscribe from channel ${channel}:`, err);
+    });
+  }
+}
+
+/**
+ * A per-consumer handle onto the shared subscriber. Tracks which channels the
+ * consumer is subscribed to so they can be released individually or all at
+ * once via close().
+ */
+export interface PubSubSubscription {
+  /** Subscribes this handle's listener to the given channels. */
+  subscribe(...channels: string[]): Promise<void>;
+  /** Unsubscribes this handle's listener from the given channels. */
+  unsubscribe(...channels: string[]): void;
+  /** Releases all channels held by this handle. The handle cannot be reused. */
+  close(): void;
+}
+
+/**
+ * Creates a pub/sub subscription backed by the single shared Redis subscriber
+ * connection for this process. Channel subscriptions are reference-counted
+ * across handles and messages are fanned out in-process, so N concurrent
+ * consumers (e.g. SSE connections) cost one Redis connection instead of N.
+ *
+ * @param onMessage - Called for every message on a channel this handle subscribed to
+ * @returns A subscription handle, or null if Redis is not configured
+ */
+export function createPubSubSubscription(
+  onMessage: ChannelMessageListener
+): PubSubSubscription | null {
+  const client = getSharedSubscriberClient();
+  if (!client) {
+    return null;
+  }
+
+  const ownChannels = new Set<string>();
+  let closed = false;
+
+  const unsubscribe = (...channels: string[]): void => {
+    for (const channel of channels) {
+      if (!ownChannels.delete(channel)) continue;
+      removeChannelListener(channel, onMessage);
+    }
+  };
+
+  return {
+    async subscribe(...channels: string[]): Promise<void> {
+      if (closed) return;
+
+      const added = channels.filter((channel) => !ownChannels.has(channel));
+      for (const channel of added) {
+        ownChannels.add(channel);
+      }
+
+      const results = await Promise.allSettled(
+        added.map((channel) => addChannelListener(client, channel, onMessage))
+      );
+
+      let firstError: unknown = null;
+      results.forEach((result, i) => {
+        if (result.status === "rejected") {
+          ownChannels.delete(added[i]);
+          firstError ??= result.reason;
+        }
+      });
+      if (firstError !== null) {
+        throw firstError;
+      }
+    },
+    unsubscribe,
+    close(): void {
+      if (closed) return;
+      closed = true;
+      unsubscribe(...ownChannels);
+    },
+  };
 }
 
 /**

--- a/tests/integration/pubsub-subscription.test.ts
+++ b/tests/integration/pubsub-subscription.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Integration tests for the shared Redis pub/sub subscriber (#874).
+ *
+ * Verifies that createPubSubSubscription multiplexes all channel
+ * subscriptions in the process over a single shared Redis connection:
+ * in-process fan-out to multiple handles, per-channel filtering, and
+ * reference-counted Redis-level SUBSCRIBE/UNSUBSCRIBE.
+ *
+ * Uses a real Redis via docker-compose.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import Redis from "ioredis";
+import { createPubSubSubscription } from "../../src/server/redis/pubsub";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+
+// Raw Redis client for publishing and inspecting subscription counts,
+// independent of the shared subscriber under test.
+let redis: Redis;
+
+beforeAll(() => {
+  const redisUrl = process.env.REDIS_URL;
+  if (!redisUrl) {
+    throw new Error("REDIS_URL must be set for integration tests");
+  }
+  redis = new Redis(redisUrl);
+});
+
+afterAll(async () => {
+  await redis.quit();
+});
+
+function uniqueChannel(): string {
+  return `test:${generateUuidv7()}:events`;
+}
+
+/** Number of Redis-level subscribers on a channel (counts connections, not listeners). */
+async function numsub(channel: string): Promise<number> {
+  const result = (await redis.call("pubsub", "numsub", channel)) as [string, number | string];
+  return Number(result[1]);
+}
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 5000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+/** Collects received messages for assertion. */
+function collector(): {
+  messages: Array<{ channel: string; message: string }>;
+  listener: (channel: string, message: string) => void;
+} {
+  const messages: Array<{ channel: string; message: string }> = [];
+  return {
+    messages,
+    listener: (channel, message) => {
+      messages.push({ channel, message });
+    },
+  };
+}
+
+describe("createPubSubSubscription", () => {
+  it("delivers published messages to a subscribed handle", async () => {
+    const channel = uniqueChannel();
+    const received = collector();
+    const handle = createPubSubSubscription(received.listener);
+    expect(handle).not.toBeNull();
+
+    try {
+      await handle!.subscribe(channel);
+      expect(await numsub(channel)).toBe(1);
+
+      await redis.publish(channel, "hello");
+      await waitFor(() => received.messages.length === 1);
+      expect(received.messages[0]).toEqual({ channel, message: "hello" });
+    } finally {
+      handle!.close();
+    }
+  });
+
+  it("fans out one Redis-level subscription to multiple handles", async () => {
+    const channel = uniqueChannel();
+    const receivedA = collector();
+    const receivedB = collector();
+    const handleA = createPubSubSubscription(receivedA.listener);
+    const handleB = createPubSubSubscription(receivedB.listener);
+
+    try {
+      await Promise.all([handleA!.subscribe(channel), handleB!.subscribe(channel)]);
+
+      // Both handles share a single connection-level subscription
+      expect(await numsub(channel)).toBe(1);
+
+      await redis.publish(channel, "fan-out");
+      await waitFor(() => receivedA.messages.length === 1 && receivedB.messages.length === 1);
+      expect(receivedA.messages[0]).toEqual({ channel, message: "fan-out" });
+      expect(receivedB.messages[0]).toEqual({ channel, message: "fan-out" });
+    } finally {
+      handleA!.close();
+      handleB!.close();
+    }
+  });
+
+  it("only delivers messages for channels the handle subscribed to", async () => {
+    const channelA = uniqueChannel();
+    const channelB = uniqueChannel();
+    const receivedA = collector();
+    const receivedB = collector();
+    const handleA = createPubSubSubscription(receivedA.listener);
+    const handleB = createPubSubSubscription(receivedB.listener);
+
+    try {
+      await Promise.all([handleA!.subscribe(channelA), handleB!.subscribe(channelB)]);
+
+      await redis.publish(channelA, "for-a");
+      await waitFor(() => receivedA.messages.length === 1);
+
+      expect(receivedA.messages).toEqual([{ channel: channelA, message: "for-a" }]);
+      expect(receivedB.messages).toEqual([]);
+    } finally {
+      handleA!.close();
+      handleB!.close();
+    }
+  });
+
+  it("keeps the channel subscribed until the last handle releases it", async () => {
+    const channel = uniqueChannel();
+    const receivedA = collector();
+    const receivedB = collector();
+    const handleA = createPubSubSubscription(receivedA.listener);
+    const handleB = createPubSubSubscription(receivedB.listener);
+
+    await Promise.all([handleA!.subscribe(channel), handleB!.subscribe(channel)]);
+
+    // Closing one handle must not tear down the shared channel subscription
+    handleA!.close();
+    expect(await numsub(channel)).toBe(1);
+
+    await redis.publish(channel, "after-close");
+    await waitFor(() => receivedB.messages.length === 1);
+    expect(receivedB.messages[0]).toEqual({ channel, message: "after-close" });
+    expect(receivedA.messages).toEqual([]);
+
+    // Closing the last handle unsubscribes at the Redis level
+    handleB!.close();
+    await waitFor(async () => (await numsub(channel)) === 0);
+  });
+
+  it("unsubscribes individual channels without affecting others", async () => {
+    const channelA = uniqueChannel();
+    const channelB = uniqueChannel();
+    const received = collector();
+    const handle = createPubSubSubscription(received.listener);
+
+    try {
+      await handle!.subscribe(channelA, channelB);
+      expect(await numsub(channelA)).toBe(1);
+      expect(await numsub(channelB)).toBe(1);
+
+      handle!.unsubscribe(channelA);
+      await waitFor(async () => (await numsub(channelA)) === 0);
+      expect(await numsub(channelB)).toBe(1);
+
+      await redis.publish(channelA, "dropped");
+      await redis.publish(channelB, "kept");
+      await waitFor(() => received.messages.length === 1);
+      expect(received.messages).toEqual([{ channel: channelB, message: "kept" }]);
+    } finally {
+      handle!.close();
+    }
+  });
+
+  it("ignores subscribe calls after close", async () => {
+    const channel = uniqueChannel();
+    const received = collector();
+    const handle = createPubSubSubscription(received.listener);
+
+    handle!.close();
+    handle!.close(); // idempotent
+    await handle!.subscribe(channel);
+    expect(await numsub(channel)).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #874.

## Summary
- **One Redis subscriber connection per process** instead of one per SSE connection: new `createPubSubSubscription()` in `src/server/redis/pubsub.ts` multiplexes channel subscriptions over a single shared ioredis client, with reference-counted Redis-level SUBSCRIBE/UNSUBSCRIBE and in-process fan-out to each SSE connection's handler. Redis connections no longer scale 1:1 with users online.
- **One client connection per session**: `useRealtimeUpdates` now opens the `EventSource` directly instead of first probing with a throwaway `fetch` (which doubled per-connect auth + subscription-query work and raced the initial channel set). The Redis-down fallback is detected only on the EventSource error path via a new lightweight `HEAD /api/v1/events` handler that just pings Redis (no auth/DB work); a 503 switches to polling exactly as before.
- Fixes the doc drift called out in the issue: stale "phase 6.2" note in `pubsub.ts`, incomplete event lists in DESIGN.md "Channel Design" and the SSE d2 diagram.

The other smaller findings in #874 (session revalidation for long-lived streams, `entry_state_changed` count sequencing, max connection lifetime) are intentionally left out of scope here.

## Test plan
- [x] New integration tests (`tests/integration/pubsub-subscription.test.ts`) covering fan-out to multiple handles, per-channel filtering, refcounted SUBSCRIBE/UNSUBSCRIBE (verified via `PUBSUB NUMSUB`), and close semantics
- [x] `pnpm test:e2e` — realtime SSE → cache → UI tests pass against the shared subscriber and probe-free client
- [x] `pnpm test:unit`, `pnpm test:integration`, `pnpm typecheck`, eslint all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)