### PR TITLE
Split signup providers into public vs invite-gated lists

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,12 +43,26 @@ PORT=3000
 # =============================================================================
 # Signup & Admin (Optional)
 # =============================================================================
-# By default, Lion Reader runs in invite-only mode.
-# Set to "true" to allow anyone to register without an invite.
-ALLOW_ALL_SIGNUPS=false
+# Signups are controlled by two comma-separated provider lists. Valid providers:
+# email, google, apple, discord.
+#
+# ALLOWED_SIGNUP_PROVIDERS: providers allowed to sign up with a valid invite.
+#   Default (unset): all providers.
+# ALLOWED_PUBLIC_SIGNUP_PROVIDERS: subset allowed to sign up WITHOUT an invite.
+#   Default (unset): none -> fully invite-only. Always intersected with
+#   ALLOWED_SIGNUP_PROVIDERS, so it can never widen access beyond it.
+#
+# Examples:
+#   Fully invite-only:   leave both unset
+#   Open to everyone:    ALLOWED_PUBLIC_SIGNUP_PROVIDERS=email,google,apple,discord
+#   OAuth public, email by invite only:
+#     ALLOWED_SIGNUP_PROVIDERS=google,apple,email
+#     ALLOWED_PUBLIC_SIGNUP_PROVIDERS=google,apple
+# ALLOWED_SIGNUP_PROVIDERS=email,google,apple,discord
+# ALLOWED_PUBLIC_SIGNUP_PROVIDERS=
 
 # Secret for admin API endpoints (invite management).
-# Required when running in invite-only mode (ALLOW_ALL_SIGNUPS=false).
+# Required whenever any provider is invite-only (so you can mint invites).
 # Generate a secure random string: openssl rand -base64 32
 # ALLOWLIST_SECRET=your-secure-secret-here
 
@@ -316,8 +330,7 @@ ALLOW_ALL_SIGNUPS=false
 #   fly secrets set DATABASE_URL="postgres://..."
 #   fly secrets set REDIS_URL="redis://..."
 #
-# Signup/Admin:
-#   fly secrets set ALLOW_ALL_SIGNUPS="true"  # or keep false for invite-only
+# Signup/Admin (provider lists usually live in fly.toml [env]; secret here):
 #   fly secrets set ALLOWLIST_SECRET="your-secure-secret"
 #
 # Security:

--- a/README.md
+++ b/README.md
@@ -175,10 +175,11 @@ By default, Lion Reader runs in invite-only mode. New users need an invite link 
 
 ### Environment Variables
 
-| Variable            | Default | Description                                          |
-| ------------------- | ------- | ---------------------------------------------------- |
-| `ALLOW_ALL_SIGNUPS` | `false` | Set to `true` to allow anyone to register            |
-| `ALLOWLIST_SECRET`  | -       | Secret for admin API (required for invite-only mode) |
+| Variable                          | Default | Description                                                                                  |
+| --------------------------------- | ------- | -------------------------------------------------------------------------------------------- |
+| `ALLOWED_SIGNUP_PROVIDERS`        | all     | Comma-separated providers (`email,google,apple,discord`) allowed to sign up _with_ an invite |
+| `ALLOWED_PUBLIC_SIGNUP_PROVIDERS` | none    | Subset allowed to sign up _without_ an invite. Empty = fully invite-only                     |
+| `ALLOWLIST_SECRET`                | -       | Secret for admin API (required whenever any provider is invite-only)                         |
 
 ### Creating Invites
 

--- a/fly.toml
+++ b/fly.toml
@@ -27,8 +27,9 @@ primary_region = "lax"
   discord = "node dist/discord-bot.js"
 
 [env]
-  ALLOW_ALL_SIGNUPS = "true"
-  ALLOWED_SIGNUP_PROVIDERS = "apple,google"
+  # apple/google are open to the public; email is allowed only with a valid invite.
+  ALLOWED_SIGNUP_PROVIDERS = "apple,google,email"
+  ALLOWED_PUBLIC_SIGNUP_PROVIDERS = "apple,google"
   NEXT_PUBLIC_APP_URL = "https://lionreader.com"
   NODE_ENV = "production"
   PORT = "3000"

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -112,9 +112,12 @@ function RegisterForm() {
     });
   };
 
-  // Determine allowed signup providers
-  const allowedProviders = signupConfigData?.allowedSignupProviders;
-  const isEmailAllowed = !allowedProviders || allowedProviders.includes("email");
+  // Which providers may sign up depends on whether an invite is present:
+  // with a token, the full allowlist applies; without one, only public providers.
+  const effectiveProviders = inviteToken
+    ? (signupConfigData?.allowedSignupProviders ?? [])
+    : (signupConfigData?.publicSignupProviders ?? []);
+  const isEmailAllowed = effectiveProviders.includes("email");
 
   // Show loading state while fetching config
   if (isLoadingConfig) {
@@ -128,9 +131,10 @@ function RegisterForm() {
     );
   }
 
-  // If invite-only mode and no invite token, show error message
-  const requiresInvite = signupConfigData?.requiresInvite ?? false;
-  if (requiresInvite && !inviteToken) {
+  // No provider can sign up in this context (no invite present and nothing is
+  // public). With a token the allowlist is never empty, so this only triggers
+  // for invite-required instances reached without an invite link.
+  if (effectiveProviders.length === 0) {
     return (
       <div>
         <h2 className="ui-text-xl mb-6 font-semibold text-zinc-900 dark:text-zinc-50">
@@ -172,7 +176,7 @@ function RegisterForm() {
         mode="signup"
         onError={(error) => setErrors({ form: error })}
         inviteToken={inviteToken ?? undefined}
-        allowedProviders={allowedProviders}
+        allowedProviders={effectiveProviders}
       />
 
       {isEmailAllowed && (

--- a/src/server/auth/signup-providers.ts
+++ b/src/server/auth/signup-providers.ts
@@ -1,0 +1,44 @@
+/**
+ * Signup provider access resolution.
+ *
+ * Pure logic for deciding whether a given signup provider is allowed publicly,
+ * only with a valid invite, or not at all. Shared by the signup service (which
+ * enforces it) and the signupConfig endpoint (which describes it to the UI).
+ */
+
+import type { SignupProvider } from "@/server/config/env";
+
+export type SignupProviderAccess =
+  /** Provider can sign up without an invite. */
+  | "public"
+  /** Provider can sign up, but only with a valid invite. */
+  | "invite-only"
+  /** Provider cannot sign up at all. */
+  | "denied";
+
+export interface SignupProviderLists {
+  /** Providers allowed with a valid invite (master allowlist). */
+  allowedSignupProviders: readonly SignupProvider[];
+  /** Providers allowed without an invite (subset of allowedSignupProviders). */
+  publicSignupProviders: readonly SignupProvider[];
+}
+
+/**
+ * Resolve how a provider may sign up given the configured provider lists.
+ *
+ * `publicSignupProviders` is assumed to already be a subset of
+ * `allowedSignupProviders` (enforced at config-parse time), so a public
+ * provider is implicitly allowed with an invite too.
+ */
+export function resolveSignupProviderAccess(
+  provider: SignupProvider,
+  lists: SignupProviderLists
+): SignupProviderAccess {
+  if (!lists.allowedSignupProviders.includes(provider)) {
+    return "denied";
+  }
+  if (lists.publicSignupProviders.includes(provider)) {
+    return "public";
+  }
+  return "invite-only";
+}

--- a/src/server/auth/signup.ts
+++ b/src/server/auth/signup.ts
@@ -14,6 +14,7 @@ import * as Sentry from "@sentry/nextjs";
 
 import { users, invites } from "@/server/db/schema";
 import { signupConfig, announcementFeedConfig, type SignupProvider } from "@/server/config/env";
+import { resolveSignupProviderAccess } from "@/server/auth/signup-providers";
 import { generateUuidv7 } from "@/lib/uuidv7";
 import { errors } from "@/server/trpc/errors";
 import { logger } from "@/lib/logger";
@@ -73,13 +74,15 @@ export async function createUser(tx: DbOrTx, params: CreateUserParams): Promise<
 
   let claimedInviteId: string | undefined;
 
-  // Check if the signup provider is allowed
-  if (!signupConfig.allowedSignupProviders.includes(provider)) {
+  // Determine how this provider may sign up: publicly, only with an invite, or
+  // not at all. Public providers skip the invite requirement entirely.
+  const access = resolveSignupProviderAccess(provider, signupConfig);
+  if (access === "denied") {
     throw errors.signupProviderNotAllowed(provider);
   }
 
-  // If invite required, try to claim it atomically
-  if (!signupConfig.allowAllSignups) {
+  // Invite-only providers must present and claim a valid invite atomically.
+  if (access === "invite-only") {
     if (!inviteToken) {
       throw errors.inviteRequired();
     }

--- a/src/server/config/env.ts
+++ b/src/server/config/env.ts
@@ -14,15 +14,17 @@ export type SignupProvider = (typeof ALL_SIGNUP_PROVIDERS)[number];
 
 /**
  * Parse a comma-separated provider list (e.g. "apple,google,email") into known
- * providers. Unknown values are silently dropped. Returns an empty array when
- * the env var is unset or contains no recognized providers.
+ * providers. Unknown values are silently dropped and duplicates collapsed (so a
+ * value like "google,google" can't produce duplicate React keys downstream).
+ * Returns an empty array when the env var is unset or has no recognized providers.
  */
 function parseProviderList(raw: string | undefined): SignupProvider[] {
   if (!raw) return [];
-  return raw
+  const parsed = raw
     .split(",")
     .map((s) => s.trim().toLowerCase())
     .filter((s): s is SignupProvider => ALL_SIGNUP_PROVIDERS.includes(s as SignupProvider));
+  return Array.from(new Set(parsed));
 }
 
 /**

--- a/src/server/config/env.ts
+++ b/src/server/config/env.ts
@@ -13,44 +13,74 @@ export const ALL_SIGNUP_PROVIDERS = ["email", "google", "apple", "discord"] as c
 export type SignupProvider = (typeof ALL_SIGNUP_PROVIDERS)[number];
 
 /**
- * Parse ALLOWED_SIGNUP_PROVIDERS env var into a list of allowed providers.
- * Format: comma-separated list, e.g. "apple,google,email"
- * Default: all providers allowed (when env var is not set)
+ * Parse a comma-separated provider list (e.g. "apple,google,email") into known
+ * providers. Unknown values are silently dropped. Returns an empty array when
+ * the env var is unset or contains no recognized providers.
  */
-function parseAllowedSignupProviders(): readonly SignupProvider[] {
-  const raw = process.env.ALLOWED_SIGNUP_PROVIDERS;
-  if (!raw) return ALL_SIGNUP_PROVIDERS;
-
-  const providers = raw
+function parseProviderList(raw: string | undefined): SignupProvider[] {
+  if (!raw) return [];
+  return raw
     .split(",")
     .map((s) => s.trim().toLowerCase())
     .filter((s): s is SignupProvider => ALL_SIGNUP_PROVIDERS.includes(s as SignupProvider));
+}
 
-  return providers.length > 0 ? providers : ALL_SIGNUP_PROVIDERS;
+/**
+ * Providers permitted to sign up when a valid invite is presented (the master
+ * allowlist). Parsed from ALLOWED_SIGNUP_PROVIDERS. Defaults to all providers;
+ * a set-but-unrecognized value also falls back to all to avoid accidentally
+ * locking everyone out from a typo.
+ */
+function resolveAllowedSignupProviders(): readonly SignupProvider[] {
+  const raw = process.env.ALLOWED_SIGNUP_PROVIDERS;
+  if (!raw) return ALL_SIGNUP_PROVIDERS;
+  const parsed = parseProviderList(raw);
+  return parsed.length > 0 ? parsed : ALL_SIGNUP_PROVIDERS;
+}
+
+/**
+ * Providers permitted to sign up WITHOUT an invite. Parsed from
+ * ALLOWED_PUBLIC_SIGNUP_PROVIDERS. Defaults to empty (fully invite-only) and is
+ * always intersected with the master allowlist so it can never widen access
+ * beyond ALLOWED_SIGNUP_PROVIDERS.
+ */
+function resolvePublicSignupProviders(): readonly SignupProvider[] {
+  const allowed = resolveAllowedSignupProviders();
+  return parseProviderList(process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS).filter((p) =>
+    allowed.includes(p)
+  );
 }
 
 /**
  * Signup configuration.
- * ALLOW_ALL_SIGNUPS=true bypasses invite requirement.
- * ALLOWLIST_SECRET protects admin endpoints for managing invites.
- * ALLOWED_SIGNUP_PROVIDERS limits which providers can be used for new signups.
+ *
+ * Two provider lists govern who may create an account:
+ * - ALLOWED_SIGNUP_PROVIDERS: providers allowed with a valid invite (default: all).
+ * - ALLOWED_PUBLIC_SIGNUP_PROVIDERS: subset allowed without an invite (default: none).
+ *
+ * An empty public list means fully invite-only (the previous ALLOW_ALL_SIGNUPS=false
+ * behavior); listing every provider publicly is equivalent to the old
+ * ALLOW_ALL_SIGNUPS=true. A provider can therefore be public, invite-only, or denied.
+ *
+ * ALLOWLIST_SECRET protects the admin endpoints used to mint invites.
+ *
+ * Read lazily via getters so tests can set the env after import.
  */
 export const signupConfig = {
-  /** If true, anyone can sign up without an invite. Defaults to false. */
-  allowAllSignups: process.env.ALLOW_ALL_SIGNUPS === "true",
-
-  /** Secret for admin API endpoints. If not set, admin endpoints are disabled. Read lazily so tests can set it after import. */
+  /** Secret for admin API endpoints. If not set, admin endpoints are disabled. */
   get allowlistSecret() {
     return process.env.ADMIN_SECRET ?? process.env.ALLOWLIST_SECRET;
   },
 
-  /**
-   * List of providers allowed for new signups.
-   * Parsed from ALLOWED_SIGNUP_PROVIDERS env var (comma-separated).
-   * Default: all providers allowed.
-   * Stacks with invite requirement (both must be satisfied).
-   */
-  allowedSignupProviders: parseAllowedSignupProviders(),
+  /** Providers allowed for new signups when a valid invite is presented. */
+  get allowedSignupProviders(): readonly SignupProvider[] {
+    return resolveAllowedSignupProviders();
+  },
+
+  /** Providers allowed for new signups without an invite (subset of allowedSignupProviders). */
+  get publicSignupProviders(): readonly SignupProvider[] {
+    return resolvePublicSignupProviders();
+  },
 };
 
 /** Public-facing app URL. Used for sitemap, robots.txt, metadata, and User-Agent header. */

--- a/src/server/trpc/routers/auth.ts
+++ b/src/server/trpc/routers/auth.ts
@@ -780,14 +780,20 @@ export const authRouter = createTRPCRouter({
     .input(z.object({}).optional())
     .output(
       z.object({
+        /** True when no provider can sign up publicly (an invite is required for any signup). */
         requiresInvite: z.boolean(),
+        /** Providers allowed with a valid invite. */
         allowedSignupProviders: z.array(z.enum(ALL_SIGNUP_PROVIDERS)),
+        /** Providers allowed without an invite (subset of allowedSignupProviders). */
+        publicSignupProviders: z.array(z.enum(ALL_SIGNUP_PROVIDERS)),
       })
     )
     .query(() => {
+      const publicSignupProviders = [...signupConfig.publicSignupProviders];
       return {
-        requiresInvite: !signupConfig.allowAllSignups,
+        requiresInvite: publicSignupProviders.length === 0,
         allowedSignupProviders: [...signupConfig.allowedSignupProviders],
+        publicSignupProviders,
       };
     }),
 

--- a/tests/unit/signup-providers.test.ts
+++ b/tests/unit/signup-providers.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 
 import { resolveSignupProviderAccess } from "@/server/auth/signup-providers";
+import { signupConfig } from "@/server/config/env";
 
 describe("resolveSignupProviderAccess", () => {
   it("denies a provider not in the allowlist", () => {
@@ -51,5 +52,55 @@ describe("resolveSignupProviderAccess", () => {
         })
       ).toBe("public");
     }
+  });
+});
+
+describe("signupConfig provider parsing", () => {
+  const ORIGINAL = {
+    allowed: process.env.ALLOWED_SIGNUP_PROVIDERS,
+    public: process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS,
+  };
+
+  afterEach(() => {
+    // Restore so we don't leak env into other tests (getters read env lazily).
+    process.env.ALLOWED_SIGNUP_PROVIDERS = ORIGINAL.allowed;
+    process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS = ORIGINAL.public;
+    if (ORIGINAL.allowed === undefined) delete process.env.ALLOWED_SIGNUP_PROVIDERS;
+    if (ORIGINAL.public === undefined) delete process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS;
+  });
+
+  it("defaults to all-allowed, none-public (fully invite-only)", () => {
+    delete process.env.ALLOWED_SIGNUP_PROVIDERS;
+    delete process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS;
+    expect([...signupConfig.allowedSignupProviders].sort()).toEqual([
+      "apple",
+      "discord",
+      "email",
+      "google",
+    ]);
+    expect(signupConfig.publicSignupProviders).toEqual([]);
+  });
+
+  it("trims, lowercases, drops unknowns, and dedupes duplicates", () => {
+    process.env.ALLOWED_SIGNUP_PROVIDERS = " Google , google ,email, bogus ";
+    process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS = "";
+    expect(signupConfig.allowedSignupProviders).toEqual(["google", "email"]);
+  });
+
+  it("intersects the public list with the allowlist (cannot widen access)", () => {
+    process.env.ALLOWED_SIGNUP_PROVIDERS = "google,apple";
+    // discord is not in the allowlist, so it must be dropped from public.
+    process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS = "google,discord";
+    expect(signupConfig.publicSignupProviders).toEqual(["google"]);
+  });
+
+  it("falls back to all when the allowlist is set but has no known providers", () => {
+    process.env.ALLOWED_SIGNUP_PROVIDERS = "bogus,nonsense";
+    expect([...signupConfig.allowedSignupProviders].sort()).toEqual([
+      "apple",
+      "discord",
+      "email",
+      "google",
+    ]);
   });
 });

--- a/tests/unit/signup-providers.test.ts
+++ b/tests/unit/signup-providers.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+
+import { resolveSignupProviderAccess } from "@/server/auth/signup-providers";
+
+describe("resolveSignupProviderAccess", () => {
+  it("denies a provider not in the allowlist", () => {
+    expect(
+      resolveSignupProviderAccess("discord", {
+        allowedSignupProviders: ["email", "google", "apple"],
+        publicSignupProviders: ["google", "apple"],
+      })
+    ).toBe("denied");
+  });
+
+  it("treats a provider in the public list as public", () => {
+    expect(
+      resolveSignupProviderAccess("google", {
+        allowedSignupProviders: ["email", "google", "apple"],
+        publicSignupProviders: ["google", "apple"],
+      })
+    ).toBe("public");
+  });
+
+  it("treats an allowed-but-not-public provider as invite-only", () => {
+    expect(
+      resolveSignupProviderAccess("email", {
+        allowedSignupProviders: ["email", "google", "apple"],
+        publicSignupProviders: ["google", "apple"],
+      })
+    ).toBe("invite-only");
+  });
+
+  it("makes every allowed provider invite-only when the public list is empty", () => {
+    for (const provider of ["email", "google"] as const) {
+      expect(
+        resolveSignupProviderAccess(provider, {
+          allowedSignupProviders: ["email", "google", "apple", "discord"],
+          publicSignupProviders: [],
+        })
+      ).toBe("invite-only");
+    }
+  });
+
+  it("makes every allowed provider public when all are listed publicly", () => {
+    const all = ["email", "google", "apple", "discord"] as const;
+    for (const provider of all) {
+      expect(
+        resolveSignupProviderAccess(provider, {
+          allowedSignupProviders: all,
+          publicSignupProviders: all,
+        })
+      ).toBe("public");
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Public signups are disabled on the production instance, but even **with** a valid invite you can only sign up via Google/Apple — there's no way to create an email/password account (e.g. for a bot).

The cause: two orthogonal flags governed signups and didn't compose:

- `ALLOW_ALL_SIGNUPS` — is an invite required?
- `ALLOWED_SIGNUP_PROVIDERS` — which providers are allowed, **regardless** of invite.

The provider check ran before the invite logic (`createUser` in `signup.ts`), so an invite could never unlock a provider the allowlist excluded. "Email allowed, but only with an invite" was impossible to express.

## Change

Replace `ALLOW_ALL_SIGNUPS` with a second provider list, so each provider is independently **public**, **invite-only**, or **denied**:

| Env var | Default | Meaning |
| --- | --- | --- |
| `ALLOWED_SIGNUP_PROVIDERS` | all | Providers allowed to sign up **with** a valid invite |
| `ALLOWED_PUBLIC_SIGNUP_PROVIDERS` | none | Subset allowed **without** an invite |

- Empty public list = fully invite-only (the old `ALLOW_ALL_SIGNUPS=false`).
- Public list = every provider = the old `ALLOW_ALL_SIGNUPS=true`.
- The public list is intersected with the allowlist, so it can never widen access beyond it.

A new pure helper `resolveSignupProviderAccess(provider, lists)` returns `public | invite-only | denied` and is shared by the signup service (enforcement) and the `signupConfig` endpoint (UI description). The register page now chooses the effective provider list based on whether an invite is present in the URL; `signupConfig` additionally returns `publicSignupProviders`, and `requiresInvite` now means "no provider is public".

### Production behavior (`fly.toml`)

```toml
ALLOWED_SIGNUP_PROVIDERS = "apple,google,email"   # email allowed with an invite
ALLOWED_PUBLIC_SIGNUP_PROVIDERS = "apple,google"  # public OAuth only, no public email
```

This **preserves** current public behavior (apple/google open, no public email signup) and **enables** invite-gated email/bot accounts. Deploying picks up the new env automatically; the old `ALLOW_ALL_SIGNUPS` secret can be removed.

## Testing

- `pnpm typecheck`, `pnpm lint` — clean
- `pnpm test:unit` — 1890 pass, including new `tests/unit/signup-providers.test.ts` covering the resolver (public/invite-only/denied, empty + full public lists)
- Default behavior is provably unchanged (no invite → invite-only), and no existing test sets these env vars, so integration/e2e behavior is unaffected. Integration/e2e were not run locally (no Docker in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)