### PR TITLE
Serialize catch-up syncs to prevent double-applied delta updates (#897)

### DIFF
--- a/src/lib/events/sync-scheduler.ts
+++ b/src/lib/events/sync-scheduler.ts
@@ -1,0 +1,86 @@
+/**
+ * Sync Serialization Scheduler
+ *
+ * Pure decision logic that serializes catch-up syncs so two of them never run
+ * concurrently. Without this, overlapping syncs (a poll tick firing while a
+ * slow sync is still awaiting `sync.events`, a visibility-triggered sync over an
+ * in-flight poll, or the `hasMore` continuation racing a poll) read the same
+ * cursors and process the same events twice. Idempotent handlers shrug that off,
+ * but delta-based handlers (`new_entry` incrementing unread counts) double-apply,
+ * inflating counts until the next absolute-count event corrects them. See #897.
+ *
+ * A naive "skip if already syncing" lock isn't enough: a request that arrives
+ * while a sync is running (e.g. the catch-up sync triggered on SSE `open`) must
+ * still run *after* the in-flight sync finishes, or events between the two
+ * cursor reads are missed until the next poll/reconnect. So instead of dropping
+ * overlapping requests we coalesce them into a single follow-up run.
+ *
+ * `reduceSyncScheduler(state, event)` returns the next state plus whether the
+ * caller should start a sync now. Keeping it pure makes the serialization
+ * behavior unit-testable without timers or network mocks, the same way the
+ * connection state machine in `connection-state.ts` is.
+ */
+
+export interface SyncSchedulerState {
+  /** A sync is currently in flight. */
+  running: boolean;
+  /**
+   * A sync was requested while one was already running, so another should run
+   * once the in-flight one settles. Multiple overlapping requests collapse into
+   * this single flag (one follow-up, not one per request).
+   */
+  pending: boolean;
+}
+
+export const INITIAL_SYNC_SCHEDULER_STATE: SyncSchedulerState = {
+  running: false,
+  pending: false,
+};
+
+export type SyncSchedulerEvent =
+  /** Something wants a sync (poll tick, visibility, catch-up on connect). */
+  | { type: "request" }
+  /**
+   * The in-flight sync settled. `hasMore` is true when the server reported more
+   * events than the page returned, so the drain must continue with another run.
+   */
+  | { type: "completed"; hasMore: boolean };
+
+export interface SyncSchedulerResult {
+  state: SyncSchedulerState;
+  /** When true, the caller should begin executing one sync now. */
+  startSync: boolean;
+}
+
+/**
+ * Computes the next scheduler state and whether to start a sync.
+ *
+ * - `request` while idle starts a sync immediately.
+ * - `request` while running sets `pending` so exactly one follow-up runs later.
+ * - `completed` starts another sync when a request was queued (`pending`) or the
+ *   server still `hasMore`; otherwise it returns to idle.
+ *
+ * A `completed` event with no sync running is ignored (returns the same state),
+ * since there is nothing to settle.
+ */
+export function reduceSyncScheduler(
+  state: SyncSchedulerState,
+  event: SyncSchedulerEvent
+): SyncSchedulerResult {
+  switch (event.type) {
+    case "request":
+      if (state.running) {
+        return { state: { running: true, pending: true }, startSync: false };
+      }
+      return { state: { running: true, pending: false }, startSync: true };
+
+    case "completed":
+      if (!state.running) {
+        return { state, startSync: false };
+      }
+      if (state.pending || event.hasMore) {
+        return { state: { running: true, pending: false }, startSync: true };
+      }
+      return { state: { running: false, pending: false }, startSync: false };
+  }
+}

--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -35,6 +35,12 @@ import {
 } from "@/lib/events/connection-state";
 import { advanceCursors, type SyncCursors } from "@/lib/events/cursors";
 import { parseSyncEvent } from "@/lib/events/parse";
+import {
+  INITIAL_SYNC_SCHEDULER_STATE,
+  reduceSyncScheduler,
+  type SyncSchedulerEvent,
+  type SyncSchedulerState,
+} from "@/lib/events/sync-scheduler";
 
 /**
  * Return type for the useRealtimeUpdates hook.
@@ -124,7 +130,11 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
 
   // Latest callbacks, readable from the stable dispatch closure below
   const handleEventRef = useRef<(event: MessageEvent) => void>(() => {});
-  const performSyncRef = useRef<() => Promise<void>>(async () => {});
+  const requestSyncRef = useRef<() => void>(() => {});
+
+  // Serializes catch-up syncs so two never run at once and double-apply
+  // delta-based cache updates (#897). State is pure; the glue below executes it.
+  const syncSchedulerStateRef = useRef<SyncSchedulerState>(INITIAL_SYNC_SCHEDULER_STATE);
 
   // Check if user is authenticated
   const userQuery = trpc.auth.me.useQuery(undefined, {
@@ -158,12 +168,16 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
   }, [handleEvent]);
 
   /**
-   * Performs a sync to catch up on missed changes.
-   * Uses the sync.events endpoint which returns events in the same format as SSE,
-   * allowing us to reuse the same handleSyncEvent logic for both paths.
-   * Used during polling mode and for catch-up sync after SSE reconnection.
+   * Runs a single catch-up sync against the sync.events endpoint, which returns
+   * events in the same format as SSE so we reuse the same handleSyncEvent logic
+   * for both paths. Returns whether the server has more events to drain.
+   *
+   * This must never run concurrently with itself: two runs would read the same
+   * cursors and double-apply delta-based cache updates (#897). Serialization is
+   * handled by the scheduler glue below — always go through `requestSync`, never
+   * call this directly.
    */
-  const performSync = useCallback(async () => {
+  const runSyncOnce = useCallback(async (): Promise<boolean> => {
     try {
       const currentCursors = cursorsRef.current;
 
@@ -181,18 +195,35 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
         handleSyncEvent(utils, queryClient, event);
       }
 
-      // If there are more events, schedule another sync soon
-      if (result.hasMore) {
-        // Use setTimeout to avoid blocking - the next poll or manual sync will pick up more
-        setTimeout(() => performSyncRef.current(), 100);
-      }
+      return result.hasMore;
     } catch (error) {
       console.error("Sync failed:", error);
+      return false;
     }
   }, [utils, queryClient]);
+
+  /**
+   * Serializes sync execution. Every sync trigger (poll tick, visibility,
+   * catch-up on connect, hasMore continuation) goes through here so at most one
+   * sync runs at a time; overlapping requests coalesce into a single follow-up
+   * once the in-flight sync settles. See `sync-scheduler.ts` for the rationale.
+   */
+  const requestSync = useCallback(() => {
+    function dispatchSchedulerEvent(event: SyncSchedulerEvent): void {
+      const { state, startSync } = reduceSyncScheduler(syncSchedulerStateRef.current, event);
+      syncSchedulerStateRef.current = state;
+      if (startSync) {
+        void runSyncOnce().then((hasMore) => {
+          dispatchSchedulerEvent({ type: "completed", hasMore });
+        });
+      }
+    }
+
+    dispatchSchedulerEvent({ type: "request" });
+  }, [runSyncOnce]);
   useEffect(() => {
-    performSyncRef.current = performSync;
-  }, [performSync]);
+    requestSyncRef.current = requestSync;
+  }, [requestSync]);
 
   /**
    * Stable dispatcher: runs the pure transition function and executes the
@@ -242,7 +273,7 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
         case "start-poll-interval":
           if (!pollIntervalRef.current) {
             pollIntervalRef.current = setInterval(() => {
-              void performSyncRef.current();
+              requestSyncRef.current();
             }, action.intervalMs);
           }
           break;
@@ -268,7 +299,7 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
           }
           break;
         case "sync":
-          void performSyncRef.current();
+          requestSyncRef.current();
           break;
       }
     }

--- a/tests/unit/frontend/events/sync-scheduler.test.ts
+++ b/tests/unit/frontend/events/sync-scheduler.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for the sync serialization scheduler.
+ *
+ * These encode the #897 invariant: two catch-up syncs must never run
+ * concurrently (they would read the same cursors and double-apply delta-based
+ * cache updates), yet a request that arrives mid-sync must not be dropped — it
+ * has to run once the in-flight sync settles.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  INITIAL_SYNC_SCHEDULER_STATE,
+  reduceSyncScheduler,
+  type SyncSchedulerEvent,
+  type SyncSchedulerState,
+} from "@/lib/events/sync-scheduler";
+
+/**
+ * Drives the scheduler the way the async hook glue does: starting a sync only
+ * *kicks off* an in-flight run (it does not settle inline), so a burst of
+ * synchronous requests lands while a sync is genuinely running — the real #897
+ * race. Completions are deferred and drained afterward, and each may start a
+ * follow-up. Returns how many syncs actually ran so tests can assert
+ * serialization directly; the harness also asserts no sync ever starts while
+ * another is running.
+ */
+function runScenario(
+  requests: number,
+  hasMoreSequence: boolean[] = [],
+  from: SyncSchedulerState = INITIAL_SYNC_SCHEDULER_STATE
+): { state: SyncSchedulerState; syncsRun: number } {
+  let state = from;
+  let running = false;
+  let syncsRun = 0;
+  let hasMoreIndex = 0;
+  const pendingCompletions: Array<() => void> = [];
+
+  const dispatch = (event: SyncSchedulerEvent): void => {
+    const result = reduceSyncScheduler(state, event);
+    state = result.state;
+    if (result.startSync) {
+      // The scheduler must never ask us to start a sync while one is running.
+      expect(running).toBe(false);
+      running = true;
+      syncsRun += 1;
+      // Defer the completion: the sync is now "in flight" until drained.
+      pendingCompletions.push(() => {
+        running = false;
+        const hasMore = hasMoreSequence[hasMoreIndex++] ?? false;
+        dispatch({ type: "completed", hasMore });
+      });
+    }
+  };
+
+  // Burst of synchronous requests, all landing while the first sync is in flight.
+  for (let i = 0; i < requests; i++) {
+    dispatch({ type: "request" });
+  }
+
+  // Settle in-flight syncs one at a time; each may kick off a follow-up.
+  while (pendingCompletions.length > 0) {
+    pendingCompletions.shift()!();
+  }
+
+  return { state, syncsRun };
+}
+
+describe("reduceSyncScheduler", () => {
+  it("starts a sync when idle", () => {
+    const result = reduceSyncScheduler(INITIAL_SYNC_SCHEDULER_STATE, { type: "request" });
+    expect(result.startSync).toBe(true);
+    expect(result.state).toEqual({ running: true, pending: false });
+  });
+
+  it("does not start a second sync while one is running, but marks it pending", () => {
+    const running: SyncSchedulerState = { running: true, pending: false };
+    const result = reduceSyncScheduler(running, { type: "request" });
+    expect(result.startSync).toBe(false);
+    expect(result.state).toEqual({ running: true, pending: true });
+  });
+
+  it("collapses multiple overlapping requests into a single pending follow-up", () => {
+    let state: SyncSchedulerState = { running: true, pending: false };
+    for (let i = 0; i < 5; i++) {
+      state = reduceSyncScheduler(state, { type: "request" }).state;
+    }
+    expect(state).toEqual({ running: true, pending: true });
+  });
+
+  it("returns to idle when a sync completes with nothing queued", () => {
+    const running: SyncSchedulerState = { running: true, pending: false };
+    const result = reduceSyncScheduler(running, { type: "completed", hasMore: false });
+    expect(result.startSync).toBe(false);
+    expect(result.state).toEqual({ running: false, pending: false });
+  });
+
+  it("starts the queued follow-up when a sync completes with a request pending", () => {
+    const pending: SyncSchedulerState = { running: true, pending: true };
+    const result = reduceSyncScheduler(pending, { type: "completed", hasMore: false });
+    expect(result.startSync).toBe(true);
+    expect(result.state).toEqual({ running: true, pending: false });
+  });
+
+  it("continues draining when the server still hasMore, even with nothing queued", () => {
+    const running: SyncSchedulerState = { running: true, pending: false };
+    const result = reduceSyncScheduler(running, { type: "completed", hasMore: true });
+    expect(result.startSync).toBe(true);
+    expect(result.state).toEqual({ running: true, pending: false });
+  });
+
+  it("ignores a completion when no sync is running", () => {
+    const result = reduceSyncScheduler(INITIAL_SYNC_SCHEDULER_STATE, {
+      type: "completed",
+      hasMore: false,
+    });
+    expect(result.startSync).toBe(false);
+    expect(result.state).toBe(INITIAL_SYNC_SCHEDULER_STATE);
+  });
+});
+
+describe("reduceSyncScheduler serialization (driven scenarios)", () => {
+  it("runs a single sync for a single request", () => {
+    const { state, syncsRun } = runScenario(1);
+    expect(syncsRun).toBe(1);
+    expect(state).toEqual(INITIAL_SYNC_SCHEDULER_STATE);
+  });
+
+  it("never runs two syncs concurrently and ends idle", () => {
+    // runScenario asserts running===false on every start, so reaching here
+    // without throwing proves serialization held.
+    const { state, syncsRun } = runScenario(10);
+    expect(syncsRun).toBeGreaterThan(0);
+    expect(state).toEqual(INITIAL_SYNC_SCHEDULER_STATE);
+  });
+
+  it("coalesces a burst of synchronous requests into at most two runs", () => {
+    // The first request runs immediately; the rest collapse into one follow-up.
+    const { syncsRun } = runScenario(4);
+    expect(syncsRun).toBe(2);
+  });
+
+  it("drains all pages when the server reports hasMore", () => {
+    // One request, but the server returns hasMore twice before draining.
+    const { state, syncsRun } = runScenario(1, [true, true, false]);
+    expect(syncsRun).toBe(3);
+    expect(state).toEqual(INITIAL_SYNC_SCHEDULER_STATE);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #897. `performSync` had no concurrency guard, so two syncs could run at once — a poll tick firing during a slow sync, a visibility-triggered sync overlapping an in-flight poll, or the `hasMore` continuation racing a poll. Both reads `cursorsRef.current` before either advanced it, processing the **same events twice**. Idempotent handlers (absolute counts) tolerate this, but delta-based handlers (`new_entry` incrementing unread counts) double-apply and inflate counts until the next absolute-count event corrects them.

## Changes
- **`src/lib/events/sync-scheduler.ts`** (new): a pure `reduceSyncScheduler` state machine that serializes syncs — at most one runs at a time, and overlapping requests coalesce into a single follow-up rather than being dropped. A naive "skip if syncing" lock isn't enough: a skipped catch-up sync (e.g. on SSE `open`) must still run after the in-flight one, or events between the two cursor reads are missed until the next poll/reconnect. The `hasMore` continuation is folded into the same mechanism (replacing the old `setTimeout(..., 100)`).
- **`src/lib/hooks/useRealtimeUpdates.ts`**: split `performSync` into a single-run `runSyncOnce` (returns `hasMore`) plus `requestSync` glue that drives the scheduler. All sync triggers (poll interval, connect/visibility `sync` action) now go through `requestSync`.
- **`tests/unit/frontend/events/sync-scheduler.test.ts`** (new): unit tests, including a driver that models the async in-flight window and asserts no two syncs ever run concurrently.

## Test plan
- [x] `pnpm test:unit` (1776 passing, incl. 11 new scheduler tests)
- [x] `pnpm typecheck`
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)