### PR TITLE
Log OAuth token-exchange outcome (diagnose connector post-token failure)

### DIFF
--- a/src/app/oauth/token/route.ts
+++ b/src/app/oauth/token/route.ts
@@ -47,7 +47,6 @@ async function handleToken(request: NextRequest): Promise<Response> {
   const rateLimitResponse = await checkRouteRateLimit(request, "oauth", { json: true });
   if (rateLimitResponse) return rateLimitResponse;
 
-  logger.info("OAuth token request");
   // Parse form data or JSON body
   let body: Record<string, string>;
 
@@ -58,6 +57,7 @@ async function handleToken(request: NextRequest): Promise<Response> {
   } else if (contentType.includes("application/json")) {
     body = await request.json();
   } else {
+    logger.warn("OAuth token request: unsupported content type", { contentType });
     return NextResponse.json(
       createOAuthError(OAUTH_ERRORS.INVALID_REQUEST, "Unsupported content type"),
       { status: 400 }
@@ -65,6 +65,17 @@ async function handleToken(request: NextRequest): Promise<Response> {
   }
 
   const grantType = body.grant_type;
+
+  // Log what the client sent (no secrets) so token-exchange failures are
+  // debuggable — grant type + which required params are present.
+  logger.info("OAuth token request", {
+    grantType,
+    clientId: body.client_id,
+    hasCode: !!body.code,
+    hasCodeVerifier: !!body.code_verifier,
+    hasRedirectUri: !!body.redirect_uri,
+    hasRefreshToken: !!body.refresh_token,
+  });
 
   if (grantType === "authorization_code") {
     return handleAuthorizationCodeGrant(body);
@@ -192,6 +203,14 @@ async function handleAuthorizationCodeGrant(body: Record<string, string>) {
     clientId: client_id,
     userId: authCodeData.userId,
     scopes: authCodeData.scopes,
+    resource: authCodeData.resource,
+  });
+
+  logger.info("OAuth token issued", {
+    grantType: "authorization_code",
+    clientId: client_id,
+    userId: authCodeData.userId,
+    scope: tokens.scope,
     resource: authCodeData.resource,
   });
 

--- a/src/server/oauth/service.ts
+++ b/src/server/oauth/service.ts
@@ -29,6 +29,7 @@ import {
   OAUTH_SCOPES,
 } from "./utils";
 import { getResourceIdentifier } from "./config";
+import { logger } from "@/lib/logger";
 import { USER_AGENT } from "@/server/http/user-agent";
 import { fetchWithSsrfProtection } from "@/server/http/ssrf";
 import { readResponseBufferWithSizeLimit } from "@/server/http/fetch";
@@ -272,6 +273,12 @@ export async function validateAndConsumeAuthCode(
     .returning();
 
   if (result.length === 0) {
+    // The atomic claim matched nothing: the code is unknown, already used,
+    // expired, or the client_id / redirect_uri don't match what was stored.
+    logger.warn("OAuth code exchange rejected: code claim failed", {
+      clientId,
+      redirectUri,
+    });
     return null;
   }
 
@@ -279,6 +286,7 @@ export async function validateAndConsumeAuthCode(
 
   // Validate PKCE
   if (!validatePkceS256(codeVerifier, authCode.codeChallenge)) {
+    logger.warn("OAuth code exchange rejected: PKCE verification failed", { clientId });
     return null;
   }
 


### PR DESCRIPTION
## Why

After #981, the claude.ai connector now gets all the way through discovery → `/authorize` (root) → `/token` (root), but the subsequent MCP request still arrives with **no `Authorization` header** (401). Two possibilities we currently can't distinguish:

1. The token exchange **failed** (claude.ai has no token) — a server-side bug we can fix.
2. The token exchange **succeeded** but claude.ai didn't attach the token — the known claude.ai-side "post-token no auth header" bug (anthropics/claude-ai-mcp #136, #162, #325).

The token endpoint only logged `"OAuth token request"` at entry — no outcome — and we've never actually verified our `/token` issues a token with a real code (mcp-remote stopped at the browser step).

## What

- Enrich the token-request log with grant type + which required params are present (no secrets).
- Log **`OAuth token issued`** on success (client, user, scope, resource).
- Log the rejection reason inside `validateAndConsumeAuthCode`: `code claim failed` (unknown / used / expired / mismatched `client_id` or `redirect_uri`) vs `PKCE verification failed`.

Useful observability regardless, and it settles the current debug: if we see `OAuth token issued`, the ball is in claude.ai's court; otherwise we get the exact server-side reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)