### PR TITLE
Add sort options to admin user list; make "last active" durable

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -193,7 +193,15 @@ Each provider is enabled by setting its environment variables (client ID and sec
 2. Server hashes token, checks Redis cache
 3. Cache miss: query Postgres, fill cache (TTL: 5 minutes)
 4. Validate: not revoked, not expired
-5. Update `last_active_at` asynchronously
+5. Update `last_active_at` asynchronously (on both the session row and, throttled,
+   the denormalized `users.last_active_at` column)
+
+`users.last_active_at` is a denormalized copy of the most recent session activity.
+It exists so the admin "last active" view survives retention cleanup, which deletes
+expired sessions (see `runRetentionCleanup`); deriving activity from
+`MAX(sessions.last_active_at)` would blank out any user idle longer than the 30-day
+session lifetime. `updateLastActiveAt` refreshes it fire-and-forget, skipping the
+write when it was updated within the last minute to avoid write/index churn.
 
 ### Token Format
 

--- a/migrations/0077_users_last_active_at.sql
+++ b/migrations/0077_users_last_active_at.sql
@@ -1,0 +1,28 @@
+-- Denormalize last-active tracking onto users (admin user list "Last active").
+--
+-- The admin user list derived "Last active" from MAX(sessions.last_active_at),
+-- but the daily retention cleanup (0075) deletes sessions ~1 day after they
+-- expire. Since sessions live 30 days from creation, any user inactive longer
+-- than that lost every session row and showed as "Never" — the activity history
+-- the admin page relied on was being cleaned up out from under it.
+--
+-- Store last_active_at on the user row so it survives session cleanup, backfill
+-- from any surviving sessions, and index it for the admin activity sort.
+
+ALTER TABLE users ADD COLUMN last_active_at timestamp with time zone;
+
+--> statement-breakpoint
+
+UPDATE users u
+SET last_active_at = s.max_last_active
+FROM (
+  SELECT user_id, MAX(last_active_at) AS max_last_active
+  FROM sessions
+  GROUP BY user_id
+) s
+WHERE s.user_id = u.id;
+
+--> statement-breakpoint
+
+-- Supports ORDER BY last_active_at DESC NULLS LAST, id DESC (admin activity sort).
+CREATE INDEX idx_users_last_active_at ON users (last_active_at DESC NULLS LAST, id DESC);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -533,6 +533,13 @@
       "when": 1782950900000,
       "tag": "0076_redundant_indexes_and_invites_fk",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1782951000000,
+      "tag": "0077_users_last_active_at",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -376,7 +376,8 @@ CREATE TABLE public.users (
     summarization_prompt text,
     tos_agreed_at timestamp with time zone,
     privacy_policy_agreed_at timestamp with time zone,
-    not_eu_agreed_at timestamp with time zone
+    not_eu_agreed_at timestamp with time zone,
+    last_active_at timestamp with time zone
 );
 
 CREATE VIEW public.visible_entries AS
@@ -679,6 +680,8 @@ CREATE INDEX idx_user_entries_starred ON public.user_entries USING btree (user_i
 CREATE INDEX idx_user_entries_unread ON public.user_entries USING btree (user_id) WHERE (read = false);
 
 CREATE INDEX idx_user_entries_updated_at ON public.user_entries USING btree (user_id, updated_at);
+
+CREATE INDEX idx_users_last_active_at ON public.users USING btree (last_active_at DESC NULLS LAST, id DESC);
 
 CREATE INDEX idx_websub_expiring ON public.websub_subscriptions USING btree (expires_at);
 

--- a/src/components/admin/AdminUsersContent.tsx
+++ b/src/components/admin/AdminUsersContent.tsx
@@ -24,6 +24,17 @@ import { SpinnerIcon, GoogleIcon, AppleIcon, DiscordIcon } from "@/components/ui
 const DEBOUNCE_MS = 300;
 const PAGE_SIZE = 50;
 
+// Sort options for the user list. Values must match the admin.listUsers `sort`
+// enum on the backend.
+type UserSort = "activity" | "created" | "oldest" | "email";
+
+const SORT_OPTIONS: { value: UserSort; label: string }[] = [
+  { value: "activity", label: "Most recent activity" },
+  { value: "created", label: "Newest" },
+  { value: "oldest", label: "Oldest" },
+  { value: "email", label: "Email (A–Z)" },
+];
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -150,6 +161,7 @@ export default function AdminUsersContent() {
 
   const [searchInput, setSearchInput] = useState(initialSearch);
   const [debouncedSearch, setDebouncedSearch] = useState(initialSearch);
+  const [sort, setSort] = useState<UserSort>("activity");
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
   // Debounce search input
@@ -165,6 +177,7 @@ export default function AdminUsersContent() {
     {
       limit: PAGE_SIZE,
       search: debouncedSearch || undefined,
+      sort,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -214,14 +227,33 @@ export default function AdminUsersContent() {
         <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">Users</h2>
       </div>
 
-      {/* Search */}
-      <div className="mb-4">
-        <Input
-          id="user-search"
-          placeholder="Search by email..."
-          value={searchInput}
-          onChange={(e) => setSearchInput(e.target.value)}
-        />
+      {/* Search + sort */}
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="flex-1">
+          <Input
+            id="user-search"
+            placeholder="Search by email..."
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+          />
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <label htmlFor="user-sort" className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+            Sort by
+          </label>
+          <select
+            id="user-sort"
+            value={sort}
+            onChange={(e) => setSort(e.target.value as UserSort)}
+            className="ui-text-sm block rounded-md border border-zinc-300 bg-white px-3 py-2 text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+          >
+            {SORT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
 
       {/* Users List */}

--- a/src/components/admin/AdminUsersContent.tsx
+++ b/src/components/admin/AdminUsersContent.tsx
@@ -90,6 +90,7 @@ interface User {
   email: string;
   createdAt: Date;
   lastActiveAt: Date | null;
+  lastTokenUsedAt: Date | null;
   providers: string[];
   subscriptionCount: number;
   entryCount: number;
@@ -119,6 +120,9 @@ function UserRow({ user }: { user: User }) {
       <div className="ui-text-xs flex flex-wrap gap-x-4 gap-y-1 text-zinc-500 dark:text-zinc-400">
         <span>Member since {formatDate(user.createdAt)}</span>
         <span>Last active: {user.lastActiveAt ? formatDate(user.lastActiveAt) : "Never"}</span>
+        <span>
+          Last API/MCP use: {user.lastTokenUsedAt ? formatDate(user.lastTokenUsedAt) : "Never"}
+        </span>
         <span>
           Subscriptions:{" "}
           <ClientLink

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -10,7 +10,7 @@
  */
 
 import crypto from "crypto";
-import { eq, and, isNull, gt, lt, or } from "drizzle-orm";
+import { eq, and, isNull, gt, sql } from "drizzle-orm";
 import { db, type Database } from "@/server/db";
 import { sessions, users, type User, type Session } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
@@ -362,32 +362,32 @@ const USER_LAST_ACTIVE_REFRESH_MS = 60 * 1000;
 
 /**
  * Updates last_active_at for both the session and (throttled) the user row.
- * Done asynchronously to not block the request.
+ * Done asynchronously (fire-and-forget) so it never blocks the request.
  *
  * The user-row copy is denormalized so the admin "last active" view survives
  * session retention cleanup (expired sessions are deleted), rather than being
  * derived from MAX(sessions.last_active_at).
+ *
+ * This runs on every authenticated request, so it's a single round-trip via a
+ * writable CTE rather than two sequential statements. The session row is always
+ * touched; the user row is only touched when its timestamp is stale, so the
+ * common case is a no-op on the users table (no row write, no index churn) while
+ * still costing just one query.
  */
 async function updateLastActiveAt(sessionId: string, userId: string): Promise<void> {
   const now = new Date();
+  const staleCutoff = new Date(now.getTime() - USER_LAST_ACTIVE_REFRESH_MS);
   try {
-    await db.update(sessions).set({ lastActiveAt: now }).where(eq(sessions.id, sessionId));
+    await db.execute(sql`
+      WITH touched_session AS (
+        UPDATE ${sessions} SET last_active_at = ${now} WHERE id = ${sessionId}
+      )
+      UPDATE ${users} SET last_active_at = ${now}
+      WHERE id = ${userId}
+        AND (last_active_at IS NULL OR last_active_at < ${staleCutoff})
+    `);
   } catch (err) {
-    console.error("Failed to update session last_active_at:", err);
-  }
-  try {
-    const staleCutoff = new Date(now.getTime() - USER_LAST_ACTIVE_REFRESH_MS);
-    await db
-      .update(users)
-      .set({ lastActiveAt: now })
-      .where(
-        and(
-          eq(users.id, userId),
-          or(isNull(users.lastActiveAt), lt(users.lastActiveAt, staleCutoff))
-        )
-      );
-  } catch (err) {
-    console.error("Failed to update user last_active_at:", err);
+    console.error("Failed to update last_active_at:", err);
   }
 }
 

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -10,7 +10,7 @@
  */
 
 import crypto from "crypto";
-import { eq, and, isNull, gt } from "drizzle-orm";
+import { eq, and, isNull, gt, lt, or } from "drizzle-orm";
 import { db, type Database } from "@/server/db";
 import { sessions, users, type User, type Session } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
@@ -260,6 +260,8 @@ function deserializeFromCache(data: string): SessionData {
         ? new Date(cached.userPrivacyPolicyAgreedAt)
         : null,
       notEuAgreedAt: cached.userNotEuAgreedAt ? new Date(cached.userNotEuAgreedAt) : null,
+      // Not cached in Redis; only the admin activity view reads it, from the DB.
+      lastActiveAt: null,
     },
     hasGroqApiKey: cached.userHasGroqApiKey ?? false,
     hasAnthropicApiKey: cached.userHasAnthropicApiKey ?? false,
@@ -286,7 +288,7 @@ export async function validateSession(token: string): Promise<SessionData | null
         // Verify session is still valid (not expired, not revoked)
         if (data.session.expiresAt > new Date() && data.session.revokedAt === null) {
           // Update last_active_at asynchronously (fire and forget)
-          void updateLastActiveAt(data.session.id);
+          void updateLastActiveAt(data.session.id, data.session.userId);
           return data;
         }
 
@@ -345,20 +347,47 @@ export async function validateSession(token: string): Promise<SessionData | null
   }
 
   // Update last_active_at asynchronously (fire and forget)
-  void updateLastActiveAt(sessionData.session.id);
+  void updateLastActiveAt(sessionData.session.id, sessionData.session.userId);
 
   return sessionData;
 }
 
 /**
- * Updates the last_active_at timestamp for a session.
- * This is done asynchronously to not block the request.
+ * How stale the denormalized users.last_active_at may be before we refresh it.
+ * The per-session timestamp updates on every request, but the user row only
+ * needs to be roughly current (it feeds the admin activity view), so we skip
+ * the write when it was updated within this window to avoid write/index churn.
  */
-async function updateLastActiveAt(sessionId: string): Promise<void> {
+const USER_LAST_ACTIVE_REFRESH_MS = 60 * 1000;
+
+/**
+ * Updates last_active_at for both the session and (throttled) the user row.
+ * Done asynchronously to not block the request.
+ *
+ * The user-row copy is denormalized so the admin "last active" view survives
+ * session retention cleanup (expired sessions are deleted), rather than being
+ * derived from MAX(sessions.last_active_at).
+ */
+async function updateLastActiveAt(sessionId: string, userId: string): Promise<void> {
+  const now = new Date();
   try {
-    await db.update(sessions).set({ lastActiveAt: new Date() }).where(eq(sessions.id, sessionId));
+    await db.update(sessions).set({ lastActiveAt: now }).where(eq(sessions.id, sessionId));
   } catch (err) {
     console.error("Failed to update session last_active_at:", err);
+  }
+  try {
+    const staleCutoff = new Date(now.getTime() - USER_LAST_ACTIVE_REFRESH_MS);
+    await db
+      .update(users)
+      .set({ lastActiveAt: now })
+      .where(
+        and(
+          eq(users.id, userId),
+          or(isNull(users.lastActiveAt), lt(users.lastActiveAt, staleCutoff))
+        )
+      );
+  } catch (err) {
+    console.error("Failed to update user last_active_at:", err);
   }
 }
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -65,31 +65,44 @@ export const invites = pgTable(
  * Users table - stores user accounts.
  * Primary key uses UUIDv7 for time-ordering and global uniqueness.
  */
-export const users = pgTable("users", {
-  id: uuid("id").primaryKey(),
-  email: citext("email").unique().notNull(),
-  emailVerifiedAt: timestamp("email_verified_at", { withTimezone: true }),
-  passwordHash: text("password_hash"), // null if OAuth-only (future)
-  inviteId: uuid("invite_id").references(() => invites.id, { onDelete: "set null" }),
+export const users = pgTable(
+  "users",
+  {
+    id: uuid("id").primaryKey(),
+    email: citext("email").unique().notNull(),
+    emailVerifiedAt: timestamp("email_verified_at", { withTimezone: true }),
+    passwordHash: text("password_hash"), // null if OAuth-only (future)
+    inviteId: uuid("invite_id").references(() => invites.id, { onDelete: "set null" }),
 
-  // Preferences
-  showSpam: boolean("show_spam").notNull().default(false), // Show spam entries from email feeds
+    // Preferences
+    showSpam: boolean("show_spam").notNull().default(false), // Show spam entries from email feeds
 
-  // User-configured API keys (override server defaults when set)
-  groqApiKey: text("groq_api_key"), // For narration LLM preprocessing
-  anthropicApiKey: text("anthropic_api_key"), // For AI summarization
-  summarizationModel: text("summarization_model"), // Anthropic model for summaries
-  summarizationMaxWords: integer("summarization_max_words"), // Override SUMMARIZATION_MAX_WORDS
-  summarizationPrompt: text("summarization_prompt"), // Custom summarization prompt
+    // User-configured API keys (override server defaults when set)
+    groqApiKey: text("groq_api_key"), // For narration LLM preprocessing
+    anthropicApiKey: text("anthropic_api_key"), // For AI summarization
+    summarizationModel: text("summarization_model"), // Anthropic model for summaries
+    summarizationMaxWords: integer("summarization_max_words"), // Override SUMMARIZATION_MAX_WORDS
+    summarizationPrompt: text("summarization_prompt"), // Custom summarization prompt
 
-  // Signup confirmation: each records when the user accepted the agreement
-  tosAgreedAt: timestamp("tos_agreed_at", { withTimezone: true }),
-  privacyPolicyAgreedAt: timestamp("privacy_policy_agreed_at", { withTimezone: true }),
-  notEuAgreedAt: timestamp("not_eu_agreed_at", { withTimezone: true }),
+    // Signup confirmation: each records when the user accepted the agreement
+    tosAgreedAt: timestamp("tos_agreed_at", { withTimezone: true }),
+    privacyPolicyAgreedAt: timestamp("privacy_policy_agreed_at", { withTimezone: true }),
+    notEuAgreedAt: timestamp("not_eu_agreed_at", { withTimezone: true }),
 
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-});
+    // Denormalized most-recent activity timestamp (updated fire-and-forget on
+    // session validation, see updateLastActiveAt). Kept on the user row so the
+    // admin "last active" view survives session retention cleanup, which deletes
+    // expired sessions (the previous MAX(sessions.last_active_at) source).
+    lastActiveAt: timestamp("last_active_at", { withTimezone: true }),
+
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    // Supports the admin user list "most recent activity" sort + keyset cursor.
+    index("idx_users_last_active_at").on(table.lastActiveAt.desc().nullsLast(), table.id.desc()),
+  ]
+);
 
 /**
  * Sessions table - stores user sessions.

--- a/src/server/trpc/routers/admin.ts
+++ b/src/server/trpc/routers/admin.ts
@@ -6,7 +6,7 @@
  */
 
 import { z } from "zod";
-import { eq, and, isNull, sql, desc, asc, lt, gt, ilike, count, max } from "drizzle-orm";
+import { eq, and, isNull, sql, desc, asc, lt, gt, ilike, count } from "drizzle-orm";
 import crypto from "crypto";
 
 import { createTRPCRouter, adminProcedure } from "../trpc";
@@ -18,7 +18,6 @@ import {
   invites,
   jobs,
   oauthAccounts,
-  sessions,
   userEntries,
 } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
@@ -55,6 +54,17 @@ const paginationInput = z.object({
   cursor: z.string().uuid().optional(),
   limit: z.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
 });
+
+/**
+ * Sort options for the admin user list. Each sorts by a durable, indexable
+ * column on the users row so keyset (cursor) pagination stays correct:
+ * - `activity`: most recent activity first (last_active_at DESC NULLS LAST)
+ * - `created`:  newest accounts first (UUIDv7 id DESC)
+ * - `oldest`:   oldest accounts first (id ASC)
+ * - `email`:    email A→Z
+ */
+const USER_SORT = z.enum(["activity", "created", "oldest", "email"]);
+type UserSort = z.infer<typeof USER_SORT>;
 
 // ============================================================================
 // INVITE ENDPOINTS
@@ -498,10 +508,10 @@ const userEndpoints = {
   /**
    * List ALL users in the system.
    *
-   * Supports search by email (partial match, case-insensitive).
-   * Includes computed fields: OAuth providers, subscription count, entry count,
-   * scoring model stats, and total entry size estimate.
-   * Ordered by createdAt DESC (newest first).
+   * Supports search by email (partial match, case-insensitive) and a choice of
+   * sort orders (see USER_SORT). Includes computed fields: OAuth providers,
+   * subscription count, entry count, and last activity.
+   * Defaults to most-recent-activity first.
    */
   listUsers: adminProcedure
     .meta({
@@ -516,6 +526,7 @@ const userEndpoints = {
       paginationInput
         .extend({
           search: z.string().optional(),
+          sort: USER_SORT.default("activity"),
         })
         .optional()
     )
@@ -539,6 +550,7 @@ const userEndpoints = {
       const limit = input?.limit ?? DEFAULT_LIMIT;
       const cursor = input?.cursor;
       const search = input?.search;
+      const sort: UserSort = input?.sort ?? "activity";
 
       // Subquery: OAuth provider names as a JSON array
       const providersSq = ctx.db
@@ -562,26 +574,70 @@ const userEndpoints = {
         .from(userEntries)
         .where(eq(userEntries.userId, users.id));
 
-      // Subquery: most recent session activity (includes revoked sessions —
-      // a revoked session still indicates the user was active at that time)
-      const lastActiveAtSq = ctx.db
-        .select({ max: max(sessions.lastActiveAt).as("max") })
-        .from(sessions)
-        .where(eq(sessions.userId, users.id));
-
       const conditions = [];
-
-      // Cursor-based pagination: id < cursor (order by id DESC, since UUIDv7 is time-ordered)
-      if (cursor) {
-        conditions.push(lt(users.id, cursor));
-      }
 
       // Search by email
       if (search) {
         conditions.push(ilike(users.email, `%${search}%`));
       }
 
+      // Keyset (cursor) pagination. The cursor is a user id; the row it points
+      // at is looked up via subquery so we can compare against the sort column.
+      // Each branch mirrors its ORDER BY below.
+      if (cursor) {
+        const cursorActive = sql`(SELECT u2.last_active_at FROM users u2 WHERE u2.id = ${cursor})`;
+        const cursorEmail = sql`(SELECT u2.email FROM users u2 WHERE u2.id = ${cursor})`;
+        switch (sort) {
+          case "created":
+            conditions.push(lt(users.id, cursor));
+            break;
+          case "oldest":
+            conditions.push(gt(users.id, cursor));
+            break;
+          case "email":
+            conditions.push(
+              sql`(
+                ${users.email} > ${cursorEmail}
+                OR (${users.email} = ${cursorEmail} AND ${users.id} > ${cursor})
+              )`
+            );
+            break;
+          case "activity":
+            // ORDER BY last_active_at DESC NULLS LAST, id DESC. When the cursor
+            // row has activity, later rows have lower activity (or NULL), or the
+            // same activity with a lower id. When the cursor is already in the
+            // NULL tail, only lower-id NULL rows remain.
+            conditions.push(
+              sql`(
+                (
+                  ${cursorActive} IS NOT NULL
+                  AND (
+                    ${users.lastActiveAt} < ${cursorActive}
+                    OR ${users.lastActiveAt} IS NULL
+                    OR (${users.lastActiveAt} = ${cursorActive} AND ${users.id} < ${cursor})
+                  )
+                )
+                OR (
+                  ${cursorActive} IS NULL
+                  AND ${users.lastActiveAt} IS NULL
+                  AND ${users.id} < ${cursor}
+                )
+              )`
+            );
+            break;
+        }
+      }
+
       const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+      const orderBy =
+        sort === "created"
+          ? [desc(users.id)]
+          : sort === "oldest"
+            ? [asc(users.id)]
+            : sort === "email"
+              ? [asc(users.email), asc(users.id)]
+              : [sql`${users.lastActiveAt} DESC NULLS LAST`, desc(users.id)];
 
       const rows = await ctx.db
         .select({
@@ -591,11 +647,11 @@ const userEndpoints = {
           providers: sql<string[]>`(${providersSq})`.as("providers"),
           subscriptionCount: sql<number>`(${subscriptionCountSq})`.as("subscription_count"),
           entryCount: sql<number>`(${entryCountSq})`.as("entry_count"),
-          lastActiveAt: sql<Date | null>`(${lastActiveAtSq})`.as("last_active_at"),
+          lastActiveAt: users.lastActiveAt,
         })
         .from(users)
         .where(whereClause)
-        .orderBy(desc(users.id))
+        .orderBy(...orderBy)
         .limit(limit + 1);
 
       const hasMore = rows.length > limit;
@@ -668,14 +724,15 @@ const overviewEndpoints = {
         // Total users
         ctx.db.select({ count: count() }).from(users),
 
-        // Active users: single scan with conditional aggregation
+        // Active users: single scan over the denormalized users.last_active_at
+        // (durable across session retention cleanup, unlike a sessions scan).
         ctx.db
           .select({
-            active7d: sql<number>`COUNT(DISTINCT CASE WHEN ${sessions.lastActiveAt} > ${sevenDaysAgo} THEN ${sessions.userId} END)`,
-            active30d: sql<number>`COUNT(DISTINCT ${sessions.userId})`,
+            active7d: sql<number>`COUNT(*) FILTER (WHERE ${users.lastActiveAt} > ${sevenDaysAgo})`,
+            active30d: sql<number>`COUNT(*) FILTER (WHERE ${users.lastActiveAt} > ${thirtyDaysAgo})`,
           })
-          .from(sessions)
-          .where(gt(sessions.lastActiveAt, thirtyDaysAgo)),
+          .from(users)
+          .where(gt(users.lastActiveAt, thirtyDaysAgo)),
 
         // Feed stats: single scan for total and broken counts
         ctx.db

--- a/src/server/trpc/routers/admin.ts
+++ b/src/server/trpc/routers/admin.ts
@@ -6,7 +6,7 @@
  */
 
 import { z } from "zod";
-import { eq, and, isNull, sql, desc, asc, lt, gt, ilike, count } from "drizzle-orm";
+import { eq, and, isNull, sql, desc, asc, lt, gt, ilike, count, max } from "drizzle-orm";
 import crypto from "crypto";
 
 import { createTRPCRouter, adminProcedure } from "../trpc";
@@ -18,6 +18,8 @@ import {
   invites,
   jobs,
   oauthAccounts,
+  oauthAccessTokens,
+  apiTokens,
   userEntries,
 } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
@@ -541,6 +543,11 @@ const userEndpoints = {
             subscriptionCount: z.number(),
             entryCount: z.number(),
             lastActiveAt: z.date().nullable(),
+            // Most recent API-token / OAuth-MCP token use. Durable for
+            // long-lived API tokens (extension/integrations); for MCP OAuth
+            // access tokens it only reflects ~the last day, since those are
+            // short-lived and pruned by retention cleanup soon after expiry.
+            lastTokenUsedAt: z.date().nullable(),
           })
         ),
         nextCursor: z.string().optional(),
@@ -573,6 +580,19 @@ const userEndpoints = {
         .select({ count: count().as("count") })
         .from(userEntries)
         .where(eq(userEntries.userId, users.id));
+
+      // Subqueries: most recent token use, tracked separately from session
+      // activity. API tokens (extension/integrations) are long-lived so this is
+      // durable; OAuth access tokens (remote MCP) are short-lived and pruned by
+      // retention, so they only contribute usage from ~the last day.
+      const apiTokenLastUsedSq = ctx.db
+        .select({ max: max(apiTokens.lastUsedAt).as("max") })
+        .from(apiTokens)
+        .where(eq(apiTokens.userId, users.id));
+      const oauthTokenLastUsedSq = ctx.db
+        .select({ max: max(oauthAccessTokens.lastUsedAt).as("max") })
+        .from(oauthAccessTokens)
+        .where(eq(oauthAccessTokens.userId, users.id));
 
       const conditions = [];
 
@@ -648,6 +668,11 @@ const userEndpoints = {
           subscriptionCount: sql<number>`(${subscriptionCountSq})`.as("subscription_count"),
           entryCount: sql<number>`(${entryCountSq})`.as("entry_count"),
           lastActiveAt: users.lastActiveAt,
+          // GREATEST ignores NULLs, so this is the newer of the two, or NULL.
+          lastTokenUsedAt:
+            sql<Date | null>`GREATEST((${apiTokenLastUsedSq}), (${oauthTokenLastUsedSq}))`.as(
+              "last_token_used_at"
+            ),
         })
         .from(users)
         .where(whereClause)
@@ -667,6 +692,7 @@ const userEndpoints = {
           subscriptionCount: Number(row.subscriptionCount),
           entryCount: Number(row.entryCount),
           lastActiveAt: row.lastActiveAt ? new Date(row.lastActiveAt) : null,
+          lastTokenUsedAt: row.lastTokenUsedAt ? new Date(row.lastTokenUsedAt) : null,
         })),
         nextCursor,
       };

--- a/tests/integration/admin.test.ts
+++ b/tests/integration/admin.test.ts
@@ -12,7 +12,15 @@ process.env.ADMIN_SECRET = "test-admin-secret";
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { eq, sql } from "drizzle-orm";
 import { db } from "../../src/server/db";
-import { users, feeds, subscriptions, invites, jobs, sessions } from "../../src/server/db/schema";
+import {
+  users,
+  feeds,
+  subscriptions,
+  invites,
+  jobs,
+  sessions,
+  apiTokens,
+} from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
@@ -436,6 +444,45 @@ describe("Admin API", () => {
       expect(result.items).toHaveLength(1);
       expect(result.items[0].lastActiveAt).toBeInstanceOf(Date);
       expect(result.items[0].lastActiveAt!.getTime()).toBe(activeTime.getTime());
+    });
+
+    it("reports most recent token use separately from session activity", async () => {
+      const ctx = createAdminContext();
+      const caller = createCaller(ctx);
+
+      const userId = await createTestUser("token-user");
+
+      // Session activity and token use are independent signals.
+      const sessionTime = new Date("2026-04-01T00:00:00Z");
+      await db.update(users).set({ lastActiveAt: sessionTime }).where(eq(users.id, userId));
+
+      const tokenUsedTime = new Date("2026-05-20T00:00:00Z");
+      await db.insert(apiTokens).values({
+        id: generateUuidv7(),
+        userId,
+        tokenHash: `token-hash-${userId}`,
+        scopes: ["mcp"],
+        lastUsedAt: tokenUsedTime,
+      });
+
+      const result = await caller.admin.listUsers({ search: "token-user" });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].lastActiveAt!.getTime()).toBe(sessionTime.getTime());
+      expect(result.items[0].lastTokenUsedAt).toBeInstanceOf(Date);
+      expect(result.items[0].lastTokenUsedAt!.getTime()).toBe(tokenUsedTime.getTime());
+    });
+
+    it("returns null token use for users who never used a token", async () => {
+      const ctx = createAdminContext();
+      const caller = createCaller(ctx);
+
+      await createTestUser("no-token-user");
+
+      const result = await caller.admin.listUsers({ search: "no-token-user" });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].lastTokenUsedAt).toBeNull();
     });
 
     it("sorts by most recent activity by default, nulls last", async () => {

--- a/tests/integration/admin.test.ts
+++ b/tests/integration/admin.test.ts
@@ -393,28 +393,123 @@ describe("Admin API", () => {
       expect(result.items[0].email).toContain("findme-unique");
     });
 
-    it("returns lastActiveAt from sessions", async () => {
+    it("returns lastActiveAt from the denormalized user column", async () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
       const userId = await createTestUser("active-user");
 
-      // Create a session for this user
-      const sessionId = generateUuidv7();
-      const sessionTime = new Date("2026-03-15T12:00:00Z");
-      await db.insert(sessions).values({
-        id: sessionId,
-        userId,
-        tokenHash: `test-hash-${sessionId}`,
-        expiresAt: new Date("2027-01-01T00:00:00Z"),
-        lastActiveAt: sessionTime,
-      });
+      const activeTime = new Date("2026-03-15T12:00:00Z");
+      await db.update(users).set({ lastActiveAt: activeTime }).where(eq(users.id, userId));
 
       const result = await caller.admin.listUsers({ search: "active-user" });
 
       expect(result.items).toHaveLength(1);
       expect(result.items[0].lastActiveAt).toBeInstanceOf(Date);
-      expect(result.items[0].lastActiveAt!.getTime()).toBe(sessionTime.getTime());
+      expect(result.items[0].lastActiveAt!.getTime()).toBe(activeTime.getTime());
+    });
+
+    it("keeps lastActiveAt after the user's sessions are cleaned up", async () => {
+      // Regression: activity used to be derived from MAX(sessions.last_active_at),
+      // so retention cleanup deleting expired sessions blanked it out. It now
+      // lives on the user row and must survive with no sessions at all.
+      const ctx = createAdminContext();
+      const caller = createCaller(ctx);
+
+      const userId = await createTestUser("retained-user");
+      const activeTime = new Date("2026-02-01T09:00:00Z");
+      await db.update(users).set({ lastActiveAt: activeTime }).where(eq(users.id, userId));
+
+      // Create then delete a session, simulating retention cleanup.
+      const sessionId = generateUuidv7();
+      await db.insert(sessions).values({
+        id: sessionId,
+        userId,
+        tokenHash: `test-hash-${sessionId}`,
+        expiresAt: new Date("2026-03-03T09:00:00Z"),
+        lastActiveAt: activeTime,
+      });
+      await db.delete(sessions).where(eq(sessions.id, sessionId));
+
+      const result = await caller.admin.listUsers({ search: "retained-user" });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].lastActiveAt).toBeInstanceOf(Date);
+      expect(result.items[0].lastActiveAt!.getTime()).toBe(activeTime.getTime());
+    });
+
+    it("sorts by most recent activity by default, nulls last", async () => {
+      const ctx = createAdminContext();
+      const caller = createCaller(ctx);
+
+      const idNever = await createTestUser("sort-never");
+      const idOld = await createTestUser("sort-old");
+      const idRecent = await createTestUser("sort-recent");
+
+      await db
+        .update(users)
+        .set({ lastActiveAt: new Date("2026-01-01T00:00:00Z") })
+        .where(eq(users.id, idOld));
+      await db
+        .update(users)
+        .set({ lastActiveAt: new Date("2026-06-01T00:00:00Z") })
+        .where(eq(users.id, idRecent));
+      // idNever keeps a null lastActiveAt.
+
+      const result = await caller.admin.listUsers({ search: "sort-" });
+
+      const order = result.items.map((u) => u.id);
+      expect(order).toEqual([idRecent, idOld, idNever]);
+    });
+
+    it("sorts by email A→Z", async () => {
+      const ctx = createAdminContext();
+      const caller = createCaller(ctx);
+
+      // Emails are prefixed with the UUIDv7 id, so create then rewrite them to
+      // control alphabetical order independently of creation order.
+      const id1 = await createTestUser("email-sort");
+      const id2 = await createTestUser("email-sort");
+      await db.update(users).set({ email: "zzz-emailsort@test.com" }).where(eq(users.id, id1));
+      await db.update(users).set({ email: "aaa-emailsort@test.com" }).where(eq(users.id, id2));
+
+      const result = await caller.admin.listUsers({ search: "emailsort", sort: "email" });
+
+      expect(result.items.map((u) => u.id)).toEqual([id2, id1]);
+    });
+
+    it("paginates a sorted list without overlap", async () => {
+      const ctx = createAdminContext();
+      const caller = createCaller(ctx);
+
+      const ids: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const id = await createTestUser("activity-page");
+        ids.push(id);
+        await db
+          .update(users)
+          .set({ lastActiveAt: new Date(`2026-0${i + 1}-01T00:00:00Z`) })
+          .where(eq(users.id, id));
+      }
+
+      const page1 = await caller.admin.listUsers({ search: "activity-page", limit: 2 });
+      expect(page1.items).toHaveLength(2);
+      expect(page1.nextCursor).toBeDefined();
+
+      const page2 = await caller.admin.listUsers({
+        search: "activity-page",
+        limit: 2,
+        cursor: page1.nextCursor,
+      });
+
+      const page1Ids = new Set(page1.items.map((u) => u.id));
+      for (const user of page2.items) {
+        expect(page1Ids.has(user.id)).toBe(false);
+      }
+
+      // Most-recent first across both pages.
+      const combined = [...page1.items, ...page2.items].filter((u) => ids.includes(u.id));
+      expect(combined.map((u) => u.id)).toEqual([ids[2], ids[1], ids[0]]);
     });
 
     it("pagination works", async () => {

--- a/tests/integration/entries-perf.test.ts
+++ b/tests/integration/entries-perf.test.ts
@@ -81,6 +81,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        lastActiveAt: null,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -70,6 +70,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        lastActiveAt: null,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/feed-redirect.test.ts
+++ b/tests/integration/feed-redirect.test.ts
@@ -76,6 +76,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        lastActiveAt: null,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/opml-import.test.ts
+++ b/tests/integration/opml-import.test.ts
@@ -67,6 +67,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        lastActiveAt: null,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/sanitized-entry-content.test.ts
+++ b/tests/integration/sanitized-entry-content.test.ts
@@ -51,6 +51,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        lastActiveAt: null,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -69,6 +69,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        lastActiveAt: null,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/subscriptions.test.ts
+++ b/tests/integration/subscriptions.test.ts
@@ -62,6 +62,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        lastActiveAt: null,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,
@@ -700,7 +701,11 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         lastEntriesUpdatedAt: fetchTime,
       });
       for (let i = 0; i < count; i++) {
-        await createTestEntry(feedId, { guid: `${url}-${i}`, fetchedAt: fetchTime, lastSeenAt: fetchTime });
+        await createTestEntry(feedId, {
+          guid: `${url}-${i}`,
+          fetchedAt: fetchTime,
+          lastSeenAt: fetchTime,
+        });
       }
       return feedId;
     }

--- a/tests/integration/sync-events.test.ts
+++ b/tests/integration/sync-events.test.ts
@@ -64,6 +64,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        lastActiveAt: null,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/tags.test.ts
+++ b/tests/integration/tags.test.ts
@@ -71,6 +71,7 @@ function createAuthContext(userId: string): Context {
         passwordHash: "test-hash",
         inviteId: null,
         showSpam: false,
+        lastActiveAt: null,
         groqApiKey: null,
         anthropicApiKey: null,
         summarizationModel: null,

--- a/tests/integration/token-scopes.test.ts
+++ b/tests/integration/token-scopes.test.ts
@@ -61,6 +61,7 @@ function buildSession(userId: string): NonNullable<Context["session"]> {
       passwordHash: "test-hash",
       inviteId: null,
       showSpam: false,
+      lastActiveAt: null,
       groqApiKey: null,
       anthropicApiKey: null,
       summarizationModel: null,


### PR DESCRIPTION
## What

Three related changes to the Admin **Users** page.

### 1. Sort options (defaulting to most recent activity)

The user list now has a **Sort by** dropdown:

- **Most recent activity** (default)
- **Newest**
- **Oldest**
- **Email (A–Z)**

Each sorts by a durable, indexable column on the `users` row, so cursor (keyset) pagination stays correct per sort.

### 2. Fix "Last active" broken by session cleanup

The "Last active" column derived activity from `MAX(sessions.last_active_at)`. The daily retention cleanup (#953) deletes sessions ~1 day after they expire, and sessions live 30 days from creation — so any user idle longer than ~31 days lost every session row and showed as **"Never"**. The cleanup was quietly removing the data this page depended on.

Rather than keep expired sessions around (which would defeat the cleanup and let the table grow unbounded), this **denormalizes `last_active_at` onto the `users` row** so it survives cleanup:

- **Migration `0077`** adds `users.last_active_at`, backfills from surviving sessions, and indexes `(last_active_at DESC NULLS LAST, id DESC)` for the activity sort + cursor.
- `updateLastActiveAt` now refreshes the user column fire-and-forget alongside the session row, **throttled to once/minute** to avoid write/index churn.
- `admin.listUsers` reads the column directly; `getOverview`'s active-user metrics use it too (durable + simpler).

This also restores the accuracy of the retention job's own invariant that deleting sessions "never changes behavior."

### 3. Surface most recent API/MCP token use separately

`last_active_at` only covers the web app, so a user who mostly hits Lion Reader via the browser extension (API token) or remote MCP (OAuth access token) looked idle. The list now shows a separate **"Last API/MCP use"** field = `GREATEST(max api_tokens.last_used_at, max oauth_access_tokens.last_used_at)`.

- Durable for long-lived **API tokens** (extension/integrations).
- For **MCP OAuth access tokens** it only reflects ~the last day, since those are short-lived (~1h) and pruned by retention soon after expiry. Documented on the output field; a durable MCP-usage signal would need its own persisted column (not done here, per the "show separately" decision).

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (1920 tests) all pass locally.
- Added integration tests in `tests/integration/admin.test.ts`: activity/email sorting, sorted pagination without overlap, `lastActiveAt` surviving session deletion (regression), and `lastTokenUsedAt` reporting.
- ⚠️ Integration/e2e tests were **not** run locally (no Postgres/Redis in this environment) — they run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)