### PR TITLE
Avoid Suspense fallback throttle on warm-cache entry navigation

### DIFF
--- a/docs/diagrams/frontend-data-flow.d2
+++ b/docs/diagrams/frontend-data-flow.d2
@@ -116,9 +116,9 @@ ui: {
   }
 
   suspending_list: {
-    label: SuspendingEntryList
+    label: EntryListContainer
     shape: rectangle
-    tooltip: "Entry list with Suspense and keyboard navigation"
+    tooltip: "Entry list container with inline loading and keyboard navigation"
   }
 
   entry_list: {

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,7 +1,14 @@
 # Source Code Guidelines
 
-- Use Suspense and useSuspenseQuery with appropriate fallbacks and well-factored components with small suspense boundaries unless you have a good reason not to
+- Choose between Suspense and inline loading by the criterion below, not by default. Keep components well-factored with small boundaries either way.
 - Always use client-only navigation. Don't use Next.js's `<Link>` or `useRouter` - they trigger SSR fetches and prefetching we don't want. Use `<ClientLink>` from `@/components/ui` for internal navigation instead.
+
+## Suspense vs. inline loading
+
+Suspense's 300ms `FALLBACK_THROTTLE_MS` makes interaction-triggered swaps on a warm cache feel laggy (the committed fallback is held even when data is ready).
+
+- **Page-load / persistent-shell data** (route first render, sidebar counts, `fallback={null}`): `useSuspenseQuery` + `<Suspense>`.
+- **Interaction-triggered swaps usually served from cache** (open entry, switch list view, route titles): `useQuery` + an inline `if (isLoading) return <Fallback/>`, with `throwOnError: true` to keep the `ErrorBoundary`, and keep the server prefetch. A hand-written cache-reading "smart fallback" means use this, not Suspense. See `EntryContent` / `EntryListContainer`.
 
 ## Frontend State Management
 

--- a/src/FRONTEND_STATE.md
+++ b/src/FRONTEND_STATE.md
@@ -47,11 +47,11 @@ Centralized helpers in `src/lib/cache/` ensure consistent updates across the cod
 
 ### Entry Queries
 
-| Query                     | Used In                                                     | Filters                                                                                               | Description                    |
-| ------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `entries.list` (infinite) | `EntryList`, `SuspendingEntryList`, `UnifiedEntriesContent` | `subscriptionId`, `tagId`, `uncategorized`, `unreadOnly`, `starredOnly`, `sortOrder`, `type`, `limit` | Paginated entry list           |
-| `entries.get`             | `EntryContent`                                              | `{ id }`                                                                                              | Single entry with full content |
-| `entries.count`           | `Sidebar`                                                   | `{}`, `{ type: "saved" }`, or `{ starredOnly: true }`                                                 | Unread count for badges        |
+| Query                     | Used In                                                    | Filters                                                                                               | Description                    |
+| ------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `entries.list` (infinite) | `EntryList`, `EntryListContainer`, `UnifiedEntriesContent` | `subscriptionId`, `tagId`, `uncategorized`, `unreadOnly`, `starredOnly`, `sortOrder`, `type`, `limit` | Paginated entry list           |
+| `entries.get`             | `EntryContent`                                             | `{ id }`                                                                                              | Single entry with full content |
+| `entries.count`           | `Sidebar`                                                  | `{}`, `{ type: "saved" }`, or `{ starredOnly: true }`                                                 | Unread count for badges        |
 
 ### Subscription Queries
 
@@ -291,7 +291,7 @@ Returns the updated entry with score fields:
 | `src/lib/events/cursors.ts`                        | Pure sync-cursor bookkeeping                                       |
 | `src/lib/hooks/useKeyboardShortcuts.ts`            | Keyboard navigation and entry selection                            |
 | `src/components/entries/UnifiedEntriesContent.tsx` | Unified entry page with navigation and pagination                  |
-| `src/components/entries/SuspendingEntryList.tsx`   | Entry list wrapper with Suspense and pagination                    |
+| `src/components/entries/EntryListContainer.tsx`    | Stateful entry list container (query, pagination, keyboard nav)    |
 | `src/components/layout/Sidebar.tsx`                | Subscription delete with optimistic update                         |
 | `src/components/entries/EntryContent.tsx`          | Entry display with mutations                                       |
 | `src/components/entries/EntryList.tsx`             | Entry list with infinite scroll                                    |

--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -4,22 +4,26 @@
  * Displays the full content of a single entry.
  * Fetches entry data and delegates rendering to the shared EntryContentBody.
  *
- * Uses Suspense for data fetching with a smart fallback that shows cached
- * entry metadata from the list while full content loads.
+ * Uses a non-suspending useQuery with an inline fallback (cached entry metadata
+ * from the list while full content loads) rather than Suspense, to avoid React's
+ * 300ms FALLBACK_THROTTLE_MS on warm-cache opens. See "Suspense vs. inline
+ * loading" in src/CLAUDE.md.
  */
 
 "use client";
 
-import { Suspense, useEffect, useRef, useCallback, useState } from "react";
+import { useEffect, useRef, useCallback, useState } from "react";
 import { trpc } from "@/lib/trpc/client";
 import { toast } from "sonner";
 import { useEntryMutations } from "@/lib/hooks/useEntryMutations";
 import { useShowOriginalPreference } from "@/lib/hooks/useShowOriginalPreference";
+import { useIsHydrated } from "@/lib/hooks/useIsHydrated";
 import { ScrollContainer } from "@/components/layout/ScrollContainerContext";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { getDomain } from "@/lib/format";
 import { EntryContentBody } from "./EntryContentBody";
 import { EntryContentFallback } from "./EntryContentFallback";
+import { EntryContentSkeleton } from "./EntryContentStates";
 
 /**
  * Props for the EntryContent component.
@@ -58,7 +62,8 @@ interface EntryContentProps {
 
 /**
  * Inner component that fetches and displays entry content.
- * Uses useSuspenseQuery so the parent Suspense boundary handles loading state.
+ * Uses a non-suspending useQuery and renders its own inline loading fallback;
+ * there is no parent Suspense boundary (only an ErrorBoundary).
  */
 function EntryContentInner({
   entryId,
@@ -70,15 +75,26 @@ function EntryContentInner({
 }: EntryContentProps) {
   const utils = trpc.useUtils();
 
+  // False during SSR + first client render. The cache-reading fallback below
+  // would mismatch (empty server cache vs. hydrated client cache), so until
+  // hydration we render a deterministic skeleton. See useIsHydrated.
+  const isHydrated = useIsHydrated();
+
   // Track whether we've sent the auto-mark-read mutation
   const hasSentMarkReadMutation = useRef(false);
 
-  // Fetch the entry - useSuspenseQuery throws promise until data ready
-  // Fallback component shows cached header while this suspends
-  const [data] = trpc.entries.get.useSuspenseQuery({ id: entryId });
+  // Fetch the entry with a non-suspending query so the loading state is
+  // rendered inline (see the `!entry` branch below) instead of via a Suspense
+  // fallback. A committed Suspense fallback is pinned on screen for React's
+  // FALLBACK_THROTTLE_MS (300ms) even when the data is already cached, which
+  // made opening an entry feel laggy on a warm cache. `throwOnError` preserves
+  // the surrounding ErrorBoundary behavior that useSuspenseQuery gave us.
+  // See "Suspense vs. inline loading" in src/CLAUDE.md.
+  const { data } = trpc.entries.get.useQuery({ id: entryId }, { throwOnError: true });
 
-  // Entry is guaranteed to exist after suspense resolves
-  const entry = data.entry;
+  // Undefined while the query is loading; the `!entry` branch renders the
+  // fallback. Every hook below already tolerates an absent entry.
+  const entry = data?.entry;
 
   // Show original preference is stored per-feed in localStorage
   const [showOriginal, setShowOriginal] = useShowOriginalPreference(entry?.feedId);
@@ -300,7 +316,25 @@ function EntryContentInner({
     markRead([entryId], !entry.read);
   };
 
-  // Entry is guaranteed to exist after suspense resolves
+  // Deterministic skeleton on the server + first client render so hydration
+  // matches (the smart fallback below reads the cache, which differs between
+  // server and client at that point).
+  if (!isHydrated) {
+    return (
+      <ScrollContainer className="h-full overflow-y-auto">
+        <EntryContentSkeleton />
+      </ScrollContainer>
+    );
+  }
+
+  // Loading state (post-hydration, client-only): render the smart fallback
+  // inline (cached header + skeleton) instead of suspending. `entry` is
+  // undefined only while the query is loading; once it resolves (or hits the
+  // warm cache) we render content immediately, with no Suspense throttle.
+  if (!entry) {
+    return <EntryContentFallback entryId={entryId} onBack={onBack} />;
+  }
+
   // Wrap in scroll container - each entry gets its own container that starts at scroll 0
   // ScrollContainer provides context so useImagePrefetch can observe this container
   return (
@@ -353,15 +387,16 @@ function EntryContentInner({
 /**
  * EntryContent component.
  *
- * Wrapper that provides Suspense boundary with smart fallback and error handling.
- * The fallback shows cached entry metadata from the list while full content loads.
+ * Wrapper that provides error handling. EntryContentInner uses a non-suspending
+ * query and renders its own inline loading fallback (cached entry metadata from
+ * the list while full content loads), deliberately avoiding a Suspense boundary
+ * so React's 300ms fallback throttle doesn't lag warm-cache opens. See
+ * "Suspense vs. inline loading" in src/CLAUDE.md.
  */
 export function EntryContent(props: EntryContentProps) {
   return (
     <ErrorBoundary message="Failed to load entry">
-      <Suspense fallback={<EntryContentFallback entryId={props.entryId} onBack={props.onBack} />}>
-        <EntryContentInner {...props} />
-      </Suspense>
+      <EntryContentInner {...props} />
     </ErrorBoundary>
   );
 }

--- a/src/components/entries/EntryList.tsx
+++ b/src/components/entries/EntryList.tsx
@@ -1,16 +1,16 @@
 /**
  * EntryList Component
  *
- * Displays a paginated list of entries with infinite scroll.
- * Supports filtering by feed, unread only, and starred only.
+ * Presentational paginated entry list with infinite scroll. The entries and
+ * query state are always supplied by the parent container (which owns the
+ * `entries.list` query); this component only renders them, wires up the
+ * infinite-scroll observer, and shows loading/error/empty states.
  */
 
 "use client";
 
-import { useEffect, useRef, useCallback, useMemo } from "react";
-import { trpc } from "@/lib/trpc/client";
+import { useEffect, useRef, useCallback } from "react";
 import type { EntryListData } from "@/lib/hooks/types";
-import type { EntryType } from "@/lib/hooks/useEntryMutations";
 import { useScrollContainer } from "@/components/layout/ScrollContainerContext";
 import { EntryListItem } from "./EntryListItem";
 import { EntryListSkeleton } from "./EntryListSkeleton";
@@ -22,59 +22,8 @@ import {
 } from "./EntryListStates";
 
 /**
- * Filter options for the entry list.
- */
-interface EntryListFilters {
-  /**
-   * Filter by specific subscription ID.
-   */
-  subscriptionId?: string;
-
-  /**
-   * Filter by tag ID (entries from subscriptions with this tag).
-   */
-  tagId?: string;
-
-  /**
-   * Show only entries from uncategorized feeds (feeds with no tags).
-   */
-  uncategorized?: boolean;
-
-  /**
-   * Show only unread entries.
-   */
-  unreadOnly?: boolean;
-
-  /**
-   * Show only starred entries.
-   */
-  starredOnly?: boolean;
-
-  /**
-   * Sort order: "newest" (default) or "oldest".
-   */
-  sortOrder?: "newest" | "oldest";
-
-  /**
-   * Filter by entry type (web, email, saved).
-   */
-  type?: EntryType;
-}
-
-/**
- * Entry data passed to parent for keyboard actions.
- */
-export interface EntryListEntryData {
-  id: string;
-  url: string | null;
-  read: boolean;
-  starred: boolean;
-  subscriptionId?: string | null;
-}
-
-/**
- * External query state that can be provided to avoid creating a duplicate query.
- * Use with useEntryListQuery hook to keep the query mounted while viewing entries.
+ * Query state for the list, supplied by the parent container that owns the
+ * `entries.list` query.
  */
 export interface ExternalQueryState {
   /**
@@ -115,12 +64,6 @@ export interface ExternalQueryState {
 
 interface EntryListProps {
   /**
-   * Filter options for the list.
-   * Required when not providing externalEntries.
-   */
-  filters?: EntryListFilters;
-
-  /**
    * Callback when an entry is clicked.
    */
   onEntryClick?: (entryId: string) => void;
@@ -129,12 +72,6 @@ interface EntryListProps {
    * Callback when mousedown fires on an entry (used for prefetching).
    */
   onEntryMouseDown?: (entryId: string) => void;
-
-  /**
-   * Number of entries to fetch per page.
-   * @default 10
-   */
-  pageSize?: number;
 
   /**
    * Custom empty state message.
@@ -147,13 +84,6 @@ interface EntryListProps {
   selectedEntryId?: string | null;
 
   /**
-   * Callback to receive entry data when entries are loaded.
-   * Used by parent components for keyboard navigation and actions.
-   * Not needed when using externalEntries.
-   */
-  onEntriesLoaded?: (entries: EntryListEntryData[]) => void;
-
-  /**
    * Callback when the read status indicator is clicked.
    */
   onToggleRead?: (entryId: string, currentlyRead: boolean) => void;
@@ -164,15 +94,14 @@ interface EntryListProps {
   onToggleStar?: (entryId: string, currentlyStarred: boolean) => void;
 
   /**
-   * External entries provided by parent (e.g., from useEntryListQuery).
-   * When provided, the component won't create its own query.
+   * Entries to render (the parent container owns the query).
    */
-  externalEntries?: EntryListData[];
+  externalEntries: EntryListData[];
 
   /**
-   * External query state when using externalEntries.
+   * Query state for the entries (the parent container owns the query).
    */
-  externalQueryState?: ExternalQueryState;
+  externalQueryState: ExternalQueryState;
 
   /**
    * CSS value for IntersectionObserver rootMargin.
@@ -187,83 +116,28 @@ interface EntryListProps {
  * EntryList component with infinite scroll.
  */
 export function EntryList({
-  filters = {},
   onEntryClick,
   onEntryMouseDown,
-  pageSize = 10,
   emptyMessage = "No entries to display",
   selectedEntryId,
-  onEntriesLoaded,
   onToggleRead,
   onToggleStar,
-  externalEntries,
+  externalEntries: allEntries,
   externalQueryState,
   rootMargin = "100px",
 }: EntryListProps) {
   const loadMoreRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useScrollContainer();
-  const useExternalData = externalEntries !== undefined && externalQueryState !== undefined;
 
-  // Use infinite query for cursor-based pagination (only when not using external data)
-  // Note: refetchOnMount is intentionally not set (defaults to smart behavior based on staleTime)
-  // When using external data from useEntryListQuery, that hook handles pathname-based refetching
-  const internalQuery = trpc.entries.list.useInfiniteQuery(
-    {
-      subscriptionId: filters.subscriptionId,
-      tagId: filters.tagId,
-      uncategorized: filters.uncategorized,
-      unreadOnly: filters.unreadOnly,
-      starredOnly: filters.starredOnly,
-      sortOrder: filters.sortOrder,
-      type: filters.type,
-      limit: pageSize,
-    },
-    {
-      getNextPageParam: (lastPage) => lastPage.nextCursor,
-      // Disable when using external data
-      enabled: !useExternalData,
-    }
-  );
-
-  // Flatten all pages into a single array of entries (from internal query)
-  const internalEntries = useMemo(
-    () => internalQuery.data?.pages.flatMap((page) => page.items) ?? [],
-    [internalQuery.data?.pages]
-  );
-
-  // Use external entries if provided, otherwise use internal query results
-  const allEntries = useExternalData ? externalEntries : internalEntries;
-
-  // Query state - use external if provided, otherwise use internal
-  const isLoading = useExternalData ? externalQueryState.isLoading : internalQuery.isLoading;
-  const isError = useExternalData ? externalQueryState.isError : internalQuery.isError;
-  const errorMessage = useExternalData
-    ? externalQueryState.errorMessage
-    : internalQuery.error?.message;
-  const isFetchingNextPage = useExternalData
-    ? externalQueryState.isFetchingNextPage
-    : internalQuery.isFetchingNextPage;
-  const hasNextPage = useExternalData
-    ? externalQueryState.hasNextPage
-    : (internalQuery.hasNextPage ?? false);
-  const fetchNextPage = useExternalData
-    ? externalQueryState.fetchNextPage
-    : internalQuery.fetchNextPage;
-  const refetch = useExternalData ? externalQueryState.refetch : internalQuery.refetch;
-
-  // Notify parent of entry data for keyboard navigation and actions
-  useEffect(() => {
-    if (onEntriesLoaded && !useExternalData) {
-      const entries: EntryListEntryData[] = allEntries.map((entry) => ({
-        id: entry.id,
-        url: entry.url,
-        read: entry.read,
-        starred: entry.starred,
-        subscriptionId: entry.subscriptionId,
-      }));
-      onEntriesLoaded(entries);
-    }
-  }, [allEntries, onEntriesLoaded, useExternalData]);
+  const {
+    isLoading,
+    isError,
+    errorMessage,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    refetch,
+  } = externalQueryState;
 
   // Intersection Observer for infinite scroll
   const handleObserver = useCallback(
@@ -301,7 +175,7 @@ export function EntryList({
   // Initial loading state - only show skeleton if we have no entries to display
   // (placeholder data from parent lists provides entries even while loading)
   if (isLoading && allEntries.length === 0) {
-    return <EntryListSkeleton count={pageSize > 10 ? 10 : pageSize} />;
+    return <EntryListSkeleton count={5} />;
   }
 
   // Error state

--- a/src/components/entries/EntryListContainer.tsx
+++ b/src/components/entries/EntryListContainer.tsx
@@ -1,9 +1,17 @@
 /**
- * SuspendingEntryList Component
+ * EntryListContainer Component
  *
- * A wrapper around EntryList that uses useSuspenseInfiniteQuery.
- * Suspends until entry data is ready, allowing independent loading
- * from other parts of the page (like entry content).
+ * Stateful container around the presentational EntryList. Owns the
+ * `entries.list` query plus all list behavior: keyboard navigation (next/prev,
+ * j/k), pagination triggering near the end, scroll restoration on close, entry
+ * open/prefetch, and URL state.
+ *
+ * Loads entries with a non-suspending useInfiniteQuery and renders a smart
+ * inline loading fallback (cached entries from parent lists) while the query
+ * loads. It deliberately does NOT suspend: a committed Suspense fallback is
+ * pinned on screen for React's FALLBACK_THROTTLE_MS (300ms) even on a
+ * warm-cache navigation, which made switching list views feel laggy. See
+ * "Suspense vs. inline loading" in src/CLAUDE.md.
  *
  * Uses useEntriesListInput to get query input, ensuring cache is shared
  * with the parent's non-suspending query (used for navigation).
@@ -19,30 +27,42 @@ import { useKeyboardShortcutsContext } from "@/components/keyboard/KeyboardShort
 import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
 import { useUrlViewPreferences } from "@/lib/hooks/useUrlViewPreferences";
 import { useEntriesListInput } from "@/lib/hooks/useEntriesListInput";
+import { useIsHydrated } from "@/lib/hooks/useIsHydrated";
 import { useScrollContainer } from "@/components/layout/ScrollContainerContext";
 import { EntryList, type ExternalQueryState } from "./EntryList";
+import { EntryListFallback } from "./EntryListFallback";
+import { EntryListSkeleton } from "./EntryListSkeleton";
 
-interface SuspendingEntryListProps {
+interface EntryListContainerProps {
   emptyMessage: string;
 }
 
-export function SuspendingEntryList({ emptyMessage }: SuspendingEntryListProps) {
+export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
   const { openEntryId, setOpenEntryId } = useEntryUrlState();
   const { showUnreadOnly, sortOrder, toggleShowUnreadOnly } = useUrlViewPreferences();
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
   const utils = trpc.useUtils();
   const scrollContainerRef = useScrollContainer();
 
+  // False during SSR + first client render. The smart (cache-reading) fallback
+  // below would mismatch hydration (empty server cache vs. hydrated client
+  // cache), so until hydration we render a deterministic skeleton.
+  const isHydrated = useIsHydrated();
+
   // Get query input from URL - shared with parent's non-suspending query
   const queryInput = useEntriesListInput();
 
-  // Suspending query - component suspends until data is ready
-  // Shares cache with parent's useInfiniteQuery via same queryInput
-  const [data, { fetchNextPage, hasNextPage, isFetchingNextPage, refetch }] =
-    trpc.entries.list.useSuspenseInfiniteQuery(queryInput, {
+  // Non-suspending query so the loading state renders inline (see the
+  // `isLoading` branch below) instead of via a Suspense fallback that React
+  // would pin for 300ms on warm-cache navigations. `throwOnError` preserves the
+  // surrounding ErrorBoundary behavior. Shares cache with the parent's
+  // useInfiniteQuery via the same queryInput.
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, refetch, isLoading } =
+    trpc.entries.list.useInfiniteQuery(queryInput, {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       staleTime: Infinity,
       refetchOnWindowFocus: false,
+      throwOnError: true,
     });
 
   // Flatten entries from all pages
@@ -189,31 +209,52 @@ export function SuspendingEntryList({ emptyMessage }: SuspendingEntryListProps) 
     onNavigatePrevious: goToPreviousEntry,
   });
 
-  // External query state for EntryList
+  // Query state for the presentational EntryList
   const externalQueryState: ExternalQueryState = useMemo(
     () => ({
-      isLoading: false, // Suspense handles loading
-      isError: false, // ErrorBoundary handles errors
+      isLoading,
+      isError: false, // throwOnError sends errors to the ErrorBoundary
       errorMessage: undefined,
       isFetchingNextPage,
       hasNextPage: hasNextPage ?? false,
       fetchNextPage,
       refetch,
     }),
-    [isFetchingNextPage, hasNextPage, fetchNextPage, refetch]
+    [isLoading, isFetchingNextPage, hasNextPage, fetchNextPage, refetch]
   );
+
+  // Deterministic skeleton on the server + first client render so hydration
+  // matches (EntryListFallback reads the cache, which differs between server
+  // and client at that point).
+  if (!isHydrated) {
+    return <EntryListSkeleton count={5} />;
+  }
+
+  // Loading state (post-hydration, client-only): show the smart fallback
+  // (cached entries from parent lists) inline instead of suspending. Resolved/
+  // cached data skips this and renders the real list on first paint. Placeholder
+  // rows are clickable since the fallback lives here with the list's handlers.
+  if (isLoading && entries.length === 0) {
+    return (
+      <EntryListFallback
+        filters={{
+          subscriptionId: queryInput.subscriptionId,
+          tagId: queryInput.tagId,
+          uncategorized: queryInput.uncategorized,
+          starredOnly: queryInput.starredOnly,
+          type: queryInput.type,
+          unreadOnly: showUnreadOnly,
+          sortOrder,
+        }}
+        skeletonCount={5}
+        selectedEntryId={selectedEntryId}
+        onEntryClick={handleEntryClick}
+      />
+    );
+  }
 
   return (
     <EntryList
-      filters={{
-        subscriptionId: queryInput.subscriptionId,
-        tagId: queryInput.tagId,
-        uncategorized: queryInput.uncategorized,
-        starredOnly: queryInput.starredOnly,
-        type: queryInput.type,
-        unreadOnly: showUnreadOnly,
-        sortOrder,
-      }}
       onEntryClick={handleEntryClick}
       onEntryMouseDown={handleEntryMouseDown}
       selectedEntryId={selectedEntryId}

--- a/src/components/entries/EntryPageLayout.tsx
+++ b/src/components/entries/EntryPageLayout.tsx
@@ -44,7 +44,7 @@ interface EntryPageLayoutProps {
   /** Entry content slot - full screen view when an entry is open */
   entryContentSlot: ReactNode;
 
-  /** Entry list slot - wrapped in Suspense by caller */
+  /** Entry list slot - renders its own inline loading fallback (no Suspense) */
   entryListSlot: ReactNode;
 
   /** Context description for the mark all read dialog (e.g., "all feeds", "this subscription") */

--- a/src/components/entries/UnifiedEntriesContent.tsx
+++ b/src/components/entries/UnifiedEntriesContent.tsx
@@ -14,18 +14,18 @@
 
 "use client";
 
-import { Suspense, useMemo, useEffect, useRef } from "react";
+import { useMemo, useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { EntryPageLayout, TitleSkeleton, TitleText } from "./EntryPageLayout";
 import { EntryContent } from "./EntryContent";
-import { SuspendingEntryList } from "./SuspendingEntryList";
-import { EntryListFallback } from "./EntryListFallback";
+import { EntryListContainer } from "./EntryListContainer";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { NotFoundCard } from "@/components/ui/not-found-card";
 import { useEntryUrlState } from "@/lib/hooks/useEntryUrlState";
 import { useUrlViewPreferences } from "@/lib/hooks/useUrlViewPreferences";
 import { useEntriesListInput } from "@/lib/hooks/useEntriesListInput";
+import { useIsHydrated } from "@/lib/hooks/useIsHydrated";
 import { extractParamsFromPathname } from "@/lib/navigation";
 import { type ViewType } from "@/lib/hooks/viewPreferences";
 import { trpc } from "@/lib/trpc/client";
@@ -190,33 +190,54 @@ function useRouteInfo(): RouteInfo {
 }
 
 /**
- * Title component for subscription pages.
- * Uses useSuspenseQuery so it suspends until data is available.
+ * Title component for subscription pages. Non-suspending (to avoid React's
+ * 300ms fallback throttle): renders a deterministic skeleton until hydrated,
+ * then the title from subscriptions.get, falling back to the sidebar list cache
+ * so the real title shows even before subscriptions.get resolves.
  */
 function SubscriptionTitle({ subscriptionId }: { subscriptionId: string }) {
-  const [subscription] = trpc.subscriptions.get.useSuspenseQuery({ id: subscriptionId });
-  if (!subscription) {
-    // This shouldn't happen with suspense, but handle it gracefully
-    return <TitleText>Untitled Feed</TitleText>;
-  }
-  return (
-    <TitleText>{subscription.title ?? subscription.originalTitle ?? "Untitled Feed"}</TitleText>
+  const isHydrated = useIsHydrated();
+  const queryClient = useQueryClient();
+  const { data: subscription } = trpc.subscriptions.get.useQuery(
+    { id: subscriptionId },
+    { throwOnError: true }
   );
+
+  if (!isHydrated) {
+    return <TitleSkeleton />;
+  }
+  if (subscription) {
+    return (
+      <TitleText>{subscription.title ?? subscription.originalTitle ?? "Untitled Feed"}</TitleText>
+    );
+  }
+  // Not loaded yet — show the title from the sidebar list cache if present.
+  const cached = findCachedSubscription(queryClient, subscriptionId);
+  if (cached) {
+    return <TitleText>{cached.title ?? cached.originalTitle ?? "Untitled Feed"}</TitleText>;
+  }
+  return <TitleSkeleton />;
 }
 
 /**
- * Title component for tag pages.
- * Uses useSuspenseQuery so it suspends until data is available.
+ * Title component for tag pages. Non-suspending: deterministic skeleton until
+ * hydrated, then the tag name from the (globally prefetched) tags.list cache.
  */
 function TagTitle({ tagId }: { tagId: string }) {
-  const [tagsData] = trpc.tags.list.useSuspenseQuery();
-  const tag = tagsData?.items.find((t) => t.id === tagId);
+  const isHydrated = useIsHydrated();
+  const { data: tagsData } = trpc.tags.list.useQuery(undefined, { throwOnError: true });
+
+  if (!isHydrated || !tagsData) {
+    return <TitleSkeleton />;
+  }
+  const tag = tagsData.items.find((t) => t.id === tagId);
   return <TitleText>{tag?.name ?? "Unknown Tag"}</TitleText>;
 }
 
 /**
- * Title component that handles all route types.
- * Static titles render immediately; dynamic titles suspend until data loads.
+ * Title component that handles all route types. Static titles render
+ * immediately; subscription/tag titles render their own non-suspending loading
+ * state (deterministic skeleton until hydrated, then cached title).
  */
 function EntryListTitle({ routeInfo }: { routeInfo: RouteInfo }) {
   // Static title - render immediately
@@ -224,12 +245,10 @@ function EntryListTitle({ routeInfo }: { routeInfo: RouteInfo }) {
     return <TitleText>{routeInfo.title}</TitleText>;
   }
 
-  // Subscription title - suspends until subscription data loads
   if (routeInfo.subscriptionId) {
     return <SubscriptionTitle subscriptionId={routeInfo.subscriptionId} />;
   }
 
-  // Tag title - suspends until tags data loads
   if (routeInfo.tagId) {
     return <TagTitle tagId={routeInfo.tagId} />;
   }
@@ -238,55 +257,19 @@ function EntryListTitle({ routeInfo }: { routeInfo: RouteInfo }) {
 }
 
 /**
- * Smart title fallback that tries to show cached title instead of skeleton.
- * Used as the Suspense fallback for the title slot.
- */
-function TitleFallback({ routeInfo }: { routeInfo: RouteInfo }) {
-  const utils = trpc.useUtils();
-  const queryClient = useQueryClient();
-
-  // Static title - render immediately (shouldn't suspend anyway, but handle it)
-  if (routeInfo.title !== null) {
-    return <TitleText>{routeInfo.title}</TitleText>;
-  }
-
-  // Subscription title from cache
-  if (routeInfo.subscriptionId) {
-    const subscription = findCachedSubscription(queryClient, routeInfo.subscriptionId);
-    if (subscription) {
-      return (
-        <TitleText>{subscription.title ?? subscription.originalTitle ?? "Untitled Feed"}</TitleText>
-      );
-    }
-    return <TitleSkeleton />;
-  }
-
-  // Tag title from cache
-  if (routeInfo.tagId) {
-    const tagsData = utils.tags.list.getData();
-    const tag = tagsData?.items.find((t) => t.id === routeInfo.tagId);
-    if (tag) {
-      return <TitleText>{tag.name}</TitleText>;
-    }
-    return <TitleSkeleton />;
-  }
-
-  return <TitleText>All Items</TitleText>;
-}
-
-/**
  * Inner content component that renders based on route.
- * Entry content and entry list have independent Suspense boundaries.
+ * Title, entry content, and entry list each render their own non-suspending
+ * inline loading state (no Suspense boundaries).
  */
 function UnifiedEntriesContentInner() {
   const routeInfo = useRouteInfo();
   const { showUnreadOnly } = useUrlViewPreferences();
   const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
 
-  // Get query input based on current URL - shared with SuspendingEntryList
+  // Get query input based on current URL - shared with EntryListContainer
   const queryInput = useEntriesListInput();
 
-  // Non-suspending query for navigation - shares cache with SuspendingEntryList
+  // Non-suspending query for navigation - shares cache with EntryListContainer
   const entriesQuery = trpc.entries.list.useInfiniteQuery(queryInput, {
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     staleTime: Infinity,
@@ -411,14 +394,10 @@ function UnifiedEntriesContentInner() {
     );
   }
 
-  // Title has its own Suspense boundary with smart fallback that uses cache
-  const titleSlot = (
-    <Suspense fallback={<TitleFallback routeInfo={routeInfo} />}>
-      <EntryListTitle routeInfo={routeInfo} />
-    </Suspense>
-  );
+  // Title renders its own inline loading fallback (no Suspense)
+  const titleSlot = <EntryListTitle routeInfo={routeInfo} />;
 
-  // Entry content - has its own internal Suspense boundary
+  // Entry content - renders its own inline loading fallback (no Suspense)
   const entryContentSlot = openEntryId ? (
     <EntryContent
       key={openEntryId}
@@ -431,30 +410,13 @@ function UnifiedEntriesContentInner() {
     />
   ) : null;
 
-  // Entry list - has its own Suspense boundary
+  // Entry list - renders its own inline loading fallback (no Suspense)
   const entryListSlot = (
-    <Suspense
-      fallback={
-        <EntryListFallback
-          filters={{
-            subscriptionId: queryInput.subscriptionId,
-            tagId: queryInput.tagId,
-            uncategorized: queryInput.uncategorized,
-            starredOnly: queryInput.starredOnly,
-            type: queryInput.type,
-            unreadOnly: queryInput.unreadOnly,
-            sortOrder: queryInput.sortOrder,
-          }}
-          skeletonCount={5}
-        />
+    <EntryListContainer
+      emptyMessage={
+        showUnreadOnly ? emptyMessages.emptyMessageUnread : emptyMessages.emptyMessageAll
       }
-    >
-      <SuspendingEntryList
-        emptyMessage={
-          showUnreadOnly ? emptyMessages.emptyMessageUnread : emptyMessages.emptyMessageAll
-        }
-      />
-    </Suspense>
+    />
   );
 
   return (
@@ -477,9 +439,10 @@ function UnifiedEntriesContentInner() {
  * to determine what to render. When navigation happens via pushState, usePathname()
  * updates and this component re-renders with the appropriate content.
  *
- * Note: No outer Suspense needed because UnifiedEntriesContentInner uses only
- * non-suspending queries. All suspending queries are inside child components
- * with their own Suspense boundaries (title, entry list, entry content).
+ * Note: No Suspense is used. The title, entry list, and entry content each use
+ * non-suspending queries and render their own inline loading fallback, to avoid
+ * React's 300ms fallback throttle on warm-cache navigations. An ErrorBoundary
+ * (with throwOnError on the queries) handles load failures.
  */
 export function UnifiedEntriesContent() {
   return (

--- a/src/lib/cache/entry-cache.ts
+++ b/src/lib/cache/entry-cache.ts
@@ -6,7 +6,7 @@
  * Strategy:
  * - For individual entry views (entries.get): update directly
  * - For entry lists (entries.list): update in place without invalidation
- *   (entries stay visible until navigation; SuspendingEntryList refetches on pathname change)
+ *   (entries stay visible until navigation; EntryListContainer refetches on pathname change)
  * - For counts (subscriptions, tags): update directly via count-cache helpers
  */
 

--- a/src/lib/cache/operations.ts
+++ b/src/lib/cache/operations.ts
@@ -201,7 +201,7 @@ function removeSubscriptionFromInfiniteQueries(
  * - entries.count({ type: "saved" }) for saved entries
  *
  * Note: Does NOT invalidate entries.list - entries stay visible until navigation.
- * SuspendingEntryList refetches on pathname change, so lists update on next navigation.
+ * EntryListContainer refetches on pathname change, so lists update on next navigation.
  *
  * @param utils - tRPC utils for cache access
  * @param entries - Entries with their context (subscriptionId, starred, type)
@@ -491,7 +491,7 @@ export function handleSubscriptionDeleted(
  * Does NOT invalidate entries.list - new entries appear on next navigation.
  * Note: We don't have full entry data from SSE events, so we can't update
  * entries.get or entries.list caches. That's OK - entries will be fetched
- * when user navigates to that view (SuspendingEntryList refetches on pathname change).
+ * when user navigates to that view (EntryListContainer refetches on pathname change).
  *
  * @param utils - tRPC utils for cache access
  * @param subscriptionId - Subscription the entry belongs to

--- a/src/lib/hooks/useIsHydrated.ts
+++ b/src/lib/hooks/useIsHydrated.ts
@@ -1,0 +1,32 @@
+/**
+ * useIsHydrated Hook
+ *
+ * Returns `false` during SSR and on the first client render (the hydration
+ * pass), then `true` after hydration commits.
+ *
+ * Use it to gate **cache-dependent** rendering that would otherwise mismatch
+ * between the server and client. Our route-specific queries (entries.list,
+ * entries.get) are prefetched with `void prefetch(...)` and dehydrated while
+ * still pending, so at SSR time the server cache is empty (renders a loading
+ * skeleton) but the streamed result lands before client hydration (renders
+ * content) — a hydration mismatch for non-suspending `useQuery` consumers.
+ * Rendering a deterministic skeleton until `isHydrated` makes the server and
+ * the first client render agree; the cache-reading "smart" fallback and the
+ * resolved content only render afterward (client-only), so they can't mismatch.
+ *
+ * `useSyncExternalStore` is used (rather than useState + useEffect) because
+ * React intentionally uses the server snapshot during hydration, guaranteeing
+ * the first client render matches the server without a flash of mismatched DOM.
+ */
+
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const emptySubscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export function useIsHydrated(): boolean {
+  return useSyncExternalStore(emptySubscribe, getClientSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
Opening an entry or switching list views felt laggy even when the data was already cached: React's FALLBACK_THROTTLE_MS pins a committed Suspense fallback on screen for 300ms, so a ~2ms cache hit was held for the full throttle window.

Convert the interaction-triggered boundaries (entry content, entry list, and route titles) from useSuspenseQuery/useSuspenseInfiniteQuery to non-suspending useQuery/useInfiniteQuery that render an inline loading fallback, so the swap happens the instant data is ready. throwOnError preserves the surrounding ErrorBoundary behavior.

To keep SSR hydration consistent (these queries are dehydrated while pending, so the server renders a skeleton but the client hydrates with streamed data), gate the cache-reading "smart" fallback behind a new useIsHydrated hook: render a deterministic, cache-free skeleton on the server and first client render, then the smart fallback / content after hydration. Client-side navigation skips the gate, so the throttle fix holds with no flash.

Also:
- Strip EntryList's now-dead internal-query mode; it is purely presentational (entries + query state always supplied by the parent).
- Rename SuspendingEntryList -> EntryListContainer (it no longer suspends) and update references and docs.
- Rewrite the src/CLAUDE.md guideline to choose Suspense vs. inline loading by criterion rather than defaulting to Suspense.