### PR TITLE
Ignore pinch-zoom and mid-pan swipes for article navigation

### DIFF
--- a/src/components/entries/EntryArticle.tsx
+++ b/src/components/entries/EntryArticle.tsx
@@ -59,6 +59,7 @@ export interface EntryArticleProps {
   /** Touch event handlers for swipe gestures */
   onTouchStart?: React.TouchEventHandler;
   onTouchEnd?: React.TouchEventHandler;
+  onTouchCancel?: React.TouchEventHandler;
 }
 
 export function EntryArticle({
@@ -84,6 +85,7 @@ export function EntryArticle({
   stickyControls,
   onTouchStart,
   onTouchEnd,
+  onTouchCancel,
 }: EntryArticleProps) {
   const displayFooterDomain = footerLinkDomain ?? (url ? getDomain(url) : "original site");
 
@@ -92,6 +94,7 @@ export function EntryArticle({
       className="mx-auto max-w-3xl px-4 py-6 sm:py-8"
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
+      onTouchCancel={onTouchCancel}
     >
       {/* Back button slot */}
       {backButton}

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -291,7 +291,11 @@ export function EntryContentBody({
     narration.state.status,
   ]);
 
-  const { onTouchStart: handleTouchStart, onTouchEnd: handleTouchEnd } = useSwipeGesture({
+  const {
+    onTouchStart: handleTouchStart,
+    onTouchEnd: handleTouchEnd,
+    onTouchCancel: handleTouchCancel,
+  } = useSwipeGesture({
     onSwipeLeft: onSwipeNext,
     onSwipeRight: onSwipePrevious,
     enabled: Boolean(onSwipeNext || onSwipePrevious),
@@ -328,6 +332,7 @@ export function EntryContentBody({
       contentRef={contentRef}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchCancel}
       backButton={
         onBack ? (
           <button

--- a/src/components/entries/EntryContentHelpers.ts
+++ b/src/components/entries/EntryContentHelpers.ts
@@ -47,3 +47,53 @@ export function detectSwipeDirection(
   }
   return deltaX < 0 ? "left" : "right";
 }
+
+/**
+ * Tolerance (CSS px) for treating the visual viewport as flush against a layout
+ * viewport edge; absorbs sub-pixel rounding from pinch-zoom.
+ */
+const VIEWPORT_EDGE_EPSILON = 1;
+
+export type ViewportEdges = {
+  /** Visual viewport is at (or near) the left edge of the layout viewport. */
+  atLeftEdge: boolean;
+  /** Visual viewport is at (or near) the right edge of the layout viewport. */
+  atRightEdge: boolean;
+};
+
+/**
+ * Capture whether the (possibly pinch-zoomed) visual viewport is panned against
+ * the left/right edge of the layout viewport.
+ *
+ * When the page isn't zoomed the visual viewport fills the layout viewport, so
+ * both edges read true. Returns both-true when the visualViewport API is
+ * unavailable (SSR, older browsers), degrading to the un-zoomed default so
+ * navigation is never blocked.
+ */
+export function getViewportEdges(): ViewportEdges {
+  const vv = typeof window !== "undefined" ? window.visualViewport : null;
+  if (!vv || typeof document === "undefined") {
+    return { atLeftEdge: true, atRightEdge: true };
+  }
+  const layoutWidth = document.documentElement.clientWidth;
+  return {
+    atLeftEdge: vv.offsetLeft <= VIEWPORT_EDGE_EPSILON,
+    atRightEdge: vv.offsetLeft + vv.width >= layoutWidth - VIEWPORT_EDGE_EPSILON,
+  };
+}
+
+/**
+ * Whether a swipe in the given direction may navigate, given the viewport edge
+ * state captured when the gesture began.
+ *
+ * Swiping left advances to the next article, which only makes sense once the
+ * user has panned to the right edge of a zoomed article; swiping right (to the
+ * previous article) requires the left edge. When the article isn't zoomed both
+ * edges are true, so navigation is always allowed and behavior is unchanged.
+ */
+export function isSwipeNavigationAllowed(
+  direction: "left" | "right",
+  edges: ViewportEdges
+): boolean {
+  return direction === "left" ? edges.atRightEdge : edges.atLeftEdge;
+}

--- a/src/lib/hooks/useSwipeGesture.ts
+++ b/src/lib/hooks/useSwipeGesture.ts
@@ -81,5 +81,14 @@ export function useSwipeGesture({
     [enabled, onSwipeLeft, onSwipeRight]
   );
 
-  return { onTouchStart, onTouchEnd };
+  // Browsers frequently fire `touchcancel` (not `touchend`) when they hijack a
+  // gesture for pinch-zoom/scroll. Abandon any in-progress swipe and clear the
+  // multi-touch flag once all fingers lift, so it can't linger stale-true into
+  // the next gesture.
+  const onTouchCancel = useCallback((e: React.TouchEvent) => {
+    touchStartRef.current = null;
+    if (e.touches.length === 0) multiTouchRef.current = false;
+  }, []);
+
+  return { onTouchStart, onTouchEnd, onTouchCancel };
 }

--- a/src/lib/hooks/useSwipeGesture.ts
+++ b/src/lib/hooks/useSwipeGesture.ts
@@ -1,5 +1,10 @@
 import { useCallback, useRef } from "react";
-import { detectSwipeDirection } from "@/components/entries/EntryContentHelpers";
+import {
+  detectSwipeDirection,
+  getViewportEdges,
+  isSwipeNavigationAllowed,
+  type ViewportEdges,
+} from "@/components/entries/EntryContentHelpers";
 
 export function useSwipeGesture({
   onSwipeLeft,
@@ -10,19 +15,46 @@ export function useSwipeGesture({
   onSwipeRight?: () => void;
   enabled?: boolean;
 }) {
-  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+  const touchStartRef = useRef<{
+    x: number;
+    y: number;
+    edges: ViewportEdges;
+  } | null>(null);
+  // Set once a gesture ever involves more than one finger (pinch-to-zoom, etc.).
+  // Such a gesture is never treated as a navigation swipe, even after fingers
+  // lift back down to one.
+  const multiTouchRef = useRef(false);
 
   const onTouchStart = useCallback(
     (e: React.TouchEvent) => {
       if (!enabled) return;
+      // A second finger means pinch-zoom or another multi-touch gesture, not a
+      // navigation swipe. Abandon any in-progress swipe.
+      if (e.touches.length > 1) {
+        multiTouchRef.current = true;
+        touchStartRef.current = null;
+        return;
+      }
+      multiTouchRef.current = false;
       const touch = e.touches[0];
-      touchStartRef.current = { x: touch.clientX, y: touch.clientY };
+      touchStartRef.current = {
+        x: touch.clientX,
+        y: touch.clientY,
+        // Capture the pan position at the start of the gesture so a swipe that
+        // begins mid-pan of a zoomed article scrolls instead of navigating.
+        edges: getViewportEdges(),
+      };
     },
     [enabled]
   );
 
   const onTouchEnd = useCallback(
     (e: React.TouchEvent) => {
+      // Ignore any gesture that became multi-touch; reset once all fingers lift.
+      if (multiTouchRef.current) {
+        if (e.touches.length === 0) multiTouchRef.current = false;
+        return;
+      }
       if (!enabled || !touchStartRef.current) return;
 
       const touch = e.changedTouches[0];
@@ -33,6 +65,12 @@ export function useSwipeGesture({
         x: touch.clientX,
         y: touch.clientY,
       });
+      if (!direction) return;
+
+      // When the article is pinch-zoomed, only navigate if the swipe started
+      // against the edge it moves toward; otherwise the user is panning around
+      // the zoomed content.
+      if (!isSwipeNavigationAllowed(direction, start.edges)) return;
 
       if (direction === "left") {
         onSwipeLeft?.();

--- a/tests/unit/frontend/components/entry-swipe-navigation.test.ts
+++ b/tests/unit/frontend/components/entry-swipe-navigation.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
 import {
   detectSwipeDirection,
+  getViewportEdges,
   isSwipeNavigationAllowed,
   type ViewportEdges,
 } from "@/components/entries/EntryContentHelpers";
@@ -47,5 +49,71 @@ describe("isSwipeNavigationAllowed", () => {
   it("blocks navigation when panned to neither edge of a zoomed article", () => {
     expect(isSwipeNavigationAllowed("left", neither)).toBe(false);
     expect(isSwipeNavigationAllowed("right", neither)).toBe(false);
+  });
+});
+
+describe("getViewportEdges", () => {
+  const LAYOUT_WIDTH = 400;
+  const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
+
+  function setLayoutWidth(width: number) {
+    Object.defineProperty(document.documentElement, "clientWidth", {
+      configurable: true,
+      value: width,
+    });
+  }
+
+  function setVisualViewport(vv: Partial<VisualViewport> | null) {
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: vv,
+    });
+  }
+
+  afterEach(() => {
+    if (originalVisualViewport) {
+      Object.defineProperty(window, "visualViewport", originalVisualViewport);
+    }
+    // Drop the clientWidth override so jsdom's default getter is restored.
+    delete (document.documentElement as unknown as { clientWidth?: number }).clientWidth;
+  });
+
+  it("reports both edges when the visualViewport API is unavailable", () => {
+    setVisualViewport(null);
+    expect(getViewportEdges()).toEqual({ atLeftEdge: true, atRightEdge: true });
+  });
+
+  it("reports both edges when not zoomed (viewport fills layout)", () => {
+    setLayoutWidth(LAYOUT_WIDTH);
+    setVisualViewport({ offsetLeft: 0, width: LAYOUT_WIDTH });
+    expect(getViewportEdges()).toEqual({ atLeftEdge: true, atRightEdge: true });
+  });
+
+  it("reports only the left edge when zoomed and panned fully left", () => {
+    setLayoutWidth(LAYOUT_WIDTH);
+    // Zoomed 2x: visual viewport is half as wide, panned to the left.
+    setVisualViewport({ offsetLeft: 0, width: 200 });
+    expect(getViewportEdges()).toEqual({ atLeftEdge: true, atRightEdge: false });
+  });
+
+  it("reports only the right edge when zoomed and panned fully right", () => {
+    setLayoutWidth(LAYOUT_WIDTH);
+    setVisualViewport({ offsetLeft: 200, width: 200 });
+    expect(getViewportEdges()).toEqual({ atLeftEdge: false, atRightEdge: true });
+  });
+
+  it("reports neither edge when zoomed and panned to the middle", () => {
+    setLayoutWidth(LAYOUT_WIDTH);
+    setVisualViewport({ offsetLeft: 100, width: 200 });
+    expect(getViewportEdges()).toEqual({
+      atLeftEdge: false,
+      atRightEdge: false,
+    });
+  });
+
+  it("treats sub-pixel offsets within the epsilon as flush against an edge", () => {
+    setLayoutWidth(LAYOUT_WIDTH);
+    setVisualViewport({ offsetLeft: 0.5, width: LAYOUT_WIDTH - 0.5 });
+    expect(getViewportEdges()).toEqual({ atLeftEdge: true, atRightEdge: true });
   });
 });

--- a/tests/unit/frontend/components/entry-swipe-navigation.test.ts
+++ b/tests/unit/frontend/components/entry-swipe-navigation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectSwipeDirection,
+  isSwipeNavigationAllowed,
+  type ViewportEdges,
+} from "@/components/entries/EntryContentHelpers";
+
+describe("detectSwipeDirection", () => {
+  it("detects a leftward swipe past the threshold", () => {
+    expect(detectSwipeDirection({ x: 200, y: 0 }, { x: 100, y: 0 })).toBe("left");
+  });
+
+  it("detects a rightward swipe past the threshold", () => {
+    expect(detectSwipeDirection({ x: 100, y: 0 }, { x: 200, y: 0 })).toBe("right");
+  });
+
+  it("ignores short horizontal movement below the threshold", () => {
+    expect(detectSwipeDirection({ x: 100, y: 0 }, { x: 120, y: 0 })).toBeNull();
+  });
+
+  it("ignores mostly-vertical movement (scrolling)", () => {
+    expect(detectSwipeDirection({ x: 100, y: 0 }, { x: 160, y: 100 })).toBeNull();
+  });
+});
+
+describe("isSwipeNavigationAllowed", () => {
+  const bothEdges: ViewportEdges = { atLeftEdge: true, atRightEdge: true };
+  const leftOnly: ViewportEdges = { atLeftEdge: true, atRightEdge: false };
+  const rightOnly: ViewportEdges = { atLeftEdge: false, atRightEdge: true };
+  const neither: ViewportEdges = { atLeftEdge: false, atRightEdge: false };
+
+  it("allows navigation in both directions when not zoomed (both edges)", () => {
+    expect(isSwipeNavigationAllowed("left", bothEdges)).toBe(true);
+    expect(isSwipeNavigationAllowed("right", bothEdges)).toBe(true);
+  });
+
+  it("allows swipe-left (next) only when panned to the right edge", () => {
+    expect(isSwipeNavigationAllowed("left", rightOnly)).toBe(true);
+    expect(isSwipeNavigationAllowed("left", leftOnly)).toBe(false);
+  });
+
+  it("allows swipe-right (previous) only when panned to the left edge", () => {
+    expect(isSwipeNavigationAllowed("right", leftOnly)).toBe(true);
+    expect(isSwipeNavigationAllowed("right", rightOnly)).toBe(false);
+  });
+
+  it("blocks navigation when panned to neither edge of a zoomed article", () => {
+    expect(isSwipeNavigationAllowed("left", neither)).toBe(false);
+    expect(isSwipeNavigationAllowed("right", neither)).toBe(false);
+  });
+});

--- a/tests/unit/frontend/hooks/useSwipeGesture.test.ts
+++ b/tests/unit/frontend/hooks/useSwipeGesture.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSwipeGesture } from "@/lib/hooks/useSwipeGesture";
+
+type Point = { clientX: number; clientY: number };
+
+function touchEvent(touches: Point[], changedTouches: Point[] = touches) {
+  return { touches, changedTouches } as unknown as React.TouchEvent;
+}
+
+const LEFT = 200;
+const RIGHT = 50; // moving from x=200 to x=50 is a leftward swipe past threshold
+
+describe("useSwipeGesture", () => {
+  // Force the un-zoomed default (both edges) so these tests exercise the
+  // multi-touch lifecycle, not the zoom edge-gating (covered elsewhere).
+  const original = Object.getOwnPropertyDescriptor(window, "visualViewport");
+  beforeEach(() => {
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: null,
+    });
+  });
+  afterEach(() => {
+    if (original) Object.defineProperty(window, "visualViewport", original);
+  });
+
+  function setup() {
+    const onSwipeLeft = vi.fn();
+    const onSwipeRight = vi.fn();
+    const { result } = renderHook(() => useSwipeGesture({ onSwipeLeft, onSwipeRight }));
+    return { onSwipeLeft, onSwipeRight, handlers: result.current };
+  }
+
+  it("fires onSwipeLeft for a single-finger leftward swipe", () => {
+    const { onSwipeLeft, handlers } = setup();
+    handlers.onTouchStart(touchEvent([{ clientX: LEFT, clientY: 0 }]));
+    handlers.onTouchEnd(touchEvent([], [{ clientX: RIGHT, clientY: 0 }]));
+    expect(onSwipeLeft).toHaveBeenCalledOnce();
+  });
+
+  it("does not navigate when a second finger joins (pinch-zoom)", () => {
+    const { onSwipeLeft, onSwipeRight, handlers } = setup();
+    handlers.onTouchStart(touchEvent([{ clientX: LEFT, clientY: 0 }]));
+    // Second finger down → multi-touch.
+    handlers.onTouchStart(
+      touchEvent([
+        { clientX: LEFT, clientY: 0 },
+        { clientX: 100, clientY: 0 },
+      ])
+    );
+    // One finger lifts (other remains): still multi-touch, no navigation.
+    handlers.onTouchEnd(
+      touchEvent([{ clientX: 100, clientY: 0 }], [{ clientX: RIGHT, clientY: 0 }])
+    );
+    // Last finger lifts.
+    handlers.onTouchEnd(touchEvent([], [{ clientX: 100, clientY: 0 }]));
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it("recovers on the next single-finger swipe after a pinch", () => {
+    const { onSwipeLeft, handlers } = setup();
+    handlers.onTouchStart(touchEvent([{ clientX: LEFT, clientY: 0 }]));
+    handlers.onTouchStart(
+      touchEvent([
+        { clientX: LEFT, clientY: 0 },
+        { clientX: 100, clientY: 0 },
+      ])
+    );
+    handlers.onTouchEnd(touchEvent([], [{ clientX: 100, clientY: 0 }]));
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+
+    // Fresh single-finger swipe should work again.
+    handlers.onTouchStart(touchEvent([{ clientX: LEFT, clientY: 0 }]));
+    handlers.onTouchEnd(touchEvent([], [{ clientX: RIGHT, clientY: 0 }]));
+    expect(onSwipeLeft).toHaveBeenCalledOnce();
+  });
+
+  it("clears the multi-touch flag on touchcancel so the next swipe works", () => {
+    const { onSwipeLeft, handlers } = setup();
+    // Pinch begins, then the browser hijacks it with touchcancel (no touchend).
+    handlers.onTouchStart(touchEvent([{ clientX: LEFT, clientY: 0 }]));
+    handlers.onTouchStart(
+      touchEvent([
+        { clientX: LEFT, clientY: 0 },
+        { clientX: 100, clientY: 0 },
+      ])
+    );
+    handlers.onTouchCancel?.(touchEvent([]));
+
+    // Next single-finger swipe navigates.
+    handlers.onTouchStart(touchEvent([{ clientX: LEFT, clientY: 0 }]));
+    handlers.onTouchEnd(touchEvent([], [{ clientX: RIGHT, clientY: 0 }]));
+    expect(onSwipeLeft).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the flag set on touchcancel while a finger remains down", () => {
+    const { onSwipeLeft, handlers } = setup();
+    handlers.onTouchStart(touchEvent([{ clientX: LEFT, clientY: 0 }]));
+    handlers.onTouchStart(
+      touchEvent([
+        { clientX: LEFT, clientY: 0 },
+        { clientX: 100, clientY: 0 },
+      ])
+    );
+    // touchcancel with one finger still down must NOT reset the flag.
+    handlers.onTouchCancel?.(touchEvent([{ clientX: 100, clientY: 0 }]));
+    handlers.onTouchEnd(touchEvent([], [{ clientX: RIGHT, clientY: 0 }]));
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

The next/previous article swipe recorded a single touch's start/end point and navigated on any qualifying horizontal motion. That meant **pinch-to-zoom** and **panning around a zoomed-in article** both triggered navigation, making zoomed reading frustrating on touch devices.

## Fix

Two guards added to `useSwipeGesture`:

1. **Multi-touch cancellation** — if a gesture ever has more than one active touch, it is never treated as a navigation swipe (covers pinch-zoom and other two-finger gestures). The flag resets only once all fingers lift.
2. **Edge-gated navigation** — capture the visual viewport pan position at `touchstart`. When the article is pinch-zoomed, only navigate if the swipe started against the edge it moves toward:
   - swipe-left → next requires the viewport at the **right** edge
   - swipe-right → previous requires the **left** edge

   When the article isn't zoomed, the visual viewport fills the layout viewport so both edges read true and behavior is unchanged. Degrades to the unzoomed default when the `visualViewport` API is unavailable (SSR/older browsers).

New pure, testable helpers `getViewportEdges` / `isSwipeNavigationAllowed` live in `EntryContentHelpers`, with unit tests in `tests/unit/frontend/components/entry-swipe-navigation.test.ts`.

## Testing

- `pnpm test:unit` — all pass (new swipe-navigation cases included)
- `pnpm typecheck` — clean

The edge math is DOM-read-in-hook / pure-logic-in-helper, so the branching is covered by unit tests. Manual verification on a real touch device with a zoomed article is worth a spot-check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)