### PR TITLE
DB/migrations/jobs hygiene: journal drift, dead tables, missing indexes, retention cleanup (#953)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Use the database views for frontend queries instead of manual joins:
 - **`user_feeds`**: Active subscriptions with feed data merged. Use for `subscriptions.list/get/export`. Already filters out unsubscribed entries and resolves title (custom or original).
 - **`visible_entries`**: Entries with visibility rules applied. Use for `entries.list/get/count`. Includes read/starred state and subscription_id. An entry is visible if a `user_entries` row exists for the `(user, entry)` pair AND (the entry is from an active subscription OR is starred). Privacy gating happens when `user_entries` rows are inserted (subscribe-time / fetch-time), not in the view. See "Entry Visibility" in docs/DESIGN.md.
 
-These views are defined in `migrations/0035_subscription_views.sql` and have Drizzle schemas in `src/server/db/schema.ts`.
+These views were introduced in `migrations/0035_subscription_views.sql` (current `visible_entries` definition: `migrations/0073_drop_entry_scoring.sql`) and have Drizzle schemas in `src/server/db/schema.ts`.
 
 ## API Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ See docs/diagrams/ for more detail. These diagrams are very helpful for quickly 
 Use the database views for frontend queries instead of manual joins:
 
 - **`user_feeds`**: Active subscriptions with feed data merged. Use for `subscriptions.list/get/export`. Already filters out unsubscribed entries and resolves title (custom or original).
-- **`visible_entries`**: Entries with visibility rules applied. Use for `entries.list/get/count`. Includes read/starred state and subscription_id. An entry is visible if a `user_entries` row exists for the `(user, entry)` pair AND (the entry is from an active subscription OR is starred). Privacy gating happens when `user_entries` rows are inserted (subscribe-time / fetch-time), not in the view. See "Entry Visibility" in docs/DESIGN.md.
+- **`visible_entries`**: Entries with visibility rules applied. Use for `entries.list/get/count`. Includes read/starred state and subscription_id. An entry is visible if a `user_entries` row exists for the `(user, entry)` pair AND (the entry is from an active subscription OR is starred OR is a saved article). Privacy gating happens when `user_entries` rows are inserted (subscribe-time / fetch-time), not in the view. See "Entry Visibility" in docs/DESIGN.md.
 
 These views were introduced in `migrations/0035_subscription_views.sql` (current `visible_entries` definition: `migrations/0073_drop_entry_scoring.sql`) and have Drizzle schemas in `src/server/db/schema.ts`.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -146,7 +146,7 @@ See `docs/features/subscription-centric-api.md` for design details.
 
 ### Key Design Decisions
 
-**Entry Visibility**: Visibility is enforced at query time by the `visible_entries` view, which requires a `user_entries` row to exist for the `(user, entry)` pair AND that the entry is either from an active subscription (`subscription.unsubscribed_at IS NULL`) or is starred. The existence of the `user_entries` row is the durable record of visibility.
+**Entry Visibility**: Visibility is enforced at query time by the `visible_entries` view, which requires a `user_entries` row to exist for the `(user, entry)` pair AND that the entry is either from an active subscription (`subscription.unsubscribed_at IS NULL`), is starred, or is a saved article (saved articles live in a per-user feed with no subscription row, so their `user_entries` row alone grants visibility). The predicate is fail-closed: a `user_entries` row whose entry matches no subscription is hidden unless starred/saved. The existence of the `user_entries` row is the durable record of visibility.
 
 The `user_entries` rows are created outside the view at:
 

--- a/docs/features/job-queue-design.md
+++ b/docs/features/job-queue-design.md
@@ -58,6 +58,8 @@ Fetches a feed and processes new entries.
 
 **Failure handling**: Failures tracked on `feeds.consecutive_failures`. Backoff applied to `next_run_at`.
 
+**Dual scheduling state**: the schedule lives in two places — `jobs.next_run_at` is the **authoritative** value (claiming only reads the job row), while `feeds.next_fetch_at` is a denormalized copy written by the fetch handler for display surfaces (feed stats, broken feeds, admin). They are updated together on each fetch but can drift when only one is touched (e.g. WebSub backup-poll scheduling via `updateFeedJobNextRun`); treat `feeds.next_fetch_at` as informational only.
+
 ### `renew_websub`
 
 Renews expiring WebSub subscriptions.

--- a/docs/features/job-queue-design.md
+++ b/docs/features/job-queue-design.md
@@ -86,6 +86,20 @@ Singleton health check enforcing "at least one feed must fetch successfully ever
 
 **Failure handling**: Failures tracked on `jobs.consecutive_failures` since there's no associated feed.
 
+### `cleanup`
+
+Daily retention cleanup (see `src/server/services/retention.ts`). Deletes rows that expire but are never deleted on any other path: expired sessions, expired OAuth authorization codes / access tokens / refresh tokens, long-revoked (30+ days) sessions and refresh tokens, and parked one-time `process_opml_import` jobs (completed one-time jobs reschedule themselves 365 days out instead of deleting their row).
+
+**Payload**: `{}` (empty)
+
+**Lifecycle**:
+
+1. Self-creates on first claim (singleton, like `renew_websub`)
+2. Runs daily
+3. Always enabled
+
+**Failure handling**: Failures tracked on `jobs.consecutive_failures` since there's no associated feed.
+
 ## Worker Behavior
 
 ### Claiming Jobs

--- a/migrations/0060_previous_feed_ids_gin_index.sql
+++ b/migrations/0060_previous_feed_ids_gin_index.sql
@@ -1,3 +1,0 @@
--- Add GIN index on previous_feed_ids for efficient @> lookups in
--- redirect deduplication queries (entry-processor.ts).
-CREATE INDEX idx_subscriptions_previous_feed_ids ON subscriptions USING GIN (previous_feed_ids);

--- a/migrations/0071_entries_published_sort_index.sql
+++ b/migrations/0071_entries_published_sort_index.sql
@@ -7,6 +7,13 @@
 --
 -- Measured improvement (10K entries): 16.6ms → 0.48ms for first page,
 -- 15.5ms → 0.36ms for cursor-paginated pages.
+--
+-- This index was originally created manually on production with CREATE INDEX
+-- CONCURRENTLY (which can't run inside the migration runner's per-migration
+-- transaction) and the migration file was never journaled, so databases built
+-- from the journal silently lacked it (issue #953). It is now journaled without
+-- CONCURRENTLY — a plain CREATE INDEX is fine for fresh/small databases — and
+-- IF NOT EXISTS makes it a no-op where the index already exists.
 
-CREATE INDEX CONCURRENTLY idx_entries_published_coalesce
+CREATE INDEX IF NOT EXISTS idx_entries_published_coalesce
 ON entries ((COALESCE(published_at, fetched_at)) DESC, id DESC);

--- a/migrations/0072_entries_feed_published_sort_index.sql
+++ b/migrations/0072_entries_feed_published_sort_index.sql
@@ -9,6 +9,11 @@
 -- The global index remains the better choice for "all entries" queries that
 -- don't filter by feed_id. Write overhead is minimal since entry inserts
 -- only happen in the background worker.
+--
+-- Like 0071, this was originally applied manually with CREATE INDEX CONCURRENTLY
+-- and never journaled (issue #953); journaled here without CONCURRENTLY (the
+-- runner wraps each migration in a transaction) and with IF NOT EXISTS so it's
+-- a no-op on databases where it already exists.
 
-CREATE INDEX CONCURRENTLY idx_entries_feed_published_coalesce
+CREATE INDEX IF NOT EXISTS idx_entries_feed_published_coalesce
 ON entries (feed_id, (COALESCE(published_at, fetched_at)) DESC, id DESC);

--- a/migrations/0073_drop_entry_scoring.sql
+++ b/migrations/0073_drop_entry_scoring.sql
@@ -10,9 +10,11 @@
 -- The rebuilt view also switches the visibility predicate from fail-open to
 -- fail-closed: the old `s.unsubscribed_at IS NULL` evaluates TRUE when the
 -- LEFT JOINs match no subscription at all, so an orphaned user_entries row
--- (no subscription_feeds/subscriptions match) was visible. The documented
--- rule is "active subscription OR starred", so require a matching active
--- subscription explicitly.
+-- (no subscription_feeds/subscriptions match) was visible. The rule is
+-- "active subscription OR starred OR saved article", so require one of those
+-- explicitly. Saved articles live in a per-user feed with no subscription
+-- row — for them the user_entries row alone is the visibility record (they
+-- previously rode on the fail-open behavior).
 
 DROP VIEW visible_entries;
 
@@ -69,7 +71,7 @@ CREATE VIEW visible_entries AS
      JOIN entries e ON ((e.id = ue.entry_id)))
      LEFT JOIN subscription_feeds sf ON (((sf.user_id = ue.user_id) AND (sf.feed_id = e.feed_id))))
      LEFT JOIN subscriptions s ON ((s.id = sf.subscription_id)))
-  WHERE (((s.id IS NOT NULL) AND (s.unsubscribed_at IS NULL)) OR (ue.starred = true));
+  WHERE (((s.id IS NOT NULL) AND (s.unsubscribed_at IS NULL)) OR (ue.starred = true) OR (e.type = 'saved'::feed_type));
 
 --> statement-breakpoint
 

--- a/migrations/0073_drop_entry_scoring.sql
+++ b/migrations/0073_drop_entry_scoring.sql
@@ -1,0 +1,87 @@
+-- Drop the dead ML-scoring tables and rebuild visible_entries without them (issue #953).
+--
+-- entry_score_predictions and user_score_models (and the users columns
+-- algorithmic_feed_enabled / best_feed_score_weight / best_feed_uncertainty_weight)
+-- have no Drizzle definition and no application code referencing them — the
+-- entry-scoring feature was removed. Yet visible_entries still LEFT JOINed
+-- entry_score_predictions on every entries query, paying a dead join on the
+-- hottest path.
+--
+-- The rebuilt view also switches the visibility predicate from fail-open to
+-- fail-closed: the old `s.unsubscribed_at IS NULL` evaluates TRUE when the
+-- LEFT JOINs match no subscription at all, so an orphaned user_entries row
+-- (no subscription_feeds/subscriptions match) was visible. The documented
+-- rule is "active subscription OR starred", so require a matching active
+-- subscription explicitly.
+
+DROP VIEW visible_entries;
+
+--> statement-breakpoint
+
+CREATE VIEW visible_entries AS
+ SELECT ue.user_id,
+    e.id,
+    e.feed_id,
+    e.type,
+    e.guid,
+    e.url,
+    e.title,
+    e.author,
+    e.content_original,
+    e.content_cleaned,
+    e.summary,
+    e.site_name,
+    e.image_url,
+    e.published_at,
+    e.fetched_at,
+    e.last_seen_at,
+    e.content_hash,
+    e.full_content_hash,
+    e.spam_score,
+    e.is_spam,
+    e.list_unsubscribe_mailto,
+    e.list_unsubscribe_https,
+    e.list_unsubscribe_post,
+    e.created_at,
+    GREATEST(e.updated_at, ue.updated_at) AS updated_at,
+    e.full_content_original,
+    e.full_content_cleaned,
+    e.full_content_fetched_at,
+    e.full_content_error,
+    ue.read,
+    ue.starred,
+    ue.score,
+    ue.has_marked_read_on_list,
+    ue.has_marked_unread,
+    ue.has_starred,
+    s.id AS subscription_id,
+    e.unsubscribe_url,
+    ue.read_changed_at,
+    e.wallabag_id,
+    ue.published_or_fetched_at,
+    e.content_original_sanitized,
+    e.content_cleaned_sanitized,
+    e.content_sanitized_version,
+    e.full_content_original_sanitized,
+    e.full_content_cleaned_sanitized,
+    e.full_content_sanitized_version
+   FROM (((user_entries ue
+     JOIN entries e ON ((e.id = ue.entry_id)))
+     LEFT JOIN subscription_feeds sf ON (((sf.user_id = ue.user_id) AND (sf.feed_id = e.feed_id))))
+     LEFT JOIN subscriptions s ON ((s.id = sf.subscription_id)))
+  WHERE (((s.id IS NOT NULL) AND (s.unsubscribed_at IS NULL)) OR (ue.starred = true));
+
+--> statement-breakpoint
+
+DROP TABLE entry_score_predictions;
+
+--> statement-breakpoint
+
+DROP TABLE user_score_models;
+
+--> statement-breakpoint
+
+ALTER TABLE users
+  DROP COLUMN algorithmic_feed_enabled,
+  DROP COLUMN best_feed_score_weight,
+  DROP COLUMN best_feed_uncertainty_weight;

--- a/migrations/0074_jobs_polling_index.sql
+++ b/migrations/0074_jobs_polling_index.sql
@@ -1,0 +1,13 @@
+-- Restore the jobs polling index (issue #953).
+--
+-- 0046_simplify_jobs.sql dropped the jobs.enabled column, which implicitly
+-- dropped the old partial polling index (idx_jobs_polling ... WHERE enabled =
+-- true). Since then every claim query — claimJob, claimFeedJob, and
+-- claimSingletonJob run every ~5s by each worker — has been a sequential scan
+-- + sort over a table that grows by one row per feed forever.
+--
+-- All three claim queries filter on type (equality or ANY) and next_run_at
+-- (<= now) and order by next_run_at, so (type, next_run_at) serves them all
+-- with an ordered index scan.
+
+CREATE INDEX idx_jobs_polling ON jobs (type, next_run_at);

--- a/migrations/0075_cleanup_job.sql
+++ b/migrations/0075_cleanup_job.sql
@@ -1,0 +1,27 @@
+-- Support the new `cleanup` singleton job (issue #953).
+--
+-- 1. Extend the singleton-uniqueness partial index so claimSingletonJob's
+--    INSERT...catch race protection covers the new job type.
+--
+-- 2. Make oauth_refresh_tokens.replaced_by_id ON DELETE SET NULL. The rotation
+--    chain FK previously had no ON DELETE action, so deleting an expired token
+--    that a surviving (older) token still points at would fail; the cleanup
+--    job deletes expired/long-revoked refresh tokens in bulk.
+
+DROP INDEX jobs_singleton_type_unique;
+
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX jobs_singleton_type_unique ON jobs (type)
+  WHERE type IN ('renew_websub', 'monitor_feed_health', 'cleanup');
+
+--> statement-breakpoint
+
+ALTER TABLE oauth_refresh_tokens
+  DROP CONSTRAINT oauth_refresh_tokens_replaced_by_id_fkey;
+
+--> statement-breakpoint
+
+ALTER TABLE oauth_refresh_tokens
+  ADD CONSTRAINT oauth_refresh_tokens_replaced_by_id_fkey
+  FOREIGN KEY (replaced_by_id) REFERENCES oauth_refresh_tokens(id) ON DELETE SET NULL;

--- a/migrations/0076_redundant_indexes_and_invites_fk.sql
+++ b/migrations/0076_redundant_indexes_and_invites_fk.sql
@@ -1,0 +1,65 @@
+-- Drop redundant indexes and add the missing invites FK (issue #953).
+--
+-- Every token table carried both a UNIQUE constraint and a duplicate plain
+-- index on the same column — pure write amplification, the unique index
+-- already serves lookups. idx_subscriptions_user and idx_tags_user are
+-- prefixes of their tables' composite UNIQUE constraints, and
+-- idx_narration_needs_generation indexes the primary-key column.
+
+DROP INDEX idx_sessions_token; -- duplicate of sessions_token_hash_unique
+
+--> statement-breakpoint
+
+DROP INDEX idx_api_tokens_token; -- duplicate of api_tokens_token_hash_key
+
+--> statement-breakpoint
+
+DROP INDEX idx_oauth_access_tokens_token; -- duplicate of oauth_access_tokens_token_hash_key
+
+--> statement-breakpoint
+
+DROP INDEX idx_oauth_refresh_tokens_token; -- duplicate of oauth_refresh_tokens_token_hash_key
+
+--> statement-breakpoint
+
+DROP INDEX idx_oauth_auth_codes_code; -- duplicate of oauth_authorization_codes_code_hash_key
+
+--> statement-breakpoint
+
+DROP INDEX idx_oauth_clients_client_id; -- duplicate of oauth_clients_client_id_key
+
+--> statement-breakpoint
+
+DROP INDEX idx_ingest_addresses_token; -- duplicate of ingest_addresses_token_unique
+
+--> statement-breakpoint
+
+DROP INDEX idx_invites_token; -- duplicate of invites_token_unique
+
+--> statement-breakpoint
+
+DROP INDEX idx_subscriptions_user; -- prefix of uq_subscriptions_user_feed
+
+--> statement-breakpoint
+
+DROP INDEX idx_tags_user; -- prefix of uq_tags_user_name
+
+--> statement-breakpoint
+
+DROP INDEX idx_narration_needs_generation; -- indexed the primary-key column
+
+--> statement-breakpoint
+
+-- invites.used_by_user_id had no foreign key; user deletion (see
+-- deleteUser in src/server/services/users.ts) expects it to null out.
+-- Null out any references already left dangling by past user deletions so
+-- the constraint validates.
+UPDATE invites SET used_by_user_id = NULL
+WHERE used_by_user_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM users WHERE users.id = invites.used_by_user_id);
+
+--> statement-breakpoint
+
+ALTER TABLE invites
+  ADD CONSTRAINT invites_used_by_user_id_fkey
+  FOREIGN KEY (used_by_user_id) REFERENCES users(id) ON DELETE SET NULL;

--- a/migrations/CLAUDE.md
+++ b/migrations/CLAUDE.md
@@ -1,4 +1,5 @@
 - We use a custom migration runner, not drizzle-kit. The migration format looks like drizzle-kit's but drizzle-kit is not installed. Never run migrations with drizzle-kit, always use `pnpm db:migrate` or `pnpm db:migrate:test`. See ../scripts/migrate.ts if you need details.
-- Always add new migrations to meta/\_journal.json. Only migrations in the journal will be run.
+- Always add new migrations to meta/\_journal.json. Only migrations in the journal will be run (tests/unit/migrations-journal.test.ts enforces that every .sql file is journaled).
+- Never use `CREATE INDEX CONCURRENTLY` in a migration — the runner wraps each migration in a transaction, so it can't run. If an index must be built concurrently on production, apply it manually first, then journal a plain `CREATE INDEX IF NOT EXISTS` migration so other databases get it too.
 - Test new migrations using `pnpm test:integration`
 - Read @schema.sql and keep it up to date with `pnpm db:schema`

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -505,6 +505,13 @@
       "when": 1782950500000,
       "tag": "0072_entries_feed_published_sort_index",
       "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1782950600000,
+      "tag": "0073_drop_entry_scoring",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -512,6 +512,13 @@
       "when": 1782950600000,
       "tag": "0073_drop_entry_scoring",
       "breakpoints": true
+    },
+    {
+      "idx": 73,
+      "version": "7",
+      "when": 1782950700000,
+      "tag": "0074_jobs_polling_index",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -519,6 +519,13 @@
       "when": 1782950700000,
       "tag": "0074_jobs_polling_index",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
+      "when": 1782950800000,
+      "tag": "0075_cleanup_job",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -491,6 +491,20 @@
       "when": 1770708800000,
       "tag": "0070_sanitized_entry_html",
       "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1782950400000,
+      "tag": "0071_entries_published_sort_index",
+      "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1782950500000,
+      "tag": "0072_entries_feed_published_sort_index",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1782950800000,
       "tag": "0075_cleanup_job",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1782950900000,
+      "tag": "0076_redundant_indexes_and_invites_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -622,6 +622,8 @@ CREATE INDEX idx_invites_token ON public.invites USING btree (token);
 
 CREATE INDEX idx_jobs_feed_id ON public.jobs USING btree (((payload ->> 'feedId'::text))) WHERE (type = 'fetch_feed'::text);
 
+CREATE INDEX idx_jobs_polling ON public.jobs USING btree (type, next_run_at);
+
 CREATE INDEX idx_narration_needs_generation ON public.narration_content USING btree (id);
 
 CREATE INDEX idx_oauth_access_tokens_client ON public.oauth_access_tokens USING btree (client_id);

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -430,7 +430,7 @@ CREATE VIEW public.visible_entries AS
      JOIN public.entries e ON ((e.id = ue.entry_id)))
      LEFT JOIN public.subscription_feeds sf ON (((sf.user_id = ue.user_id) AND (sf.feed_id = e.feed_id))))
      LEFT JOIN public.subscriptions s ON ((s.id = sf.subscription_id)))
-  WHERE (((s.id IS NOT NULL) AND (s.unsubscribed_at IS NULL)) OR (ue.starred = true));
+  WHERE (((s.id IS NOT NULL) AND (s.unsubscribed_at IS NULL)) OR (ue.starred = true) OR (e.type = 'saved'::public.feed_type));
 
 CREATE TABLE public.websub_subscriptions (
     id uuid NOT NULL,
@@ -580,8 +580,6 @@ ALTER TABLE ONLY public.users
 ALTER TABLE ONLY public.websub_subscriptions
     ADD CONSTRAINT websub_subscriptions_pkey PRIMARY KEY (id);
 
-CREATE INDEX idx_api_tokens_token ON public.api_tokens USING btree (token_hash);
-
 CREATE INDEX idx_api_tokens_user ON public.api_tokens USING btree (user_id);
 
 CREATE INDEX idx_blocked_senders_user ON public.blocked_senders USING btree (user_id);
@@ -612,25 +610,17 @@ CREATE INDEX idx_feeds_type ON public.feeds USING btree (type);
 
 CREATE INDEX idx_feeds_user_id ON public.feeds USING btree (user_id);
 
-CREATE INDEX idx_ingest_addresses_token ON public.ingest_addresses USING btree (token);
-
 CREATE INDEX idx_ingest_addresses_user ON public.ingest_addresses USING btree (user_id);
 
 CREATE INDEX idx_invites_expires ON public.invites USING btree (expires_at);
-
-CREATE INDEX idx_invites_token ON public.invites USING btree (token);
 
 CREATE INDEX idx_jobs_feed_id ON public.jobs USING btree (((payload ->> 'feedId'::text))) WHERE (type = 'fetch_feed'::text);
 
 CREATE INDEX idx_jobs_polling ON public.jobs USING btree (type, next_run_at);
 
-CREATE INDEX idx_narration_needs_generation ON public.narration_content USING btree (id);
-
 CREATE INDEX idx_oauth_access_tokens_client ON public.oauth_access_tokens USING btree (client_id);
 
 CREATE INDEX idx_oauth_access_tokens_expires ON public.oauth_access_tokens USING btree (expires_at);
-
-CREATE INDEX idx_oauth_access_tokens_token ON public.oauth_access_tokens USING btree (token_hash);
 
 CREATE INDEX idx_oauth_access_tokens_user ON public.oauth_access_tokens USING btree (user_id);
 
@@ -638,13 +628,9 @@ CREATE INDEX idx_oauth_accounts_scopes ON public.oauth_accounts USING gin (scope
 
 CREATE INDEX idx_oauth_accounts_user ON public.oauth_accounts USING btree (user_id);
 
-CREATE INDEX idx_oauth_auth_codes_code ON public.oauth_authorization_codes USING btree (code_hash);
-
 CREATE INDEX idx_oauth_auth_codes_expires ON public.oauth_authorization_codes USING btree (expires_at);
 
 CREATE INDEX idx_oauth_auth_codes_user ON public.oauth_authorization_codes USING btree (user_id);
-
-CREATE INDEX idx_oauth_clients_client_id ON public.oauth_clients USING btree (client_id);
 
 CREATE INDEX idx_oauth_consent_grants_client ON public.oauth_consent_grants USING btree (client_id);
 
@@ -656,8 +642,6 @@ CREATE INDEX idx_oauth_refresh_tokens_client ON public.oauth_refresh_tokens USIN
 
 CREATE INDEX idx_oauth_refresh_tokens_expires ON public.oauth_refresh_tokens USING btree (expires_at);
 
-CREATE INDEX idx_oauth_refresh_tokens_token ON public.oauth_refresh_tokens USING btree (token_hash);
-
 CREATE INDEX idx_oauth_refresh_tokens_user ON public.oauth_refresh_tokens USING btree (user_id);
 
 CREATE INDEX idx_opml_imports_status ON public.opml_imports USING btree (status);
@@ -665,8 +649,6 @@ CREATE INDEX idx_opml_imports_status ON public.opml_imports USING btree (status)
 CREATE INDEX idx_opml_imports_user ON public.opml_imports USING btree (user_id);
 
 CREATE INDEX idx_sessions_last_active ON public.sessions USING btree (last_active_at);
-
-CREATE INDEX idx_sessions_token ON public.sessions USING btree (token_hash);
 
 CREATE INDEX idx_sessions_user ON public.sessions USING btree (user_id);
 
@@ -682,13 +664,9 @@ CREATE INDEX idx_subscriptions_feed ON public.subscriptions USING btree (feed_id
 
 CREATE INDEX idx_subscriptions_feed_active ON public.subscriptions USING btree (feed_id) WHERE (unsubscribed_at IS NULL);
 
-CREATE INDEX idx_subscriptions_user ON public.subscriptions USING btree (user_id);
-
 CREATE INDEX idx_subscriptions_user_active ON public.subscriptions USING btree (user_id) WHERE (unsubscribed_at IS NULL);
 
 CREATE INDEX idx_tags_updated_at ON public.tags USING btree (user_id, updated_at);
-
-CREATE INDEX idx_tags_user ON public.tags USING btree (user_id);
 
 CREATE INDEX idx_user_entries_entry_id ON public.user_entries USING btree (entry_id);
 
@@ -729,6 +707,9 @@ ALTER TABLE ONLY public.feeds
 
 ALTER TABLE ONLY public.ingest_addresses
     ADD CONSTRAINT ingest_addresses_user_id_users_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.invites
+    ADD CONSTRAINT invites_used_by_user_id_fkey FOREIGN KEY (used_by_user_id) REFERENCES public.users(id) ON DELETE SET NULL;
 
 ALTER TABLE ONLY public.oauth_access_tokens
     ADD CONSTRAINT oauth_access_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -99,15 +99,6 @@ CREATE TABLE public.entries (
     CONSTRAINT entries_unsubscribe_only_email CHECK (((type = 'email'::public.feed_type) OR ((list_unsubscribe_mailto IS NULL) AND (list_unsubscribe_https IS NULL) AND (list_unsubscribe_post IS NULL))))
 );
 
-CREATE TABLE public.entry_score_predictions (
-    user_id uuid NOT NULL,
-    entry_id uuid NOT NULL,
-    predicted_score real NOT NULL,
-    confidence real NOT NULL,
-    model_version integer NOT NULL,
-    predicted_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
 CREATE TABLE public.entry_summaries (
     id uuid NOT NULL,
     content_hash text NOT NULL,
@@ -369,21 +360,6 @@ CREATE VIEW public.user_feeds AS
      JOIN public.feeds f ON ((f.id = s.feed_id)))
   WHERE (s.unsubscribed_at IS NULL);
 
-CREATE TABLE public.user_score_models (
-    user_id uuid NOT NULL,
-    model_data text NOT NULL,
-    vocabulary jsonb NOT NULL,
-    idf_values jsonb NOT NULL,
-    feed_ids text[] NOT NULL,
-    training_count integer NOT NULL,
-    model_version integer DEFAULT 1 NOT NULL,
-    trained_at timestamp with time zone DEFAULT now() NOT NULL,
-    cv_mae real,
-    cv_correlation real,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
 CREATE TABLE public.users (
     id uuid NOT NULL,
     email public.citext NOT NULL,
@@ -398,9 +374,6 @@ CREATE TABLE public.users (
     summarization_model text,
     summarization_max_words integer,
     summarization_prompt text,
-    algorithmic_feed_enabled boolean DEFAULT true NOT NULL,
-    best_feed_score_weight real DEFAULT 1 NOT NULL,
-    best_feed_uncertainty_weight real DEFAULT 1 NOT NULL,
     tos_agreed_at timestamp with time zone,
     privacy_policy_agreed_at timestamp with time zone,
     not_eu_agreed_at timestamp with time zone
@@ -443,8 +416,6 @@ CREATE VIEW public.visible_entries AS
     ue.has_marked_unread,
     ue.has_starred,
     s.id AS subscription_id,
-    esp.predicted_score,
-    esp.confidence AS prediction_confidence,
     e.unsubscribe_url,
     ue.read_changed_at,
     e.wallabag_id,
@@ -455,12 +426,11 @@ CREATE VIEW public.visible_entries AS
     e.full_content_original_sanitized,
     e.full_content_cleaned_sanitized,
     e.full_content_sanitized_version
-   FROM ((((public.user_entries ue
+   FROM (((public.user_entries ue
      JOIN public.entries e ON ((e.id = ue.entry_id)))
      LEFT JOIN public.subscription_feeds sf ON (((sf.user_id = ue.user_id) AND (sf.feed_id = e.feed_id))))
      LEFT JOIN public.subscriptions s ON ((s.id = sf.subscription_id)))
-     LEFT JOIN public.entry_score_predictions esp ON (((esp.user_id = ue.user_id) AND (esp.entry_id = e.id))))
-  WHERE ((s.unsubscribed_at IS NULL) OR (ue.starred = true));
+  WHERE (((s.id IS NOT NULL) AND (s.unsubscribed_at IS NULL)) OR (ue.starred = true));
 
 CREATE TABLE public.websub_subscriptions (
     id uuid NOT NULL,
@@ -489,9 +459,6 @@ ALTER TABLE ONLY public.blocked_senders
 
 ALTER TABLE ONLY public.entries
     ADD CONSTRAINT entries_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY public.entry_score_predictions
-    ADD CONSTRAINT entry_score_predictions_pkey PRIMARY KEY (user_id, entry_id);
 
 ALTER TABLE ONLY public.entry_summaries
     ADD CONSTRAINT entry_summaries_pkey PRIMARY KEY (id);
@@ -604,9 +571,6 @@ ALTER TABLE ONLY public.websub_subscriptions
 ALTER TABLE ONLY public.user_entries
     ADD CONSTRAINT user_entry_states_user_id_entry_id_pk PRIMARY KEY (user_id, entry_id);
 
-ALTER TABLE ONLY public.user_score_models
-    ADD CONSTRAINT user_score_models_pkey PRIMARY KEY (user_id);
-
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_email_unique UNIQUE (email);
 
@@ -639,10 +603,6 @@ CREATE INDEX idx_entries_spam ON public.entries USING btree (feed_id, is_spam);
 CREATE INDEX idx_entries_type ON public.entries USING btree (type);
 
 CREATE INDEX idx_entries_wallabag_id ON public.entries USING btree (wallabag_id);
-
-CREATE INDEX idx_entry_score_predictions_entry ON public.entry_score_predictions USING btree (entry_id);
-
-CREATE INDEX idx_entry_score_predictions_user_score ON public.entry_score_predictions USING btree (user_id, predicted_score DESC);
 
 CREATE INDEX idx_entry_summaries_prompt_version ON public.entry_summaries USING btree (prompt_version) WHERE (summary_text IS NOT NULL);
 
@@ -740,8 +700,6 @@ CREATE INDEX idx_user_entries_unread ON public.user_entries USING btree (user_id
 
 CREATE INDEX idx_user_entries_updated_at ON public.user_entries USING btree (user_id, updated_at);
 
-CREATE INDEX idx_user_score_models_trained ON public.user_score_models USING btree (trained_at);
-
 CREATE INDEX idx_websub_expiring ON public.websub_subscriptions USING btree (expires_at);
 
 CREATE INDEX idx_websub_feed ON public.websub_subscriptions USING btree (feed_id);
@@ -760,12 +718,6 @@ ALTER TABLE ONLY public.blocked_senders
 
 ALTER TABLE ONLY public.entries
     ADD CONSTRAINT entries_feed_id_feeds_id_fk FOREIGN KEY (feed_id) REFERENCES public.feeds(id) ON DELETE CASCADE;
-
-ALTER TABLE ONLY public.entry_score_predictions
-    ADD CONSTRAINT entry_score_predictions_entry_id_fkey FOREIGN KEY (entry_id) REFERENCES public.entries(id) ON DELETE CASCADE;
-
-ALTER TABLE ONLY public.entry_score_predictions
-    ADD CONSTRAINT entry_score_predictions_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY public.entry_summaries
     ADD CONSTRAINT entry_summaries_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
@@ -832,9 +784,6 @@ ALTER TABLE ONLY public.user_entries
 
 ALTER TABLE ONLY public.user_entries
     ADD CONSTRAINT user_entry_states_user_id_users_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
-
-ALTER TABLE ONLY public.user_score_models
-    ADD CONSTRAINT user_score_models_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_invite_id_invites_id_fk FOREIGN KEY (invite_id) REFERENCES public.invites(id) ON DELETE SET NULL;

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -706,7 +706,7 @@ CREATE INDEX idx_websub_expiring ON public.websub_subscriptions USING btree (exp
 
 CREATE INDEX idx_websub_feed ON public.websub_subscriptions USING btree (feed_id);
 
-CREATE UNIQUE INDEX jobs_singleton_type_unique ON public.jobs USING btree (type) WHERE (type = ANY (ARRAY['renew_websub'::text, 'monitor_feed_health'::text]));
+CREATE UNIQUE INDEX jobs_singleton_type_unique ON public.jobs USING btree (type) WHERE (type = ANY (ARRAY['renew_websub'::text, 'monitor_feed_health'::text, 'cleanup'::text]));
 
 CREATE UNIQUE INDEX uq_feeds_saved_user ON public.feeds USING btree (user_id) WHERE (type = 'saved'::public.feed_type);
 
@@ -746,7 +746,7 @@ ALTER TABLE ONLY public.oauth_refresh_tokens
     ADD CONSTRAINT oauth_refresh_tokens_access_token_id_fkey FOREIGN KEY (access_token_id) REFERENCES public.oauth_access_tokens(id) ON DELETE SET NULL;
 
 ALTER TABLE ONLY public.oauth_refresh_tokens
-    ADD CONSTRAINT oauth_refresh_tokens_replaced_by_id_fkey FOREIGN KEY (replaced_by_id) REFERENCES public.oauth_refresh_tokens(id);
+    ADD CONSTRAINT oauth_refresh_tokens_replaced_by_id_fkey FOREIGN KEY (replaced_by_id) REFERENCES public.oauth_refresh_tokens(id) ON DELETE SET NULL;
 
 ALTER TABLE ONLY public.oauth_refresh_tokens
     ADD CONSTRAINT oauth_refresh_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -808,10 +808,13 @@ export const jobs = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    // Index for polling: jobs that are due
-    index("idx_jobs_polling").on(table.nextRunAt),
+    // Index for polling: claim queries filter on type + next_run_at <= now
+    // and order by next_run_at (restored by migration 0074)
+    index("idx_jobs_polling").on(table.type, table.nextRunAt),
     // Index for looking up feed jobs by feedId
-    index("idx_jobs_feed_id").on(sql`(${table.payload}->>'feedId')`),
+    index("idx_jobs_feed_id")
+      .on(sql`(${table.payload}->>'feedId')`)
+      .where(sql`type = 'fetch_feed'`),
     // Enforce one row per singleton job type so claimSingletonJob's
     // INSERT...catch actually races correctly (see SINGLETON_JOB_TYPES).
     uniqueIndex("jobs_singleton_type_unique")

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -819,7 +819,7 @@ export const jobs = pgTable(
     // INSERT...catch actually races correctly (see SINGLETON_JOB_TYPES).
     uniqueIndex("jobs_singleton_type_unique")
       .on(table.type)
-      .where(sql`type IN ('renew_websub', 'monitor_feed_health')`),
+      .where(sql`type IN ('renew_websub', 'monitor_feed_health', 'cleanup')`),
   ]
 );
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,6 +1,7 @@
 import {
   boolean,
   check,
+  customType,
   index,
   integer,
   jsonb,
@@ -15,8 +16,19 @@ import {
   unique,
   uniqueIndex,
   uuid,
+  type AnyPgColumn,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
+
+/**
+ * Postgres citext (case-insensitive text). Behaves as a plain string in
+ * TypeScript; the case-insensitive comparison semantics live in the database.
+ */
+const citext = customType<{ data: string }>({
+  dataType() {
+    return "citext";
+  },
+});
 
 // ============================================================================
 // ENUMS
@@ -41,13 +53,12 @@ export const invites = pgTable(
     token: text("token").unique().notNull(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     usedAt: timestamp("used_at", { withTimezone: true }),
-    usedByUserId: uuid("used_by_user_id"), // FK added after users table defined
+    usedByUserId: uuid("used_by_user_id").references((): AnyPgColumn => users.id, {
+      onDelete: "set null",
+    }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [
-    index("idx_invites_token").on(table.token),
-    index("idx_invites_expires").on(table.expiresAt),
-  ]
+  (table) => [index("idx_invites_expires").on(table.expiresAt)]
 );
 
 /**
@@ -56,7 +67,7 @@ export const invites = pgTable(
  */
 export const users = pgTable("users", {
   id: uuid("id").primaryKey(),
-  email: text("email").unique().notNull(),
+  email: citext("email").unique().notNull(),
   emailVerifiedAt: timestamp("email_verified_at", { withTimezone: true }),
   passwordHash: text("password_hash"), // null if OAuth-only (future)
   inviteId: uuid("invite_id").references(() => invites.id, { onDelete: "set null" }),
@@ -101,10 +112,7 @@ export const sessions = pgTable(
     revokedAt: timestamp("revoked_at", { withTimezone: true }),
     lastActiveAt: timestamp("last_active_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [
-    index("idx_sessions_user").on(table.userId),
-    index("idx_sessions_token").on(table.tokenHash),
-  ]
+  (table) => [index("idx_sessions_user").on(table.userId)]
 );
 
 /**
@@ -135,10 +143,7 @@ export const apiTokens = pgTable(
     revokedAt: timestamp("revoked_at", { withTimezone: true }),
     lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
   },
-  (table) => [
-    index("idx_api_tokens_user").on(table.userId),
-    index("idx_api_tokens_token").on(table.tokenHash),
-  ]
+  (table) => [index("idx_api_tokens_user").on(table.userId)]
 );
 
 // ============================================================================
@@ -185,26 +190,22 @@ export const oauthAccounts = pgTable(
  * OAuth clients table - registered OAuth 2.1 clients.
  * Supports both pre-registered clients and Client ID Metadata Documents (CIMD).
  */
-export const oauthClients = pgTable(
-  "oauth_clients",
-  {
-    id: uuid("id").primaryKey(),
-    clientId: text("client_id").unique().notNull(), // URL for CIMD, or custom ID
-    clientSecretHash: text("client_secret_hash"), // NULL for public clients
-    name: text("name").notNull(),
-    redirectUris: text("redirect_uris").array().notNull(), // Allowed redirect URIs
-    grantTypes: text("grant_types")
-      .array()
-      .notNull()
-      .default(sql`'{authorization_code,refresh_token}'`),
-    scopes: text("scopes").array(), // Available scopes for this client
-    isPublic: boolean("is_public").notNull().default(true), // PKCE required for public clients
-    metadataUrl: text("metadata_url"), // For Client ID Metadata Documents
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-  },
-  (table) => [index("idx_oauth_clients_client_id").on(table.clientId)]
-);
+export const oauthClients = pgTable("oauth_clients", {
+  id: uuid("id").primaryKey(),
+  clientId: text("client_id").unique().notNull(), // URL for CIMD, or custom ID
+  clientSecretHash: text("client_secret_hash"), // NULL for public clients
+  name: text("name").notNull(),
+  redirectUris: text("redirect_uris").array().notNull(), // Allowed redirect URIs
+  grantTypes: text("grant_types")
+    .array()
+    .notNull()
+    .default(sql`'{authorization_code,refresh_token}'`),
+  scopes: text("scopes").array(), // Available scopes for this client
+  isPublic: boolean("is_public").notNull().default(true), // PKCE required for public clients
+  metadataUrl: text("metadata_url"), // For Client ID Metadata Documents
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
 
 /**
  * OAuth authorization codes table - short-lived codes for OAuth flow.
@@ -231,7 +232,6 @@ export const oauthAuthorizationCodes = pgTable(
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
   },
   (table) => [
-    index("idx_oauth_auth_codes_code").on(table.codeHash),
     index("idx_oauth_auth_codes_user").on(table.userId),
     index("idx_oauth_auth_codes_expires").on(table.expiresAt),
     check("oauth_auth_codes_pkce_s256", sql`${table.codeChallengeMethod} = 'S256'`),
@@ -259,7 +259,6 @@ export const oauthAccessTokens = pgTable(
     lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
   },
   (table) => [
-    index("idx_oauth_access_tokens_token").on(table.tokenHash),
     index("idx_oauth_access_tokens_user").on(table.userId),
     index("idx_oauth_access_tokens_client").on(table.clientId),
     index("idx_oauth_access_tokens_expires").on(table.expiresAt),
@@ -290,7 +289,6 @@ export const oauthRefreshTokens = pgTable(
     replacedById: uuid("replaced_by_id"), // Token rotation chain (self-reference added manually)
   },
   (table) => [
-    index("idx_oauth_refresh_tokens_token").on(table.tokenHash),
     index("idx_oauth_refresh_tokens_user").on(table.userId),
     index("idx_oauth_refresh_tokens_client").on(table.clientId),
     index("idx_oauth_refresh_tokens_expires").on(table.expiresAt),
@@ -356,6 +354,9 @@ export const feeds = pgTable(
     // Timestamp when entries last changed (new, updated, or removed from feed)
     // This matches entries.lastSeenAt for entries currently in the feed
     lastEntriesUpdatedAt: timestamp("last_entries_updated_at", { withTimezone: true }),
+    // Informational copy of the schedule for display surfaces (feed stats,
+    // broken feeds, admin). The authoritative value is jobs.next_run_at —
+    // job claiming never reads this column, and the two can drift.
     nextFetchAt: timestamp("next_fetch_at", { withTimezone: true }),
 
     // Error tracking
@@ -524,7 +525,6 @@ export const tags = pgTable(
     // Each user can only have one tag with a given name
     unique("uq_tags_user_name").on(table.userId, table.name),
     // Index for listing tags by user
-    index("idx_tags_user").on(table.userId),
     // Index for sync queries
     index("idx_tags_updated_at").on(table.userId, table.updatedAt),
   ]
@@ -584,7 +584,6 @@ export const subscriptions = pgTable(
   (table) => [
     // Unique constraint on user + feed
     unique("uq_subscriptions_user_feed").on(table.userId, table.feedId),
-    index("idx_subscriptions_user").on(table.userId),
     index("idx_subscriptions_feed").on(table.feedId),
   ]
 );
@@ -719,7 +718,8 @@ export const userFeeds = pgView("user_feeds", {
  * visible_entries view - Entries with visibility rules and subscription context.
  * An entry is visible if:
  * 1. User has a user_entries row for it, AND
- * 2. Either the entry is from an active subscription, OR the entry is starred
+ * 2. Either the entry is from an active subscription, OR the entry is starred,
+ *    OR it is a saved article (saved feeds have no subscription rows)
  *
  * Note: This view is defined in migration 0035_subscription_views.sql
  * (most recently redefined in 0073_drop_entry_scoring.sql).
@@ -872,26 +872,19 @@ export const websubSubscriptions = pgTable(
  * Narration content table - stores LLM-processed text for text-to-speech.
  * Keyed by content hash for deduplication across entries and saved articles.
  */
-export const narrationContent = pgTable(
-  "narration_content",
-  {
-    id: uuid("id").primaryKey(), // UUIDv7
-    contentHash: text("content_hash").unique().notNull(), // SHA256 of source content
+export const narrationContent = pgTable("narration_content", {
+  id: uuid("id").primaryKey(), // UUIDv7
+  contentHash: text("content_hash").unique().notNull(), // SHA256 of source content
 
-    contentNarration: text("content_narration"), // null until generated
-    generatedAt: timestamp("generated_at", { withTimezone: true }),
+  contentNarration: text("content_narration"), // null until generated
+  generatedAt: timestamp("generated_at", { withTimezone: true }),
 
-    // Error tracking for retry logic
-    error: text("error"),
-    errorAt: timestamp("error_at", { withTimezone: true }),
+  // Error tracking for retry logic
+  error: text("error"),
+  errorAt: timestamp("error_at", { withTimezone: true }),
 
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  },
-  (table) => [
-    // Index for finding narration that needs generation (null narration, no recent error)
-    index("idx_narration_needs_generation").on(table.id),
-  ]
-);
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
 
 // ============================================================================
 // AI SUMMARIZATION
@@ -911,7 +904,7 @@ export const entrySummaries = pgTable(
 
     summaryText: text("summary_text"), // null until generated
     modelId: text("model_id"), // e.g., "claude-sonnet-4-20250514"
-    promptVersion: integer("prompt_version").notNull().default(1), // for cache invalidation
+    promptVersion: smallint("prompt_version").notNull().default(1), // for cache invalidation
 
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     generatedAt: timestamp("generated_at", { withTimezone: true }), // when summary was generated
@@ -945,7 +938,7 @@ export const ingestAddresses = pgTable(
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
 
-    token: text("token").unique().notNull(), // Random token for the email address
+    token: citext("token").unique().notNull(), // Random token for the email address
     label: text("label"), // User-provided name for the address
 
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -954,8 +947,6 @@ export const ingestAddresses = pgTable(
   (table) => [
     // For listing addresses by user
     index("idx_ingest_addresses_user").on(table.userId),
-    // For looking up by token during email processing
-    index("idx_ingest_addresses_token").on(table.token),
   ]
 );
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -721,7 +721,8 @@ export const userFeeds = pgView("user_feeds", {
  * 1. User has a user_entries row for it, AND
  * 2. Either the entry is from an active subscription, OR the entry is starred
  *
- * Note: This view is defined in migration 0035_subscription_views.sql.
+ * Note: This view is defined in migration 0035_subscription_views.sql
+ * (most recently redefined in 0073_drop_entry_scoring.sql).
  * The Drizzle definition here allows type-safe queries against the view.
  */
 export const visibleEntries = pgView("visible_entries", {

--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -59,6 +59,7 @@ import {
 import { generateUuidv7 } from "@/lib/uuidv7";
 import { getFeedPlugin } from "@/server/plugins";
 import { createSubscription } from "../services/subscriptions";
+import { runRetentionCleanup } from "../services/retention";
 import {
   findPermanentRedirectUrl,
   isHttpToHttpsUpgrade,
@@ -1349,6 +1350,33 @@ export async function handleMonitorFeedHealth(
       failingFeedCount: snapshot.failingFeedCount,
       pollableFeedCount: snapshot.pollableFeedCount,
     },
+  };
+}
+
+/** How often the retention cleanup runs. */
+const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Handler for cleanup jobs (singleton, runs daily).
+ *
+ * Deletes rows that expire but were never deleted anywhere (issue #953):
+ * expired sessions, expired OAuth authorization codes / access tokens /
+ * refresh tokens, long-revoked credentials, and parked one-time
+ * process_opml_import jobs. See src/server/services/retention.ts.
+ */
+export async function handleCleanup(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _payload: JobPayloads["cleanup"]
+): Promise<JobHandlerResult> {
+  const now = new Date();
+  const deleted = await runRetentionCleanup(db);
+
+  logger.info("Retention cleanup completed", { ...deleted });
+
+  return {
+    success: true,
+    nextRunAt: new Date(now.getTime() + CLEANUP_INTERVAL_MS),
+    metadata: { ...deleted },
   };
 }
 

--- a/src/server/jobs/queue.ts
+++ b/src/server/jobs/queue.ts
@@ -564,13 +564,16 @@ export async function claimSingletonJob(type: JobType): Promise<Job | null> {
       throw error;
     }
 
-    // Another worker created the job first - try to claim it
+    // Another worker created the job first - try to claim it. Keep the
+    // next_run_at <= now check: if the winner already ran and rescheduled the
+    // job, we must not immediately re-run it.
     const retryResult = await db.execute<RawJobRow>(sql`
       UPDATE ${jobs}
       SET
         running_since = ${now},
         updated_at = ${now}
       WHERE type = ${type}
+        AND next_run_at <= ${now}
         AND (running_since IS NULL OR running_since < ${staleThreshold})
       RETURNING *
     `);
@@ -579,7 +582,7 @@ export async function claimSingletonJob(type: JobType): Promise<Job | null> {
       return rowToJob(retryResult.rows[0]);
     }
 
-    // Job exists and is running - that's fine
+    // Job exists and is running or already rescheduled - that's fine
     return null;
   }
 }

--- a/src/server/jobs/queue.ts
+++ b/src/server/jobs/queue.ts
@@ -87,6 +87,9 @@ export interface JobPayloads {
   // de-duplication are owned by the external healthchecks.io monitor, so no
   // state is carried across runs.
   monitor_feed_health: Record<string, never>;
+  // Daily retention cleanup of expired/revoked credentials and parked
+  // one-time jobs. See src/server/services/retention.ts.
+  cleanup: Record<string, never>;
 }
 
 export type JobType = keyof JobPayloads;
@@ -491,7 +494,7 @@ export async function listJobs(
 /**
  * Singleton job types that have exactly one instance and self-create on first run.
  */
-export const SINGLETON_JOB_TYPES: JobType[] = ["renew_websub", "monitor_feed_health"];
+export const SINGLETON_JOB_TYPES: JobType[] = ["renew_websub", "monitor_feed_health", "cleanup"];
 
 /**
  * Tries to claim a singleton job for processing.

--- a/src/server/jobs/queue.ts
+++ b/src/server/jobs/queue.ts
@@ -115,6 +115,39 @@ const STALE_JOB_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 export const JOB_LEASE_HEARTBEAT_MS = 60 * 1000; // 1 minute
 
 /**
+ * Base delay before retrying a job whose handler threw: 1 minute.
+ */
+const EXCEPTION_RETRY_BASE_MS = 60 * 1000;
+
+/**
+ * Maximum delay between retries of a job whose handler keeps throwing: 24 hours.
+ */
+const EXCEPTION_RETRY_MAX_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Calculates the retry delay for a job whose handler threw an exception.
+ *
+ * Handlers that fail gracefully return their own nextRunAt (feed fetches use
+ * calculateNextFetch's failure backoff), but an unexpected throw used to be
+ * retried on a flat 60s forever — a deterministically-throwing handler would
+ * hammer its remote host every minute (issue #953). Instead, mirror the feed
+ * failure backoff: exponential from 1 minute, doubling per consecutive
+ * failure, capped at 24 hours (1m, 2m, 4m, ... ~17h, 24h).
+ *
+ * @param consecutiveFailures - The job's failure count *before* this failure
+ *   (i.e. `job.consecutiveFailures` as claimed; finishJob increments it)
+ * @returns Delay in milliseconds until the next retry
+ */
+export function calculateExceptionRetryDelayMs(consecutiveFailures: number): number {
+  const exponent = Math.max(0, consecutiveFailures);
+  // Avoid overflow for huge failure counts: past 2^31 the cap always wins.
+  if (exponent >= 31) {
+    return EXCEPTION_RETRY_MAX_MS;
+  }
+  return Math.min(EXCEPTION_RETRY_BASE_MS * 2 ** exponent, EXCEPTION_RETRY_MAX_MS);
+}
+
+/**
  * Options for creating a new job.
  */
 export interface CreateJobOptions<T extends JobType> {

--- a/src/server/jobs/worker.ts
+++ b/src/server/jobs/worker.ts
@@ -29,6 +29,7 @@ import {
   handleRenewWebsub,
   handleProcessOpmlImport,
   handleMonitorFeedHealth,
+  handleCleanup,
   type JobHandlerResult,
 } from "./handlers";
 import type { Job } from "../db/schema";
@@ -313,6 +314,11 @@ function createWorker(config: WorkerConfig = {}): Worker {
         case "monitor_feed_health": {
           const payload = getJobPayload<"monitor_feed_health">(job);
           result = await handleMonitorFeedHealth(payload);
+          break;
+        }
+        case "cleanup": {
+          const payload = getJobPayload<"cleanup">(job);
+          result = await handleCleanup(payload);
           break;
         }
         case "process_opml_import": {

--- a/src/server/jobs/worker.ts
+++ b/src/server/jobs/worker.ts
@@ -13,6 +13,7 @@
  */
 
 import {
+  calculateExceptionRetryDelayMs,
   claimJob as defaultClaimJob,
   claimSingletonJob,
   claimFeedJob,
@@ -362,8 +363,11 @@ function createWorker(config: WorkerConfig = {}): Worker {
       const duration = Date.now() - startTime;
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
 
-      // On exception, schedule retry with backoff
-      const nextRunAt = new Date(Date.now() + 60 * 1000); // 1 minute
+      // On exception, schedule the retry with exponential backoff based on how
+      // many times this job has failed in a row (finishJob increments the count).
+      const nextRunAt = new Date(
+        Date.now() + calculateExceptionRetryDelayMs(job.consecutiveFailures)
+      );
 
       try {
         await finishWithLease({

--- a/src/server/services/retention.ts
+++ b/src/server/services/retention.ts
@@ -1,0 +1,110 @@
+/**
+ * Retention cleanup for rows that expire but were never deleted (issue #953).
+ *
+ * Run by the `cleanup` singleton job once a day. Every row deleted here is
+ * already dead to the application — expired/revoked credentials all fail
+ * validation on their read paths, and parked one-time jobs never run again —
+ * so deletion only reclaims space and index bloat, never changes behavior.
+ */
+
+import { and, eq, gt, isNull, lt, or } from "drizzle-orm";
+import type { Database } from "../db";
+import {
+  jobs,
+  oauthAccessTokens,
+  oauthAuthorizationCodes,
+  oauthRefreshTokens,
+  sessions,
+} from "../db/schema";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Grace period after expiry before a row is deleted. Generous slack for clock
+ * skew and in-flight requests; these rows already fail validation everywhere.
+ */
+const EXPIRY_GRACE_MS = DAY_MS;
+
+/**
+ * How long revoked sessions and refresh tokens are retained after revocation.
+ * Revoked refresh tokens are kept for a while so rotation reuse-detection
+ * (spotting a stolen token being replayed) still has something to match.
+ */
+const REVOKED_RETENTION_MS = 30 * DAY_MS;
+
+/**
+ * One-time jobs are "parked" after completion by scheduling them far in the
+ * future (365 days; see handleProcessOpmlImport). Anything scheduled further
+ * out than this threshold is such a parked job and can be deleted.
+ */
+const PARKED_JOB_THRESHOLD_MS = 180 * DAY_MS;
+
+/**
+ * Row counts deleted by a cleanup run, keyed for job metadata/logging.
+ */
+export interface RetentionCleanupResult {
+  sessions: number;
+  oauthAuthorizationCodes: number;
+  oauthAccessTokens: number;
+  oauthRefreshTokens: number;
+  parkedJobs: number;
+}
+
+/**
+ * Deletes expired/revoked credentials and parked one-time jobs.
+ */
+export async function runRetentionCleanup(db: Database): Promise<RetentionCleanupResult> {
+  const now = Date.now();
+  const expiryCutoff = new Date(now - EXPIRY_GRACE_MS);
+  const revokedCutoff = new Date(now - REVOKED_RETENTION_MS);
+  const parkedCutoff = new Date(now + PARKED_JOB_THRESHOLD_MS);
+
+  const expiredSessions = await db
+    .delete(sessions)
+    .where(or(lt(sessions.expiresAt, expiryCutoff), lt(sessions.revokedAt, revokedCutoff)));
+
+  const expiredAuthCodes = await db
+    .delete(oauthAuthorizationCodes)
+    .where(lt(oauthAuthorizationCodes.expiresAt, expiryCutoff));
+
+  // Refresh tokens reference access tokens with ON DELETE SET NULL, and the
+  // rotation chain (replaced_by_id) is also SET NULL, so bulk deletes can't
+  // fail on FK order.
+  const expiredAccessTokens = await db
+    .delete(oauthAccessTokens)
+    .where(
+      or(
+        lt(oauthAccessTokens.expiresAt, expiryCutoff),
+        lt(oauthAccessTokens.revokedAt, revokedCutoff)
+      )
+    );
+
+  const expiredRefreshTokens = await db
+    .delete(oauthRefreshTokens)
+    .where(
+      or(
+        lt(oauthRefreshTokens.expiresAt, expiryCutoff),
+        lt(oauthRefreshTokens.revokedAt, revokedCutoff)
+      )
+    );
+
+  // Completed one-time jobs park themselves by scheduling next_run_at a year
+  // out. running_since IS NULL guards against deleting anything in flight.
+  const parkedJobs = await db
+    .delete(jobs)
+    .where(
+      and(
+        eq(jobs.type, "process_opml_import"),
+        isNull(jobs.runningSince),
+        gt(jobs.nextRunAt, parkedCutoff)
+      )
+    );
+
+  return {
+    sessions: expiredSessions.rowCount ?? 0,
+    oauthAuthorizationCodes: expiredAuthCodes.rowCount ?? 0,
+    oauthAccessTokens: expiredAccessTokens.rowCount ?? 0,
+    oauthRefreshTokens: expiredRefreshTokens.rowCount ?? 0,
+    parkedJobs: parkedJobs.rowCount ?? 0,
+  };
+}

--- a/src/server/services/users.ts
+++ b/src/server/services/users.ts
@@ -66,7 +66,7 @@ export async function deleteUser(db: Database, userId: string): Promise<void> {
     // - subscriptions (which cascades to subscription_tags)
     // - user_entries, tags
     // - ingest_addresses, blocked_senders, opml_imports
-    // - user_score_models, entry_score_predictions, entry_summaries
+    // - entry_summaries
     // - email/saved feeds (user_id FK with cascade)
     // - invites.used_by_user_id is set to NULL
     await tx.delete(users).where(eq(users.id, userId));

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -227,6 +227,26 @@ describe("Entries", () => {
       expect(result.items.map((e) => e.id)).toContain(entry2Id);
     });
 
+    it("hides orphaned entries (user_entries row with no subscription) unless starred", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/feed.xml");
+      // No subscription is created: these user_entries rows are orphaned.
+      // Fail-closed visibility (migration 0073) requires a matching active
+      // subscription OR starred, so only the starred entry is visible.
+      const orphanedId = await createTestEntry(feedId, { title: "Orphaned" });
+      const orphanedStarredId = await createTestEntry(feedId, { title: "Orphaned Starred" });
+
+      await createUserEntry(userId, orphanedId);
+      await createUserEntry(userId, orphanedStarredId, { starred: true });
+
+      const ctx = createAuthContext(userId);
+      const caller = createCaller(ctx);
+
+      const result = await caller.entries.list({});
+
+      expect(result.items.map((e) => e.id)).toEqual([orphanedStarredId]);
+    });
+
     it("filters by unreadOnly", async () => {
       const userId = await createTestUser();
       const feedId = await createTestFeed("https://example.com/feed.xml");

--- a/tests/integration/retention.test.ts
+++ b/tests/integration/retention.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Integration tests for the retention cleanup service (run by the daily
+ * `cleanup` singleton job).
+ *
+ * Verifies that expired/long-revoked credentials and parked one-time jobs are
+ * deleted, and — just as importantly — that live rows are left alone.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { db } from "../../src/server/db";
+import {
+  jobs,
+  oauthAccessTokens,
+  oauthAuthorizationCodes,
+  oauthRefreshTokens,
+  sessions,
+  users,
+} from "../../src/server/db/schema";
+import { runRetentionCleanup } from "../../src/server/services/retention";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const TEST_CLIENT_ID = "retention-test-client";
+
+async function createTestUser(): Promise<string> {
+  const userId = generateUuidv7();
+  await db.insert(users).values({
+    id: userId,
+    email: `retention-${userId}@test.com`,
+    passwordHash: "test-hash",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  return userId;
+}
+
+async function createSession(userId: string, expiresAt: Date, revokedAt?: Date): Promise<string> {
+  const id = generateUuidv7();
+  await db.insert(sessions).values({
+    id,
+    userId,
+    tokenHash: `hash-${id}`,
+    expiresAt,
+    revokedAt: revokedAt ?? null,
+    createdAt: new Date(),
+    lastActiveAt: new Date(),
+  });
+  return id;
+}
+
+async function createAccessToken(userId: string, expiresAt: Date): Promise<string> {
+  const id = generateUuidv7();
+  await db.insert(oauthAccessTokens).values({
+    id,
+    tokenHash: `hash-${id}`,
+    clientId: TEST_CLIENT_ID,
+    userId,
+    scopes: ["mcp"],
+    expiresAt,
+    createdAt: new Date(),
+  });
+  return id;
+}
+
+async function createRefreshToken(
+  userId: string,
+  expiresAt: Date,
+  options: { revokedAt?: Date; accessTokenId?: string; replacedById?: string } = {}
+): Promise<string> {
+  const id = generateUuidv7();
+  await db.insert(oauthRefreshTokens).values({
+    id,
+    tokenHash: `hash-${id}`,
+    clientId: TEST_CLIENT_ID,
+    userId,
+    scopes: ["mcp"],
+    expiresAt,
+    revokedAt: options.revokedAt ?? null,
+    accessTokenId: options.accessTokenId ?? null,
+    replacedById: options.replacedById ?? null,
+    createdAt: new Date(),
+  });
+  return id;
+}
+
+async function createAuthCode(userId: string, expiresAt: Date): Promise<string> {
+  const id = generateUuidv7();
+  await db.insert(oauthAuthorizationCodes).values({
+    id,
+    codeHash: `hash-${id}`,
+    clientId: TEST_CLIENT_ID,
+    userId,
+    redirectUri: "https://example.com/callback",
+    scopes: ["mcp"],
+    codeChallenge: "challenge",
+    codeChallengeMethod: "S256",
+    expiresAt,
+    createdAt: new Date(),
+  });
+  return id;
+}
+
+async function cleanupTables(): Promise<void> {
+  await db.delete(oauthRefreshTokens);
+  await db.delete(oauthAccessTokens);
+  await db.delete(oauthAuthorizationCodes);
+  await db.delete(sessions);
+  await db.delete(jobs);
+  await db.delete(users);
+}
+
+describe("runRetentionCleanup", () => {
+  beforeEach(cleanupTables);
+  afterAll(cleanupTables);
+
+  it("deletes expired sessions and keeps live ones", async () => {
+    const userId = await createTestUser();
+    const expired = await createSession(userId, new Date(Date.now() - 2 * DAY_MS));
+    const live = await createSession(userId, new Date(Date.now() + DAY_MS));
+    // Expired less than the 1-day grace period ago: kept.
+    const justExpired = await createSession(userId, new Date(Date.now() - 60 * 1000));
+    // Revoked long ago but not yet expired: deleted.
+    const longRevoked = await createSession(
+      userId,
+      new Date(Date.now() + DAY_MS),
+      new Date(Date.now() - 31 * DAY_MS)
+    );
+
+    const result = await runRetentionCleanup(db);
+
+    expect(result.sessions).toBe(2);
+    const remaining = (await db.select({ id: sessions.id }).from(sessions)).map((r) => r.id);
+    expect(remaining.sort()).toEqual([live, justExpired].sort());
+    expect(remaining).not.toContain(expired);
+    expect(remaining).not.toContain(longRevoked);
+  });
+
+  it("deletes expired OAuth authorization codes, access tokens, and refresh tokens", async () => {
+    const userId = await createTestUser();
+
+    const expiredCode = await createAuthCode(userId, new Date(Date.now() - 2 * DAY_MS));
+    const liveCode = await createAuthCode(userId, new Date(Date.now() + 10 * 60 * 1000));
+
+    const expiredAccess = await createAccessToken(userId, new Date(Date.now() - 2 * DAY_MS));
+    const liveAccess = await createAccessToken(userId, new Date(Date.now() + 60 * 60 * 1000));
+
+    const expiredRefresh = await createRefreshToken(userId, new Date(Date.now() - 2 * DAY_MS));
+    const liveRefresh = await createRefreshToken(userId, new Date(Date.now() + 30 * DAY_MS));
+
+    const result = await runRetentionCleanup(db);
+
+    expect(result.oauthAuthorizationCodes).toBe(1);
+    expect(result.oauthAccessTokens).toBe(1);
+    expect(result.oauthRefreshTokens).toBe(1);
+
+    const codes = (
+      await db.select({ id: oauthAuthorizationCodes.id }).from(oauthAuthorizationCodes)
+    ).map((r) => r.id);
+    expect(codes).toEqual([liveCode]);
+    expect(codes).not.toContain(expiredCode);
+
+    const access = (await db.select({ id: oauthAccessTokens.id }).from(oauthAccessTokens)).map(
+      (r) => r.id
+    );
+    expect(access).toEqual([liveAccess]);
+    expect(access).not.toContain(expiredAccess);
+
+    const refresh = (await db.select({ id: oauthRefreshTokens.id }).from(oauthRefreshTokens)).map(
+      (r) => r.id
+    );
+    expect(refresh).toEqual([liveRefresh]);
+    expect(refresh).not.toContain(expiredRefresh);
+  });
+
+  it("handles refresh-token rotation chains (replaced_by_id) without FK failures", async () => {
+    const userId = await createTestUser();
+
+    // Rotation: old token revoked long ago points at its expired replacement.
+    // Both are deletable; the replaced_by_id FK is ON DELETE SET NULL so the
+    // deletion order can't matter.
+    const newToken = await createRefreshToken(userId, new Date(Date.now() - 2 * DAY_MS), {
+      revokedAt: new Date(Date.now() - 31 * DAY_MS),
+    });
+    await createRefreshToken(userId, new Date(Date.now() - 2 * DAY_MS), {
+      revokedAt: new Date(Date.now() - 32 * DAY_MS),
+      replacedById: newToken,
+    });
+    // A live token pointing at a deletable one must survive with the pointer nulled.
+    const survivor = await createRefreshToken(userId, new Date(Date.now() + 30 * DAY_MS), {
+      replacedById: newToken,
+    });
+
+    const result = await runRetentionCleanup(db);
+
+    expect(result.oauthRefreshTokens).toBe(2);
+    const remaining = await db
+      .select({ id: oauthRefreshTokens.id, replacedById: oauthRefreshTokens.replacedById })
+      .from(oauthRefreshTokens);
+    expect(remaining).toEqual([{ id: survivor, replacedById: null }]);
+  });
+
+  it("deletes parked one-time OPML import jobs but not scheduled or running ones", async () => {
+    const parkedId = generateUuidv7();
+    const dueId = generateUuidv7();
+    const runningId = generateUuidv7();
+    const feedJobId = generateUuidv7();
+    const now = new Date();
+
+    await db.insert(jobs).values([
+      // Completed one-time job, parked 365 days out.
+      {
+        id: parkedId,
+        type: "process_opml_import",
+        payload: { importId: generateUuidv7() },
+        nextRunAt: new Date(now.getTime() + 365 * DAY_MS),
+      },
+      // Pending import: due now.
+      {
+        id: dueId,
+        type: "process_opml_import",
+        payload: { importId: generateUuidv7() },
+        nextRunAt: now,
+      },
+      // Defensive: far-future next_run_at but currently running.
+      {
+        id: runningId,
+        type: "process_opml_import",
+        payload: { importId: generateUuidv7() },
+        nextRunAt: new Date(now.getTime() + 365 * DAY_MS),
+        runningSince: now,
+      },
+      // Recurring feed job parked far out (e.g. after a redirect merge): kept.
+      {
+        id: feedJobId,
+        type: "fetch_feed",
+        payload: { feedId: generateUuidv7() },
+        nextRunAt: new Date(now.getTime() + 365 * DAY_MS),
+      },
+    ]);
+
+    const result = await runRetentionCleanup(db);
+
+    expect(result.parkedJobs).toBe(1);
+    const remaining = (await db.select({ id: jobs.id }).from(jobs)).map((r) => r.id);
+    expect(remaining.sort()).toEqual([dueId, runningId, feedJobId].sort());
+    expect(remaining).not.toContain(parkedId);
+  });
+
+  it("returns zero counts when there is nothing to delete", async () => {
+    const result = await runRetentionCleanup(db);
+    expect(result).toEqual({
+      sessions: 0,
+      oauthAuthorizationCodes: 0,
+      oauthAccessTokens: 0,
+      oauthRefreshTokens: 0,
+      parkedJobs: 0,
+    });
+  });
+});

--- a/tests/unit/job-exception-backoff.test.ts
+++ b/tests/unit/job-exception-backoff.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for the job exception-retry backoff.
+ *
+ * When a job handler throws (as opposed to returning a failure result with its
+ * own nextRunAt), the worker schedules the retry with exponential backoff based
+ * on the job's consecutive failure count, instead of a flat 60s forever.
+ */
+
+import { describe, it, expect } from "vitest";
+import { calculateExceptionRetryDelayMs } from "../../src/server/jobs/queue";
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+
+describe("calculateExceptionRetryDelayMs", () => {
+  it("retries after 1 minute on the first exception", () => {
+    expect(calculateExceptionRetryDelayMs(0)).toBe(MINUTE_MS);
+  });
+
+  it("doubles the delay per consecutive failure", () => {
+    expect(calculateExceptionRetryDelayMs(1)).toBe(2 * MINUTE_MS);
+    expect(calculateExceptionRetryDelayMs(2)).toBe(4 * MINUTE_MS);
+    expect(calculateExceptionRetryDelayMs(5)).toBe(32 * MINUTE_MS);
+    expect(calculateExceptionRetryDelayMs(9)).toBe(512 * MINUTE_MS); // ~8.5h
+  });
+
+  it("caps the delay at 24 hours", () => {
+    expect(calculateExceptionRetryDelayMs(10)).toBe(1024 * MINUTE_MS); // ~17h, still under cap
+    expect(calculateExceptionRetryDelayMs(11)).toBe(24 * HOUR_MS);
+    expect(calculateExceptionRetryDelayMs(100)).toBe(24 * HOUR_MS);
+    expect(calculateExceptionRetryDelayMs(Number.MAX_SAFE_INTEGER)).toBe(24 * HOUR_MS);
+  });
+
+  it("treats negative counts as zero", () => {
+    expect(calculateExceptionRetryDelayMs(-1)).toBe(MINUTE_MS);
+  });
+});

--- a/tests/unit/migrations-journal.test.ts
+++ b/tests/unit/migrations-journal.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Consistency checks between the migrations directory and meta/_journal.json.
+ *
+ * The migration runner only executes migrations listed in the journal, so a
+ * .sql file that never gets journaled is silently skipped — databases built
+ * from the journal (CI, tests, DR restores, new environments) end up missing
+ * it even though it was applied manually to production (issue #953). These
+ * tests fail CI when the journal and the directory drift apart.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { describe, it, expect } from "vitest";
+import { parseJournal, type Journal } from "../../scripts/run-migrations";
+
+const MIGRATIONS_DIR = path.join(__dirname, "..", "..", "migrations");
+
+function loadJournal(): Journal {
+  const content = fs.readFileSync(path.join(MIGRATIONS_DIR, "meta", "_journal.json"), "utf-8");
+  return parseJournal(content);
+}
+
+function migrationFilesOnDisk(): string[] {
+  return fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql") && f !== "schema.sql")
+    .map((f) => f.replace(/\.sql$/, ""))
+    .sort();
+}
+
+describe("migrations journal", () => {
+  it("journals every migration .sql file on disk", () => {
+    const journaled = new Set(loadJournal().entries.map((e) => e.tag));
+    const unjournaled = migrationFilesOnDisk().filter((tag) => !journaled.has(tag));
+    expect(unjournaled).toEqual([]);
+  });
+
+  it("has a .sql file on disk for every journal entry", () => {
+    const onDisk = new Set(migrationFilesOnDisk());
+    const missing = loadJournal()
+      .entries.map((e) => e.tag)
+      .filter((tag) => !onDisk.has(tag));
+    expect(missing).toEqual([]);
+  });
+
+  it("has unique tags and sequential idx values", () => {
+    const entries = loadJournal().entries;
+    const tags = entries.map((e) => e.tag);
+    expect(new Set(tags).size).toBe(tags.length);
+    entries.forEach((entry, i) => {
+      expect(entry.idx).toBe(i);
+    });
+  });
+
+  it("does not use CREATE INDEX CONCURRENTLY (the runner wraps each migration in a transaction)", () => {
+    const offenders = migrationFilesOnDisk().filter((tag) => {
+      const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, `${tag}.sql`), "utf-8");
+      const withoutComments = sql.replace(/--[^\n]*/g, "");
+      return /\bCONCURRENTLY\b/i.test(withoutComments);
+    });
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #953.

## Migrations & schema drift

- **Journal the timeline sort-index migrations.** Three files were on disk but missing from `meta/_journal.json`. The obsolete `0060_previous_feed_ids_gin_index.sql` (indexed a column dropped by `0060_subscription_feeds.sql`) is deleted; the two entries sort-index migrations are renumbered to 0071/0072 (fixing the triple `0060` prefix), rewritten without `CONCURRENTLY` (the runner wraps each migration in a transaction) and with `IF NOT EXISTS` so they're a no-op on prod where they were applied manually, and appended to the journal. A new unit test (`tests/unit/migrations-journal.test.ts`) fails CI if any `.sql` file is unjournaled, a journal entry is missing on disk, `idx` values aren't sequential, or a migration uses `CONCURRENTLY`.
- **Drop the dead entry-scoring schema** (migration 0073): `entry_score_predictions`, `user_score_models`, and the three `users.*_feed_*` columns had no Drizzle definitions and no code references, yet `visible_entries` still LEFT JOINed the predictions table on every entries query. The view is rebuilt without the join.
- **`visible_entries` is now fail-closed**: visibility requires a matching *active* subscription, OR starred, OR `type = 'saved'`. The `saved` arm is load-bearing — saved feeds are per-user with no subscription row and previously rode on the fail-open predicate (the saved-articles integration tests caught this immediately when I first made the view strictly subscription-or-starred). Orphaned `user_entries` rows for web/email entries are now hidden; new integration test covers this.
- **Drizzle ↔ DB reconciliation** (migration 0076 + `schema.ts`): dropped the duplicate plain indexes shadowing UNIQUE constraints on every token table, the prefix-redundant `idx_subscriptions_user`/`idx_tags_user`, and `idx_narration_needs_generation` (indexed the PK); added the missing `invites.used_by_user_id` FK (`ON DELETE SET NULL`, which `deleteUser` already assumed), nulling dangling references first; `users.email` / `ingest_addresses.token` are now `citext` in Drizzle and `entry_summaries.prompt_version` is `smallint`, matching the database.

## Job queue

- **Restored the polling index** (migration 0074): `0046_simplify_jobs.sql` implicitly dropped it with the `enabled` column, leaving every ~5s claim query a seq scan + sort. New `idx_jobs_polling (type, next_run_at)` serves all three claim queries; the stale Drizzle declarations are aligned.
- **Exception-path retry backoff**: a throwing handler was retried on a flat 60s forever. Now exponential from 1 minute per consecutive failure, capped at 24h (unit-tested).
- **Daily `cleanup` singleton job** (migration 0075 + `src/server/services/retention.ts`): deletes expired sessions / OAuth authorization codes / access tokens / refresh tokens (1-day grace after expiry), long-revoked (30+ days) sessions and refresh tokens (retention window preserved for rotation reuse-detection), and parked one-time `process_opml_import` jobs. `oauth_refresh_tokens.replaced_by_id` becomes `ON DELETE SET NULL` so rotation-chain deletes can't fail on FK order. Integration-tested, including the rotation-chain case. Orphaned feed/entry GC was intentionally left out: subscriptions are never hard-deleted, so truly orphaned feeds shouldn't exist, and deleting them risks cascading starred entries.
- **`claimSingletonJob` insert-race retry** now keeps the `next_run_at <= now` predicate so a lost race can't immediately re-run a just-finished singleton.
- **Dual scheduling state documented**: `jobs.next_run_at` is authoritative; `feeds.next_fetch_at` is an informational copy for display surfaces.

## Deploy notes

- All migrations are expand/contract-safe against current master (no deployed code references any dropped object, and the view keeps every column the Drizzle view schema declares).
- 0071/0072 assume prod's manually-created indexes are named `idx_entries_published_coalesce` / `idx_entries_feed_published_coalesce` (as dumped in `schema.sql`); `IF NOT EXISTS` makes them no-ops there. If prod used different names, the release_command will build them non-concurrently — worth a quick `\di` check before merging.

## Testing

- `pnpm typecheck`, `pnpm test:unit` (1892), `pnpm test:integration` (396) all green
- Test database dropped and rebuilt **from an empty journal run** — all 76 migrations apply cleanly and produce the committed `schema.sql`
- `pnpm test:e2e` (4 realtime scenarios) green against the rebuilt DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)