### PR TITLE
Change default summary model to claude-sonnet-5

### DIFF
--- a/src/lib/summarization/constants.ts
+++ b/src/lib/summarization/constants.ts
@@ -7,7 +7,7 @@
 /**
  * Default Anthropic model for summarization.
  */
-export const DEFAULT_SUMMARIZATION_MODEL = "claude-sonnet-4-6";
+export const DEFAULT_SUMMARIZATION_MODEL = "claude-sonnet-5";
 
 /**
  * Default maximum words for generated summaries.


### PR DESCRIPTION
## Summary

Changes the default summarization model fallback from `claude-sonnet-4-6` to `claude-sonnet-5` (released today).

## Details

- Updates `DEFAULT_SUMMARIZATION_MODEL` in `src/lib/summarization/constants.ts`.
- This constant is only the **fallback** default — the selectable model list is still fetched live from the Anthropic `models.list()` API, and users can override per-request or via the `SUMMARIZATION_MODEL` env var.
- Left the static demo summary card (`DemoRouter.tsx`) on `claude-sonnet-4-6` since it represents a fixed, previously-generated summary with a pinned date, not the live default.

## Notes

Sonnet 5 ships with an updated tokenizer (~1.0–1.35× more tokens for the same input). No code changes are needed for that here, but it's worth keeping in mind for summarization cost/length budgeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)