### PR TITLE
Stop advertising CIMD so claude.ai uses DCR (fixes MCP connector)

### DIFF
--- a/src/server/oauth/config.ts
+++ b/src/server/oauth/config.ts
@@ -53,8 +53,18 @@ export function getAuthorizationServerMetadata() {
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
     token_endpoint_auth_methods_supported: ["none"],
-    // MCP-specific: indicates support for Client ID Metadata Documents
-    client_id_metadata_document_supported: true,
+    // NB: we intentionally do NOT advertise `client_id_metadata_document_supported`.
+    // Clients pick their registration method by priority: pre-registered → CIMD →
+    // DCR. claude.ai treats CIMD (when advertised alongside `"none"` auth) as
+    // preferred and sets up the client entirely client-side (its own metadata-doc
+    // URL as client_id, no /oauth/register call). In practice that CIMD setup
+    // fails inside claude.ai's connector flow and it aborts *before* ever calling
+    // /oauth/authorize — observed in prod logs as discovery completing, then a
+    // silent ~3s gap, then "Couldn't register with the sign-in service" with no
+    // register/authorize request reaching us. Not advertising CIMD drops claude.ai
+    // (and other clients) to Dynamic Client Registration, which works. The
+    // server-side CIMD resolution in `resolveClient` is retained, so a client that
+    // explicitly presents a URL client_id still works.
   };
 }
 

--- a/tests/unit/oauth-config.test.ts
+++ b/tests/unit/oauth-config.test.ts
@@ -13,6 +13,7 @@ import {
   getResourceIdentifier,
   getAcceptedResourceIdentifiers,
   getProtectedResourceMetadata,
+  getAuthorizationServerMetadata,
 } from "../../src/server/oauth/config";
 
 describe("OAuth resource identifiers", () => {
@@ -51,5 +52,23 @@ describe("OAuth resource identifiers", () => {
     ]);
     // Origin (legacy) must remain accepted so pre-change tokens keep working.
     expect(getAcceptedResourceIdentifiers()).toContain(getIssuer());
+  });
+
+  it("does NOT advertise Client ID Metadata Document support", () => {
+    // Advertising `client_id_metadata_document_supported` makes claude.ai prefer
+    // CIMD over Dynamic Client Registration; its CIMD setup fails inside the
+    // connector flow (it never calls /oauth/register or /oauth/authorize) and
+    // surfaces as "Couldn't register with the sign-in service". Omitting the flag
+    // drops clients to DCR, which works. Do not re-add without confirming
+    // claude.ai's CIMD flow actually completes.
+    const metadata = getAuthorizationServerMetadata();
+    expect("client_id_metadata_document_supported" in metadata).toBe(false);
+  });
+
+  it("advertises the endpoints and PKCE claude.ai requires for DCR", () => {
+    const metadata = getAuthorizationServerMetadata();
+    expect(metadata.registration_endpoint).toBe("https://reader.example.com/oauth/register");
+    expect(metadata.code_challenge_methods_supported).toEqual(["S256"]);
+    expect(metadata.token_endpoint_auth_methods_supported).toEqual(["none"]);
   });
 });


### PR DESCRIPTION
## Root cause (from production logs)

Follow-up to #974. Fly logs from a real failed claude.ai connect show the discovery chain completing cleanly:

```
POST /api/mcp            → 401 (no_authorization_header)   ✅ WWW-Authenticate returned
GET  /.well-known/oauth-protected-resource                  ✅
GET  /.well-known/oauth-protected-resource/api/mcp          ✅ (path-inserted)
GET  /.well-known/oauth-authorization-server                ✅
   … ~3s gap, no further server requests …
POST /api/mcp            → 401 (no_authorization_header)   ← claude retries and gives up
```

**No `/oauth/register` and no `/oauth/authorize` request ever reached the server.** Our register handler logs on its first line (before rate limiting), so its absence proves claude.ai **never attempts Dynamic Client Registration** — which is why #974's rate-limit/CORS hardening didn't fix it (Claude wasn't reaching those endpoints).

Why claude.ai skips DCR: our authorization-server metadata advertised `client_id_metadata_document_supported: true` together with `token_endpoint_auth_methods_supported: ["none"]`. Per Claude's client-registration priority (**pre-registered → CIMD → DCR**), that combination makes claude.ai prefer **CIMD** (Client ID Metadata Documents). CIMD setup is entirely client-side (Claude uses its own hosted metadata-doc URL as `client_id`, with no registration call), and that setup fails inside claude.ai's connector flow — so it aborts before ever calling `/oauth/authorize`, exactly matching the ~3s gap with zero server calls, surfaced as "Couldn't register with the sign-in service."

## Fix

Stop advertising `client_id_metadata_document_supported`. This drops all clients to DCR (`POST /oauth/register`), which is verified working. The server-side CIMD resolution in `resolveClient` is **retained**, so any client that explicitly presents a URL `client_id` still works — we just no longer *steer* clients toward CIMD.

Adds a regression test asserting the flag is absent (with a comment explaining why) plus assertions that the DCR endpoint + PKCE claude.ai needs are advertised.

## Tests
`pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (1933) pass. The real confirmation is a live claude.ai reconnect after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)