### PR TITLE
Perf: replace correlated subquery in listTags with single aggregation (#831)

### DIFF
--- a/src/server/services/counts.ts
+++ b/src/server/services/counts.ts
@@ -190,10 +190,13 @@ async function getSubscriptionTagCounts(
 ): Promise<{ tags: TagCount[]; uncategorized: { unread: number } | null }> {
   // Single query: get tag IDs for this subscription and their unread counts.
   // If the subscription has no tags, the result will be empty.
+  // COUNT(DISTINCT) dedupes entries reachable through multiple subscriptions
+  // of the same tag (overlapping subscription_feeds from redirect/merge
+  // history), matching listTags semantics.
   const tagCounts = await db
     .select({
       tagId: subscriptionTags.tagId,
-      unread: sql<number>`count(*) FILTER (WHERE NOT ${visibleEntries.read})::int`,
+      unread: sql<number>`count(DISTINCT ${visibleEntries.id}) FILTER (WHERE NOT ${visibleEntries.read})::int`,
     })
     .from(subscriptionTags)
     .innerJoin(visibleEntries, eq(visibleEntries.subscriptionId, subscriptionTags.subscriptionId))
@@ -223,7 +226,7 @@ async function getSubscriptionTagCounts(
   // Subscription has no tags - get uncategorized count
   const uncategorizedResult = await db
     .select({
-      unread: sql<number>`count(*) FILTER (WHERE NOT ${visibleEntries.read})::int`,
+      unread: sql<number>`count(DISTINCT ${visibleEntries.id}) FILTER (WHERE NOT ${visibleEntries.read})::int`,
     })
     .from(visibleEntries)
     .innerJoin(userFeeds, eq(userFeeds.id, visibleEntries.subscriptionId))
@@ -350,7 +353,8 @@ export async function getBulkEntryRelatedCounts(
       ? db
           .select({
             tagId: subscriptionTags.tagId,
-            unread: sql<number>`count(*) FILTER (WHERE NOT ${visibleEntries.read})::int`,
+            // COUNT(DISTINCT) for parity with listTags (see getSubscriptionTagCounts)
+            unread: sql<number>`count(DISTINCT ${visibleEntries.id}) FILTER (WHERE NOT ${visibleEntries.read})::int`,
           })
           .from(subscriptionTags)
           .innerJoin(
@@ -363,7 +367,7 @@ export async function getBulkEntryRelatedCounts(
     hasUncategorized
       ? db
           .select({
-            unread: sql<number>`count(*) FILTER (WHERE NOT ${visibleEntries.read})::int`,
+            unread: sql<number>`count(DISTINCT ${visibleEntries.id}) FILTER (WHERE NOT ${visibleEntries.read})::int`,
           })
           .from(visibleEntries)
           .innerJoin(userFeeds, eq(userFeeds.id, visibleEntries.subscriptionId))

--- a/src/server/services/tags.ts
+++ b/src/server/services/tags.ts
@@ -73,6 +73,7 @@ export async function listTags(db: typeof dbType, userId: string): Promise<ListT
       subscriptions,
       and(
         eq(subscriptionTags.subscriptionId, subscriptions.id),
+        eq(subscriptions.userId, userId),
         isNull(subscriptions.unsubscribedAt)
       )
     )

--- a/src/server/services/tags.ts
+++ b/src/server/services/tags.ts
@@ -52,18 +52,21 @@ export interface UpdateTagParams {
 }
 
 // ============================================================================
-// Service Functions
+// Helper: Per-Tag Unread Counts
 // ============================================================================
 
 /**
- * Lists all tags for a user with feed counts and unread counts.
- * Also returns uncategorized subscription counts.
+ * Builds a grouped subquery of per-tag unread counts for a user.
+ *
+ * COUNT(DISTINCT entry_id) dedupes entries reachable through multiple
+ * subscriptions of the same tag, which is possible when subscription_feeds
+ * rows overlap via feed redirect/merge history. Computing all tags in one
+ * grouped aggregation (instead of a correlated subquery per tag row) keeps
+ * listTags to a single scan (#831); Postgres pushes a tag_id equality
+ * predicate into the GROUP BY, so updateTag can reuse it for one tag.
  */
-export async function listTags(db: typeof dbType, userId: string): Promise<ListTagsResult> {
-  // Pre-compute per-tag unread counts in a single grouped aggregation, then
-  // LEFT JOIN it to the tags query. This replaces a correlated subquery that
-  // re-ran the 5-table join once per tag row (#831).
-  const tagUnreadCounts = db
+function tagUnreadCountsQuery(db: typeof dbType, userId: string) {
+  return db
     .select({
       tagId: subscriptionTags.tagId,
       unreadCount: sql<number>`COUNT(DISTINCT ${userEntries.entryId})::int`.as("unread_count"),
@@ -89,6 +92,18 @@ export async function listTags(db: typeof dbType, userId: string): Promise<ListT
     )
     .groupBy(subscriptionTags.tagId)
     .as("tag_unread_counts");
+}
+
+// ============================================================================
+// Service Functions
+// ============================================================================
+
+/**
+ * Lists all tags for a user with feed counts and unread counts.
+ * Also returns uncategorized subscription counts.
+ */
+export async function listTags(db: typeof dbType, userId: string): Promise<ListTagsResult> {
+  const tagUnreadCounts = tagUnreadCountsQuery(db, userId);
 
   const [userTags, uncategorizedResult] = await Promise.all([
     db
@@ -265,6 +280,7 @@ export async function updateTag(
   await db.update(tags).set(updateData).where(eq(tags.id, tagId));
 
   // Get updated tag with feed count and unread count
+  const tagUnreadCounts = tagUnreadCountsQuery(db, userId);
   const [updatedTag, unreadResult] = await Promise.all([
     db
       .select({
@@ -281,28 +297,9 @@ export async function updateTag(
       .groupBy(tags.id)
       .limit(1),
     db
-      .select({
-        unreadCount: sql<number>`count(*)::int`,
-      })
-      .from(subscriptionTags)
-      .innerJoin(
-        subscriptions,
-        and(
-          eq(subscriptionTags.subscriptionId, subscriptions.id),
-          isNull(subscriptions.unsubscribedAt)
-        )
-      )
-      .innerJoin(subscriptionFeeds, eq(subscriptionFeeds.subscriptionId, subscriptions.id))
-      .innerJoin(entries, eq(entries.feedId, subscriptionFeeds.feedId))
-      .innerJoin(
-        userEntries,
-        and(
-          eq(userEntries.entryId, entries.id),
-          eq(userEntries.userId, userId),
-          eq(userEntries.read, false)
-        )
-      )
-      .where(eq(subscriptionTags.tagId, tagId)),
+      .select({ unreadCount: tagUnreadCounts.unreadCount })
+      .from(tagUnreadCounts)
+      .where(eq(tagUnreadCounts.tagId, tagId)),
   ]);
 
   if (updatedTag.length === 0) {

--- a/src/server/services/tags.ts
+++ b/src/server/services/tags.ts
@@ -52,33 +52,6 @@ export interface UpdateTagParams {
 }
 
 // ============================================================================
-// Helper: Tag Unread Count Query
-// ============================================================================
-
-/**
- * Builds a subquery for counting unread entries associated with a tag.
- * Shared between list and update to avoid duplication.
- */
-function tagUnreadCountSql(userId: string) {
-  return sql<number>`(
-    SELECT COUNT(*)::int
-    FROM ${subscriptionTags} st
-    INNER JOIN ${subscriptions} s
-      ON st.subscription_id = s.id
-      AND s.unsubscribed_at IS NULL
-    INNER JOIN ${subscriptionFeeds} sf
-      ON sf.subscription_id = s.id
-    INNER JOIN ${entries} e
-      ON e.feed_id = sf.feed_id
-    INNER JOIN ${userEntries} ue
-      ON ue.entry_id = e.id
-      AND ue.user_id = ${userId}
-      AND ue.read = false
-    WHERE st.tag_id = "tags"."id"
-  )`;
-}
-
-// ============================================================================
 // Service Functions
 // ============================================================================
 
@@ -87,6 +60,35 @@ function tagUnreadCountSql(userId: string) {
  * Also returns uncategorized subscription counts.
  */
 export async function listTags(db: typeof dbType, userId: string): Promise<ListTagsResult> {
+  // Pre-compute per-tag unread counts in a single grouped aggregation, then
+  // LEFT JOIN it to the tags query. This replaces a correlated subquery that
+  // re-ran the 5-table join once per tag row (#831).
+  const tagUnreadCounts = db
+    .select({
+      tagId: subscriptionTags.tagId,
+      unreadCount: sql<number>`COUNT(DISTINCT ${userEntries.entryId})::int`.as("unread_count"),
+    })
+    .from(subscriptionTags)
+    .innerJoin(
+      subscriptions,
+      and(
+        eq(subscriptionTags.subscriptionId, subscriptions.id),
+        isNull(subscriptions.unsubscribedAt)
+      )
+    )
+    .innerJoin(subscriptionFeeds, eq(subscriptionFeeds.subscriptionId, subscriptions.id))
+    .innerJoin(entries, eq(entries.feedId, subscriptionFeeds.feedId))
+    .innerJoin(
+      userEntries,
+      and(
+        eq(userEntries.entryId, entries.id),
+        eq(userEntries.userId, userId),
+        eq(userEntries.read, false)
+      )
+    )
+    .groupBy(subscriptionTags.tagId)
+    .as("tag_unread_counts");
+
   const [userTags, uncategorizedResult] = await Promise.all([
     db
       .select({
@@ -99,9 +101,10 @@ export async function listTags(db: typeof dbType, userId: string): Promise<ListT
           FROM ${subscriptionTags}
           WHERE ${subscriptionTags.tagId} = "tags"."id"
         )`,
-        unreadCount: tagUnreadCountSql(userId),
+        unreadCount: sql<number>`COALESCE(${tagUnreadCounts.unreadCount}, 0)`,
       })
       .from(tags)
+      .leftJoin(tagUnreadCounts, eq(tagUnreadCounts.tagId, tags.id))
       .where(and(eq(tags.userId, userId), isNull(tags.deletedAt)))
       .orderBy(tags.name),
     // Count uncategorized subscriptions (those with no tags)

--- a/tests/integration/counts.test.ts
+++ b/tests/integration/counts.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Integration tests for the entry counts service.
+ *
+ * These verify the per-tag and uncategorized unread counts used by mutations
+ * and SSE cache updates, in particular that they deduplicate entries reachable
+ * through multiple subscriptions (overlapping subscription_feeds rows from
+ * feed redirect/merge history) and stay consistent with listTags.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { db } from "../../src/server/db";
+import {
+  users,
+  tags,
+  subscriptions,
+  subscriptionFeeds,
+  subscriptionTags,
+  feeds,
+  entries,
+  userEntries,
+} from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { getEntryRelatedCounts, getBulkEntryRelatedCounts } from "../../src/server/services/counts";
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+async function createTestUser(emailPrefix: string = "user"): Promise<string> {
+  const userId = generateUuidv7();
+  await db.insert(users).values({
+    id: userId,
+    email: `${emailPrefix}-${userId}@test.com`,
+    passwordHash: "test-hash",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  return userId;
+}
+
+async function createTestFeed(url: string): Promise<string> {
+  const feedId = generateUuidv7();
+  await db.insert(feeds).values({
+    id: feedId,
+    type: "web",
+    url,
+    title: `Test Feed ${feedId}`,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  return feedId;
+}
+
+async function createTestSubscription(userId: string, feedId: string): Promise<string> {
+  const subscriptionId = generateUuidv7();
+  await db.insert(subscriptions).values({
+    id: subscriptionId,
+    userId,
+    feedId,
+    subscribedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  await db
+    .insert(subscriptionFeeds)
+    .values({ subscriptionId, feedId, userId })
+    .onConflictDoNothing();
+  return subscriptionId;
+}
+
+async function createTestEntry(feedId: string, userIds: string[]): Promise<string> {
+  const entryId = generateUuidv7();
+  const now = new Date();
+  await db.insert(entries).values({
+    id: entryId,
+    feedId,
+    type: "web",
+    guid: `guid-${entryId}`,
+    title: `Entry ${entryId}`,
+    contentHash: `hash-${entryId}`,
+    fetchedAt: now,
+    lastSeenAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  if (userIds.length > 0) {
+    await db.insert(userEntries).values(
+      userIds.map((userId) => ({
+        userId,
+        entryId,
+        read: false,
+        starred: false,
+      }))
+    );
+  }
+
+  return entryId;
+}
+
+/**
+ * Creates the overlapping-subscriptions fixture: sub1 covers feedA and feedB
+ * (redirect/merge history in subscription_feeds), sub2 covers feedB directly.
+ * An unread entry in feedB is visible through both subscriptions; an unread
+ * entry in feedA only through sub1.
+ */
+async function createOverlappingSubscriptions(userId: string) {
+  const feedIdA = await createTestFeed("https://feed-a.com/rss");
+  const feedIdB = await createTestFeed("https://feed-b.com/rss");
+  const subId1 = await createTestSubscription(userId, feedIdA);
+  const subId2 = await createTestSubscription(userId, feedIdB);
+  await db.insert(subscriptionFeeds).values({ subscriptionId: subId1, feedId: feedIdB, userId });
+
+  const entryIdA = await createTestEntry(feedIdA, [userId]);
+  const entryIdB = await createTestEntry(feedIdB, [userId]);
+
+  return { feedIdA, feedIdB, subId1, subId2, entryIdA, entryIdB };
+}
+
+async function linkTag(userId: string, name: string, subscriptionIds: string[]): Promise<string> {
+  const tagId = generateUuidv7();
+  await db.insert(tags).values({ id: tagId, userId, name, createdAt: new Date() });
+  await db.insert(subscriptionTags).values(
+    subscriptionIds.map((subscriptionId) => ({
+      tagId,
+      subscriptionId,
+      createdAt: new Date(),
+    }))
+  );
+  return tagId;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("Entry counts service", () => {
+  beforeEach(async () => {
+    await db.delete(userEntries);
+    await db.delete(entries);
+    await db.delete(subscriptionTags);
+    await db.delete(tags);
+    await db.delete(subscriptions);
+    await db.delete(feeds);
+    await db.delete(users);
+  });
+
+  afterAll(async () => {
+    await db.delete(userEntries);
+    await db.delete(entries);
+    await db.delete(subscriptionTags);
+    await db.delete(tags);
+    await db.delete(subscriptions);
+    await db.delete(feeds);
+    await db.delete(users);
+  });
+
+  describe("getEntryRelatedCounts", () => {
+    it("deduplicates tag counts for entries reachable through multiple subscriptions", async () => {
+      const userId = await createTestUser();
+      const { subId1, subId2, entryIdB } = await createOverlappingSubscriptions(userId);
+      const tagId = await linkTag(userId, "Tech", [subId1, subId2]);
+
+      const counts = await getEntryRelatedCounts(db, userId, entryIdB);
+
+      expect(counts.tags).toEqual([{ id: tagId, unread: 2 }]);
+    });
+
+    it("deduplicates the uncategorized count for entries reachable through multiple subscriptions", async () => {
+      const userId = await createTestUser();
+      const { entryIdB } = await createOverlappingSubscriptions(userId);
+
+      const counts = await getEntryRelatedCounts(db, userId, entryIdB);
+
+      expect(counts.tags).toEqual([]);
+      expect(counts.uncategorized).toEqual({ unread: 2 });
+    });
+
+    it("does not count other users' unread entries in tag counts", async () => {
+      const userId = await createTestUser("user-a");
+      const otherUserId = await createTestUser("user-b");
+
+      const feedId = await createTestFeed("https://shared.com/rss");
+      const subId = await createTestSubscription(userId, feedId);
+      await createTestSubscription(otherUserId, feedId);
+      const tagId = await linkTag(userId, "Mine", [subId]);
+
+      const entryId = await createTestEntry(feedId, [userId, otherUserId]);
+      await createTestEntry(feedId, [otherUserId]);
+
+      const counts = await getEntryRelatedCounts(db, userId, entryId);
+
+      expect(counts.tags).toEqual([{ id: tagId, unread: 1 }]);
+    });
+  });
+
+  describe("getBulkEntryRelatedCounts", () => {
+    it("deduplicates tag counts for entries reachable through multiple subscriptions", async () => {
+      const userId = await createTestUser();
+      const { subId1, subId2 } = await createOverlappingSubscriptions(userId);
+      const tagId = await linkTag(userId, "Tech", [subId1, subId2]);
+
+      const counts = await getBulkEntryRelatedCounts(db, userId, [
+        { subscriptionId: subId1, type: "web" },
+      ]);
+
+      expect(counts.tags).toEqual([{ id: tagId, unread: 2 }]);
+    });
+
+    it("deduplicates the uncategorized count for entries reachable through multiple subscriptions", async () => {
+      const userId = await createTestUser();
+      const { subId1 } = await createOverlappingSubscriptions(userId);
+
+      const counts = await getBulkEntryRelatedCounts(db, userId, [
+        { subscriptionId: subId1, type: "web" },
+      ]);
+
+      expect(counts.tags).toEqual([]);
+      expect(counts.uncategorized).toEqual({ unread: 2 });
+    });
+  });
+});

--- a/tests/integration/tags.test.ts
+++ b/tests/integration/tags.test.ts
@@ -324,6 +324,113 @@ describe("Tags API", () => {
       expect(empty?.unreadCount).toBe(0);
     });
 
+    it("deduplicates unread entries reachable through multiple subscriptions of the same tag", async () => {
+      const userId = await createTestUser();
+
+      const tagId = generateUuidv7();
+      await db.insert(tags).values({ id: tagId, userId, name: "Tech", createdAt: new Date() });
+
+      // sub1 subscribed to feedA but previously covered feedB (redirect/merge
+      // history), so subscription_feeds maps it to both. sub2 is subscribed to
+      // feedB directly. An unread entry in feedB is reachable through both
+      // subscriptions and must be counted once.
+      const feedIdA = await createTestFeed("https://feed-a.com/rss");
+      const feedIdB = await createTestFeed("https://feed-b.com/rss");
+      const subId1 = await createTestSubscription(userId, feedIdA);
+      const subId2 = await createTestSubscription(userId, feedIdB);
+      await db
+        .insert(subscriptionFeeds)
+        .values({ subscriptionId: subId1, feedId: feedIdB, userId });
+      await linkTagToSubscription(tagId, subId1);
+      await linkTagToSubscription(tagId, subId2);
+
+      await createTestEntry(feedIdA, { userIds: [userId] });
+      await createTestEntry(feedIdB, { userIds: [userId] });
+
+      const ctx = createAuthContext(userId);
+      const caller = createCaller(ctx);
+      const result = await caller.tags.list();
+
+      expect(result.items[0].unreadCount).toBe(2);
+    });
+
+    it("does not count other users' unread entries on shared feeds", async () => {
+      const userId = await createTestUser("user-a");
+      const otherUserId = await createTestUser("user-b");
+
+      // Both users subscribe to the same feed and tag their subscriptions
+      const feedId = await createTestFeed("https://shared.com/rss");
+      const subId = await createTestSubscription(userId, feedId);
+      const otherSubId = await createTestSubscription(otherUserId, feedId);
+
+      const tagId = generateUuidv7();
+      const otherTagId = generateUuidv7();
+      await db.insert(tags).values([
+        { id: tagId, userId, name: "Mine", createdAt: new Date() },
+        { id: otherTagId, userId: otherUserId, name: "Theirs", createdAt: new Date() },
+      ]);
+      await linkTagToSubscription(tagId, subId);
+      await linkTagToSubscription(otherTagId, otherSubId);
+
+      // One entry visible to both users, one visible only to the other user
+      await createTestEntry(feedId, { userIds: [userId, otherUserId] });
+      await createTestEntry(feedId, { userIds: [otherUserId] });
+
+      const ctx = createAuthContext(userId);
+      const caller = createCaller(ctx);
+      const result = await caller.tags.list();
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].name).toBe("Mine");
+      expect(result.items[0].unreadCount).toBe(1);
+    });
+
+    it("excludes unread entries from unsubscribed subscriptions", async () => {
+      const userId = await createTestUser();
+
+      const tagId = generateUuidv7();
+      await db.insert(tags).values({ id: tagId, userId, name: "Tech", createdAt: new Date() });
+
+      const feedId = await createTestFeed("https://feed1.com/rss");
+      const subId = await createTestSubscription(userId, feedId);
+      await linkTagToSubscription(tagId, subId);
+      await createTestEntry(feedId, { userIds: [userId] });
+
+      await db
+        .update(subscriptions)
+        .set({ unsubscribedAt: new Date() })
+        .where(eq(subscriptions.id, subId));
+
+      const ctx = createAuthContext(userId);
+      const caller = createCaller(ctx);
+      const result = await caller.tags.list();
+
+      expect(result.items[0].unreadCount).toBe(0);
+    });
+
+    it("returns zero unread for a tag whose entries are all read", async () => {
+      const userId = await createTestUser();
+
+      const tagId = generateUuidv7();
+      await db.insert(tags).values({ id: tagId, userId, name: "Tech", createdAt: new Date() });
+
+      const feedId = await createTestFeed("https://feed1.com/rss");
+      const subId = await createTestSubscription(userId, feedId);
+      await linkTagToSubscription(tagId, subId);
+      const entryId = await createTestEntry(feedId, { userIds: [userId] });
+      await db
+        .update(userEntries)
+        .set({ read: true })
+        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, entryId)));
+
+      const ctx = createAuthContext(userId);
+      const caller = createCaller(ctx);
+      const result = await caller.tags.list();
+
+      expect(result.items[0].feedCount).toBe(1);
+      expect(result.items[0].unreadCount).toBe(0);
+    });
+
     it("returns tags ordered by name", async () => {
       const userId = await createTestUser();
 
@@ -541,6 +648,40 @@ describe("Tags API", () => {
       const result = await caller.tags.update({ id: tagId, name: "Technology" });
 
       expect(result.tag.feedCount).toBe(1);
+    });
+
+    it("returns unread count consistent with tags.list", async () => {
+      const userId = await createTestUser("user-a");
+      const otherUserId = await createTestUser("user-b");
+
+      const tagId = generateUuidv7();
+      await db.insert(tags).values({ id: tagId, userId, name: "Tech", createdAt: new Date() });
+
+      // Overlapping subscription_feeds within the tag (dedup case) plus a
+      // second user on the shared feed (scoping case) — update must count the
+      // same way list does.
+      const feedIdA = await createTestFeed("https://feed-a.com/rss");
+      const feedIdB = await createTestFeed("https://feed-b.com/rss");
+      const subId1 = await createTestSubscription(userId, feedIdA);
+      const subId2 = await createTestSubscription(userId, feedIdB);
+      await db
+        .insert(subscriptionFeeds)
+        .values({ subscriptionId: subId1, feedId: feedIdB, userId });
+      await linkTagToSubscription(tagId, subId1);
+      await linkTagToSubscription(tagId, subId2);
+      await createTestSubscription(otherUserId, feedIdB);
+
+      await createTestEntry(feedIdA, { userIds: [userId] });
+      await createTestEntry(feedIdB, { userIds: [userId, otherUserId] });
+
+      const ctx = createAuthContext(userId);
+      const caller = createCaller(ctx);
+
+      const updateResult = await caller.tags.update({ id: tagId, name: "Technology" });
+      const listResult = await caller.tags.list();
+
+      expect(updateResult.tag.unreadCount).toBe(2);
+      expect(listResult.items[0].unreadCount).toBe(2);
     });
 
     it("throws error when tag not found", async () => {

--- a/tests/integration/tags.test.ts
+++ b/tests/integration/tags.test.ts
@@ -287,6 +287,43 @@ describe("Tags API", () => {
       expect(result.items[0].feedCount).toBe(2);
     });
 
+    it("returns tags with correct unread counts", async () => {
+      const userId = await createTestUser();
+
+      const techTagId = generateUuidv7();
+      const emptyTagId = generateUuidv7();
+      await db.insert(tags).values([
+        { id: techTagId, userId, name: "Tech", createdAt: new Date() },
+        { id: emptyTagId, userId, name: "Empty", createdAt: new Date() },
+      ]);
+
+      const feedId1 = await createTestFeed("https://feed1.com/rss");
+      const feedId2 = await createTestFeed("https://feed2.com/rss");
+      const subId1 = await createTestSubscription(userId, feedId1);
+      const subId2 = await createTestSubscription(userId, feedId2);
+      await linkTagToSubscription(techTagId, subId1);
+      await linkTagToSubscription(techTagId, subId2);
+
+      // feed1: 2 unread entries; feed2: 1 unread + 1 read entry
+      await createTestEntry(feedId1, { userIds: [userId] });
+      await createTestEntry(feedId1, { userIds: [userId] });
+      await createTestEntry(feedId2, { userIds: [userId] });
+      const readEntryId = await createTestEntry(feedId2, { userIds: [userId] });
+      await db
+        .update(userEntries)
+        .set({ read: true })
+        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, readEntryId)));
+
+      const ctx = createAuthContext(userId);
+      const caller = createCaller(ctx);
+      const result = await caller.tags.list();
+
+      const tech = result.items.find((t) => t.name === "Tech");
+      const empty = result.items.find((t) => t.name === "Empty");
+      expect(tech?.unreadCount).toBe(3);
+      expect(empty?.unreadCount).toBe(0);
+    });
+
     it("returns tags ordered by name", async () => {
       const userId = await createTestUser();
 


### PR DESCRIPTION
## Summary

Fixes #831, plus follow-up fixes from review for the same defect pattern in sibling endpoints.

### listTags (#831)
`listTags` built `unreadCount` via `tagUnreadCountSql`, a correlated subquery that re-ran a 5-table join (`subscription_tags` → `subscriptions` → `subscription_feeds` → `entries` → `user_entries`) **once per tag row**, on every sidebar load. Replaced with a single grouped aggregation (`GROUP BY subscription_tags.tag_id`) joined once via `LEFT JOIN`, scoped to the current user's subscriptions (review feedback — feeds are shared, so the unscoped aggregation would scan other subscribers' data).

### updateTag
`updateTag`'s inline unread query had both defects too: `COUNT(*)` over-counted entries reachable through multiple subscriptions of the same tag (possible when `subscription_feeds` rows overlap via feed redirect/merge history), and it lacked the `subscriptions.user_id` filter. The grouped aggregation is now extracted into `tagUnreadCountsQuery()` and shared by both endpoints, so a rename/recolor returns the same `unreadCount` the sidebar shows. (Postgres pushes the `tag_id` equality into the GROUP BY, so the single-tag use stays cheap.)

### counts service (SSE/mutation badge updates)
The per-tag and uncategorized counts in `src/server/services/counts.ts` counted `visible_entries` rows with `COUNT(*)`; the view emits one row per (user, entry, subscription) path, so the same overlap case double-counted and could disagree with `listTags`. Switched to `COUNT(DISTINCT id)`. Subscription and global counts are unchanged: an entry appears at most once per subscription, and the global semantics intentionally match `countEntries`.

Note: in the (rare) overlap case, `visible_entries` itself still yields duplicate rows, which affects `entries.list`/`countEntries` globally — that's a view-level question left out of scope here.

## Test plan

- [x] `pnpm typecheck`
- [x] Full `pnpm test:integration` passes (349 tests incl. new ones)
- [x] New tests in `tests/integration/tags.test.ts`: tag unread counts, dedup across overlapping subscriptions, cross-user isolation on shared feeds, unsubscribed-subscription exclusion, all-read tag, and `updateTag`/`listTags` consistency
- [x] New `tests/integration/counts.test.ts`: dedup + isolation for `getEntryRelatedCounts` / `getBulkEntryRelatedCounts` tag and uncategorized counts
- [x] Verified the 5 new regression tests **fail** against the pre-fix code and pass with the fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)