### PR TITLE
Ship entries.get original content as a diff, not a second full copy (#926)

### DIFF
--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -314,8 +314,8 @@ function EntryContentInner({
         author={entry.author}
         url={entry.url}
         date={entry.publishedAt ?? entry.fetchedAt}
-        contentOriginal={entry.contentOriginal}
-        contentCleaned={entry.contentCleaned}
+        content={entry.content}
+        contentOriginalDiff={entry.contentOriginalDiff}
         fallbackContent={entry.summary}
         read={entry.read}
         starred={entry.starred}

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -9,6 +9,7 @@
 
 import { useEffect, useRef, useMemo } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { applyContentDiff, type ContentDiff } from "@/lib/content-diff";
 import { Button } from "@/components/ui/button";
 import {
   StarIcon,
@@ -51,10 +52,14 @@ export interface EntryContentBodyProps {
   date: Date;
   /** Optional prefix for the date (e.g., "Saved") */
   datePrefix?: string;
-  /** The original HTML content */
-  contentOriginal: string | null;
-  /** The cleaned HTML content */
-  contentCleaned: string | null;
+  /** The HTML content to display by default (cleaned when available, else original) */
+  content: string | null;
+  /**
+   * Diff to reconstruct the original (pre-cleaning) HTML from `content`, present
+   * only when a distinct original exists. Reconstructed lazily for the
+   * "Show Original" toggle so we don't ship a near-duplicate second copy.
+   */
+  contentOriginalDiff: ContentDiff | null;
   /** Fallback text content (summary or excerpt) */
   fallbackContent: string | null;
   /** Whether the article has been read */
@@ -134,8 +139,8 @@ export function EntryContentBody({
   url,
   date,
   datePrefix,
-  contentOriginal,
-  contentCleaned,
+  content,
+  contentOriginalDiff,
   fallbackContent,
   read,
   starred,
@@ -182,19 +187,30 @@ export function EntryContentBody({
   );
   const showFullContent = fetchFullContent && hasFullContent;
 
+  // Reconstruct the original (pre-cleaning) body from the displayed content plus
+  // the diff. Present only when a feed plugin actually cleaned the content, so
+  // its presence is what enables the "Show Original" toggle.
+  const contentOriginal = useMemo(
+    () =>
+      contentOriginalDiff && content !== null
+        ? applyContentDiff(content, contentOriginalDiff)
+        : null,
+    [content, contentOriginalDiff]
+  );
+
   // Check if both feed content versions are available for toggle
   // Only show this toggle when NOT showing full content
-  const hasBothVersions = Boolean(contentCleaned && contentOriginal) && !showFullContent;
+  const hasBothVersions = Boolean(contentOriginal) && !showFullContent;
 
   // Select content based on state
-  // Priority: full content (if enabled and available) > cleaned feed content > original feed content
+  // Priority: full content (if enabled and available) > original feed content (toggle) > default feed content
   let contentToDisplay: string | null;
   if (showFullContent) {
     contentToDisplay = fullContentCleaned ?? fullContentOriginal ?? null;
-  } else if (showOriginal) {
+  } else if (showOriginal && contentOriginal) {
     contentToDisplay = contentOriginal;
   } else {
-    contentToDisplay = contentCleaned ?? contentOriginal;
+    contentToDisplay = content;
   }
 
   // Set up narration with highlighting support

--- a/src/lib/content-diff.ts
+++ b/src/lib/content-diff.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+/**
+ * Compact representation of how to reconstruct one HTML body from another.
+ *
+ * Feed plugins (e.g. LessWrong, whose cleaner only strips a "Published on
+ * [date]" prefix) produce a `contentCleaned` that differs from
+ * `contentOriginal` by a single small contiguous edit. Shipping both full
+ * bodies from `entries.get` roughly doubles the payload for such entries while
+ * the renderer only ever shows one at a time. Instead we ship the displayed
+ * body (cleaned) in full plus this diff, and reconstruct the original on the
+ * client only when the user toggles "Show Original" — preserving the
+ * one-round-trip load while removing the near-duplicate copy.
+ *
+ * The diff stores the lengths of the shared prefix/suffix between the two
+ * bodies and only the differing middle of the target. When the two bodies
+ * diverge a lot (e.g. a saved article's raw page vs. its Readability extract)
+ * the middle approaches the full target, so this never costs more than sending
+ * the target outright.
+ */
+export const contentDiffSchema = z.object({
+  /** Length of the common prefix shared with the base body. */
+  prefixLen: z.number().int().nonnegative(),
+  /** Length of the common suffix shared with the base body. */
+  suffixLen: z.number().int().nonnegative(),
+  /** The target body's differing middle segment. */
+  middle: z.string(),
+});
+
+export type ContentDiff = z.infer<typeof contentDiffSchema>;
+
+/**
+ * Compute a diff that reconstructs `target` from `base`.
+ *
+ * Finds the longest common prefix and (non-overlapping) suffix of the two
+ * strings and records only the target's differing middle.
+ */
+export function computeContentDiff(base: string, target: string): ContentDiff {
+  const maxLen = Math.min(base.length, target.length);
+
+  let prefixLen = 0;
+  while (prefixLen < maxLen && base[prefixLen] === target[prefixLen]) {
+    prefixLen++;
+  }
+
+  let suffixLen = 0;
+  while (
+    suffixLen < maxLen - prefixLen &&
+    base[base.length - 1 - suffixLen] === target[target.length - 1 - suffixLen]
+  ) {
+    suffixLen++;
+  }
+
+  return {
+    prefixLen,
+    suffixLen,
+    middle: target.slice(prefixLen, target.length - suffixLen),
+  };
+}
+
+/**
+ * Reconstruct the target body from `base` and a diff produced by
+ * {@link computeContentDiff}.
+ */
+export function applyContentDiff(base: string, diff: ContentDiff): string {
+  return base.slice(0, diff.prefixLen) + diff.middle + base.slice(base.length - diff.suffixLen);
+}

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -37,6 +37,7 @@ import { sanitizeEntryHtml, SANITIZER_VERSION } from "@/server/html/sanitize";
 import { withSanitizedEntryContent } from "@/server/html/sanitize-entry";
 import { publishEntryStateChanged } from "@/server/redis/pubsub";
 import { logger } from "@/lib/logger";
+import { computeContentDiff, contentDiffSchema, type ContentDiff } from "@/lib/content-diff";
 
 // Endpoints exposed via the MCP tool surface; accessible to tokens with the `mcp` scope.
 const mcpProcedure = scopedProtectedProcedure(API_TOKEN_SCOPES.MCP);
@@ -129,8 +130,12 @@ const entryFullSchema = z.object({
   url: z.string().nullable(),
   title: z.string().nullable(),
   author: z.string().nullable(),
-  contentOriginal: z.string().nullable(),
-  contentCleaned: z.string().nullable(),
+  // The body to display by default (cleaned content when a feed plugin cleaned
+  // it, otherwise the original). When a distinct original exists, it is shipped
+  // as a compact diff (`contentOriginalDiff`) instead of a second full copy —
+  // see src/lib/content-diff.ts and issue #926.
+  content: z.string().nullable(),
+  contentOriginalDiff: contentDiffSchema.nullable(),
   summary: z.string().nullable(),
   publishedAt: z.date().nullable(),
   fetchedAt: z.date(),
@@ -405,6 +410,38 @@ async function resolveSanitizedContent(
 }
 
 /**
+ * Choose the body to display and, when a distinct original exists, encode it as
+ * a compact diff instead of a second full copy (issue #926).
+ *
+ * The default-displayed body is the cleaned content when a feed plugin cleaned
+ * it, otherwise the original. `contentCleaned` is only populated when cleaning
+ * actually changed something, so a non-null cleaned body always implies a
+ * distinct original worth offering via the "Show Original" toggle.
+ */
+function deriveDisplayContent(
+  contentOriginal: string | null,
+  contentCleaned: string | null
+): { content: string | null; contentOriginalDiff: ContentDiff | null } {
+  // No cleaning happened: the original is the only body, shown directly.
+  if (contentCleaned === null) {
+    return { content: contentOriginal, contentOriginalDiff: null };
+  }
+
+  // Cleaning happened but there's nothing to fall back to (or both are
+  // identical after sanitizing): just show the cleaned body, no toggle.
+  if (contentOriginal === null || contentOriginal === contentCleaned) {
+    return { content: contentCleaned, contentOriginalDiff: null };
+  }
+
+  // Distinct original: ship the cleaned body plus a diff to rebuild the original
+  // on demand, instead of two near-duplicate full copies.
+  return {
+    content: contentCleaned,
+    contentOriginalDiff: computeContentDiff(contentCleaned, contentOriginal),
+  };
+}
+
+/**
  * Transform a raw full entry row into the entryFullSchema shape.
  * Strips internal fields, resolves sanitized content, and defaults fetchFullContent.
  */
@@ -439,10 +476,15 @@ async function toFullEntry(
     fullContentSanitizedVersion,
   });
 
+  const { content: displayContent, contentOriginalDiff } = deriveDisplayContent(
+    content.contentOriginal,
+    content.contentCleaned
+  );
+
   return {
     ...rest,
-    contentOriginal: content.contentOriginal,
-    contentCleaned: content.contentCleaned,
+    content: displayContent,
+    contentOriginalDiff,
     fullContentOriginal: content.fullContentOriginal,
     fullContentCleaned: content.fullContentCleaned,
     fetchFullContent: row.fetchFullContent ?? false,

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -289,7 +289,7 @@ describe("Entries", () => {
 
       expect(result.entry.id).toBe(entryId);
       expect(result.entry.title).toBe("Test Entry");
-      expect(result.entry.contentCleaned).toBe("<p>This is test content</p>");
+      expect(result.entry.content).toBe("<p>This is test content</p>");
     });
 
     it("throws error for entry that doesn't exist", async () => {

--- a/tests/integration/sanitized-entry-content.test.ts
+++ b/tests/integration/sanitized-entry-content.test.ts
@@ -167,7 +167,7 @@ describe("entries.get sanitized content", () => {
     const caller = createCaller(createAuthContext(userId));
     const { entry } = await caller.entries.get({ id: entryId });
 
-    expect(entry.contentCleaned).toBe("<p>STORED_SENTINEL</p>");
+    expect(entry.content).toBe("<p>STORED_SENTINEL</p>");
   });
 
   it("re-sanitizes from raw and self-heals when the stored version is missing", async () => {
@@ -196,9 +196,9 @@ describe("entries.get sanitized content", () => {
     const { entry } = await caller.entries.get({ id: entryId });
 
     // Returned content is sanitized.
-    expect(entry.contentCleaned).toContain("hello");
-    expect(entry.contentCleaned).not.toContain("<script>");
-    expect(entry.contentCleaned).not.toContain("onclick");
+    expect(entry.content).toContain("hello");
+    expect(entry.content).not.toContain("<script>");
+    expect(entry.content).not.toContain("onclick");
 
     // The heal is persisted (fire-and-forget), so a later read is a stored hit.
     await eventually(async () => {

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -17,6 +17,7 @@ import { eq, and } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import { users, entries, userEntries, feeds } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { applyContentDiff } from "../../src/lib/content-diff";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
 
@@ -385,8 +386,11 @@ describe("Saved Articles API", () => {
       // entries.get sanitizes content on the read path (toFullEntry), which
       // strips the <html>/<body> wrapper (invalid inside a content fragment).
       // Allowed tags like <article> pass through unchanged.
-      expect(result.entry.contentOriginal).toBe("Original content");
-      expect(result.entry.contentCleaned).toBe("<article>Cleaned content</article>");
+      // The cleaned body is displayed; the original is shipped as a diff.
+      expect(result.entry.content).toBe("<article>Cleaned content</article>");
+      expect(applyContentDiff(result.entry.content!, result.entry.contentOriginalDiff!)).toBe(
+        "Original content"
+      );
       expect(result.entry.summary).toBe("This is a test excerpt for the article.");
     });
 
@@ -818,7 +822,7 @@ describe("Saved Articles API", () => {
       // is served through the sanitizing read path.
       expect(result.article.title).toBe("Updated OG Title");
       const fetched = await caller.entries.get({ id: result.article.id });
-      expect(fetched.entry.contentCleaned).toContain("updated content");
+      expect(fetched.entry.content).toContain("updated content");
     });
 
     it("marks as unread but preserves starred state when refetching", async () => {
@@ -1026,7 +1030,7 @@ describe("Saved Articles API", () => {
       // The mutation response carries metadata only; the body (cleaned by
       // Readability and sanitized) is served through the read path.
       const fetched = await caller.entries.get({ id: result.article.id });
-      expect(fetched.entry.contentCleaned).toContain("article content");
+      expect(fetched.entry.content).toContain("article content");
     });
 
     it("uses provided title parameter over extracted metadata", async () => {
@@ -1146,12 +1150,15 @@ describe("Saved Articles API", () => {
 
       // The read path serves sanitized content.
       const fetched = await caller.entries.get({ id: result.article.id });
-      for (const body of [fetched.entry.contentOriginal, fetched.entry.contentCleaned]) {
+      const original = fetched.entry.contentOriginalDiff
+        ? applyContentDiff(fetched.entry.content ?? "", fetched.entry.contentOriginalDiff)
+        : fetched.entry.content;
+      for (const body of [original, fetched.entry.content]) {
         expect(body).not.toContain("<script");
         expect(body).not.toContain("onerror");
         expect(body).not.toContain("javascript:");
       }
-      expect(fetched.entry.contentOriginal).toContain("Legitimate article body");
+      expect(original).toContain("Legitimate article body");
     });
   });
 });

--- a/tests/unit/content-diff.test.ts
+++ b/tests/unit/content-diff.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { computeContentDiff, applyContentDiff } from "../../src/lib/content-diff";
+
+/** Round-trip: applying the diff to the base must rebuild the target exactly. */
+function expectRoundTrip(base: string, target: string) {
+  const diff = computeContentDiff(base, target);
+  expect(applyContentDiff(base, diff)).toBe(target);
+  return diff;
+}
+
+describe("content-diff", () => {
+  it("reconstructs the target from base + diff", () => {
+    expectRoundTrip(
+      "<article>hello</article>",
+      "Published on 2024<br/><br/><article>hello</article>"
+    );
+  });
+
+  it("produces a tiny middle for a prefix-only edit (LessWrong case)", () => {
+    const cleaned = "<p>The actual article body that is fairly long.</p>";
+    const original = `Published on Jan 1, 2024<br/><br/>${cleaned}`;
+    const diff = expectRoundTrip(cleaned, original);
+
+    // Only the stripped prefix is carried in the diff, not the whole body.
+    expect(diff.middle).toBe("Published on Jan 1, 2024<br/><br/>");
+    expect(diff.middle.length).toBeLessThan(cleaned.length);
+  });
+
+  it("handles a suffix-only edit", () => {
+    expectRoundTrip("the body", "the body<footer>extra</footer>");
+  });
+
+  it("handles an edit in the middle", () => {
+    expectRoundTrip("<p>start MID end</p>", "<p>start DIFFERENT MIDDLE end</p>");
+  });
+
+  it("handles identical strings", () => {
+    const diff = expectRoundTrip("same", "same");
+    expect(diff.middle).toBe("");
+  });
+
+  it("handles an empty base", () => {
+    expectRoundTrip("", "now there is content");
+  });
+
+  it("handles an empty target", () => {
+    expectRoundTrip("had content", "");
+  });
+
+  it("does not let an overlapping prefix/suffix double-count", () => {
+    // "aaaa" vs "aa": prefix and suffix both want to match the shared a's, but
+    // the suffix must not overlap the prefix.
+    expectRoundTrip("aaaa", "aa");
+    expectRoundTrip("aa", "aaaa");
+  });
+});


### PR DESCRIPTION
Fixes #926.

## Problem

`entries.get` returned both `contentOriginal` and `contentCleaned`. For plugin feeds (e.g. LessWrong, whose cleaner only strips a `Published on [date]` prefix) these are **near-duplicate large blobs** — so a ~700 KB article shipped ~1.4 MB (pre-compression), roughly doubling the DB read, serialize, and payload cost, even though the renderer only ever shows one body at a time.

## Approach

The user's constraint was: keep the one-round-trip load (don't make the client decide which body it wants, then fetch). So instead of lazy-fetching, the original is shipped **inline as a compact diff** rather than a second full copy.

The tRPC entry output now has:

- **`content`** — the body displayed by default (cleaned when a plugin cleaned it, else original). Always shipped in full → one RTT preserved.
- **`contentOriginalDiff`** — a prefix/suffix diff (`src/lib/content-diff.ts`) that reconstructs the distinct original on the client. Present only when a cleaner actually changed something; the **Show Original** toggle applies it lazily in `EntryContentBody`.

The diff stores only the differing middle plus shared prefix/suffix lengths, so it's tiny exactly when the bodies are near-duplicates (LessWrong: just the stripped prefix) and degrades to ~no savings — **never worse** than today — when they genuinely differ (e.g. a saved article's raw page vs. its Readability extract).

## Scope

- Only the **frontend-facing tRPC output** changed. The service-layer `getEntry` shape (used by MCP, Google Reader, wallabag) is untouched, so those external API formats keep both bodies.
- `entry_updated` SSE patches only metadata (title/author/summary/url/publishedAt), never content, so the field rename is cache-safe.
- Full-content fields (`fullContent*`) are out of scope — that's #924.

## Tests

- New `tests/unit/content-diff.test.ts` round-trips prefix/suffix/middle/empty/overlap cases.
- Updated integration tests (`entries`, `saved-articles`, `sanitized-entry-content`) to the new `content` + `contentOriginalDiff` shape, reconstructing the original via `applyContentDiff` where the original body is asserted.
- `pnpm typecheck`, `pnpm lint`, and `pnpm test:unit` pass. Integration tests couldn't run here (no local Postgres/Redis) — they'll run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)