### PR TITLE
Stop catch-up sync drain after disconnect (#898 follow-up)

### DIFF
--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -210,6 +210,16 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
    */
   const requestSync = useCallback(() => {
     function dispatchSchedulerEvent(event: SyncSchedulerEvent): void {
+      // Don't start or continue syncs once disconnected (unmount/logout sets
+      // this synchronously). Otherwise an in-flight sync's `hasMore` drain would
+      // keep firing background sync.events requests after the hook is gone. This
+      // guards both the initial `request` and the `completed` re-entry below.
+      // Reset to idle so a later reconnect's catch-up sync starts cleanly
+      // instead of being stuck behind an abandoned `running` flag.
+      if (stateRef.current.phase === "disconnected") {
+        syncSchedulerStateRef.current = INITIAL_SYNC_SCHEDULER_STATE;
+        return;
+      }
       const { state, startSync } = reduceSyncScheduler(syncSchedulerStateRef.current, event);
       syncSchedulerStateRef.current = state;
       if (startSync) {


### PR DESCRIPTION
## Summary
Follow-up to the [Gemini review](https://github.com/brendanlong/lion-reader/pull/898) of #898 (sync serialization). If the hook unmounts or the user logs out while a catch-up sync is in flight, the `runSyncOnce().then(...)` chain still resolves; if the server reported `hasMore`, it keeps firing background `sync.events` requests after the hook is gone.

Gemini called this a "high priority infinite loop" — it's neither infinite (the drain is bounded by actual server data) nor new (the old `setTimeout` continuation behaved similarly), but firing network requests after logout is worth stopping.

## Changes
- Guard `dispatchSchedulerEvent` on `stateRef.current.phase === "disconnected"` (set synchronously by the disconnect transition on unmount/logout), so neither the initial `request` nor the `hasMore` continuation starts work once disconnected. One check at the top covers both paths since `completed` re-enters the same function.
- Reset the scheduler state to idle on that early return. Without this, a completion landing during the disconnected window would leave `running: true` stuck, so a later reconnect's catch-up `request` would be treated as merely "pending" and never start.

The pure `sync-scheduler.ts` reducer is unchanged — this guard is hook glue that depends on the live connection phase, like the rest of the browser-API wiring.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:unit` (events suite, 50 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)