### PR TITLE
Initialize Sentry in all processes and adopt current SDK conventions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,13 @@ ENV NODE_ENV=production
 ENV DATABASE_URL="postgresql://build:build@localhost:5432/build"
 ENV REDIS_URL="redis://localhost:6379"
 
+# Client-side Sentry DSN. NEXT_PUBLIC_* vars are inlined into the client
+# bundle at build time, so a runtime secret is not enough — the DSN must be
+# provided to the build (fly.toml [build.args]). DSNs are not secret (they
+# ship in the client bundle by design). Empty means client Sentry is disabled.
+ARG NEXT_PUBLIC_SENTRY_DSN=""
+ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
+
 # Build Next.js application
 RUN pnpm build
 

--- a/fly.toml
+++ b/fly.toml
@@ -18,6 +18,11 @@ kill_timeout = 30
 
 [build]
   dockerfile = "Dockerfile"
+  # Uncomment to enable client-side Sentry: NEXT_PUBLIC_* vars are inlined at
+  # build time, so the DSN must be a build arg (a runtime secret has no
+  # effect). DSNs are not secret — they ship in the client bundle by design.
+  # [build.args]
+  #   NEXT_PUBLIC_SENTRY_DSN = "https://<key>@<org>.ingest.sentry.io/<project>"
 
 [deploy]
   # Run migrations before starting the new app version

--- a/scripts/discord-bot.ts
+++ b/scripts/discord-bot.ts
@@ -15,10 +15,17 @@
  *     bot is running; the monitor alerts if pings stop (dead/crash-looping bot)
  */
 
+import * as Sentry from "@sentry/nextjs";
 import { startDiscordBot } from "../src/server/discord/bot";
 import { startMetricsServer } from "../src/server/metrics/server";
 import { startHeartbeat } from "../src/server/notifications/healthchecks";
+import { initSentry } from "../src/server/sentry";
 import { logger } from "../src/lib/logger";
+
+// Initialize Sentry before any work starts. Next.js instrumentation only runs
+// in the app server, so this process must init explicitly (this also installs
+// Sentry's global uncaught-exception / unhandled-rejection handlers).
+initSentry();
 
 /** How often to ping the liveness heartbeat while the bot is running. */
 const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
@@ -35,14 +42,16 @@ logger.info("Starting Discord bot", {
 startMetricsServer(9093);
 
 // Handle graceful shutdown
-function shutdown(signal: string): void {
+async function shutdown(signal: string): Promise<void> {
   logger.info(`Received ${signal}, shutting down Discord bot...`);
   stopHeartbeat?.();
+  // Flush buffered Sentry events before exiting (no-op if never initialized).
+  await Sentry.close(2000);
   process.exit(0);
 }
 
-process.on("SIGINT", () => shutdown("SIGINT"));
-process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => void shutdown("SIGINT"));
+process.on("SIGTERM", () => void shutdown("SIGTERM"));
 
 startDiscordBot()
   .then(() => {

--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -17,7 +17,13 @@
 import { startWorkerWithSignalHandling } from "../src/server/jobs/worker";
 import { startMetricsServer, setHealthChecker } from "../src/server/metrics/server";
 import { startHeartbeat } from "../src/server/notifications/healthchecks";
+import { initSentry } from "../src/server/sentry";
 import { logger } from "../src/lib/logger";
+
+// Initialize Sentry before any work starts. Next.js instrumentation only runs
+// in the app server, so without this the job runner's Sentry.captureException
+// calls are silent no-ops in this process.
+initSentry();
 
 const pollIntervalMs = parseInt(process.env.WORKER_POLL_INTERVAL_MS ?? "5000", 10);
 const concurrency = parseInt(process.env.WORKER_CONCURRENCY ?? "3", 10);

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -2,26 +2,10 @@
  * Sentry Edge Configuration
  *
  * This file configures the initialization of Sentry for edge features (middleware, edge routes).
+ * Loaded from src/instrumentation.ts (edge runtime).
  * https://docs.sentry.io/platforms/javascript/guides/nextjs/
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { initSentry } from "./src/server/sentry";
 
-// Only initialize Sentry if DSN is provided
-if (process.env.SENTRY_DSN) {
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-
-    // Adjust this value in production, or use tracesSampler for greater control
-    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-
-    // Setting this option to true will print useful information to the console while you're setting up Sentry.
-    debug: false,
-
-    // Environment tag for filtering
-    environment: process.env.NODE_ENV,
-
-    // Only send errors from production
-    enabled: process.env.NODE_ENV === "production",
-  });
-}
+initSentry();

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,54 +3,10 @@
  *
  * This file configures the initialization of Sentry on the server.
  * The config added here applies to all server-side code.
+ * Loaded from src/instrumentation.ts (nodejs runtime).
  * https://docs.sentry.io/platforms/javascript/guides/nextjs/
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { initSentry } from "./src/server/sentry";
 
-// Only initialize Sentry if DSN is provided
-if (process.env.SENTRY_DSN) {
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-
-    // Adjust this value in production, or use tracesSampler for greater control
-    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-
-    // Setting this option to true will print useful information to the console while you're setting up Sentry.
-    debug: false,
-
-    // Environment tag for filtering
-    environment: process.env.NODE_ENV,
-
-    // Only send errors from production
-    enabled: process.env.NODE_ENV === "production",
-
-    // Configure which errors to ignore
-    beforeSend(event, hint) {
-      const error = hint.originalException;
-
-      // Don't report 4xx client errors (these are expected)
-      if (error instanceof Error) {
-        const errorMessage = error.message.toLowerCase();
-        if (
-          errorMessage.includes("unauthorized") ||
-          errorMessage.includes("not found") ||
-          errorMessage.includes("bad request") ||
-          errorMessage.includes("forbidden")
-        ) {
-          return null;
-        }
-      }
-
-      return event;
-    },
-
-    // Ignore common expected errors
-    ignoreErrors: [
-      // Connection errors during health checks
-      "ECONNREFUSED",
-      // Redis connection errors during shutdown
-      "Connection is closed",
-    ],
-  });
-}
+initSentry();

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,14 +1,19 @@
 /**
- * Sentry Client Configuration
+ * Client Instrumentation (Next.js convention, replaces sentry.client.config.ts)
  *
- * This file configures the initialization of Sentry on the client (browser).
- * The config added here applies whenever a user loads a page in their browser.
+ * Runs in the browser before the app hydrates. This is where client-side
+ * Sentry is initialized. Like src/instrumentation.ts, Next.js resolves this
+ * file from `src/` first, then the repo root.
+ *
+ * https://nextjs.org/docs/app/guides/instrumentation-client
  * https://docs.sentry.io/platforms/javascript/guides/nextjs/
  */
 
 import * as Sentry from "@sentry/nextjs";
 
-// Only initialize Sentry if DSN is provided
+// Only initialize Sentry if DSN is provided.
+// NEXT_PUBLIC_* vars are inlined at build time, so the DSN must be available
+// to `next build` (not just at runtime) for client Sentry to work.
 if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -18,6 +23,10 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
 
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,
+
+    // Session Replay. The sample rates below do nothing without this
+    // integration being registered.
+    integrations: [Sentry.replayIntegration()],
 
     // Enable replay for 10% of sessions
     replaysSessionSampleRate: 0.1,
@@ -64,3 +73,8 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
     ],
   });
 }
+
+// Instruments Next.js router transitions for tracing. Most in-app navigation
+// here bypasses the Next router (ClientLink uses pushState directly), so this
+// mainly covers initial-load route changes; exported to follow the convention.
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -14,6 +14,8 @@
  * https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
  */
 
+import * as Sentry from "@sentry/nextjs";
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     // Import the server Sentry config
@@ -38,6 +40,11 @@ export async function register() {
     registerResourceCleanup(async () => {
       logger.info("Closing shared resources...");
 
+      // Flush buffered Sentry events first (errors captured during the
+      // connection drain are the ones most worth keeping). No-op without a
+      // DSN.
+      await Sentry.close(2000);
+
       // Close Redis connection
       const { redis } = await import("./server/redis");
       await redis.quit();
@@ -53,3 +60,8 @@ export async function register() {
     await import("../sentry.edge.config");
   }
 }
+
+// Capture errors from Server Components, route handlers, middleware, and
+// proxies. Without this export, only errors that flow through explicit
+// captureException call sites (e.g. the tRPC error middleware) reach Sentry.
+export const onRequestError = Sentry.captureRequestError;

--- a/src/server/jobs/worker.ts
+++ b/src/server/jobs/worker.ts
@@ -442,6 +442,10 @@ export async function startWorkerWithSignalHandling(config: WorkerConfig = {}): 
     logger.info(`Received ${signal}, initiating graceful shutdown...`);
 
     await worker.stop();
+    // Flush buffered Sentry events (e.g. failures captured from the jobs that
+    // just wound down) before the process exits. No-op if Sentry never
+    // initialized.
+    await Sentry.close(2000);
     process.exit(0);
   };
 

--- a/src/server/sentry.ts
+++ b/src/server/sentry.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared server-side Sentry initialization.
+ *
+ * Used by every server-side process:
+ * - Next.js app server: via sentry.server.config.ts / sentry.edge.config.ts,
+ *   loaded from src/instrumentation.ts
+ * - Background worker: scripts/worker.ts
+ * - Discord bot: scripts/discord-bot.ts
+ *
+ * The worker and bot must call this themselves — Next.js instrumentation only
+ * runs in the app server, so without an explicit init their
+ * `Sentry.captureException` calls are silent no-ops.
+ */
+
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Initializes Sentry if SENTRY_DSN is set. Safe to call more than once
+ * (subsequent calls re-init the same client) and a no-op without a DSN.
+ */
+export function initSentry(): void {
+  if (!process.env.SENTRY_DSN) {
+    return;
+  }
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+
+    // Adjust this value in production, or use tracesSampler for greater control
+    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
+
+    // Environment tag for filtering
+    environment: process.env.NODE_ENV,
+
+    // Only send errors from production
+    enabled: process.env.NODE_ENV === "production",
+
+    // Configure which errors to ignore
+    beforeSend(event, hint) {
+      const error = hint.originalException;
+
+      // Don't report 4xx client errors (these are expected)
+      if (error instanceof Error) {
+        const errorMessage = error.message.toLowerCase();
+        if (
+          errorMessage.includes("unauthorized") ||
+          errorMessage.includes("not found") ||
+          errorMessage.includes("bad request") ||
+          errorMessage.includes("forbidden")
+        ) {
+          return null;
+        }
+      }
+
+      return event;
+    },
+
+    // Ignore common expected errors
+    ignoreErrors: [
+      // Connection errors during health checks
+      "ECONNREFUSED",
+      // Redis connection errors during shutdown
+      "Connection is closed",
+    ],
+  });
+}


### PR DESCRIPTION
Follow-up to #960 / #950, fixing the gaps found once instrumentation actually loads.

## What was broken

Once #960 made `src/instrumentation.ts` load for real, a review of the now-live Sentry setup found:

1. **The worker never initializes Sentry.** `Sentry.init` lived only in the `sentry.*.config.ts` files, which only Next.js instrumentation loads — so the job runner's `Sentry.captureException` calls for failed background jobs (`src/server/jobs/worker.ts`) have always been silent no-ops. Same for the Discord bot (which had no capture at all).
2. **`onRequestError` was missing** from instrumentation.ts — the documented mechanism (Next 15+ / `@sentry/nextjs` ≥8.28) for capturing errors from Server Components, plain route handlers (SSE, REST `/api/v1`, OAuth, webhooks, MCP), and the proxy. Only the tRPC middleware's explicit `captureException` reached Sentry.
3. **No flush on shutdown** — the new graceful-shutdown paths call `process.exit` without draining Sentry's event queue, dropping errors captured just before/during shutdown.
4. **`sentry.client.config.ts` is the deprecated convention** (not loaded at all under Turbopack) — and it configured Replay sample rates without registering `replayIntegration()`, so Session Replay was never actually on.
5. **Client Sentry could never turn on in production anyway**: `NEXT_PUBLIC_SENTRY_DSN` is inlined at `next build` time, and the Fly remote build never receives it.

## Changes

- `src/server/sentry.ts` — shared `initSentry()`; `sentry.server.config.ts` / `sentry.edge.config.ts` delegate to it; **worker and Discord bot now call it at startup** (which also installs Sentry's global crash handlers in those processes).
- `src/instrumentation.ts` — `export const onRequestError = Sentry.captureRequestError` and `Sentry.close(2000)` at the start of the shutdown resource cleanup. Worker and bot shutdown paths also flush.
- `sentry.client.config.ts` → **`src/instrumentation-client.ts`** (Next resolves it from `src/` first, same rule that bit us in #960), now with `replayIntegration()` registered and `onRouterTransitionStart` exported per convention.
- `Dockerfile` gets a `NEXT_PUBLIC_SENTRY_DSN` build ARG + a commented `[build.args]` example in `fly.toml`. **To enable client-side Sentry you'll need to uncomment that and paste the real DSN** (DSNs aren't secret — they ship in the client bundle by design). Server-side Sentry needs only the existing `SENTRY_DSN` runtime secret.

## Verification

- Dummy-DSN build confirms `instrumentation-client.ts` bundles into the client entry with the DSN inlined; `onRequestError` confirmed present in `.next/server/instrumentation.js`; `initSentry` confirmed in `dist/worker.js`.
- Worker bundle boots, processes jobs, and exits cleanly on SIGTERM both without a DSN and with an invalid one (SDK logs `Invalid Sentry Dsn` and continues — graceful degradation).
- App-server graceful shutdown still completes with the flush in the cleanup path.
- `pnpm typecheck`, `pnpm lint`, unit (1884), and the e2e suite against the production build (4 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)