### PR TITLE
Omit article body from saved.save/uploadFile responses (#927)

### DIFF
--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -77,7 +77,13 @@ const urlSchema = z.string().url("Invalid URL");
 // ============================================================================
 
 /**
- * Full saved article output schema for single article view (includes content).
+ * Saved article metadata returned from save/upload mutations.
+ *
+ * Deliberately omits the article body (`contentOriginal`/`contentCleaned`):
+ * callers only use the metadata here (title etc.), and every body render goes
+ * through `entries.get`, which sanitizes on the read path. Echoing raw bodies
+ * back here would be a stored-XSS footgun for any future caller that rendered
+ * them directly, with no upside since nothing reads them. See issue #927.
  * URL is nullable for uploaded files which don't have a source URL.
  */
 const savedArticleFullSchema = z.object({
@@ -87,8 +93,6 @@ const savedArticleFullSchema = z.object({
   siteName: z.string().nullable(),
   author: z.string().nullable(),
   imageUrl: z.string().nullable(),
-  contentOriginal: z.string().nullable(),
-  contentCleaned: z.string().nullable(),
   excerpt: z.string().nullable(),
   read: z.boolean(),
   starred: z.boolean(),
@@ -289,8 +293,6 @@ export const savedRouter = createTRPCRouter({
               siteName: entry.siteName,
               author: entry.author,
               imageUrl: entry.imageUrl,
-              contentOriginal: entry.contentOriginal,
-              contentCleaned: entry.contentCleaned,
               excerpt: entry.summary,
               read: userState.read,
               starred: userState.starred,
@@ -707,8 +709,6 @@ export const savedRouter = createTRPCRouter({
             siteName: finalSiteName,
             author: finalAuthor,
             imageUrl: metadata.imageUrl,
-            contentOriginal: html,
-            contentCleaned: finalContentCleaned,
             excerpt,
             read: false, // Marked unread since content was updated
             starred: userState.starred,
@@ -774,8 +774,6 @@ export const savedRouter = createTRPCRouter({
           siteName: finalSiteName,
           author: finalAuthor,
           imageUrl: metadata.imageUrl,
-          contentOriginal: html,
-          contentCleaned: finalContentCleaned,
           excerpt,
           read: false,
           starred: false,
@@ -951,8 +949,6 @@ export const savedRouter = createTRPCRouter({
           siteName: article.siteName,
           author: article.author,
           imageUrl: article.imageUrl,
-          contentOriginal: article.contentCleaned, // Same as cleaned for uploads
-          contentCleaned: article.contentCleaned,
           excerpt: article.excerpt,
           read: article.read,
           starred: article.starred,

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -814,9 +814,11 @@ describe("Saved Articles API", () => {
         refetch: true,
       });
 
-      // Should return updated content
+      // Mutation response carries metadata only (no body); the updated content
+      // is served through the sanitizing read path.
       expect(result.article.title).toBe("Updated OG Title");
-      expect(result.article.contentCleaned).toContain("updated content");
+      const fetched = await caller.entries.get({ id: result.article.id });
+      expect(fetched.entry.contentCleaned).toContain("updated content");
     });
 
     it("marks as unread but preserves starred state when refetching", async () => {
@@ -1021,9 +1023,10 @@ describe("Saved Articles API", () => {
       expect(result.article.siteName).toBe("Test Site");
       expect(result.article.author).toBe("Test Author");
       expect(result.article.imageUrl).toBe("https://example.com/image.jpg");
-      expect(result.article.contentOriginal).toBe(testHtml);
-      // Content should be cleaned by Readability
-      expect(result.article.contentCleaned).toContain("article content");
+      // The mutation response carries metadata only; the body (cleaned by
+      // Readability and sanitized) is served through the read path.
+      const fetched = await caller.entries.get({ id: result.article.id });
+      expect(fetched.entry.contentCleaned).toContain("article content");
     });
 
     it("uses provided title parameter over extracted metadata", async () => {
@@ -1106,6 +1109,49 @@ describe("Saved Articles API", () => {
       expect(result.article.siteName).toBeNull();
       expect(result.article.author).toBeNull();
       expect(result.article.imageUrl).toBeNull();
+    });
+
+    it("omits article body from the response; body is sanitized on read (#927)", async () => {
+      const userId = await createTestUser();
+      const ctx = createAuthContext(userId);
+      const caller = createCaller(ctx);
+
+      // Body carries XSS vectors. The mutation response must not echo content
+      // back at all (callers only use metadata, and rendering it directly would
+      // bypass the read-path sanitizer); the stored body must be sanitized when
+      // read through entries.get.
+      const maliciousHtml = `
+        <!DOCTYPE html>
+        <html>
+          <head><title>Malicious Page</title></head>
+          <body>
+            <article>
+              <p>Legitimate article body with enough text to pass quality checks.</p>
+              <script>alert('xss')</script>
+              <img src="x" onerror="alert('xss')" />
+              <a href="javascript:alert('xss')">click</a>
+            </article>
+          </body>
+        </html>
+      `;
+
+      const result = await caller.saved.save({
+        url: "https://example.com/xss-test",
+        html: maliciousHtml,
+      });
+
+      // Response carries no body fields.
+      expect(result.article).not.toHaveProperty("contentOriginal");
+      expect(result.article).not.toHaveProperty("contentCleaned");
+
+      // The read path serves sanitized content.
+      const fetched = await caller.entries.get({ id: result.article.id });
+      for (const body of [fetched.entry.contentOriginal, fetched.entry.contentCleaned]) {
+        expect(body).not.toContain("<script");
+        expect(body).not.toContain("onerror");
+        expect(body).not.toContain("javascript:");
+      }
+      expect(fetched.entry.contentOriginal).toContain("Legitimate article body");
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #927.

The `saved.save`, `saved.uploadFile`, and saved-refetch mutation responses echoed back **raw, un-sanitized** `contentOriginal`/`contentCleaned`. This is **not a live XSS today** — every browser caller renders article bodies exclusively via `entries.get`, which sanitizes on the read path — but it's a latent footgun: any future client that rendered these response fields directly via `dangerouslySetInnerHTML` (or seeded them into the `entries.get` cache) would bypass the app's single sanitize chokepoint and introduce stored XSS.

## Approach

Rather than sanitize the echoed bodies in each return branch, **drop the body fields from the response schema entirely**. The verified callers only use the metadata:

- `src/app/save/page.tsx` — uses `article.title`
- `src/app/extension/save/page.tsx` — uses `article.title`
- `src/components/saved/FileUploadButton.tsx` — ignores the response body

The article body is always read back through the sanitizing `entries.get`. Omitting the fields removes the footgun with no behavior change, avoids special-cased sanitization in the mutation, and keeps every entry write funneling its body through `withSanitizedEntryContent` → `entries.get`.

## Changes

- Remove `contentOriginal`/`contentCleaned` from `savedArticleFullSchema` and all four return sites (existing-no-refetch, refetch, new-entry, uploadFile).
- Tests: the refetch and provided-HTML cases now verify the updated body via `entries.get`; added a case asserting the response omits the body fields and that the stored content is sanitized on read (`<script>`/`onerror`/`javascript:` stripped).

## Testing

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test:integration tests/integration/saved-articles.test.ts` ✅ (368 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)