### PR TITLE
Fix stale sidebar counts when a subscription's last unread entry is read

### DIFF
--- a/src/server/services/counts.ts
+++ b/src/server/services/counts.ts
@@ -216,10 +216,6 @@ export async function getEntryRelatedCounts(
  * Fetches tag unread counts for a specific subscription's tags.
  * If the subscription has no tags, returns uncategorized count instead.
  *
- * Optimized to use a single query: always fetches tag counts for the
- * subscription's tags. If no tags exist (empty result), falls back to
- * fetching the uncategorized count.
- *
  * @param db - Database instance
  * @param userId - User ID
  * @param subscriptionId - Subscription ID
@@ -230,45 +226,55 @@ async function getSubscriptionTagCounts(
   userId: string,
   subscriptionId: string
 ): Promise<{ tags: TagCount[]; uncategorized: { unread: number } | null }> {
-  // Single query: get tag IDs for this subscription and their unread counts.
-  // If the subscription has no tags, the result will be empty.
-  // COUNT(DISTINCT) dedupes entries reachable through multiple subscriptions
-  // of the same tag (overlapping subscription_feeds from redirect/merge
-  // history), matching listTags semantics.
-  const tagCounts = await db
-    .select({
-      tagId: subscriptionTags.tagId,
-      unread: sql<number>`count(DISTINCT ${visibleEntries.id})::int`,
-    })
-    .from(subscriptionTags)
-    .innerJoin(visibleEntries, eq(visibleEntries.subscriptionId, subscriptionTags.subscriptionId))
-    // Scope to active subscriptions (user_feeds is active-only): visible_entries
-    // also surfaces starred entries from unsubscribed feeds, which must not
-    // inflate a tag's unread badge.
-    .innerJoin(
-      userFeeds,
-      and(eq(userFeeds.id, visibleEntries.subscriptionId), eq(userFeeds.userId, userId))
-    )
-    .where(
-      and(
-        eq(visibleEntries.userId, userId),
-        eq(visibleEntries.read, false),
-        // Use a subquery to find all tags for this subscription, then count
-        // entries for all subscriptions with those tags
-        inArray(
-          subscriptionTags.tagId,
-          db
-            .select({ tagId: subscriptionTags.tagId })
-            .from(subscriptionTags)
-            .where(eq(subscriptionTags.subscriptionId, subscriptionId))
+  // The subscription's tag IDs are fetched alongside the grouped counts
+  // (not derived from them): the counts query joins unread entries, so a tag
+  // whose unread count dropped to zero produces no row. Every tag must still
+  // be returned (with unread: 0) — the client sets these counts absolutely,
+  // so an omitted tag would keep its stale badge.
+  const [subTagRows, tagCounts] = await Promise.all([
+    db
+      .select({ tagId: subscriptionTags.tagId })
+      .from(subscriptionTags)
+      .where(eq(subscriptionTags.subscriptionId, subscriptionId)),
+    // COUNT(DISTINCT) dedupes entries reachable through multiple subscriptions
+    // of the same tag (overlapping subscription_feeds from redirect/merge
+    // history), matching listTags semantics.
+    db
+      .select({
+        tagId: subscriptionTags.tagId,
+        unread: sql<number>`count(DISTINCT ${visibleEntries.id})::int`,
+      })
+      .from(subscriptionTags)
+      .innerJoin(visibleEntries, eq(visibleEntries.subscriptionId, subscriptionTags.subscriptionId))
+      // Scope to active subscriptions (user_feeds is active-only): visible_entries
+      // also surfaces starred entries from unsubscribed feeds, which must not
+      // inflate a tag's unread badge.
+      .innerJoin(
+        userFeeds,
+        and(eq(userFeeds.id, visibleEntries.subscriptionId), eq(userFeeds.userId, userId))
+      )
+      .where(
+        and(
+          eq(visibleEntries.userId, userId),
+          eq(visibleEntries.read, false),
+          // Use a subquery to find all tags for this subscription, then count
+          // entries for all subscriptions with those tags
+          inArray(
+            subscriptionTags.tagId,
+            db
+              .select({ tagId: subscriptionTags.tagId })
+              .from(subscriptionTags)
+              .where(eq(subscriptionTags.subscriptionId, subscriptionId))
+          )
         )
       )
-    )
-    .groupBy(subscriptionTags.tagId);
+      .groupBy(subscriptionTags.tagId),
+  ]);
 
-  if (tagCounts.length > 0) {
+  if (subTagRows.length > 0) {
+    const unreadByTag = new Map(tagCounts.map((t) => [t.tagId, t.unread]));
     return {
-      tags: tagCounts.map((t) => ({ id: t.tagId, unread: t.unread })),
+      tags: subTagRows.map((t) => ({ id: t.tagId, unread: unreadByTag.get(t.tagId) ?? 0 })),
       uncategorized: null,
     };
   }
@@ -380,9 +386,19 @@ export async function getBulkEntryRelatedCounts(
       .where(inArray(subscriptionTags.subscriptionId, subscriptionIds)),
   ]);
 
-  baseCounts.subscriptions = subscriptionCounts
-    .filter((s) => s.subscriptionId !== null)
-    .map((s) => ({ id: s.subscriptionId!, unread: s.unread }));
+  // Zero-fill: the grouped query only returns subscriptions that still have
+  // unread entries, but the client sets these counts absolutely — omitting a
+  // subscription whose last unread entry was just read would leave its stale
+  // badge in place.
+  const unreadBySubscription = new Map(
+    subscriptionCounts
+      .filter((s) => s.subscriptionId !== null)
+      .map((s) => [s.subscriptionId!, s.unread])
+  );
+  baseCounts.subscriptions = subscriptionIds.map((id) => ({
+    id,
+    unread: unreadBySubscription.get(id) ?? 0,
+  }));
 
   const tagIds = [...new Set(subTags.map((t) => t.tagId))];
   const subscriptionsWithTags = new Set(subTags.map((t) => t.subscriptionId));
@@ -439,9 +455,9 @@ export async function getBulkEntryRelatedCounts(
       : Promise.resolve(null),
   ]);
 
-  if (tagCounts.length > 0) {
-    baseCounts.tags = tagCounts.map((t) => ({ id: t.tagId, unread: t.unread }));
-  }
+  // Zero-fill missing tags for the same reason as subscriptions above.
+  const unreadByTag = new Map(tagCounts.map((t) => [t.tagId, t.unread]));
+  baseCounts.tags = tagIds.map((id) => ({ id, unread: unreadByTag.get(id) ?? 0 }));
 
   if (uncategorizedResult) {
     baseCounts.uncategorized = { unread: uncategorizedResult[0]?.unread ?? 0 };

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -17,7 +17,9 @@ import type { BrowserContext, Page } from "@playwright/test";
 import * as schema from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 
-export type TestDb = NodePgDatabase<typeof schema>;
+// Includes $client so a TestDb satisfies the app's `typeof db` and can be
+// passed to service functions (e.g. the counts service) directly.
+export type TestDb = NodePgDatabase<typeof schema> & { $client: Pool };
 
 let pool: Pool | undefined;
 let redis: Redis | undefined;

--- a/tests/e2e/realtime.spec.ts
+++ b/tests/e2e/realtime.spec.ts
@@ -20,6 +20,7 @@ import {
   getFeedEventsChannel,
   getUserEventsChannel,
 } from "../../src/server/redis/pubsub";
+import { getBulkEntryRelatedCounts } from "../../src/server/services/counts";
 import {
   getDb,
   createConfirmedUser,
@@ -259,6 +260,56 @@ test("entry_state_changed event syncs read state and counts across lists without
   await expect(links.subscriptionRow).toContainText("(1)");
   // ...while unaffected lists keep their counts
   await expect(links.starred).toContainText("(1)");
+  await expect(links.uncategorized).toContainText("(1)");
+
+  expect(refetchProcedures(trpcCalls)).toEqual([]);
+});
+
+// Regression test: when the LAST unread entry of a subscription is read, the
+// server-computed counts must still include the subscription and its tag
+// (with unread 0). The grouped count queries used to omit lists that dropped
+// to zero, so the sidebar badges stayed stale until a refresh. Unlike the
+// test above, the event counts here come from the real counts service (as
+// entries.markRead computes them), not a hand-written literal.
+test("entry_state_changed for the last unread entry clears subscription and tag badges", async ({
+  page,
+  baseURL,
+}) => {
+  const { user, taggedFeed, taggedEntries, trpcCalls } = await seedAndOpenAll(
+    page,
+    baseURL!,
+    ({ user }) => getUserEventsChannel(user.id)
+  );
+  const links = sidebarLinks(page, taggedFeed);
+
+  await expect(links.allItems).toContainText("(3)");
+  await expect(links.newsTag).toContainText("(2)");
+  await expect(links.subscriptionRow).toContainText("(2)");
+  await expect(links.uncategorized).toContainText("(1)");
+
+  trpcCalls.length = 0;
+
+  // Simulate another device marking BOTH tagged entries read, draining the
+  // subscription: update the database, compute absolute counts with the same
+  // service entries.markRead uses, and publish the state change.
+  const db = getDb();
+  let updatedAt = new Date();
+  for (const entry of taggedEntries) {
+    updatedAt = await markEntryRead(db, user.id, entry.id);
+  }
+  const counts = await getBulkEntryRelatedCounts(db, user.id, [
+    { subscriptionId: taggedFeed.subscriptionId, type: "web" },
+  ]);
+  const lastEntry = taggedEntries[taggedEntries.length - 1];
+  await publishEntryStateChanged(user.id, lastEntry.id, true, false, updatedAt, counts);
+
+  // The sidebar defaults to unread-only mode, so once the subscription's
+  // count reaches zero the tag and subscription rows disappear entirely
+  // (with the stale non-zero count they'd stay visible)...
+  await expect(links.allItems).toContainText("(1)");
+  await expect(links.newsTag).toBeHidden();
+  await expect(links.subscriptionRow).toBeHidden();
+  // ...while the unaffected Uncategorized list keeps its count.
   await expect(links.uncategorized).toContainText("(1)");
 
   expect(refetchProcedures(trpcCalls)).toEqual([]);

--- a/tests/integration/counts.test.ts
+++ b/tests/integration/counts.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { and, eq } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import {
   users,
@@ -117,6 +118,13 @@ async function createOverlappingSubscriptions(userId: string) {
   return { feedIdA, feedIdB, subId1, subId2, entryIdA, entryIdB };
 }
 
+async function markEntryRead(userId: string, entryId: string): Promise<void> {
+  await db
+    .update(userEntries)
+    .set({ read: true })
+    .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, entryId)));
+}
+
 async function linkTag(userId: string, name: string, subscriptionIds: string[]): Promise<string> {
   const tagId = generateUuidv7();
   await db.insert(tags).values({ id: tagId, userId, name, createdAt: new Date() });
@@ -176,6 +184,26 @@ describe("Entry counts service", () => {
       expect(counts.uncategorized).toEqual({ unread: 2 });
     });
 
+    it("returns tags with unread 0 when the subscription's tags have no unread entries left", async () => {
+      // Regression test: the tag counts query only groups over unread entries,
+      // so when the last unread entry of a tagged subscription is read, the
+      // tag produced no row and the (empty) result was misread as "the
+      // subscription has no tags", returning the uncategorized count instead.
+      // The client sets counts absolutely, so the tag badge went stale.
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://events.com/rss");
+      const subId = await createTestSubscription(userId, feedId);
+      const tagId = await linkTag(userId, "Events", [subId]);
+      const entryId = await createTestEntry(feedId, [userId]);
+      await markEntryRead(userId, entryId);
+
+      const counts = await getEntryRelatedCounts(db, userId, entryId);
+
+      expect(counts.subscription).toEqual({ id: subId, unread: 0 });
+      expect(counts.tags).toEqual([{ id: tagId, unread: 0 }]);
+      expect(counts.uncategorized).toBeUndefined();
+    });
+
     it("does not count other users' unread entries in tag counts", async () => {
       const userId = await createTestUser("user-a");
       const otherUserId = await createTestUser("user-b");
@@ -217,6 +245,66 @@ describe("Entry counts service", () => {
 
       expect(counts.tags).toEqual([]);
       expect(counts.uncategorized).toEqual({ unread: 2 });
+    });
+
+    it("returns subscription and tag with unread 0 when their last unread entry is read", async () => {
+      // Regression test for the "mark the last entry read" bug: the grouped
+      // subscription/tag count queries only return rows with unread entries,
+      // so a subscription or tag that dropped to zero was omitted from the
+      // result. The client applies these counts absolutely, so the sidebar
+      // badge stayed at its previous value until a refresh.
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://events.com/rss");
+      const subId = await createTestSubscription(userId, feedId);
+      const tagId = await linkTag(userId, "Events", [subId]);
+      const entryId = await createTestEntry(feedId, [userId]);
+      await markEntryRead(userId, entryId);
+
+      const counts = await getBulkEntryRelatedCounts(db, userId, [
+        { subscriptionId: subId, type: "web" },
+      ]);
+
+      expect(counts.all).toEqual({ unread: 0 });
+      expect(counts.subscriptions).toEqual([{ id: subId, unread: 0 }]);
+      expect(counts.tags).toEqual([{ id: tagId, unread: 0 }]);
+    });
+
+    it("returns unread 0 for the drained subscription while other counts stay correct", async () => {
+      // Two tagged subscriptions; only one is drained. The drained one must be
+      // zero-filled while the shared tag keeps counting the other's entries.
+      const userId = await createTestUser();
+      const feedIdA = await createTestFeed("https://drained.com/rss");
+      const feedIdB = await createTestFeed("https://active.com/rss");
+      const subIdA = await createTestSubscription(userId, feedIdA);
+      const subIdB = await createTestSubscription(userId, feedIdB);
+      const tagId = await linkTag(userId, "Mixed", [subIdA, subIdB]);
+      const entryIdA = await createTestEntry(feedIdA, [userId]);
+      await createTestEntry(feedIdB, [userId]);
+      await markEntryRead(userId, entryIdA);
+
+      const counts = await getBulkEntryRelatedCounts(db, userId, [
+        { subscriptionId: subIdA, type: "web" },
+      ]);
+
+      expect(counts.all).toEqual({ unread: 1 });
+      expect(counts.subscriptions).toEqual([{ id: subIdA, unread: 0 }]);
+      expect(counts.tags).toEqual([{ id: tagId, unread: 1 }]);
+    });
+
+    it("returns unread 0 for an uncategorized subscription drained of unread entries", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://uncategorized.com/rss");
+      const subId = await createTestSubscription(userId, feedId);
+      const entryId = await createTestEntry(feedId, [userId]);
+      await markEntryRead(userId, entryId);
+
+      const counts = await getBulkEntryRelatedCounts(db, userId, [
+        { subscriptionId: subId, type: "web" },
+      ]);
+
+      expect(counts.subscriptions).toEqual([{ id: subId, unread: 0 }]);
+      expect(counts.tags).toEqual([]);
+      expect(counts.uncategorized).toEqual({ unread: 0 });
     });
   });
 });


### PR DESCRIPTION
## Problem

Marking the **last** unread entry in a subscription read updated the All Items count but left the subscription and tag badges stale (in the acting tab and in other tabs via SSE) until a refresh. Reading a non-last entry worked fine.

## Root cause

The grouped subscription/tag count queries in `getBulkEntryRelatedCounts` (used by `entries.markRead` responses and the `entry_state_changed` SSE events it publishes) inner-join against **unread** entries only. A subscription or tag whose unread count just dropped to zero produces no row, so it was omitted from the returned `subscriptions`/`tags` arrays. The client applies these counts absolutely — anything missing from the array is left untouched — so the badge kept its previous value.

`getSubscriptionTagCounts` (single-entry counts via `getEntryRelatedCounts`, and `new_entry` counts) had the same omission plus a second bug: an empty grouped result was indistinguishable from "the subscription has no tags", so it fell back to returning the uncategorized count instead of the tags at zero.

Notably, `getSubscriptionDeletionCounts` already zero-fills for exactly this reason — these two functions just didn't.

## Fix

Zero-fill: return every affected subscription ID and tag ID with an explicit count (0 when drained). In `getSubscriptionTagCounts`, fetch the subscription's tag IDs in parallel with the grouped counts so "no tags" and "all tags at zero" are distinguished without adding latency.

## Tests

- 4 new integration tests in `tests/integration/counts.test.ts` covering drained subscriptions/tags for both functions, including a mixed case where a shared tag must keep counting the non-drained subscription. All fail against the old code.
- New e2e test in `tests/e2e/realtime.spec.ts` that computes the `entry_state_changed` counts through the **real counts service** — the existing e2e test hand-writes the event counts, which is why this slipped past it — and asserts the drained tag/subscription rows disappear from the unread-only sidebar with zero `entries.*`/`tags.*`/`subscriptions.*` refetches.
- Widened `TestDb` in `tests/e2e/helpers.ts` with `$client` so e2e tests can pass it to service functions directly.

`pnpm typecheck`, `pnpm lint`, 1884 unit, 381 integration, and 4 e2e tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)