### PR TITLE
Serve OAuth authorize/token at origin root for the claude.ai connector

### DIFF
--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -2,6 +2,13 @@
  * Registration Page
  *
  * Allows new users to create an account with email/password or OAuth.
+ *
+ * IMPORTANT INVARIANT: this page must submit via tRPC (see `registerMutation`), NEVER a
+ * plain-HTML `POST` to `/register`. `src/proxy.ts` method-splits this URL —
+ * `POST /register` is rewritten to the OAuth Dynamic Client Registration handler
+ * `/oauth/register` (a HACK to satisfy claude.ai's root-path synthesis; see the
+ * comment in proxy.ts and anthropics/claude-ai-mcp#341). A form `POST` here
+ * would be silently hijacked into OAuth registration.
  */
 
 "use client";

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -12,5 +12,10 @@
  * We re-export the real handlers here so the flow completes at the root path.
  * `/oauth/authorize` remains for spec-compliant clients (mcp-remote, Inspector),
  * which correctly follow the advertised metadata.
+ *
+ * NOTE: route-segment config (`export const runtime`/`dynamic`/`maxDuration`/…)
+ * does NOT propagate through `export { … } from`. `/oauth/authorize` declares
+ * none today (its handlers are inherently dynamic — they read the request), so
+ * nothing is lost. If that changes, mirror the segment config here too.
  */
 export { GET, POST } from "@/app/oauth/authorize/route";

--- a/src/app/authorize/route.ts
+++ b/src/app/authorize/route.ts
@@ -1,0 +1,16 @@
+/**
+ * Root-level OAuth authorization endpoint alias (`/authorize`).
+ *
+ * claude.ai's connector synthesizes OAuth endpoints at the origin ROOT
+ * (`/authorize`, `/token`) instead of using the `authorization_endpoint` /
+ * `token_endpoint` advertised in our RFC 8414 authorization-server metadata.
+ * Observed with a manually-configured client_id: claude.ai redirected the
+ * browser to `https://lionreader.com/authorize` (404) rather than the advertised
+ * `/oauth/authorize`. This is a known claude.ai behavior — see
+ * anthropics/claude-ai-mcp #82, #341, #78 and the wiki failure catalog.
+ *
+ * We re-export the real handlers here so the flow completes at the root path.
+ * `/oauth/authorize` remains for spec-compliant clients (mcp-remote, Inspector),
+ * which correctly follow the advertised metadata.
+ */
+export { GET, POST } from "@/app/oauth/authorize/route";

--- a/src/app/token/route.ts
+++ b/src/app/token/route.ts
@@ -5,5 +5,9 @@
  * origin root and ignores the advertised `token_endpoint`. It POSTs the code
  * exchange to `https://lionreader.com/token`, so we serve the real token handler
  * here. `/oauth/token` remains for spec-compliant clients.
+ *
+ * NOTE: route-segment config does NOT propagate through `export { … } from`
+ * (see src/app/authorize/route.ts). `/oauth/token` declares none today; mirror
+ * it here if that ever changes.
  */
 export { POST, OPTIONS } from "@/app/oauth/token/route";

--- a/src/app/token/route.ts
+++ b/src/app/token/route.ts
@@ -1,0 +1,9 @@
+/**
+ * Root-level OAuth token endpoint alias (`/token`).
+ *
+ * See `src/app/authorize/route.ts`: claude.ai synthesizes OAuth endpoints at the
+ * origin root and ignores the advertised `token_endpoint`. It POSTs the code
+ * exchange to `https://lionreader.com/token`, so we serve the real token handler
+ * here. `/oauth/token` remains for spec-compliant clients.
+ */
+export { POST, OPTIONS } from "@/app/oauth/token/route";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -62,6 +62,36 @@ function isPublicPath(pathname: string): boolean {
 export function proxy(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
 
+  // ==========================================================================
+  // HACK: claude.ai OAuth "root path" workaround — `/register` is METHOD-SPLIT.
+  //
+  //   GET  /register  ->  the human signup PAGE (normal; app/(auth)/register)
+  //   POST /register  ->  rewritten to the OAuth DCR handler at /oauth/register
+  //
+  // Why this exists: claude.ai's remote-MCP connector synthesizes OAuth
+  // endpoints at the ORIGIN ROOT (/authorize, /token, /register) and ignores the
+  // authorization_endpoint/token_endpoint/registration_endpoint we advertise in
+  // RFC 8414 metadata. So its Dynamic Client Registration POST lands on
+  // `/register`, not our real `/oauth/register`. (The /authorize + /token root
+  // aliases live in src/app/{authorize,token}/route.ts.)
+  //
+  // This is deliberately ugly — ONE url doing two unrelated things by HTTP
+  // method. We accept it only because (a) Next.js can't host a page and a route
+  // handler at the same path, so we can't add a POST handler to /register
+  // directly, and (b) nothing in the app POSTs to /register (signup submits via
+  // tRPC to /api/trpc/*), so hijacking POST is safe. Anyone editing the /register
+  // page or this proxy MUST keep that invariant.
+  //
+  // REMOVE THIS once claude.ai honors the advertised registration_endpoint:
+  //   https://github.com/anthropics/claude-ai-mcp/issues/341  (tracking bug)
+  //   https://github.com/anthropics/claude-ai-mcp/issues/82   (root-path synthesis)
+  // ==========================================================================
+  if (pathname === "/register" && request.method === "POST") {
+    const dcrUrl = request.nextUrl.clone();
+    dcrUrl.pathname = "/oauth/register";
+    return NextResponse.rewrite(dcrUrl);
+  }
+
   // Allow public paths without auth check
   if (isPublicPath(pathname)) {
     return NextResponse.next();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -23,6 +23,13 @@ const PUBLIC_PATHS = [
   "/register",
   "/auth/oauth/callback",
   "/auth/oauth/complete",
+  // Root-level OAuth endpoint aliases for claude.ai (which synthesizes OAuth
+  // endpoints at the origin root — see src/app/authorize/route.ts). These handle
+  // their own auth; /token is POSTed server-to-server with no session cookie, so
+  // it must never be redirected to /login.
+  "/authorize",
+  "/token",
+  "/oauth/", // OAuth authorization/token/register + consent handle their own auth
   "/api/", // All API routes handle their own auth
   "/_next/", // Next.js static files
   "/extension/", // Extension pages handle their own auth

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -65,8 +65,14 @@ export function proxy(request: NextRequest) {
   // ==========================================================================
   // HACK: claude.ai OAuth "root path" workaround — `/register` is METHOD-SPLIT.
   //
-  //   GET  /register  ->  the human signup PAGE (normal; app/(auth)/register)
-  //   POST /register  ->  rewritten to the OAuth DCR handler at /oauth/register
+  //   GET      /register  ->  the human signup PAGE (normal; app/(auth)/register)
+  //   POST     /register  ->  rewritten to the OAuth DCR handler at /oauth/register
+  //   OPTIONS  /register  ->  same rewrite, so an in-browser MCP client's CORS
+  //                           preflight for the DCR POST is answered (the DCR
+  //                           route exports an OPTIONS handler; the signup page
+  //                           does not). claude.ai itself is server-side and
+  //                           sends no preflight, but this keeps browser clients
+  //                           (MCP Inspector, playgrounds) working at the root.
   //
   // Why this exists: claude.ai's remote-MCP connector synthesizes OAuth
   // endpoints at the ORIGIN ROOT (/authorize, /token, /register) and ignores the
@@ -86,7 +92,7 @@ export function proxy(request: NextRequest) {
   //   https://github.com/anthropics/claude-ai-mcp/issues/341  (tracking bug)
   //   https://github.com/anthropics/claude-ai-mcp/issues/82   (root-path synthesis)
   // ==========================================================================
-  if (pathname === "/register" && request.method === "POST") {
+  if (pathname === "/register" && (request.method === "POST" || request.method === "OPTIONS")) {
     const dcrUrl = request.nextUrl.clone();
     dcrUrl.pathname = "/oauth/register";
     return NextResponse.rewrite(dcrUrl);


### PR DESCRIPTION
## Root cause (caught in the act)

Using the manual Client ID workaround, the connector got far enough to reveal the bug: claude.ai redirected the browser to **`https://lionreader.com/authorize`** — a **404**, because our authorization endpoint is at `/oauth/authorize`.

claude.ai's remote-MCP connector **synthesizes OAuth endpoints at the origin root** (`/authorize`, `/token`, `/register`) and **ignores the `authorization_endpoint`/`token_endpoint`/`registration_endpoint` we advertise** in RFC 8414 metadata. Documented claude.ai behavior — [#82](https://github.com/anthropics/claude-ai-mcp/issues/82), [#341](https://github.com/anthropics/claude-ai-mcp/issues/341) (tracking, still open), [#78](https://github.com/anthropics/claude-ai-mcp/issues/78). It also explains the original "no `/oauth/register` call" symptom: in the auto-DCR flow claude.ai POSTs to root `/register`, which on our site is the **signup page** (405 to a POST), so registration silently fails and `/oauth/register` is never reached. Anthropic acknowledges the defect ([#481](https://github.com/anthropics/claude-ai-mcp/issues/481)) but there is no shipped fix; the community workaround is to serve/alias OAuth at the root.

## Fix — serve OAuth at the origin root

- `src/app/authorize/route.ts`, `src/app/token/route.ts` — re-export the real `/oauth/authorize` + `/oauth/token` handlers at the root.
- `src/proxy.ts` — **method-split `/register`**: `GET` → signup page (unchanged), **`POST` → rewritten to `/oauth/register`** (the DCR handler). This is a deliberate hack (one URL, two behaviors by method), loudly commented in `proxy.ts` and on the `/register` page, tracked to [#341](https://github.com/anthropics/claude-ai-mcp/issues/341). Safe because nothing in the app POSTs to `/register` (signup submits via tRPC).
- `src/proxy.ts` `PUBLIC_PATHS` — add `/authorize`, `/token`, `/oauth/` so the **server-to-server `POST /token`** (no session cookie) is never redirected to `/login`.

`/oauth/*` stays for spec-compliant clients (`mcp-remote`, MCP Inspector — verified they follow the advertised metadata and connect fine).

## Result

Covers both the root-path synthesis **and** the advertised paths, so the connector should work in **fully-automatic mode (no manual Client ID)**: `POST /register` (DCR) → `/authorize` → `/token` all resolve to the real handlers.

## Verification

- `pnpm typecheck` + lint pass; `pnpm build` emits the `/authorize` and `/token` route handlers.
- End-to-end confirmation is the live reconnect after deploy — ideally test **both** with the manual Client ID and **without** it (auto mode) to confirm the `/register` split works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)