### PR TITLE
Require a confirmed session for feeds.preview/discover

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -216,7 +216,7 @@ Available scopes (`API_TOKEN_SCOPES` / `OAUTH_SCOPES`):
 
 Enforcement (`src/server/trpc/trpc.ts`):
 
-- `protectedProcedure` / `confirmedProtectedProcedure` (and their `expensive*` variants) are **session-only** — token auth is rejected with `FORBIDDEN`. This protects account-management and other non-MCP endpoints (sessions, password, preferences, ingest addresses, blocked senders, OPML import, narration, summarization, feed stats, broken feeds, subscription create/update/delete/import/export, `entries.markAllRead`, `entries.fetchFullContent`) by default.
+- `protectedProcedure` / `confirmedProtectedProcedure` (and their `expensive*` variants) are **session-only** — token auth is rejected with `FORBIDDEN`. This protects account-management and other non-MCP endpoints (sessions, password, preferences, ingest addresses, blocked senders, OPML import, narration, summarization, feed stats, broken feeds, feed preview/discover, subscription create/update/delete/import/export, `entries.markAllRead`, `entries.fetchFullContent`) by default.
 - `scopedProtectedProcedure(scope | scope[])` opts an endpoint into token access; a token must hold at least one of the listed scopes (sessions bypass). The `mcp`-scoped endpoints mirror the MCP tools exactly; `saved.save` accepts `saved:write` or `mcp`.
 
 Because the default is session-only, **new endpoints are token-inaccessible until they explicitly opt in**.

--- a/src/server/trpc/routers/feeds.ts
+++ b/src/server/trpc/routers/feeds.ts
@@ -8,7 +8,7 @@
 import { z } from "zod";
 
 import { logger } from "@/lib/logger";
-import { createTRPCRouter, expensivePublicProcedure } from "../trpc";
+import { createTRPCRouter, expensiveConfirmedProtectedProcedure } from "../trpc";
 import { errors } from "../errors";
 import { feedUrlSchema } from "../validation";
 import {
@@ -275,14 +275,15 @@ export const feedsRouter = createTRPCRouter({
    * 3. Parses the feed to get metadata and sample entries
    * 4. Returns the preview without saving anything to the database
    *
-   * This is a public procedure - no authentication required - but it triggers
-   * outbound fetches, so it uses the strict "expensive" rate limit to prevent
-   * anonymous users from using it as a scanning/amplification primitive.
+   * Requires a confirmed session: the only UI that calls this is the subscribe
+   * page, which is behind auth anyway, and it triggers outbound fetches — so
+   * anonymous access would be a free scanning/amplification primitive. Also
+   * uses the strict "expensive" rate limit.
    *
    * @param url - The feed URL (or HTML page with feed discovery)
    * @returns Feed preview with title, description, and sample entries
    */
-  preview: expensivePublicProcedure
+  preview: expensiveConfirmedProtectedProcedure
     .meta({
       openapi: {
         method: "GET",
@@ -392,14 +393,14 @@ export const feedsRouter = createTRPCRouter({
    * 4. Returns all discovered feeds with title, type, and URL
    * 5. Deduplicates by URL
    *
-   * This is a public procedure - no authentication required - but it fans out
-   * several outbound fetches, so it uses the strict "expensive" rate limit to
-   * prevent anonymous users from using it as a scanning/amplification primitive.
+   * Requires a confirmed session (see `preview` above) — this one fans out
+   * several outbound fetches, so it's the stronger scanning/amplification
+   * primitive. Also uses the strict "expensive" rate limit.
    *
    * @param url - The URL to discover feeds from
    * @returns Array of discovered feeds
    */
-  discover: expensivePublicProcedure
+  discover: expensiveConfirmedProtectedProcedure
     .meta({
       openapi: {
         method: "GET",

--- a/tests/integration/token-scopes.test.ts
+++ b/tests/integration/token-scopes.test.ts
@@ -86,6 +86,18 @@ function createSessionContext(userId: string): Context {
   };
 }
 
+function createAnonymousContext(): Context {
+  return {
+    db,
+    session: null,
+    apiToken: null,
+    authType: null,
+    scopes: [],
+    sessionToken: null,
+    headers: new Headers(),
+  };
+}
+
 function createTokenContext(userId: string, scopes: ApiTokenScope[]): Context {
   return {
     db,
@@ -192,6 +204,30 @@ describe("API token scope enforcement", () => {
 
       await expectPassedScopeGate(mcpCaller.saved.delete({ id: generateUuidv7() }), "NOT_FOUND");
       await expectForbidden(writeCaller.saved.delete({ id: generateUuidv7() }));
+    });
+  });
+
+  describe("feeds.preview / feeds.discover", () => {
+    // These trigger outbound fetches, so they require a confirmed session (see
+    // issue #951): anonymous or token access would be a scanning/amplification
+    // primitive. Both rejections happen at the auth gate, before any fetch.
+    it("rejects unauthenticated callers", async () => {
+      const caller = createCaller(createAnonymousContext());
+
+      await expect(
+        caller.feeds.preview({ url: "https://example.com/feed.xml" })
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+      await expect(caller.feeds.discover({ url: "https://example.com/" })).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+      });
+    });
+
+    it("rejects API tokens (session-only)", async () => {
+      const userId = await createTestUser();
+      const caller = createCaller(createTokenContext(userId, ["mcp"]));
+
+      await expectForbidden(caller.feeds.preview({ url: "https://example.com/feed.xml" }));
+      await expectForbidden(caller.feeds.discover({ url: "https://example.com/" }));
     });
   });
 


### PR DESCRIPTION
Follow-up to #951 / PR #959, where these moved from `publicProcedure` to `expensivePublicProcedure` (rate-limited but still anonymous).

The anonymous access turned out to never be load-bearing: the only caller in the codebase is `SubscribeContent`, rendered under the `(app)/subscribe` route whose layout already redirects unauthenticated users to `/login` and unconfirmed users to `/complete-signup`. The extension and `/demo` page don't use them. The "public - allows users to preview a feed before subscribing" comments conflated "before subscribing to a feed" with "before having an account."

Since both endpoints trigger outbound fetches (`discover` fans out to ~16 common feed paths), anonymous access was a scanning/amplification primitive that per-IP rate limiting only slows — anyone with an IP pool still gets 10 burst + 1/s each of probing public hosts through our egress IP. This switches both to `expensiveConfirmedProtectedProcedure`: confirmed browser session + the same strict rate limit.

They remain session-only (no `scopedProtectedProcedure` opt-in) since they aren't part of the MCP tool surface, so no token scope semantically covers them. If we ever add preview/discover MCP tools, that's the point to revisit — and note `scopedProtectedProcedure` currently has no rate-limited variant, so the throttle would need to be added to that chain.

Also updates the session-only endpoint list in DESIGN.md and adds integration tests asserting anonymous callers get `UNAUTHORIZED` and API tokens get `FORBIDDEN` (both at the auth gate, before any outbound fetch).

Tests: `pnpm typecheck`, `pnpm lint`, `pnpm test:integration` (390 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)