### PR TITLE
Fix spoofable per-IP rate-limit key from x-forwarded-for (#983)

### DIFF
--- a/src/app/api/greader.php/accounts/ClientLogin/route.ts
+++ b/src/app/api/greader.php/accounts/ClientLogin/route.ts
@@ -18,6 +18,7 @@
 import { clientLogin } from "@/server/google-reader/auth";
 import { parseFormData, errorResponse } from "@/server/google-reader/parse";
 import { checkRouteRateLimit } from "@/server/rate-limit";
+import { extractClientInfo } from "@/server/http/client-ip";
 
 export const dynamic = "force-dynamic";
 
@@ -33,8 +34,7 @@ export async function POST(request: Request): Promise<Response> {
     return errorResponse("Error=BadAuthentication", 401);
   }
 
-  const userAgent = request.headers.get("user-agent") ?? undefined;
-  const ipAddress = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? undefined;
+  const { userAgent, ipAddress } = extractClientInfo(request.headers);
 
   const result = await clientLogin(email, password, userAgent, ipAddress);
 

--- a/src/server/auth/oauth/callback-helpers.ts
+++ b/src/server/auth/oauth/callback-helpers.ts
@@ -11,18 +11,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createSession } from "@/server/auth/session";
 import { db } from "@/server/db";
+import { extractClientInfo } from "@/server/http/client-ip";
 
 // ============================================================================
 // Types
 // ============================================================================
-
-/**
- * Client information extracted from the request
- */
-export interface ClientInfo {
-  userAgent?: string;
-  ipAddress?: string;
-}
 
 /**
  * Error codes from processOAuthCallback that should redirect to login with an error.
@@ -49,23 +42,6 @@ const SIGNUP_ERROR_MAP: Record<SignupErrorCode, string> = {
 // ============================================================================
 // Helper Functions
 // ============================================================================
-
-/**
- * Extracts client information (user agent, IP address) from a request.
- * Used for session creation to track client details.
- *
- * @param request - The incoming request
- * @returns Client info object with userAgent and ipAddress
- */
-function extractClientInfo(request: NextRequest): ClientInfo {
-  const userAgent = request.headers.get("user-agent") ?? undefined;
-  const ipAddress =
-    request.headers.get("x-forwarded-for")?.split(",")[0].trim() ??
-    request.headers.get("x-real-ip") ??
-    undefined;
-
-  return { userAgent, ipAddress };
-}
 
 /**
  * Extracts the error code from an error's cause, if present.
@@ -125,7 +101,7 @@ export async function createSessionResponse(
   appUrl: string,
   options?: { redirectStatus?: number; isNewUser?: boolean }
 ): Promise<NextResponse> {
-  const { userAgent, ipAddress } = extractClientInfo(request);
+  const { userAgent, ipAddress } = extractClientInfo(request.headers);
 
   // Create session
   const { token } = await createSession(db, {

--- a/src/server/http/client-ip.ts
+++ b/src/server/http/client-ip.ts
@@ -1,0 +1,66 @@
+/**
+ * Client IP / client info extraction from request headers.
+ *
+ * The client IP is derived from a SINGLE trusted precedence so that every
+ * consumer — rate limiting, session logging, auditing — agrees on which hop is
+ * the real client. Getting this wrong is a security bug: the leftmost
+ * `x-forwarded-for` entry is client-supplied and spoofable (Fly's proxy, like
+ * most load balancers, *appends* the real client IP rather than replacing the
+ * header), so keying anything on it lets a client forge its apparent origin.
+ */
+
+/**
+ * Client information extracted from a request, used for session creation.
+ */
+export interface ClientInfo {
+  userAgent?: string;
+  ipAddress?: string;
+}
+
+/**
+ * Derives the real client IP from request headers, using only trusted signals.
+ *
+ * Precedence:
+ * 1. `Fly-Client-IP` — set by Fly's proxy for HTTP services; clients cannot
+ *    override it (Fly strips/replaces any incoming value).
+ * 2. The RIGHTMOST `x-forwarded-for` hop — the entry our trusted proxy appended.
+ *    The leftmost entries are client-supplied and must never be trusted.
+ * 3. `x-real-ip` — set by some proxies as the single client IP.
+ *
+ * @returns the client IP, or `undefined` when no trusted header is present
+ *   (e.g. local development without a proxy).
+ */
+export function getClientIp(headers: Headers): string | undefined {
+  const flyClientIp = headers.get("fly-client-ip");
+  if (flyClientIp) {
+    return flyClientIp;
+  }
+
+  const forwardedFor = headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const hops = forwardedFor
+      .split(",")
+      .map((hop) => hop.trim())
+      .filter(Boolean);
+    if (hops.length > 0) {
+      return hops[hops.length - 1];
+    }
+  }
+
+  const realIp = headers.get("x-real-ip");
+  if (realIp) {
+    return realIp;
+  }
+
+  return undefined;
+}
+
+/**
+ * Extracts client info (user agent + IP address) for session creation/logging.
+ */
+export function extractClientInfo(headers: Headers): ClientInfo {
+  return {
+    userAgent: headers.get("user-agent") ?? undefined,
+    ipAddress: getClientIp(headers),
+  };
+}

--- a/src/server/rate-limit/index.ts
+++ b/src/server/rate-limit/index.ts
@@ -173,11 +173,30 @@ export function getClientIdentifier(userId: string | null, headers: Headers): st
     return `user:${userId}`;
   }
 
-  // Fall back to IP address
+  // Fall back to IP address.
+  //
+  // Prefer Fly's `Fly-Client-IP` header: Fly's proxy sets it to the real client
+  // IP for HTTP services and clients cannot override it (Fly strips/replaces it).
+  const flyClientIp = headers.get("fly-client-ip");
+  if (flyClientIp) {
+    return `ip:${flyClientIp}`;
+  }
+
+  // Otherwise use the RIGHTMOST `x-forwarded-for` hop. Fly's proxy (like most load
+  // balancers) *appends* the real client IP rather than replacing the header, so a
+  // client that sends `X-Forwarded-For: 1.2.3.4` arrives as `1.2.3.4, <real-ip>`.
+  // Keying on the first (leftmost) entry would let an attacker rotate a spoofed
+  // value to get a fresh token bucket per fake IP and bypass every per-IP limit;
+  // the last entry is the one our trusted proxy added.
   const forwardedFor = headers.get("x-forwarded-for");
   if (forwardedFor) {
-    // Get the first IP in the chain (client IP)
-    return `ip:${forwardedFor.split(",")[0].trim()}`;
+    const hops = forwardedFor
+      .split(",")
+      .map((hop) => hop.trim())
+      .filter(Boolean);
+    if (hops.length > 0) {
+      return `ip:${hops[hops.length - 1]}`;
+    }
   }
 
   const realIp = headers.get("x-real-ip");

--- a/src/server/rate-limit/index.ts
+++ b/src/server/rate-limit/index.ts
@@ -10,6 +10,7 @@
  */
 
 import { getRedisClient } from "@/server/redis";
+import { getClientIp } from "@/server/http/client-ip";
 import {
   type RateLimitType,
   type ConsumeResult,
@@ -173,38 +174,17 @@ export function getClientIdentifier(userId: string | null, headers: Headers): st
     return `user:${userId}`;
   }
 
-  // Fall back to IP address.
-  //
-  // Prefer Fly's `Fly-Client-IP` header: Fly's proxy sets it to the real client
-  // IP for HTTP services and clients cannot override it (Fly strips/replaces it).
-  const flyClientIp = headers.get("fly-client-ip");
-  if (flyClientIp) {
-    return `ip:${flyClientIp}`;
+  // Fall back to the client IP, derived from the trusted precedence shared with
+  // session logging (Fly-Client-IP → rightmost x-forwarded-for hop → x-real-ip).
+  // Keying on the spoofable leftmost x-forwarded-for entry would let a client
+  // rotate a fake value to get a fresh token bucket per fake IP and bypass every
+  // per-IP limit; see getClientIp.
+  const clientIp = getClientIp(headers);
+  if (clientIp) {
+    return `ip:${clientIp}`;
   }
 
-  // Otherwise use the RIGHTMOST `x-forwarded-for` hop. Fly's proxy (like most load
-  // balancers) *appends* the real client IP rather than replacing the header, so a
-  // client that sends `X-Forwarded-For: 1.2.3.4` arrives as `1.2.3.4, <real-ip>`.
-  // Keying on the first (leftmost) entry would let an attacker rotate a spoofed
-  // value to get a fresh token bucket per fake IP and bypass every per-IP limit;
-  // the last entry is the one our trusted proxy added.
-  const forwardedFor = headers.get("x-forwarded-for");
-  if (forwardedFor) {
-    const hops = forwardedFor
-      .split(",")
-      .map((hop) => hop.trim())
-      .filter(Boolean);
-    if (hops.length > 0) {
-      return `ip:${hops[hops.length - 1]}`;
-    }
-  }
-
-  const realIp = headers.get("x-real-ip");
-  if (realIp) {
-    return `ip:${realIp}`;
-  }
-
-  // Fallback for local development
+  // Fallback for local development (no trusted proxy header present)
   return "ip:unknown";
 }
 

--- a/src/server/trpc/routers/auth.ts
+++ b/src/server/trpc/routers/auth.ts
@@ -21,6 +21,7 @@ import { users, oauthAccounts } from "@/server/db/schema";
 import { signupConfig, ALL_SIGNUP_PROVIDERS } from "@/server/config/env";
 import { generateUuidv7 } from "@/lib/uuidv7";
 import { createSession, revokeSessionByToken } from "@/server/auth/session";
+import { extractClientInfo } from "@/server/http/client-ip";
 import { getEnabledProviders } from "@/server/auth/oauth/config";
 import {
   createGoogleAuthUrl,
@@ -98,19 +99,6 @@ const loginInputSchema = z.object({
 // ============================================================================
 
 /**
- * Extract client info (user agent and IP address) from request headers.
- */
-function getClientInfo(headers: Headers): {
-  userAgent: string | undefined;
-  ipAddress: string | undefined;
-} {
-  const userAgent = headers.get("user-agent") ?? undefined;
-  const ipAddress =
-    headers.get("x-forwarded-for")?.split(",")[0].trim() ?? headers.get("x-real-ip") ?? undefined;
-  return { userAgent, ipAddress };
-}
-
-/**
  * Wrap an OAuth validation function with shared error handling.
  * Catches errors and rethrows as appropriate tRPC errors.
  */
@@ -141,7 +129,7 @@ async function handleOAuthCallback(
   sessionToken: string;
   isNewUser: boolean;
 }> {
-  const { userAgent, ipAddress } = getClientInfo(headers);
+  const { userAgent, ipAddress } = extractClientInfo(headers);
 
   const { token } = await createSession(db, {
     userId: oauthResult.userId,
@@ -212,7 +200,7 @@ export const authRouter = createTRPCRouter({
       // Hash the password with argon2
       const passwordHash = await argon2.hash(password);
 
-      const { userAgent, ipAddress } = getClientInfo(ctx.headers);
+      const { userAgent, ipAddress } = extractClientInfo(ctx.headers);
 
       // Create user and session in a transaction
       const result = await ctx.db.transaction(async (tx) => {
@@ -303,7 +291,7 @@ export const authRouter = createTRPCRouter({
         throw errors.invalidCredentials();
       }
 
-      const { userAgent, ipAddress } = getClientInfo(ctx.headers);
+      const { userAgent, ipAddress } = extractClientInfo(ctx.headers);
 
       // Create new session
       const { token } = await createSession(ctx.db, {

--- a/tests/unit/client-ip.test.ts
+++ b/tests/unit/client-ip.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for client IP / client info extraction.
+ *
+ * The trusted precedence here is security-critical: it must ignore the
+ * spoofable leftmost x-forwarded-for hop so rate-limiting and session logging
+ * can't be fooled by a client-supplied value.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getClientIp, extractClientInfo } from "../../src/server/http/client-ip";
+
+describe("getClientIp", () => {
+  it("prefers the trustworthy Fly-Client-IP header over x-forwarded-for", () => {
+    const headers = new Headers({
+      "fly-client-ip": "9.9.9.9",
+      // Spoofed leftmost hop must be ignored in favor of Fly-Client-IP.
+      "x-forwarded-for": "1.2.3.4, 9.9.9.9",
+      "x-real-ip": "5.6.7.8",
+    });
+    expect(getClientIp(headers)).toBe("9.9.9.9");
+  });
+
+  it("uses the rightmost (LB-appended) x-forwarded-for hop, not the spoofable first one", () => {
+    // Fly appends the real client IP; a client-supplied leftmost value must not win.
+    const headers = new Headers({ "x-forwarded-for": "1.2.3.4, 203.0.113.7" });
+    expect(getClientIp(headers)).toBe("203.0.113.7");
+  });
+
+  it("cannot be fooled by rotating a spoofed leftmost x-forwarded-for value", () => {
+    const realClientHop = "203.0.113.7";
+    const a = getClientIp(new Headers({ "x-forwarded-for": `1.1.1.1, ${realClientHop}` }));
+    const b = getClientIp(new Headers({ "x-forwarded-for": `2.2.2.2, ${realClientHop}` }));
+    // Different spoofed prefixes still resolve to the same real client IP.
+    expect(a).toBe(b);
+    expect(a).toBe(realClientHop);
+  });
+
+  it("handles a single-hop x-forwarded-for", () => {
+    expect(getClientIp(new Headers({ "x-forwarded-for": "203.0.113.7" }))).toBe("203.0.113.7");
+  });
+
+  it("falls back to x-real-ip when no forwarded-for is present", () => {
+    expect(getClientIp(new Headers({ "x-real-ip": "5.6.7.8" }))).toBe("5.6.7.8");
+  });
+
+  it("falls back to x-real-ip when x-forwarded-for is empty/whitespace", () => {
+    const headers = new Headers({ "x-forwarded-for": " , ", "x-real-ip": "5.6.7.8" });
+    expect(getClientIp(headers)).toBe("5.6.7.8");
+  });
+
+  it("returns undefined when no trusted IP header is present", () => {
+    expect(getClientIp(new Headers())).toBeUndefined();
+  });
+});
+
+describe("extractClientInfo", () => {
+  it("bundles user agent with the trusted client IP", () => {
+    const headers = new Headers({
+      "user-agent": "test-agent/1.0",
+      "x-forwarded-for": "1.2.3.4, 203.0.113.7",
+    });
+    expect(extractClientInfo(headers)).toEqual({
+      userAgent: "test-agent/1.0",
+      ipAddress: "203.0.113.7",
+    });
+  });
+
+  it("uses undefined for missing user agent and IP", () => {
+    expect(extractClientInfo(new Headers())).toEqual({
+      userAgent: undefined,
+      ipAddress: undefined,
+    });
+  });
+});

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -15,6 +15,7 @@ import {
   type RateLimitConfig,
   type ConsumeResult,
 } from "../../src/server/rate-limit/token-bucket";
+import { getClientIdentifier } from "../../src/server/rate-limit";
 
 /**
  * Helper to create a bucket state with defaults.
@@ -308,6 +309,66 @@ describe("RATE_LIMIT_CONFIGS.oauth", () => {
     expect(RATE_LIMIT_CONFIGS.oauth.refillRate).toBeGreaterThan(
       RATE_LIMIT_CONFIGS.expensive.refillRate
     );
+  });
+});
+
+describe("getClientIdentifier", () => {
+  it("prefers the authenticated user ID over any IP header", () => {
+    const headers = new Headers({
+      "fly-client-ip": "9.9.9.9",
+      "x-forwarded-for": "1.2.3.4",
+      "x-real-ip": "5.6.7.8",
+    });
+    expect(getClientIdentifier("user-123", headers)).toBe("user:user-123");
+  });
+
+  it("prefers the trustworthy Fly-Client-IP header", () => {
+    const headers = new Headers({
+      "fly-client-ip": "9.9.9.9",
+      // Spoofed leftmost hop must be ignored in favor of Fly-Client-IP.
+      "x-forwarded-for": "1.2.3.4, 9.9.9.9",
+    });
+    expect(getClientIdentifier(null, headers)).toBe("ip:9.9.9.9");
+  });
+
+  it("uses the rightmost (LB-appended) x-forwarded-for hop, not the spoofable first one", () => {
+    // Fly appends the real client IP; a client-supplied leftmost value must not win.
+    const headers = new Headers({ "x-forwarded-for": "1.2.3.4, 203.0.113.7" });
+    expect(getClientIdentifier(null, headers)).toBe("ip:203.0.113.7");
+  });
+
+  it("cannot be bypassed by rotating a spoofed leftmost x-forwarded-for value", () => {
+    const realClientHop = "203.0.113.7";
+    const a = getClientIdentifier(
+      null,
+      new Headers({ "x-forwarded-for": `1.1.1.1, ${realClientHop}` })
+    );
+    const b = getClientIdentifier(
+      null,
+      new Headers({ "x-forwarded-for": `2.2.2.2, ${realClientHop}` })
+    );
+    // Different spoofed prefixes still resolve to the same rate-limit key.
+    expect(a).toBe(b);
+    expect(a).toBe(`ip:${realClientHop}`);
+  });
+
+  it("handles a single-hop x-forwarded-for", () => {
+    const headers = new Headers({ "x-forwarded-for": "203.0.113.7" });
+    expect(getClientIdentifier(null, headers)).toBe("ip:203.0.113.7");
+  });
+
+  it("falls back to x-real-ip when no forwarded-for is present", () => {
+    const headers = new Headers({ "x-real-ip": "5.6.7.8" });
+    expect(getClientIdentifier(null, headers)).toBe("ip:5.6.7.8");
+  });
+
+  it("falls back to x-real-ip when x-forwarded-for is empty/whitespace", () => {
+    const headers = new Headers({ "x-forwarded-for": " , ", "x-real-ip": "5.6.7.8" });
+    expect(getClientIdentifier(null, headers)).toBe("ip:5.6.7.8");
+  });
+
+  it("returns ip:unknown when no IP headers are present", () => {
+    expect(getClientIdentifier(null, new Headers())).toBe("ip:unknown");
   });
 });
 

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -313,6 +313,9 @@ describe("RATE_LIMIT_CONFIGS.oauth", () => {
 });
 
 describe("getClientIdentifier", () => {
+  // The trusted IP precedence (Fly-Client-IP → rightmost x-forwarded-for hop →
+  // x-real-ip) is covered in client-ip.test.ts; these cover the identifier
+  // framing getClientIdentifier layers on top.
   it("prefers the authenticated user ID over any IP header", () => {
     const headers = new Headers({
       "fly-client-ip": "9.9.9.9",
@@ -322,52 +325,13 @@ describe("getClientIdentifier", () => {
     expect(getClientIdentifier("user-123", headers)).toBe("user:user-123");
   });
 
-  it("prefers the trustworthy Fly-Client-IP header", () => {
-    const headers = new Headers({
-      "fly-client-ip": "9.9.9.9",
-      // Spoofed leftmost hop must be ignored in favor of Fly-Client-IP.
-      "x-forwarded-for": "1.2.3.4, 9.9.9.9",
-    });
-    expect(getClientIdentifier(null, headers)).toBe("ip:9.9.9.9");
-  });
-
-  it("uses the rightmost (LB-appended) x-forwarded-for hop, not the spoofable first one", () => {
-    // Fly appends the real client IP; a client-supplied leftmost value must not win.
+  it("keys unauthenticated requests on the trusted client IP, not the spoofable hop", () => {
+    // Rotating the spoofed leftmost hop must not yield a fresh rate-limit key.
     const headers = new Headers({ "x-forwarded-for": "1.2.3.4, 203.0.113.7" });
     expect(getClientIdentifier(null, headers)).toBe("ip:203.0.113.7");
   });
 
-  it("cannot be bypassed by rotating a spoofed leftmost x-forwarded-for value", () => {
-    const realClientHop = "203.0.113.7";
-    const a = getClientIdentifier(
-      null,
-      new Headers({ "x-forwarded-for": `1.1.1.1, ${realClientHop}` })
-    );
-    const b = getClientIdentifier(
-      null,
-      new Headers({ "x-forwarded-for": `2.2.2.2, ${realClientHop}` })
-    );
-    // Different spoofed prefixes still resolve to the same rate-limit key.
-    expect(a).toBe(b);
-    expect(a).toBe(`ip:${realClientHop}`);
-  });
-
-  it("handles a single-hop x-forwarded-for", () => {
-    const headers = new Headers({ "x-forwarded-for": "203.0.113.7" });
-    expect(getClientIdentifier(null, headers)).toBe("ip:203.0.113.7");
-  });
-
-  it("falls back to x-real-ip when no forwarded-for is present", () => {
-    const headers = new Headers({ "x-real-ip": "5.6.7.8" });
-    expect(getClientIdentifier(null, headers)).toBe("ip:5.6.7.8");
-  });
-
-  it("falls back to x-real-ip when x-forwarded-for is empty/whitespace", () => {
-    const headers = new Headers({ "x-forwarded-for": " , ", "x-real-ip": "5.6.7.8" });
-    expect(getClientIdentifier(null, headers)).toBe("ip:5.6.7.8");
-  });
-
-  it("returns ip:unknown when no IP headers are present", () => {
+  it("returns ip:unknown when no trusted IP header is present", () => {
     expect(getClientIdentifier(null, new Headers())).toBe("ip:unknown");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #983.

Per-IP rate limits keyed on the **first** `x-forwarded-for` hop. Fly's proxy (like most load balancers) **appends** the real client IP rather than replacing the header, so a client sending `X-Forwarded-For: 1.2.3.4` arrives as `1.2.3.4, <real-ip>` — and we keyed on the attacker-controlled `1.2.3.4`. Rotating that value gave a fresh token bucket per fake IP, bypassing every unauthenticated per-IP limit (including the `oauth` bucket guarding open Dynamic Client Registration at `/oauth/register`).

A subagent review found the **same spoofable pattern in three session-logging paths**, which recorded the client-controllable leftmost hop as the session's origin IP (the value shown in Settings → Sessions and used for auditing) — and derived the IP by a different rule than rate-limiting, so one request could be limited under one IP and logged under another.

## Fix

Extracted the trusted precedence into a single shared helper, `src/server/http/client-ip.ts`:

- **`getClientIp(headers)`** — `Fly-Client-IP` (proxy-set, not client-overridable) → **rightmost** `x-forwarded-for` hop → `x-real-ip`. Single source of truth for the client IP.
- **`extractClientInfo(headers)`** — `{ userAgent, ipAddress }` for session creation, replacing two byte-identical private copies (`auth.ts`, OAuth `callback-helpers.ts`) and one inline duplicate (greader `ClientLogin`).

Consumers updated to route through it:

- `getClientIdentifier` (rate-limiting) now wraps `getClientIp`.
- `greader.php/accounts/ClientLogin`, OAuth `callback-helpers.ts`, and the `auth` router (register/login/OAuth) now log the trusted client IP.

## Testing

- New `tests/unit/client-ip.test.ts`: header precedence, rightmost-hop rule, bypass scenario (rotating a spoofed prefix resolves to the same IP), single-hop, empty/whitespace XFF, and `extractClientInfo` bundling.
- Slimmed the `getClientIdentifier` tests to the identifier framing (`user:` / `ip:` / `ip:unknown`).
- `pnpm typecheck` clean; `pnpm vitest run` — 46 passed; ESLint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)