### PR TITLE
Set package.json license field to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lion-reader",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "postinstall": "node scripts/copy-onnx-wasm.mjs",
     "dev": "concurrently --kill-others --names worker,next,discord \"pnpm dev:worker\" \"pnpm dev:next\" \"pnpm dev:discord-bot\"",


### PR DESCRIPTION
Sets the `license` field in `package.json` to `MIT`, matching the [MIT LICENSE file](LICENSE) added in 541c809c.

This is metadata only — it advertises the project's license to npm/tooling and contributors. It does not change runtime behavior. `private: true` is left as-is (it only prevents accidental `npm publish` and does not affect the source license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)