### PR TITLE
Fix all feeds failing with 'Unknown feed format': use undici's fetch with the SSRF dispatcher

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -260,10 +260,12 @@ Lion Reader respects server Cache-Control headers, Retry-After directives, and H
 
 ### SSRF Protection
 
-All server-side fetches that target user-influenced URLs (feed preview/discover, feed fetching, full-content fetching, WebSub hub callbacks) are guarded against Server-Side Request Forgery to private/internal networks. The shared helper `withSsrfProtection(url, init)` in `src/server/http/ssrf.ts` wraps `fetch` options and:
+All server-side fetches that target user-influenced URLs (feed preview/discover, feed fetching, full-content fetching, WebSub hub callbacks) are guarded against Server-Side Request Forgery to private/internal networks. The shared helper `fetchWithSsrfProtection(url, init)` in `src/server/http/ssrf.ts` performs the fetch and:
 
-1. Rejects literal private/reserved IP hosts synchronously (e.g. `http://169.254.169.254/`, `http://127.0.0.1/`, decimal-encoded IPs). undici skips the custom DNS lookup for IP literals, so they must be checked here.
+1. Rejects literal private/reserved IP hosts up front (e.g. `http://169.254.169.254/`, `http://127.0.0.1/`, decimal-encoded IPs). undici skips the custom DNS lookup for IP literals, so they must be checked here.
 2. Attaches a custom undici dispatcher whose DNS `lookup` resolves the hostname, blocks if **any** resolved address is private, and connects only to the vetted address — closing the DNS-rebinding TOCTOU gap. Because `fetch` reuses the dispatcher, redirect targets are validated too.
+
+The helper must perform the fetch itself rather than hand the dispatcher to global `fetch`: the dispatcher is built from the npm `undici` package, while Node's global fetch is a different bundled undici copy that accepts a foreign dispatcher but skips response body decompression with it (observed on Node 26), corrupting every compressed response. `fetchWithSsrfProtection` uses the npm package's own `fetch` so the dispatcher and fetch always come from the same copy.
 
 Blocked ranges cover loopback, RFC 1918 private, carrier-grade NAT, link-local (incl. cloud metadata), documentation/test, multicast, and reserved space for both IPv4 and IPv6 (and IPv4-mapped IPv6). Set `ALLOW_PRIVATE_NETWORK_FETCH=true` to disable the block for dev/test environments that fetch from localhost (this is the default in `.env.test`).
 

--- a/migrations/0068_reset_feed_fetch_backoffs.sql
+++ b/migrations/0068_reset_feed_fetch_backoffs.sql
@@ -1,0 +1,29 @@
+-- Reset feed fetch failure backoffs.
+--
+-- The SSRF protection change (PR #901) paired an npm-undici dispatcher with
+-- Node's global fetch, which silently skips body decompression on Node 26.
+-- Every compressed feed fetch since then failed with "Unknown feed format",
+-- accumulating consecutive_failures and exponential backoff (up to 7 days).
+-- PR #904 fixes the fetching; this migration clears the bogus failure state
+-- so feeds recover promptly instead of waiting out their backoff.
+--
+-- Mirrors the per-feed "retry now" reset in brokenFeeds.retryFeed, applied in
+-- bulk. Jobs are rescheduled over a 5-20 minute window rather than immediately:
+-- migrations run before the new machines roll out, so an immediate run would
+-- let old (still-broken) workers re-fail some feeds, and the spread avoids
+-- refetching every feed at once.
+
+UPDATE public.feeds
+SET consecutive_failures = 0,
+    last_error = NULL,
+    next_fetch_at = now(),
+    updated_at = now()
+WHERE consecutive_failures > 0;
+
+UPDATE public.jobs
+SET consecutive_failures = 0,
+    last_error = NULL,
+    next_run_at = now() + interval '5 minutes' + random() * interval '15 minutes',
+    updated_at = now()
+WHERE type = 'fetch_feed'
+  AND consecutive_failures > 0;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -470,6 +470,13 @@
       "when": 1770678800000,
       "tag": "0067_user_entries_sort_key",
       "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1770688800000,
+      "tag": "0068_reset_feed_fetch_backoffs",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/feed/fetcher.ts
+++ b/src/server/feed/fetcher.ts
@@ -11,7 +11,7 @@ import {
   ContentTooLargeError,
   ACCEPT_ENCODING,
 } from "../http/fetch";
-import { withSsrfProtection } from "../http/ssrf";
+import { fetchWithSsrfProtection } from "../http/ssrf";
 import { usageLimitsConfig } from "../config/env";
 
 /**
@@ -372,15 +372,12 @@ export async function fetchFeed(
     const timeoutId = setTimeout(() => controller.abort(), timeout);
 
     try {
-      const response = await fetch(
-        currentUrl,
-        withSsrfProtection(currentUrl, {
-          method: "GET",
-          headers,
-          signal: controller.signal,
-          redirect: "manual", // Handle redirects manually to track permanent ones
-        })
-      );
+      const response = await fetchWithSsrfProtection(currentUrl, {
+        method: "GET",
+        headers,
+        signal: controller.signal,
+        redirect: "manual", // Handle redirects manually to track permanent ones
+      });
 
       clearTimeout(timeoutId);
 

--- a/src/server/feed/websub.ts
+++ b/src/server/feed/websub.ts
@@ -9,7 +9,7 @@
 
 import { randomBytes, createHmac, timingSafeEqual } from "crypto";
 import { eq, and, lt } from "drizzle-orm";
-import { withSsrfProtection } from "../http/ssrf";
+import { fetchWithSsrfProtection } from "../http/ssrf";
 import { db } from "../db";
 import { feeds, websubSubscriptions, type Feed, type WebsubSubscription } from "../db/schema";
 import { generateUuidv7 } from "../../lib/uuidv7";
@@ -262,22 +262,19 @@ export async function subscribeToHub(feed: Feed): Promise<SubscribeToHubResult> 
 
   // POST subscription request to hub
   try {
-    const response = await fetch(
-      feed.hubUrl,
-      withSsrfProtection(feed.hubUrl, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-        body: new URLSearchParams({
-          "hub.mode": "subscribe",
-          "hub.topic": topicUrl,
-          "hub.callback": callbackUrl,
-          "hub.secret": secret,
-          "hub.verify": "async",
-        }).toString(),
-      })
-    );
+    const response = await fetchWithSsrfProtection(feed.hubUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        "hub.mode": "subscribe",
+        "hub.topic": topicUrl,
+        "hub.callback": callbackUrl,
+        "hub.secret": secret,
+        "hub.verify": "async",
+      }).toString(),
+    });
 
     // Hub should return 202 Accepted for async verification
     // or 204 No Content for sync verification (already verified)

--- a/src/server/http/fetch.ts
+++ b/src/server/http/fetch.ts
@@ -6,7 +6,7 @@
  */
 
 import { USER_AGENT } from "./user-agent";
-import { withSsrfProtection } from "./ssrf";
+import { fetchWithSsrfProtection } from "./ssrf";
 import { errors } from "../trpc/errors";
 import { usageLimitsConfig } from "../config/env";
 
@@ -214,18 +214,15 @@ export async function fetchUrl(url: string, options?: FetchUrlOptions): Promise<
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(
-      url,
-      withSsrfProtection(url, {
-        headers: {
-          "User-Agent": userAgent,
-          Accept: accept,
-          "Accept-Encoding": ACCEPT_ENCODING,
-        },
-        signal: controller.signal,
-        redirect: "follow",
-      })
-    );
+    const response = await fetchWithSsrfProtection(url, {
+      headers: {
+        "User-Agent": userAgent,
+        Accept: accept,
+        "Accept-Encoding": ACCEPT_ENCODING,
+      },
+      signal: controller.signal,
+      redirect: "follow",
+    });
 
     if (!response.ok) {
       throw errors.feedFetchError(url, `HTTP ${response.status}`);
@@ -284,18 +281,15 @@ export async function fetchHtmlPage(
   const timeout = setTimeout(() => controller.abort(), PAGE_FETCH_TIMEOUT_MS);
 
   try {
-    const response = await fetch(
-      url,
-      withSsrfProtection(url, {
-        signal: controller.signal,
-        headers: {
-          "User-Agent": USER_AGENT,
-          Accept: HTML_ACCEPT_HEADER,
-          "Accept-Encoding": ACCEPT_ENCODING,
-        },
-        redirect: "follow",
-      })
-    );
+    const response = await fetchWithSsrfProtection(url, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent": USER_AGENT,
+        Accept: HTML_ACCEPT_HEADER,
+        "Accept-Encoding": ACCEPT_ENCODING,
+      },
+      redirect: "follow",
+    });
 
     if (!response.ok) {
       throw new HttpFetchError(response.status, response.statusText, url);

--- a/src/server/http/ssrf.ts
+++ b/src/server/http/ssrf.ts
@@ -15,7 +15,7 @@
 
 import { BlockList, isIP } from "node:net";
 import { lookup as dnsLookup, type LookupAddress, type LookupOptions } from "node:dns";
-import { Agent, type Dispatcher } from "undici";
+import { Agent, fetch as undiciFetch, type RequestInit as UndiciRequestInit } from "undici";
 
 import { securityConfig } from "../config/env";
 
@@ -179,27 +179,32 @@ function getHostname(url: string): string | null {
 }
 
 /**
- * Wraps fetch init options with SSRF protection. Pass the result straight to `fetch`.
+ * Performs a fetch with SSRF protection. Use this instead of `fetch` for any
+ * request whose URL is user-influenced.
  *
  * Two layers of protection:
- * 1. Literal IP hosts (e.g. http://169.254.169.254/) are checked synchronously and
+ * 1. Literal IP hosts (e.g. http://169.254.169.254/) are checked up front and
  *    rejected here — undici bypasses the custom DNS lookup for IP literals.
  * 2. Hostnames are validated at connection time by the attached undici dispatcher,
  *    which resolves DNS and connects only to a vetted address (rebinding-safe).
+ *    Redirects are covered too, since fetch reuses the dispatcher.
+ *
+ * The request goes through the npm `undici` package's fetch, not Node's global
+ * fetch. The dispatcher is constructed from the npm package, and Node's global
+ * fetch is a different (bundled) undici copy: on Node 26 it accepts the foreign
+ * dispatcher but skips response body decompression, returning raw gzip/brotli
+ * bytes. The dispatcher and the fetch that uses it must come from the same copy.
  *
  * @throws SsrfBlockedError if the URL targets a literal private/internal IP
  * @example
- * const res = await fetch(url, withSsrfProtection(url, { headers, signal }));
+ * const res = await fetchWithSsrfProtection(url, { headers, signal });
  */
-export function withSsrfProtection<T extends RequestInit>(
-  url: string,
-  init: T
-): T & { dispatcher?: Dispatcher } {
+export async function fetchWithSsrfProtection(url: string, init: RequestInit): Promise<Response> {
   const dispatcher = getSsrfDispatcher();
 
   // Private-network fetching explicitly allowed (dev/test): no protection.
   if (!dispatcher) {
-    return init;
+    return fetch(url, init);
   }
 
   // Literal IP hosts skip the dispatcher's DNS lookup, so check them here.
@@ -208,5 +213,11 @@ export function withSsrfProtection<T extends RequestInit>(
     throw new SsrfBlockedError(hostname, hostname);
   }
 
-  return { ...init, dispatcher };
+  const response = await undiciFetch(url, {
+    ...(init as UndiciRequestInit),
+    dispatcher,
+  });
+  // undici's Response is the same spec-compliant implementation as the global
+  // one; cast so callers keep using standard Response types.
+  return response as unknown as Response;
 }

--- a/src/server/trpc/routers/feeds.ts
+++ b/src/server/trpc/routers/feeds.ts
@@ -17,7 +17,7 @@ import {
   FEED_FETCH_TIMEOUT_MS,
   ACCEPT_ENCODING,
 } from "@/server/http/fetch";
-import { withSsrfProtection } from "@/server/http/ssrf";
+import { fetchWithSsrfProtection } from "@/server/http/ssrf";
 import { stripHtml } from "@/server/html/strip-html";
 import { USER_AGENT } from "@/server/http/user-agent";
 import { detectFeedType } from "@/server/feed/parser";
@@ -147,19 +147,16 @@ async function tryFetchAsFeed(
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(
-      url,
-      withSsrfProtection(url, {
-        headers: {
-          "User-Agent": USER_AGENT,
-          Accept:
-            "application/rss+xml, application/atom+xml, application/feed+json, application/json, application/xml, text/xml, */*",
-          "Accept-Encoding": ACCEPT_ENCODING,
-        },
-        signal: controller.signal,
-        redirect: "follow",
-      })
-    );
+    const response = await fetchWithSsrfProtection(url, {
+      headers: {
+        "User-Agent": USER_AGENT,
+        Accept:
+          "application/rss+xml, application/atom+xml, application/feed+json, application/json, application/xml, text/xml, */*",
+        "Accept-Encoding": ACCEPT_ENCODING,
+      },
+      signal: controller.signal,
+      redirect: "follow",
+    });
 
     if (!response.ok) {
       return null;


### PR DESCRIPTION
## Problem

Since the SSRF protection deploy on June 9 (#826 / PR #901), **every compressed feed fetch in production has been failing** with `Unknown feed format: unable to detect RSS, Atom, or JSON Feed`, including perfectly healthy feeds like https://www.smbc-comics.com/comic/rss. Since virtually all feeds are served compressed, this broke essentially all feed polling.

## Root cause

`withSsrfProtection` attached a dispatcher built from the **npm `undici` package** to **Node's global fetch**, which is a different, bundled copy of undici. On Node 26 (production image since May 24), global fetch accepts the foreign dispatcher but **skips response body decompression** with it — the parser receives raw gzip bytes (gzip magic `1f 8b 08`) and correctly reports an unknown format.

Reproduced against the live SMBC feed on Node 26.3.0:

```
--- Node global fetch WITH npm-undici dispatcher ---
status: 200  content-encoding: (stripped)  body: raw gzip bytes
--- Node global fetch WITHOUT dispatcher ---
status: 200  content-encoding: gzip        body: <?xml version="1.0" ...
```

- Broken with both undici 7.18.2 and 7.24.0 → today's undici bump (#902) is innocent; the breakage started with the June 9 SSRF deploy.
- Works fine on Node 22, so local dev didn't show it.
- Test/dev environments set `ALLOW_PRIVATE_NETWORK_FETCH=true`, which disables the dispatcher entirely, so CI couldn't catch it.

## Fix

Replace `withSsrfProtection(url, init)` (which returned init options for global `fetch`) with `fetchWithSsrfProtection(url, init)`, which performs the request through the npm undici package's **own** `fetch`, so the dispatcher and fetch always come from the same copy. This also structurally prevents the foot-gun of pairing the dispatcher with the wrong fetch in future call sites. All five call sites updated (feed fetcher, feed discovery, fetchUrl, fetchHtmlPage, WebSub hub subscribe).

Verified on Node 26.3.0 using the project's actual modules:

- SMBC feed fetch → 200, body decompressed, `detectFeedType` → `rss` ✅
- `http://127.0.0.1/` (literal IP) → blocked ✅
- `http://localtest.me/` (DNS resolving to loopback) → blocked ✅

`pnpm typecheck` and `pnpm test:unit` (1845 tests) pass. Integration/e2e couldn't run in this environment (no Docker access), but they run with the dispatcher disabled anyway.

## Recovery

Migration `0068_reset_feed_fetch_backoffs` clears the failure state accumulated during the outage (mirroring the per-feed "retry now" reset in `brokenFeeds.retryFeed`, in bulk): `consecutive_failures` and `last_error` are reset on affected feeds and their `fetch_feed` jobs, with jobs rescheduled over a 5–20 minute window — migrations run before the new machines roll out, so an immediate run would let old (still-broken) workers re-fail feeds, and the spread avoids refetching everything at once. Verified against the test DB with a seeded failing feed + job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
