### PR TITLE
Security: fix SSRF bypasses, unbounded reads, and OAuth gaps (#951)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -221,7 +221,7 @@ Enforcement (`src/server/trpc/trpc.ts`):
 
 Because the default is session-only, **new endpoints are token-inaccessible until they explicitly opt in**.
 
-OAuth access tokens are validated only at `POST /api/mcp` (not in the main tRPC/REST context), where the `mcp` scope and the RFC 8707 `resource`/audience binding are both enforced — a token minted for a different resource is rejected.
+OAuth access tokens are validated only at `POST /api/mcp` (not in the main tRPC/REST context), where the `mcp` scope and the RFC 8707 `resource`/audience binding are both enforced — a token minted for a different resource is rejected. `/api/mcp` also requires signup confirmation (ToS/Privacy/EU agreement) for both OAuth and API tokens, mirroring `confirmedProtectedProcedure` on the tRPC surface.
 
 The audience binding is enforced on both sides:
 

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -21,6 +21,7 @@ import {
   ErrorCode,
 } from "@modelcontextprotocol/sdk/types.js";
 import { db } from "@/server/db";
+import type { User } from "@/server/db/schema";
 import { registerTools } from "@/server/mcp/tools";
 import { validateApiToken, API_TOKEN_SCOPES } from "@/server/auth/api-token";
 import { validateAccessToken } from "@/server/oauth/service";
@@ -33,8 +34,17 @@ import { logger } from "@/lib/logger";
 // ============================================================================
 
 type AuthSuccess = { success: true; userId: string };
-type AuthFailure = { success: false; reason: string };
+type AuthFailure = { success: false; reason: string; status?: 401 | 403 };
 type AuthResult = AuthSuccess | AuthFailure;
+
+/**
+ * Checks that the user completed the signup confirmation flow (ToS, Privacy,
+ * EU check) — the same requirement `confirmedMiddleware` enforces for the
+ * tRPC surface. Without this, MCP tokens would bypass signup confirmation.
+ */
+function isSignupConfirmed(user: User): boolean {
+  return !!(user.tosAgreedAt && user.privacyPolicyAgreedAt && user.notEuAgreedAt);
+}
 
 /**
  * Extract and validate token from request headers.
@@ -76,6 +86,12 @@ async function authenticateRequest(request: NextRequest): Promise<AuthResult> {
       });
       return { success: false, reason: "oauth_token_audience_mismatch" };
     }
+    if (!isSignupConfirmed(oauthToken.user)) {
+      logger.warn("MCP auth: user has not completed signup confirmation", {
+        userId: oauthToken.userId,
+      });
+      return { success: false, reason: "signup_confirmation_required", status: 403 };
+    }
     return { success: true, userId: oauthToken.userId };
   }
 
@@ -89,6 +105,12 @@ async function authenticateRequest(request: NextRequest): Promise<AuthResult> {
         scopes: apiTokenData.token.scopes,
       });
       return { success: false, reason: "api_token_missing_mcp_scope" };
+    }
+    if (!isSignupConfirmed(apiTokenData.user)) {
+      logger.warn("MCP auth: user has not completed signup confirmation", {
+        userId: apiTokenData.user.id,
+      });
+      return { success: false, reason: "signup_confirmation_required", status: 403 };
     }
     return { success: true, userId: apiTokenData.user.id };
   }
@@ -163,10 +185,11 @@ function createMcpServer(userId: string): Server {
 // Unauthorized Response
 // ============================================================================
 
-function unauthorizedResponse(reason: string): Response {
-  logger.warn("MCP auth unauthorized", { reason });
-  return new Response(JSON.stringify({ error: "Unauthorized" }), {
-    status: 401,
+function unauthorizedResponse(failure: AuthFailure): Response {
+  logger.warn("MCP auth unauthorized", { reason: failure.reason });
+  const status = failure.status ?? 401;
+  return new Response(JSON.stringify({ error: status === 403 ? "Forbidden" : "Unauthorized" }), {
+    status,
     headers: {
       "Content-Type": "application/json",
       "WWW-Authenticate": buildWwwAuthenticateHeader(),
@@ -186,7 +209,7 @@ async function handleMcpRequest(request: NextRequest): Promise<Response> {
   // Authenticate request
   const auth = await authenticateRequest(request);
   if (!auth.success) {
-    return unauthorizedResponse(auth.reason);
+    return unauthorizedResponse(auth);
   }
   const { userId } = auth;
 
@@ -254,7 +277,7 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   const auth = await authenticateRequest(request);
   if (!auth.success) {
-    return unauthorizedResponse(auth.reason);
+    return unauthorizedResponse(auth);
   }
   return new Response(null, { status: 405 });
 }
@@ -270,7 +293,7 @@ export async function GET(request: NextRequest) {
 export async function DELETE(request: NextRequest) {
   const auth = await authenticateRequest(request);
   if (!auth.success) {
-    return unauthorizedResponse(auth.reason);
+    return unauthorizedResponse(auth);
   }
   return new Response(null, { status: 405 });
 }

--- a/src/app/oauth/authorize/route.ts
+++ b/src/app/oauth/authorize/route.ts
@@ -26,6 +26,7 @@ import {
   createOAuthError,
 } from "@/server/oauth/utils";
 import { getIssuer, getProtectedResourceMetadata } from "@/server/oauth/config";
+import { checkRouteRateLimit } from "@/server/rate-limit";
 import { logger } from "@/lib/logger";
 
 /**
@@ -70,6 +71,13 @@ function buildSuccessRedirect(redirectUri: string, code: string, state?: string)
 }
 
 export async function GET(request: NextRequest) {
+  // Rate-limit by IP: this endpoint is unauthenticated and client resolution
+  // may trigger an outbound CIMD fetch for URL client_ids.
+  const rateLimited = await checkRouteRateLimit(request, "expensive");
+  if (rateLimited) {
+    return rateLimited;
+  }
+
   logger.info("OAuth authorize GET", { url: request.nextUrl.pathname + request.nextUrl.search });
   const searchParams = request.nextUrl.searchParams;
 
@@ -248,6 +256,12 @@ export async function GET(request: NextRequest) {
  * Handle POST for consent approval (from consent page).
  */
 export async function POST(request: NextRequest) {
+  // Rate-limit by IP (see GET handler).
+  const rateLimited = await checkRouteRateLimit(request, "expensive");
+  if (rateLimited) {
+    return rateLimited;
+  }
+
   const formData = await request.formData();
 
   const clientId = formData.get("client_id") as string;
@@ -298,7 +312,25 @@ export async function POST(request: NextRequest) {
   }
 
   const userId = session.user.id;
-  const scopes = scope ? scope.split(" ") : ["mcp"];
+
+  // Re-validate the submitted scopes against the resolved client, exactly like
+  // the GET handler. The consent form's scope field is client-controlled, so
+  // trusting it verbatim would let a client obtain scopes it isn't registered
+  // for (e.g. a saved:write-only client submitting scope=mcp).
+  const requestedScopes = parseScopes(scope || undefined);
+  const scopes = validateScopes(
+    requestedScopes.length > 0 ? requestedScopes : ["mcp"], // Default to mcp scope
+    client.scopes
+  );
+
+  if (scopes.length === 0) {
+    return buildErrorRedirect(
+      redirectUri,
+      OAUTH_ERRORS.INVALID_SCOPE,
+      "No valid scopes requested",
+      state
+    );
+  }
 
   // Validate / bind the RFC 8707 resource indicator (see GET handler).
   const canonicalResource = getProtectedResourceMetadata().resource;

--- a/src/server/email/unsubscribe.ts
+++ b/src/server/email/unsubscribe.ts
@@ -8,6 +8,8 @@
 import { eq, desc, and, isNotNull, or } from "drizzle-orm";
 import { db } from "../db";
 import { entries } from "../db/schema";
+import { fetchWithSsrfProtection } from "../http/ssrf";
+import { USER_AGENT } from "../http/user-agent";
 import { logger } from "@/lib/logger";
 
 // ============================================================================
@@ -171,10 +173,13 @@ async function sendUnsubscribePost(url: string): Promise<void> {
   try {
     logger.info("Sending RFC 8058 one-click unsubscribe POST", { url });
 
-    const response = await fetch(url, {
+    // The URL comes verbatim from the attacker-controllable List-Unsubscribe
+    // email header, so this must go through the SSRF-protected fetch.
+    const response = await fetchWithSsrfProtection(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
+        "User-Agent": USER_AGENT,
       },
       body: "List-Unsubscribe=One-Click",
       signal: controller.signal,

--- a/src/server/feed/websub.ts
+++ b/src/server/feed/websub.ts
@@ -10,10 +10,18 @@
 import { randomBytes, createHmac, timingSafeEqual } from "crypto";
 import { eq, and, lt } from "drizzle-orm";
 import { fetchWithSsrfProtection } from "../http/ssrf";
+import { readResponseBufferWithSizeLimit } from "../http/fetch";
 import { db } from "../db";
 import { feeds, websubSubscriptions, type Feed, type WebsubSubscription } from "../db/schema";
 import { generateUuidv7 } from "../../lib/uuidv7";
 import { logger } from "@/lib/logger";
+
+/**
+ * Timeout for hub subscription POST requests (10 seconds).
+ * These are awaited inside the fetch job and renewal loop, so a wedged hub
+ * must not stall them indefinitely.
+ */
+const HUB_REQUEST_TIMEOUT_MS = 10000;
 
 /**
  * Private/local hostnames and IP ranges that can't receive WebSub callbacks.
@@ -261,6 +269,8 @@ export async function subscribeToHub(feed: Feed): Promise<SubscribeToHubResult> 
   }
 
   // POST subscription request to hub
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), HUB_REQUEST_TIMEOUT_MS);
   try {
     const response = await fetchWithSsrfProtection(feed.hubUrl, {
       method: "POST",
@@ -274,6 +284,7 @@ export async function subscribeToHub(feed: Feed): Promise<SubscribeToHubResult> 
         "hub.secret": secret,
         "hub.verify": "async",
       }).toString(),
+      signal: controller.signal,
     });
 
     // Hub should return 202 Accepted for async verification
@@ -289,9 +300,11 @@ export async function subscribeToHub(feed: Feed): Promise<SubscribeToHubResult> 
       return { success: true, subscriptionId };
     }
 
-    // Handle error response
-    const errorText = await response.text();
-    const errorMessage = `Hub returned ${response.status}: ${errorText.slice(0, 200)}`;
+    // Handle error response (read a bounded prefix; we only log 200 chars)
+    const errorBody = await readResponseBufferWithSizeLimit(response, 4096, feed.hubUrl).catch(() =>
+      Buffer.alloc(0)
+    );
+    const errorMessage = `Hub returned ${response.status}: ${errorBody.toString().slice(0, 200)}`;
 
     await db
       .update(websubSubscriptions)
@@ -329,6 +342,8 @@ export async function subscribeToHub(feed: Feed): Promise<SubscribeToHubResult> 
     });
 
     return { success: false, subscriptionId, error: errorMessage };
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 
@@ -451,17 +466,27 @@ export async function handleVerificationChallenge(
 /**
  * Handles an unsubscribe verification callback from a hub.
  *
- * Per W3C WebSub spec Section 5.3, we confirm unsubscribes that we requested
- * (tracked via unsubscribe_requested_at). For hub-initiated unsubscribes
- * (ones we didn't request), we also confirm and mark the subscription as
- * unsubscribed, since fighting a hub's decision to unsubscribe us is unlikely
- * to be productive.
+ * Per W3C WebSub spec Section 5.3, we only confirm unsubscribes that we
+ * requested (tracked via unsubscribe_requested_at). Unsubscribe verifications
+ * we never requested are rejected: the callback URL (feedId) and topic URL are
+ * both discoverable, so confirming unrequested unsubscribes would let anyone
+ * silently downgrade a feed from push to backup polling. A hub that genuinely
+ * drops us doesn't send a verification — it just stops delivering, and the
+ * lease-renewal/polling machinery recovers from that.
  */
 async function handleUnsubscribeVerification(
   feedId: string,
   subscription: WebsubSubscription,
   challenge: string
 ): Promise<VerificationResult> {
+  if (!subscription.unsubscribeRequestedAt) {
+    logger.warn("WebSub unsubscribe verification we never requested - rejecting", {
+      subscriptionId: subscription.id,
+      feedId,
+    });
+    return { success: false, error: "No unsubscribe was requested for this subscription" };
+  }
+
   const now = new Date();
 
   await db.transaction(async (tx) => {
@@ -471,9 +496,7 @@ async function handleUnsubscribeVerification(
       .set({
         state: "unsubscribed",
         lastChallengeAt: now,
-        lastError: subscription.unsubscribeRequestedAt
-          ? null
-          : "Hub-initiated unsubscribe confirmed",
+        lastError: null,
         updatedAt: now,
       })
       .where(eq(websubSubscriptions.id, subscription.id));
@@ -482,17 +505,10 @@ async function handleUnsubscribeVerification(
     await tx.update(feeds).set({ websubActive: false, updatedAt: now }).where(eq(feeds.id, feedId));
   });
 
-  if (subscription.unsubscribeRequestedAt) {
-    logger.info("WebSub unsubscribe verified (requested)", {
-      subscriptionId: subscription.id,
-      feedId,
-    });
-  } else {
-    logger.info("WebSub unsubscribe verified (hub-initiated)", {
-      subscriptionId: subscription.id,
-      feedId,
-    });
-  }
+  logger.info("WebSub unsubscribe verified (requested)", {
+    subscriptionId: subscription.id,
+    feedId,
+  });
 
   return { success: true, challenge };
 }

--- a/src/server/http/fetch.ts
+++ b/src/server/http/fetch.ts
@@ -114,7 +114,7 @@ export async function readResponseBufferWithSizeLimit(
  * @returns The response body as a string
  * @throws ContentTooLargeError if the response exceeds the limit
  */
-async function readResponseWithSizeLimit(
+export async function readResponseWithSizeLimit(
   response: Response,
   maxBytes: number,
   url: string

--- a/src/server/oauth/service.ts
+++ b/src/server/oauth/service.ts
@@ -29,6 +29,8 @@ import {
   OAUTH_SCOPES,
 } from "./utils";
 import { USER_AGENT } from "@/server/http/user-agent";
+import { fetchWithSsrfProtection } from "@/server/http/ssrf";
+import { readResponseBufferWithSizeLimit } from "@/server/http/fetch";
 
 // ============================================================================
 // Types
@@ -136,22 +138,41 @@ export async function resolveClient(clientId: string): Promise<ResolvedClient | 
 }
 
 /**
+ * Timeout for Client ID Metadata Document fetches (10 seconds).
+ */
+const CLIENT_METADATA_TIMEOUT_MS = 10000;
+
+/**
+ * Maximum Client ID Metadata Document size (256 KiB — real documents are tiny).
+ */
+const CLIENT_METADATA_MAX_BYTES = 256 * 1024;
+
+/**
  * Fetches Client ID Metadata Document from URL.
+ *
+ * The URL is an arbitrary client_id reachable via unauthenticated
+ * /oauth/authorize requests, so the fetch is SSRF-protected, time-limited,
+ * and size-limited.
  */
 async function fetchClientMetadata(url: string): Promise<ClientMetadata | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), CLIENT_METADATA_TIMEOUT_MS);
+
   try {
-    const response = await fetch(url, {
+    const response = await fetchWithSsrfProtection(url, {
       headers: {
         Accept: "application/json",
         "User-Agent": USER_AGENT,
       },
+      signal: controller.signal,
     });
 
     if (!response.ok) {
       return null;
     }
 
-    const metadata = (await response.json()) as ClientMetadata;
+    const body = await readResponseBufferWithSizeLimit(response, CLIENT_METADATA_MAX_BYTES, url);
+    const metadata = JSON.parse(body.toString()) as ClientMetadata;
 
     // Validate required fields
     if (!metadata.client_id || !metadata.redirect_uris || !Array.isArray(metadata.redirect_uris)) {
@@ -166,6 +187,8 @@ async function fetchClientMetadata(url: string): Promise<ClientMetadata | null> 
     return metadata;
   } catch {
     return null;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 
@@ -217,6 +240,12 @@ interface AuthCodeValidation {
 /**
  * Validates and consumes an authorization code.
  * Returns the code data if valid, null otherwise.
+ *
+ * Consumption is a single atomic UPDATE ... WHERE used_at IS NULL, so of two
+ * concurrent token requests presenting the same code exactly one succeeds
+ * (OAuth 2.1 single-use requirement). The code is claimed before PKCE
+ * verification, so a failed PKCE attempt also burns the code — that's the
+ * safe direction (an attacker who stole a code can't retry verifiers).
  */
 export async function validateAndConsumeAuthCode(
   code: string,
@@ -226,10 +255,10 @@ export async function validateAndConsumeAuthCode(
 ): Promise<AuthCodeValidation | null> {
   const codeHash = hashToken(code);
 
-  // Get the code from database
+  // Atomically claim the code
   const result = await db
-    .select()
-    .from(oauthAuthorizationCodes)
+    .update(oauthAuthorizationCodes)
+    .set({ usedAt: new Date() })
     .where(
       and(
         eq(oauthAuthorizationCodes.codeHash, codeHash),
@@ -239,7 +268,7 @@ export async function validateAndConsumeAuthCode(
         gt(oauthAuthorizationCodes.expiresAt, new Date())
       )
     )
-    .limit(1);
+    .returning();
 
   if (result.length === 0) {
     return null;
@@ -251,12 +280,6 @@ export async function validateAndConsumeAuthCode(
   if (!validatePkceS256(codeVerifier, authCode.codeChallenge)) {
     return null;
   }
-
-  // Mark code as used
-  await db
-    .update(oauthAuthorizationCodes)
-    .set({ usedAt: new Date() })
-    .where(eq(oauthAuthorizationCodes.id, authCode.id));
 
   return {
     userId: authCode.userId,
@@ -379,32 +402,48 @@ async function updateAccessTokenLastUsed(tokenId: string): Promise<void> {
 
 /**
  * Validates a refresh token and rotates it (creates new tokens, revokes old).
+ *
+ * The presented token is claimed with an atomic UPDATE ... WHERE revoked_at IS
+ * NULL, so concurrent requests with the same token can't both rotate it.
+ * Presenting an already-rotated (revoked but unexpired) token is treated as
+ * rotation reuse — evidence the token leaked — and revokes every active token
+ * for that user+client pair, per OAuth 2.1 refresh token rotation guidance.
  */
 export async function rotateRefreshToken(
   refreshToken: string,
   clientId: string
 ): Promise<TokenPair | null> {
   const tokenHash = hashToken(refreshToken);
+  const now = new Date();
 
-  // Get the refresh token
-  const result = await db
-    .select()
-    .from(oauthRefreshTokens)
+  // Atomically claim (revoke) the presented refresh token
+  const claimed = await db
+    .update(oauthRefreshTokens)
+    .set({ revokedAt: now })
     .where(
       and(
         eq(oauthRefreshTokens.tokenHash, tokenHash),
         eq(oauthRefreshTokens.clientId, clientId),
         isNull(oauthRefreshTokens.revokedAt),
-        gt(oauthRefreshTokens.expiresAt, new Date())
+        gt(oauthRefreshTokens.expiresAt, now)
       )
     )
-    .limit(1);
+    .returning();
 
-  if (result.length === 0) {
+  if (claimed.length === 0) {
+    await handlePossibleRefreshTokenReuse(tokenHash, clientId, now);
     return null;
   }
 
-  const oldRefreshToken = result[0];
+  const oldRefreshToken = claimed[0];
+
+  // Revoke the old access token if it exists
+  if (oldRefreshToken.accessTokenId) {
+    await db
+      .update(oauthAccessTokens)
+      .set({ revokedAt: now })
+      .where(eq(oauthAccessTokens.id, oldRefreshToken.accessTokenId));
+  }
 
   // Create new tokens, preserving resource binding
   const newTokens = await createTokens({
@@ -414,7 +453,7 @@ export async function rotateRefreshToken(
     resource: oldRefreshToken.resource,
   });
 
-  // Get the new refresh token ID to link rotation chain
+  // Link the rotation chain on the old token
   const newRefreshTokenHash = hashToken(newTokens.refreshToken);
   const newRefreshTokenResult = await db
     .select({ id: oauthRefreshTokens.id })
@@ -423,25 +462,65 @@ export async function rotateRefreshToken(
     .limit(1);
 
   const newRefreshTokenId = newRefreshTokenResult[0]?.id;
-
-  // Revoke old refresh token and link to new one
-  await db
-    .update(oauthRefreshTokens)
-    .set({
-      revokedAt: new Date(),
-      replacedById: newRefreshTokenId,
-    })
-    .where(eq(oauthRefreshTokens.id, oldRefreshToken.id));
-
-  // Also revoke the old access token if it exists
-  if (oldRefreshToken.accessTokenId) {
+  if (newRefreshTokenId) {
     await db
-      .update(oauthAccessTokens)
-      .set({ revokedAt: new Date() })
-      .where(eq(oauthAccessTokens.id, oldRefreshToken.accessTokenId));
+      .update(oauthRefreshTokens)
+      .set({ replacedById: newRefreshTokenId })
+      .where(eq(oauthRefreshTokens.id, oldRefreshToken.id));
   }
 
   return newTokens;
+}
+
+/**
+ * Rotation-reuse detection: if a rotation attempt failed because the token was
+ * already revoked (but is otherwise valid and unexpired), someone is replaying
+ * an old refresh token. Revoke all active tokens for that user+client so the
+ * leaked chain is dead no matter which copy the attacker holds.
+ */
+async function handlePossibleRefreshTokenReuse(
+  tokenHash: string,
+  clientId: string,
+  now: Date
+): Promise<void> {
+  const [presented] = await db
+    .select()
+    .from(oauthRefreshTokens)
+    .where(
+      and(eq(oauthRefreshTokens.tokenHash, tokenHash), eq(oauthRefreshTokens.clientId, clientId))
+    )
+    .limit(1);
+
+  if (!presented || !presented.revokedAt || presented.expiresAt <= now) {
+    // Unknown or merely expired token — not reuse, nothing to do
+    return;
+  }
+
+  console.warn(
+    `OAuth refresh token reuse detected for user ${presented.userId}, client ${clientId}; revoking all tokens for the grant`
+  );
+
+  await db
+    .update(oauthRefreshTokens)
+    .set({ revokedAt: now })
+    .where(
+      and(
+        eq(oauthRefreshTokens.userId, presented.userId),
+        eq(oauthRefreshTokens.clientId, clientId),
+        isNull(oauthRefreshTokens.revokedAt)
+      )
+    );
+
+  await db
+    .update(oauthAccessTokens)
+    .set({ revokedAt: now })
+    .where(
+      and(
+        eq(oauthAccessTokens.userId, presented.userId),
+        eq(oauthAccessTokens.clientId, clientId),
+        isNull(oauthAccessTokens.revokedAt)
+      )
+    );
 }
 
 // ============================================================================

--- a/src/server/plugins/github.ts
+++ b/src/server/plugins/github.ts
@@ -1,7 +1,8 @@
 import type { UrlPlugin, SavedArticleContent } from "./types";
 import { logger } from "@/lib/logger";
 import { USER_AGENT } from "@/server/http/user-agent";
-import { githubConfig } from "@/server/config/env";
+import { readResponseWithSizeLimit } from "@/server/http/fetch";
+import { githubConfig, usageLimitsConfig } from "@/server/config/env";
 import { wrapHtmlFragment } from "@/server/http/html";
 import { marked } from "marked";
 import { extractAndStripTitleHeader } from "@/server/html/strip-title-header";
@@ -230,21 +231,47 @@ async function fetchRepoContents(
 }
 
 /**
+ * Timeout for raw file fetches (30 seconds).
+ */
+const RAW_FETCH_TIMEOUT_MS = 30000;
+
+/**
  * Fetch raw file content directly.
+ *
+ * The host is fixed (raw.githubusercontent.com), but the path is user-chosen,
+ * so the read is size-limited and time-limited to avoid OOM/hangs on large files.
  */
 async function fetchRawContent(rawUrl: string): Promise<string | null> {
-  const response = await fetch(rawUrl, {
-    headers: {
-      "User-Agent": USER_AGENT,
-    },
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), RAW_FETCH_TIMEOUT_MS);
 
-  if (!response.ok) {
-    logger.debug("Failed to fetch raw content", { url: rawUrl, status: response.status });
+  try {
+    const response = await fetch(rawUrl, {
+      headers: {
+        "User-Agent": USER_AGENT,
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      logger.debug("Failed to fetch raw content", { url: rawUrl, status: response.status });
+      return null;
+    }
+
+    return await readResponseWithSizeLimit(
+      response,
+      usageLimitsConfig.maxSavedArticleSizeBytes,
+      rawUrl
+    );
+  } catch (error) {
+    logger.warn("Failed to fetch raw content", {
+      url: rawUrl,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return null;
+  } finally {
+    clearTimeout(timeoutId);
   }
-
-  return await response.text();
 }
 
 /**

--- a/src/server/storage/s3.ts
+++ b/src/server/storage/s3.ts
@@ -10,6 +10,13 @@ import { logger } from "@/lib/logger";
 import { storageConfig } from "@/server/config/env";
 import { randomUUID } from "crypto";
 import { USER_AGENT } from "@/server/http/user-agent";
+import { fetchWithSsrfProtection } from "@/server/http/ssrf";
+import { readResponseBufferWithSizeLimit, ContentTooLargeError } from "@/server/http/fetch";
+
+/**
+ * Maximum size for images fetched from external URLs (20MB).
+ */
+const MAX_FETCHED_IMAGE_SIZE_BYTES = 20 * 1024 * 1024;
 
 // ============================================================================
 // Configuration
@@ -293,7 +300,9 @@ export async function fetchAndUploadImage(
       headers["Authorization"] = options.authorization;
     }
 
-    const response = await fetch(imageUrl, {
+    // Image URLs come from external documents (e.g. Google Docs contentUri
+    // values), so the fetch is SSRF-protected and size-limited.
+    const response = await fetchWithSsrfProtection(imageUrl, {
       method: "GET",
       headers,
       signal: controller.signal,
@@ -307,8 +316,11 @@ export async function fetchAndUploadImage(
       return null;
     }
 
-    const arrayBuffer = await response.arrayBuffer();
-    const data = Buffer.from(arrayBuffer);
+    const data = await readResponseBufferWithSizeLimit(
+      response,
+      MAX_FETCHED_IMAGE_SIZE_BYTES,
+      imageUrl
+    );
 
     // Get content type from response or detect from data
     const contentType =
@@ -323,6 +335,11 @@ export async function fetchAndUploadImage(
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
       logger.warn("Image fetch timed out", { url: imageUrl });
+    } else if (error instanceof ContentTooLargeError) {
+      logger.warn("Image too large, skipping", {
+        url: imageUrl,
+        receivedBytes: error.receivedBytes,
+      });
     } else {
       logger.warn("Failed to fetch image", {
         url: imageUrl,

--- a/src/server/trpc/routers/feeds.ts
+++ b/src/server/trpc/routers/feeds.ts
@@ -8,16 +8,18 @@
 import { z } from "zod";
 
 import { logger } from "@/lib/logger";
-import { createTRPCRouter, publicProcedure } from "../trpc";
+import { createTRPCRouter, expensivePublicProcedure } from "../trpc";
 import { errors } from "../errors";
 import { feedUrlSchema } from "../validation";
 import {
   fetchUrl,
   isHtmlContent,
+  readResponseWithSizeLimit,
   FEED_FETCH_TIMEOUT_MS,
   ACCEPT_ENCODING,
 } from "@/server/http/fetch";
 import { fetchWithSsrfProtection } from "@/server/http/ssrf";
+import { usageLimitsConfig } from "@/server/config/env";
 import { stripHtml } from "@/server/html/strip-html";
 import { USER_AGENT } from "@/server/http/user-agent";
 import { detectFeedType } from "@/server/feed/parser";
@@ -162,7 +164,7 @@ async function tryFetchAsFeed(
       return null;
     }
 
-    const text = await response.text();
+    const text = await readResponseWithSizeLimit(response, usageLimitsConfig.maxFeedSizeBytes, url);
     const feedType = detectFeedType(text);
 
     if (feedType === "unknown") {
@@ -273,13 +275,14 @@ export const feedsRouter = createTRPCRouter({
    * 3. Parses the feed to get metadata and sample entries
    * 4. Returns the preview without saving anything to the database
    *
-   * This is a public procedure - no authentication required.
-   * It allows users to preview a feed before subscribing.
+   * This is a public procedure - no authentication required - but it triggers
+   * outbound fetches, so it uses the strict "expensive" rate limit to prevent
+   * anonymous users from using it as a scanning/amplification primitive.
    *
    * @param url - The feed URL (or HTML page with feed discovery)
    * @returns Feed preview with title, description, and sample entries
    */
-  preview: publicProcedure
+  preview: expensivePublicProcedure
     .meta({
       openapi: {
         method: "GET",
@@ -389,13 +392,14 @@ export const feedsRouter = createTRPCRouter({
    * 4. Returns all discovered feeds with title, type, and URL
    * 5. Deduplicates by URL
    *
-   * This is a public procedure - no authentication required.
-   * It allows users to discover feeds before subscribing.
+   * This is a public procedure - no authentication required - but it fans out
+   * several outbound fetches, so it uses the strict "expensive" rate limit to
+   * prevent anonymous users from using it as a scanning/amplification primitive.
    *
    * @param url - The URL to discover feeds from
    * @returns Array of discovered feeds
    */
-  discover: publicProcedure
+  discover: expensivePublicProcedure
     .meta({
       openapi: {
         method: "GET",

--- a/tests/integration/oauth-service.test.ts
+++ b/tests/integration/oauth-service.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Integration tests for OAuth 2.1 service single-use guarantees.
+ *
+ * See issue #951: authorization-code consumption was check-then-act (two
+ * concurrent token requests could both redeem the same code, violating the
+ * OAuth 2.1 single-use requirement), and refresh-token rotation had no
+ * reuse detection. Both are now atomic UPDATE ... WHERE ... RETURNING claims,
+ * and replaying a rotated refresh token revokes the whole grant.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import crypto from "crypto";
+import { inArray } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users, oauthClients } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import {
+  createAuthorizationCode,
+  validateAndConsumeAuthCode,
+  createTokens,
+  rotateRefreshToken,
+  validateAccessToken,
+} from "../../src/server/oauth/service";
+
+const createdUserIds: string[] = [];
+const createdClientIds: string[] = [];
+
+const REDIRECT_URI = "https://example.com/callback";
+const CODE_VERIFIER = "test-code-verifier-that-is-long-enough-for-rfc-7636";
+const CODE_CHALLENGE = crypto
+  .createHash("sha256")
+  .update(CODE_VERIFIER, "ascii")
+  .digest("base64url");
+
+async function createTestUser(): Promise<string> {
+  const userId = generateUuidv7();
+  await db.insert(users).values({
+    id: userId,
+    email: `oauth-service-${userId}@test.com`,
+    passwordHash: "test-hash",
+    tosAgreedAt: new Date(),
+    privacyPolicyAgreedAt: new Date(),
+    notEuAgreedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  createdUserIds.push(userId);
+  return userId;
+}
+
+async function createTestClient(): Promise<string> {
+  const clientId = generateUuidv7();
+  await db.insert(oauthClients).values({
+    id: generateUuidv7(),
+    clientId,
+    name: "Test Client",
+    redirectUris: [REDIRECT_URI],
+    scopes: ["mcp"],
+    isPublic: true,
+  });
+  createdClientIds.push(clientId);
+  return clientId;
+}
+
+async function createTestAuthCode(userId: string, clientId: string): Promise<string> {
+  return createAuthorizationCode({
+    clientId,
+    userId,
+    redirectUri: REDIRECT_URI,
+    scopes: ["mcp"],
+    codeChallenge: CODE_CHALLENGE,
+  });
+}
+
+afterAll(async () => {
+  // Cascades clean up codes/tokens via user FK
+  if (createdUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+  if (createdClientIds.length > 0) {
+    await db.delete(oauthClients).where(inArray(oauthClients.clientId, createdClientIds));
+  }
+});
+
+describe("validateAndConsumeAuthCode", () => {
+  it("redeems a valid code exactly once", async () => {
+    const userId = await createTestUser();
+    const clientId = await createTestClient();
+    const code = await createTestAuthCode(userId, clientId);
+
+    const first = await validateAndConsumeAuthCode(code, clientId, REDIRECT_URI, CODE_VERIFIER);
+    expect(first).not.toBeNull();
+    expect(first?.userId).toBe(userId);
+    expect(first?.scopes).toEqual(["mcp"]);
+
+    const second = await validateAndConsumeAuthCode(code, clientId, REDIRECT_URI, CODE_VERIFIER);
+    expect(second).toBeNull();
+  });
+
+  it("allows at most one of many concurrent redemptions to succeed", async () => {
+    const userId = await createTestUser();
+    const clientId = await createTestClient();
+    const code = await createTestAuthCode(userId, clientId);
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        validateAndConsumeAuthCode(code, clientId, REDIRECT_URI, CODE_VERIFIER)
+      )
+    );
+
+    const successes = results.filter((r) => r !== null);
+    expect(successes).toHaveLength(1);
+  });
+
+  it("burns the code when PKCE verification fails", async () => {
+    const userId = await createTestUser();
+    const clientId = await createTestClient();
+    const code = await createTestAuthCode(userId, clientId);
+
+    const bad = await validateAndConsumeAuthCode(code, clientId, REDIRECT_URI, "wrong-verifier");
+    expect(bad).toBeNull();
+
+    // The failed attempt consumed the code; a later attempt with the correct
+    // verifier must not succeed (an attacker can't retry verifiers).
+    const retry = await validateAndConsumeAuthCode(code, clientId, REDIRECT_URI, CODE_VERIFIER);
+    expect(retry).toBeNull();
+  });
+});
+
+describe("rotateRefreshToken", () => {
+  it("rotates a valid refresh token and invalidates the old one", async () => {
+    const userId = await createTestUser();
+    const clientId = await createTestClient();
+    const tokens = await createTokens({ clientId, userId, scopes: ["mcp"] });
+
+    const rotated = await rotateRefreshToken(tokens.refreshToken, clientId);
+    expect(rotated).not.toBeNull();
+    expect(rotated?.refreshToken).not.toBe(tokens.refreshToken);
+
+    // The old access token is revoked as part of rotation
+    expect(await validateAccessToken(tokens.accessToken)).toBeNull();
+  });
+
+  it("allows at most one of many concurrent rotations to succeed", async () => {
+    const userId = await createTestUser();
+    const clientId = await createTestClient();
+    const tokens = await createTokens({ clientId, userId, scopes: ["mcp"] });
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => rotateRefreshToken(tokens.refreshToken, clientId))
+    );
+
+    const successes = results.filter((r) => r !== null);
+    expect(successes).toHaveLength(1);
+  });
+
+  it("revokes the whole grant when a rotated refresh token is replayed", async () => {
+    const userId = await createTestUser();
+    const clientId = await createTestClient();
+    const tokens = await createTokens({ clientId, userId, scopes: ["mcp"] });
+
+    const rotated = await rotateRefreshToken(tokens.refreshToken, clientId);
+    expect(rotated).not.toBeNull();
+    expect(await validateAccessToken(rotated!.accessToken)).not.toBeNull();
+
+    // Replaying the already-rotated token indicates the token leaked
+    const replay = await rotateRefreshToken(tokens.refreshToken, clientId);
+    expect(replay).toBeNull();
+
+    // Reuse detection revoked the successor tokens too
+    expect(await validateAccessToken(rotated!.accessToken)).toBeNull();
+    expect(await rotateRefreshToken(rotated!.refreshToken, clientId)).toBeNull();
+  });
+
+  it("does not revoke the grant for an unknown refresh token", async () => {
+    const userId = await createTestUser();
+    const clientId = await createTestClient();
+    const tokens = await createTokens({ clientId, userId, scopes: ["mcp"] });
+
+    const bogus = await rotateRefreshToken("completely-unknown-token", clientId);
+    expect(bogus).toBeNull();
+
+    // The real grant is untouched
+    expect(await validateAccessToken(tokens.accessToken)).not.toBeNull();
+    expect(await rotateRefreshToken(tokens.refreshToken, clientId)).not.toBeNull();
+  });
+});

--- a/tests/integration/websub.test.ts
+++ b/tests/integration/websub.test.ts
@@ -248,13 +248,16 @@ describe("WebSub Integration", () => {
       expect(updatedFeed.websubActive).toBe(false);
     });
 
-    it("confirms hub-initiated unsubscribe", async () => {
+    it("rejects unsubscribe verification we never requested", async () => {
       const feed = await createTestFeed();
       const topicUrl = "https://example.com/hub-initiated.xml";
       const { subscription: createdSub } = await createTestSubscription(feed.id, {
         topicUrl,
         state: "active",
-        // No unsubscribeRequestedAt - this is hub-initiated
+        // No unsubscribeRequestedAt - we never asked to unsubscribe. The
+        // callback URL (feedId) and topic URL are both discoverable, so
+        // confirming this would let anyone silently downgrade the feed from
+        // push to polling.
       });
 
       // Mark feed as WebSub active
@@ -268,20 +271,19 @@ describe("WebSub Integration", () => {
         leaseSeconds: null,
       });
 
-      expect(result.success).toBe(true);
-      expect(result.challenge).toBe(challenge);
+      expect(result.success).toBe(false);
+      expect(result.challenge).toBeUndefined();
 
-      // Verify subscription was marked as unsubscribed with note
+      // Verify subscription is untouched
       const [subscription] = await db
         .select()
         .from(websubSubscriptions)
         .where(eq(websubSubscriptions.id, createdSub.id));
-      expect(subscription.state).toBe("unsubscribed");
-      expect(subscription.lastError).toBe("Hub-initiated unsubscribe confirmed");
+      expect(subscription.state).toBe("active");
 
-      // Verify feed is no longer marked as WebSub active
+      // Verify feed is still marked as WebSub active
       const [updatedFeed] = await db.select().from(feeds).where(eq(feeds.id, feed.id)).limit(1);
-      expect(updatedFeed.websubActive).toBe(false);
+      expect(updatedFeed.websubActive).toBe(true);
     });
 
     it("rejects unsubscribe with topic mismatch", async () => {


### PR DESCRIPTION
Fixes #951.

## SSRF-wrapper bypasses
- **RFC 8058 unsubscribe POST** (`sendUnsubscribePost`) now goes through `fetchWithSsrfProtection` and sends our `User-Agent`. The URL comes verbatim from the attacker-controllable `List-Unsubscribe` header, so this was the highest-priority item.
- **OAuth CIMD client-metadata fetch** (`fetchClientMetadata`) is SSRF-protected, has a 10s timeout and a 256KiB size cap, and `/oauth/authorize` GET/POST are now IP rate-limited (like `/oauth/register`), which rate-limits unauthenticated client resolution.
- **`fetchAndUploadImage`** is SSRF-protected and stream-limits the read to 20MB instead of unbounded `arrayBuffer()`.

## Unbounded response reads / missing timeouts
- **Feed discovery** (`tryFetchAsFeed`) uses the streaming size-limited reader (`maxFeedSizeBytes`); `readResponseWithSizeLimit` is now exported from `http/fetch`.
- **GitHub plugin** (`fetchRawContent`) gets a 30s timeout and a `maxSavedArticleSizeBytes` size cap.
- **WebSub hub POST** gets a 10s timeout (it's awaited in the fetch job and renewal loop) and a bounded error-body read.

## OAuth / rate-limit gaps
- **Consent POST scope validation**: the POST handler re-runs `parseScopes` + `validateScopes` against the resolved client, so a `saved:write`-only client can no longer obtain an `mcp`-scoped token by submitting `scope=mcp`.
- **Atomic authorization-code consumption**: `UPDATE ... WHERE used_at IS NULL ... RETURNING`, so concurrent token requests redeem a code at most once. A failed PKCE attempt burns the code (an attacker can't retry verifiers).
- **Refresh-token rotation** claims the token atomically the same way, plus rotation-reuse detection: replaying an already-rotated (revoked but unexpired) refresh token revokes every active token for that user+client grant.
- **`feeds.preview`/`discover`** moved to `expensivePublicProcedure` so anonymous users can't use the outbound fetch fan-out as a scanning/amplification primitive (related to #827).
- **`/api/mcp`** now requires signup confirmation (ToS/Privacy/EU) for both OAuth and API tokens, matching `confirmedProtectedProcedure`; returns 403 with reason logging. DESIGN.md updated.
- **WebSub unsubscribe verifications we never requested are rejected** — the callback URL (feedId) and topic URL are discoverable, so confirming them let anyone silently downgrade a feed from push to polling. Only unsubscribes tracked via `unsubscribe_requested_at` are confirmed.

## Tests
- New `tests/integration/oauth-service.test.ts`: single-use code redemption (sequential + 5-way concurrent), PKCE-failure burning, refresh rotation (concurrent), rotation-reuse revoking the grant, and no collateral revocation for unknown tokens.
- Updated `tests/integration/websub.test.ts`: hub-initiated unsubscribe is now rejected and leaves the subscription active.
- Full suite: `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (1884 passed), `pnpm test:integration` (384 passed) all green.

## Notes / trade-offs
- Rotation-reuse detection is strict (no grace window): a client that double-fires a refresh concurrently gets one success, and the failed duplicate revokes the grant, forcing re-auth. That's the safe direction; a grace period can be added later if it bites real clients.
- PKCE failure consuming the code is intentional (claimed before verification) — safer than leaving stolen codes retryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)