### PR TITLE
Settings: note the claude.ai web MCP connector is currently broken

### DIFF
--- a/src/components/settings/IntegrationsSettings.tsx
+++ b/src/components/settings/IntegrationsSettings.tsx
@@ -91,10 +91,8 @@ export function IntegrationsSettings() {
           <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Claude.ai</h3>
           <div className="mt-2">
             <Alert variant="warning">
-              The claude.ai <strong>web</strong> connector currently can&rsquo;t complete the
-              connection due to a bug on claude.ai&rsquo;s side (it completes OAuth but
-              doesn&rsquo;t send the access token on the follow-up request). We&rsquo;ve reported it
-              to Anthropic &mdash; details and status in{" "}
+              The claude.ai <strong>web</strong> connector is currently broken due to a bug on
+              claude.ai&rsquo;s side. See{" "}
               <a
                 href="https://github.com/brendanlong/lion-reader/issues/986"
                 target="_blank"
@@ -103,8 +101,7 @@ export function IntegrationsSettings() {
               >
                 this issue
               </a>
-              . For now, please use <strong>Claude Code</strong> or <strong>Claude Desktop</strong>{" "}
-              (above/below) &mdash; those work today.
+              . The MCP server should work with other tools, including Claude Code.
             </Alert>
           </div>
           <ol className="ui-text-sm mt-2 list-inside list-decimal space-y-2 text-zinc-600 dark:text-zinc-400">

--- a/src/components/settings/IntegrationsSettings.tsx
+++ b/src/components/settings/IntegrationsSettings.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { Alert } from "@/components/ui/alert";
 
 export function IntegrationsSettings() {
   const [copiedSection, setCopiedSection] = useState<string | null>(null);
@@ -88,6 +89,24 @@ export function IntegrationsSettings() {
         {/* Claude.ai */}
         <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
           <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Claude.ai</h3>
+          <div className="mt-2">
+            <Alert variant="warning">
+              The claude.ai <strong>web</strong> connector currently can&rsquo;t complete the
+              connection due to a bug on claude.ai&rsquo;s side (it completes OAuth but
+              doesn&rsquo;t send the access token on the follow-up request). We&rsquo;ve reported it
+              to Anthropic &mdash; details and status in{" "}
+              <a
+                href="https://github.com/brendanlong/lion-reader/issues/986"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium underline"
+              >
+                this issue
+              </a>
+              . For now, please use <strong>Claude Code</strong> or <strong>Claude Desktop</strong>{" "}
+              (above/below) &mdash; those work today.
+            </Alert>
+          </div>
           <ol className="ui-text-sm mt-2 list-inside list-decimal space-y-2 text-zinc-600 dark:text-zinc-400">
             <li>Click your name in the bottom-left corner</li>
             <li>


### PR DESCRIPTION
Adds a warning to the **Claude.ai** section of Integrations settings: the claude.ai *web* custom connector can't currently complete the connection due to a bug on claude.ai's side (OAuth completes but the access token isn't attached to the follow-up MCP request; auto-DCR shows "couldn't register" despite a `201`). Points users to **Claude Code / Claude Desktop** (which work today) and links the tracking issue.

- Tracking: brendanlong/lion-reader#986
- Uses the existing `Alert` (`variant="warning"`) component.

Remove the note once the claude.ai connector works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)