### PR TITLE
[temporary] Log claude.ai MCP connector requests to diagnose OAuth failure

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,47 @@
+/**
+ * TEMPORARY diagnostic request logging for the claude.ai MCP connector OAuth flow.
+ *
+ * claude.ai completes OAuth discovery against our server but then aborts with
+ * "Couldn't register…" without any `POST /oauth/register` reaching our route
+ * handlers. Route handlers only log when they're actually invoked, so a request
+ * that 404s (e.g. an unexpected well-known path) or is dropped before routing is
+ * invisible. This middleware logs EVERY request to the OAuth/MCP surface —
+ * method, path, and source IP — so we can see exactly what claude.ai sends
+ * (and from which IP: Anthropic's egress is 160.79.104.0/21) in the gap between
+ * discovery succeeding and the connector giving up.
+ *
+ * Remove once the connector issue is diagnosed.
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  try {
+    console.log(
+      JSON.stringify({
+        level: "info",
+        message: "oauth-mcp-debug request",
+        service: "lion-reader",
+        method: request.method,
+        path: request.nextUrl.pathname,
+        query: request.nextUrl.search || undefined,
+        flyClientIp: request.headers.get("fly-client-ip") ?? undefined,
+        xForwardedFor: request.headers.get("x-forwarded-for") ?? undefined,
+        contentType: request.headers.get("content-type") ?? undefined,
+        userAgent: request.headers.get("user-agent") ?? undefined,
+        origin: request.headers.get("origin") ?? undefined,
+      })
+    );
+  } catch {
+    // Never let diagnostic logging break a request.
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  // Only the OAuth/MCP discovery + registration + token surface, to avoid
+  // logging normal app traffic. Catches 404s too (middleware runs before
+  // routing), which is the whole point.
+  matcher: ["/api/mcp", "/oauth/:path*", "/.well-known/:path*"],
+};


### PR DESCRIPTION
## Purpose (temporary diagnostic — revert after)

We've now established, via `mcp-remote` (a real MCP OAuth client), that our OAuth server works end-to-end: it discovers, does DCR (gets a real `client_id`), and builds a correct authorize URL. Yet claude.ai's connector still aborts after discovery with "Couldn't register…" and **no `POST /oauth/register` reaches our route handlers**.

Our route handlers only log when invoked, so we currently can't see:
- The **source IP** of the discovery requests (we've been *assuming* they're Anthropic's `160.79.104.0/21` — unconfirmed).
- Any request that **404s or is dropped before routing** (e.g. an unexpected well-known path, or a register POST that never reaches the handler).

This adds a minimal `src/middleware.ts` that logs method + path + source IP (`fly-client-ip`, `x-forwarded-for`) for every request to `/api/mcp`, `/oauth/*`, and `/.well-known/*` — including 404s (middleware runs before routing). Wrapped in try/catch so it can never break a request; scoped by matcher to avoid logging normal app traffic.

## How to use
1. Merge + deploy.
2. Reproduce the failed connect on claude.ai.
3. Grep Fly logs for `oauth-mcp-debug request` around the attempt.

This tells us definitively whether claude.ai sends *anything* in the silent gap (→ discovery-validation abort on Anthropic's side) or whether something is being dropped at the edge, and confirms the source IP. Then revert this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)