### PR TITLE
Add unique index on jobs.type for singleton jobs (#914)

### DIFF
--- a/migrations/0069_jobs_singleton_type_unique.sql
+++ b/migrations/0069_jobs_singleton_type_unique.sql
@@ -1,0 +1,21 @@
+-- Enforce the "exactly one instance" invariant for singleton jobs.
+--
+-- claimSingletonJob (src/server/jobs/queue.ts) self-creates a singleton job row
+-- when none exists, relying on a try/catch around the INSERT to absorb the race
+-- where two workers both observe "no row exists". But there was no unique
+-- constraint on jobs.type, so the INSERT never conflicted and two workers racing
+-- during a deploy/canary rollover could each insert a row for the same singleton
+-- type. This adds the partial unique index that makes the INSERT...catch work.
+--
+-- First collapse any duplicate singleton rows that may already exist (keeping the
+-- oldest), otherwise the unique index creation would fail.
+
+DELETE FROM public.jobs j
+USING public.jobs keep
+WHERE j.type IN ('renew_websub', 'monitor_feed_health')
+  AND j.type = keep.type
+  AND j.id > keep.id;
+
+CREATE UNIQUE INDEX jobs_singleton_type_unique
+  ON public.jobs (type)
+  WHERE type IN ('renew_websub', 'monitor_feed_health');

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -477,6 +477,13 @@
       "when": 1770688800000,
       "tag": "0068_reset_feed_fetch_backoffs",
       "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1770698800000,
+      "tag": "0069_jobs_singleton_type_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -734,6 +734,8 @@ CREATE INDEX idx_websub_expiring ON public.websub_subscriptions USING btree (exp
 
 CREATE INDEX idx_websub_feed ON public.websub_subscriptions USING btree (feed_id);
 
+CREATE UNIQUE INDEX jobs_singleton_type_unique ON public.jobs USING btree (type) WHERE (type = ANY (ARRAY['renew_websub'::text, 'monitor_feed_health'::text]));
+
 CREATE UNIQUE INDEX uq_feeds_saved_user ON public.feeds USING btree (user_id) WHERE (type = 'saved'::public.feed_type);
 
 CREATE TRIGGER user_entries_fill_sort_key_trigger BEFORE INSERT ON public.user_entries FOR EACH ROW EXECUTE FUNCTION public.user_entries_fill_sort_key();

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -13,6 +13,7 @@ import {
   text,
   timestamp,
   unique,
+  uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
@@ -793,6 +794,11 @@ export const jobs = pgTable(
     index("idx_jobs_polling").on(table.nextRunAt),
     // Index for looking up feed jobs by feedId
     index("idx_jobs_feed_id").on(sql`(${table.payload}->>'feedId')`),
+    // Enforce one row per singleton job type so claimSingletonJob's
+    // INSERT...catch actually races correctly (see SINGLETON_JOB_TYPES).
+    uniqueIndex("jobs_singleton_type_unique")
+      .on(table.type)
+      .where(sql`type IN ('renew_websub', 'monitor_feed_health')`),
   ]
 );
 

--- a/src/server/jobs/queue.ts
+++ b/src/server/jobs/queue.ts
@@ -406,8 +406,10 @@ export async function claimSingletonJob(type: JobType): Promise<Job | null> {
     return null;
   }
 
-  // No job exists - create one and claim it immediately
-  // Use a transaction to handle race conditions (two workers both see no row)
+  // No job exists - create one and claim it immediately.
+  // The jobs_singleton_type_unique partial index makes this INSERT conflict if
+  // another worker creates the row first (two workers both see no row), so the
+  // catch below handles that race by claiming the row the winner created.
   try {
     const [newJob] = await db
       .insert(jobs)

--- a/src/server/jobs/queue.ts
+++ b/src/server/jobs/queue.ts
@@ -37,6 +37,28 @@ type RawJobRow = {
 } & Record<string, unknown>;
 
 /**
+ * Postgres SQLSTATE for a unique-constraint violation.
+ */
+const PG_UNIQUE_VIOLATION = "23505";
+
+/**
+ * Returns true if the error is a Postgres unique-constraint violation.
+ * The `pg` driver surfaces the SQLSTATE on the error's `code` property, but
+ * Drizzle wraps query errors and puts the original on `cause`, so we walk the
+ * cause chain.
+ */
+function isUniqueViolation(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && typeof current === "object" && current !== null; depth++) {
+    if ((current as { code?: unknown }).code === PG_UNIQUE_VIOLATION) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/**
  * Converts a raw SQL row to a Job with proper Date objects.
  */
 function rowToJob(row: RawJobRow): Job {
@@ -425,8 +447,15 @@ export async function claimSingletonJob(type: JobType): Promise<Job | null> {
       .returning();
 
     return newJob;
-  } catch {
-    // Another worker likely created the job - try to claim it
+  } catch (error) {
+    // Only the jobs_singleton_type_unique conflict (Postgres unique_violation,
+    // SQLSTATE 23505) means another worker won the race. Any other error is a
+    // genuine failure and must propagate rather than be masked as "lost race".
+    if (!isUniqueViolation(error)) {
+      throw error;
+    }
+
+    // Another worker created the job first - try to claim it
     const retryResult = await db.execute<RawJobRow>(sql`
       UPDATE ${jobs}
       SET

--- a/tests/integration/job-queue.test.ts
+++ b/tests/integration/job-queue.test.ts
@@ -19,6 +19,7 @@ import {
   ensureFeedJob,
   updateFeedJobNextRun,
   claimFeedJob,
+  claimSingletonJob,
 } from "../../src/server/jobs/queue";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 
@@ -255,6 +256,53 @@ describe("Job Queue", () => {
       const claimedIds = successfulClaims.map((r) => r!.id);
       const uniqueIds = new Set(claimedIds);
       expect(uniqueIds.size).toBe(3);
+    });
+  });
+
+  describe("claimSingletonJob", () => {
+    it("self-creates and claims a singleton job when none exists", async () => {
+      const job = await claimSingletonJob("monitor_feed_health");
+
+      expect(job).not.toBeNull();
+      expect(job!.type).toBe("monitor_feed_health");
+      expect(job!.runningSince).not.toBeNull();
+
+      // Exactly one row should exist for the type
+      const rows = await listJobs({ type: "monitor_feed_health" });
+      expect(rows).toHaveLength(1);
+    });
+
+    it("rejects non-singleton job types", async () => {
+      await expect(claimSingletonJob("fetch_feed")).rejects.toThrow(
+        "fetch_feed is not a singleton job type"
+      );
+    });
+
+    it("creates only one row when workers race to self-create", async () => {
+      // Simulate many workers all observing "no row exists" at once. The partial
+      // unique index on jobs.type means only one INSERT can win; the losers fall
+      // into the catch and either claim the row or get null (it's running).
+      const claimPromises = Array.from({ length: 5 }, () => claimSingletonJob("renew_websub"));
+      const results = await Promise.all(claimPromises);
+
+      // Exactly one worker should have claimed the (newly created) job.
+      const successfulClaims = results.filter((r) => r !== null);
+      expect(successfulClaims).toHaveLength(1);
+
+      // And crucially, only one row exists — no duplicate singleton rows.
+      const rows = await listJobs({ type: "renew_websub" });
+      expect(rows).toHaveLength(1);
+    });
+
+    it("returns null when an existing job is not yet due", async () => {
+      await createJob({
+        type: "renew_websub",
+        payload: {},
+        nextRunAt: new Date(Date.now() + 60 * 60 * 1000), // 1 hour out
+      });
+
+      const job = await claimSingletonJob("renew_websub");
+      expect(job).toBeNull();
     });
   });
 


### PR DESCRIPTION
Fixes #914.

## Problem

`claimSingletonJob` self-creates a singleton job row when none exists, relying on a `try/catch` around the `INSERT` to absorb the race where two workers both observe "no row exists". But there was **no unique constraint on `jobs.type`**, so the `INSERT` never conflicted, the `catch` never fired, and two workers racing during a deploy/canary rollover could each insert a row for the same singleton type (`renew_websub`, `monitor_feed_health`) — violating the "exactly one instance" invariant.

## Fix

- New migration `0069_jobs_singleton_type_unique.sql` adds a **partial unique index** on `jobs.type` scoped to the singleton types. It first collapses any pre-existing duplicate singleton rows (keeping the oldest) so the index creation can't fail.
- Mirror the index in the Drizzle schema (`src/server/db/schema.ts`) and `migrations/schema.sql`.
- Fix the misleading "Use a transaction to handle race conditions" comment in `claimSingletonJob` (it isn't a transaction) — it's the unique index + `INSERT...catch` that handles the race.
- Add integration tests covering self-create, the concurrent self-create race (asserts exactly one row), non-singleton rejection, and the not-due case.

## Testing

`pnpm test:integration` passes (360 passed, 12 pre-existing skips); `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)