### PR TITLE
Fix feed parser double-decoding escaped HTML in CDATA bodies

### DIFF
--- a/src/server/feed/streaming/atom-parser.ts
+++ b/src/server/feed/streaming/atom-parser.ts
@@ -4,7 +4,6 @@
  */
 
 import { Parser } from "htmlparser2";
-import { decode } from "html-entities";
 import type { ParsedEntry, SyndicationHints } from "../types";
 import type { FeedParseResult } from "./types";
 import { VALID_UPDATE_PERIODS, type UpdatePeriod } from "./syndication";
@@ -123,7 +122,10 @@ export function parseAtom(content: string): FeedParseResult {
       onclosetag(name) {
         const tagName = name.toLowerCase();
         const trimmedText = textBuffer.trim();
-        const decodedText = trimmedText ? decode(trimmedText) : undefined;
+        // Entities are decoded natively by htmlparser2 (decodeEntities: true),
+        // while CDATA stays literal. Decoding again would corrupt escaped HTML
+        // in content bodies (e.g. `&lt;tag&gt;` code samples turning into tags).
+        const decodedText = trimmedText || undefined;
 
         if (state === "in_feed_title") {
           title = decodedText;
@@ -211,7 +213,9 @@ export function parseAtom(content: string): FeedParseResult {
     },
     {
       xmlMode: true,
-      decodeEntities: false,
+      // Decode entities natively; CDATA stays literal. This avoids the
+      // double-decode that corrupted escaped HTML in content bodies.
+      decodeEntities: true,
       lowerCaseTags: true,
       lowerCaseAttributeNames: true,
     }

--- a/src/server/feed/streaming/rss-parser.ts
+++ b/src/server/feed/streaming/rss-parser.ts
@@ -4,7 +4,6 @@
  */
 
 import { Parser } from "htmlparser2";
-import { decode } from "html-entities";
 import type { ParsedEntry, SyndicationHints } from "../types";
 import type { FeedParseResult } from "./types";
 import { VALID_UPDATE_PERIODS, type UpdatePeriod } from "./syndication";
@@ -78,7 +77,12 @@ export function parseRss(content: string): FeedParseResult {
         // aren't properly closed (e.g., <link>http://example.com<pubdate>...)
         const trimmedText = textBuffer.trim();
         if (trimmedText) {
-          const decodedText = decode(trimmedText);
+          // htmlparser2 already decodes entities (decodeEntities: true) in text
+          // nodes, while leaving CDATA content literal — so escaped HTML in a
+          // <description> body and literal CDATA both arrive correctly without a
+          // second decode pass. Decoding again here would corrupt code samples
+          // by turning escaped `&lt;tag&gt;` text into real tags.
+          const decodedText = trimmedText;
 
           // Channel-level text capture for unclosed elements
           if (state === "in_channel_link") {
@@ -198,7 +202,8 @@ export function parseRss(content: string): FeedParseResult {
       onclosetag(name) {
         const tagName = name.toLowerCase();
         const trimmedText = textBuffer.trim();
-        const decodedText = trimmedText ? decode(trimmedText) : undefined;
+        // See the note in onopentag: entities are already decoded by htmlparser2.
+        const decodedText = trimmedText || undefined;
 
         // Channel-level elements
         if (state === "in_channel_title") {
@@ -309,7 +314,10 @@ export function parseRss(content: string): FeedParseResult {
     },
     {
       xmlMode: true,
-      decodeEntities: false,
+      // Decode entities in text/attributes natively. CDATA stays literal, so
+      // both entity-escaped HTML bodies and CDATA-wrapped HTML decode to the
+      // correct single-escaped form (no manual double-decode). See decodedText.
+      decodeEntities: true,
       lowerCaseTags: true,
       lowerCaseAttributeNames: true,
     }

--- a/tests/unit/streaming-feed-parser-rss.test.ts
+++ b/tests/unit/streaming-feed-parser-rss.test.ts
@@ -197,6 +197,48 @@ describe("parseRss", () => {
     });
   });
 
+  describe("escaped angle brackets in content", () => {
+    it("preserves escaped HTML/code samples in CDATA content", () => {
+      // Regression: feeds (e.g. LessWrong) deliver bodies via CDATA where literal
+      // angle brackets are escaped once (`&lt;system&gt;`). The parser must not
+      // decode these into real `<system>` tags, or the read-path sanitizer strips
+      // them, leaving empty <code> elements.
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>Code Feed</title>
+            <item>
+              <title>Roles post</title>
+              <description><![CDATA[<p>The <code>&lt;system&gt;</code> and <code>&lt;user&gt;</code> tags.</p>]]></description>
+            </item>
+          </channel>
+        </rss>`;
+
+      const result = parseRss(xml);
+
+      expect(result.entries[0].content).toBe(
+        "<p>The <code>&lt;system&gt;</code> and <code>&lt;user&gt;</code> tags.</p>"
+      );
+    });
+
+    it("preserves escaped HTML when the body is entity-escaped (not CDATA)", () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>Code Feed</title>
+            <item>
+              <title>Roles post</title>
+              <description>&lt;p&gt;The &lt;code&gt;&amp;lt;system&amp;gt;&lt;/code&gt; tag.&lt;/p&gt;</description>
+            </item>
+          </channel>
+        </rss>`;
+
+      const result = parseRss(xml);
+
+      expect(result.entries[0].content).toBe("<p>The <code>&lt;system&gt;</code> tag.</p>");
+    });
+  });
+
   describe("GUID without link", () => {
     it("parses items that have guid but no link element", () => {
       const xml = `<?xml version="1.0" encoding="ISO-8859-1" ?>


### PR DESCRIPTION
## Problem

Inline `<code>` samples in feed articles render **blank** — e.g. on [this LessWrong post](https://www.lesswrong.com/posts/d8xDGzCEYE639qqEv/), every `<system>`, `<user>`, `<think>`, `<tool>`, `<assistant>` role tag is missing. Inspecting the DOM shows the `<code>` element is present but its inner `<span>` is empty.

## Root cause

It is **not** the sanitizer — `code`/`pre` are allow-listed and survive `sanitizeEntryHtml`. The corruption happens earlier, in the RSS/Atom parsers.

Both parsers ran `htmlparser2` with `decodeEntities: false` and then called `html-entities` `decode()` on captured text:

- **Entity-escaped body** (`&lt;p&gt;…`): htmlparser2 emits the raw escaped text, so one manual decode is **correct**.
- **CDATA body** (the common case, incl. LessWrong): htmlparser2 already emits the literal HTML, so the manual decode **over-decodes** — escaped `&lt;system&gt;` text inside a `<code>` sample becomes a real `<system>` tag.

That over-decoded `<system>` is then stripped by the read-path sanitizer (correctly — it's a disallowed tag), leaving `<code><span></span></code>`: the empty elements observed in the DOM. This affects **any** feed delivering HTML via CDATA that shows literal angle brackets (code samples, `<tag>` references).

## Fix

Switch both parsers to `decodeEntities: true` and drop the manual `decode()`. htmlparser2 decodes entities in text/attributes natively while leaving CDATA literal, so both delivery forms yield the correct single-escaped HTML.

Verified against the proposed config:

| Input | Current | Fixed |
|---|---|---|
| CDATA `<code>&lt;system&gt;</code>` | `<code><system></code>` ❌ | `<code>&lt;system&gt;</code>` ✓ |
| Escaped `&lt;code&gt;&amp;lt;system&amp;gt;…` | `<code>&lt;system&gt;</code>` ✓ | `<code>&lt;system&gt;</code>` ✓ |

End-to-end against the real LessWrong RSS: 133 `<code>` tags, **0 empty** after the fix (120 role-tag samples retain intact escaped text).

## Tests

- New regression tests in `streaming-feed-parser-rss.test.ts` covering both CDATA and entity-escaped bodies.
- Full unit suite green (1896 passed) + typecheck clean.

## Note on existing entries

Already-fetched entries stored the over-decoded raw content, so the escaped text is gone from storage — re-sanitizing won't recover it. They **heal on the next feed re-fetch** (the corrected parse produces different content → new hash → entry update). The "fetch full content" path (LessWrong GraphQL) was never affected and already renders code correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)