### PR TITLE
Detect maxWords/custom prompt changes in summarization settingsChanged (#824)

### DIFF
--- a/migrations/0078_entry_summaries_settings.sql
+++ b/migrations/0078_entry_summaries_settings.sql
@@ -1,0 +1,17 @@
+-- Track the user-configurable settings used to generate each cached summary.
+--
+-- settingsChanged (summarization.generate) previously only compared the built-in
+-- prompt version and model ID, so changing summarizationMaxWords or setting a
+-- custom summarizationPrompt did not surface the "settings changed" indicator
+-- that prompts regeneration (#824). Store what was used at generation time so we
+-- have something to compare current settings against.
+--
+-- Nullable with no default so pre-existing rows read NULL and are treated as
+-- "unknown" (never reported as changed), avoiding a spurious indicator on every
+-- old summary.
+
+ALTER TABLE entry_summaries ADD COLUMN max_words integer;
+
+--> statement-breakpoint
+
+ALTER TABLE entry_summaries ADD COLUMN prompt_hash text;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -540,6 +540,13 @@
       "when": 1782951000000,
       "tag": "0077_users_last_active_at",
       "breakpoints": true
+    },
+    {
+      "idx": 77,
+      "version": "7",
+      "when": 1782951100000,
+      "tag": "0078_entry_summaries_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -109,7 +109,9 @@ CREATE TABLE public.entry_summaries (
     generated_at timestamp with time zone,
     error text,
     error_at timestamp with time zone,
-    user_id uuid
+    user_id uuid,
+    max_words integer,
+    prompt_hash text
 );
 
 CREATE TABLE public.feeds (

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -918,6 +918,8 @@ export const entrySummaries = pgTable(
     summaryText: text("summary_text"), // null until generated
     modelId: text("model_id"), // e.g., "claude-sonnet-4-20250514"
     promptVersion: smallint("prompt_version").notNull().default(1), // for cache invalidation
+    maxWords: integer("max_words"), // user's max-words setting at generation time (null = unknown)
+    promptHash: text("prompt_hash"), // SHA256 of the effective prompt at generation time (null = unknown)
 
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     generatedAt: timestamp("generated_at", { withTimezone: true }), // when summary was generated

--- a/src/server/services/summarization.ts
+++ b/src/server/services/summarization.ts
@@ -6,6 +6,7 @@
  */
 
 import Anthropic from "@anthropic-ai/sdk";
+import { createHash } from "crypto";
 import { marked } from "marked";
 import { logger } from "@/lib/logger";
 import { sanitizeEntryHtml } from "@/server/html/sanitize";
@@ -42,7 +43,7 @@ const MAX_OUTPUT_TOKENS = 1024;
  * Gets the configured max words for summaries.
  * Priority: user setting > environment variable > default.
  */
-function getMaxWords(userMaxWords?: number | null): number {
+export function getMaxWords(userMaxWords?: number | null): number {
   if (userMaxWords && userMaxWords > 0) {
     return userMaxWords;
   }
@@ -104,6 +105,17 @@ function buildSummarizationPrompt(
     .replaceAll("{{content}}", content)
     .replaceAll("{{title}}", title)
     .replaceAll("{{maxWords}}", String(maxWords));
+}
+
+/**
+ * Hashes the effective summarization prompt so cached summaries can detect when
+ * the user changes their custom prompt (or clears it back to the default).
+ * Falls back to the default template when the user has no custom prompt, so a
+ * custom prompt that matches the default hashes the same as no custom prompt.
+ */
+export function hashPrompt(userPrompt?: string | null): string {
+  const template = userPrompt || DEFAULT_SUMMARIZATION_PROMPT;
+  return createHash("sha256").update(template, "utf8").digest("hex");
 }
 
 /**

--- a/src/server/trpc/routers/summarization.ts
+++ b/src/server/trpc/routers/summarization.ts
@@ -19,6 +19,8 @@ import {
   prepareContentForSummarization,
   CURRENT_PROMPT_VERSION,
   getSummarizationModelId,
+  getMaxWords,
+  hashPrompt,
   listModels,
   DEFAULT_SUMMARIZATION_PROMPT,
 } from "@/server/services/summarization";
@@ -105,6 +107,29 @@ export const summarizationRouter = createTRPCRouter({
       const userMaxWords = ctx.session.user.summarizationMaxWords;
       const userPrompt = ctx.session.user.summarizationPrompt;
 
+      const currentModelId = getSummarizationModelId(userSummarizationModel);
+      const currentMaxWords = getMaxWords(userMaxWords);
+      const currentPromptHash = hashPrompt(userPrompt);
+
+      /**
+       * Whether the settings used to generate a cached summary differ from the
+       * user's current settings. `maxWords`/`promptHash` are only compared when
+       * present so summaries cached before these columns existed (null) aren't
+       * reported as stale. See #824.
+       */
+      const isSettingsChanged = (record: {
+        promptVersion: number;
+        modelId: string | null;
+        maxWords: number | null;
+        promptHash: string | null;
+      }): boolean => {
+        const promptVersionChanged = record.promptVersion !== CURRENT_PROMPT_VERSION;
+        const modelChanged = record.modelId !== null && record.modelId !== currentModelId;
+        const maxWordsChanged = record.maxWords !== null && record.maxWords !== currentMaxWords;
+        const promptChanged = record.promptHash !== null && record.promptHash !== currentPromptHash;
+        return promptVersionChanged || modelChanged || maxWordsChanged || promptChanged;
+      };
+
       // Fetch API key from DB on demand (not cached in session for security)
       const { anthropicApiKey: userAnthropicApiKey } = await getUserApiKeys(userId);
 
@@ -175,10 +200,6 @@ export const summarizationRouter = createTRPCRouter({
 
           const fullRecord = fullSummary[0];
           if (fullRecord?.summaryText) {
-            const currentModelId = getSummarizationModelId(userSummarizationModel);
-            const promptVersionChanged = fullRecord.promptVersion !== CURRENT_PROMPT_VERSION;
-            const modelChanged =
-              fullRecord.modelId !== null && fullRecord.modelId !== currentModelId;
             return {
               // Sanitize on read: summaries cached before server-side
               // sanitization existed may contain unsanitized HTML.
@@ -186,7 +207,7 @@ export const summarizationRouter = createTRPCRouter({
               cached: true,
               modelId: fullRecord.modelId || "unknown",
               generatedAt: fullRecord.generatedAt,
-              settingsChanged: promptVersionChanged || modelChanged,
+              settingsChanged: isSettingsChanged(fullRecord),
             };
           }
         }
@@ -205,15 +226,12 @@ export const summarizationRouter = createTRPCRouter({
 
         const feedRecord = feedSummary[0];
         if (feedRecord?.summaryText) {
-          const currentModelId = getSummarizationModelId(userSummarizationModel);
-          const promptVersionChanged = feedRecord.promptVersion !== CURRENT_PROMPT_VERSION;
-          const modelChanged = feedRecord.modelId !== null && feedRecord.modelId !== currentModelId;
           return {
             summary: sanitizeEntryHtml(feedRecord.summaryText) ?? "",
             cached: true,
             modelId: feedRecord.modelId || "unknown",
             generatedAt: feedRecord.generatedAt,
-            settingsChanged: promptVersionChanged || modelChanged,
+            settingsChanged: isSettingsChanged(feedRecord),
           };
         }
 
@@ -254,12 +272,11 @@ export const summarizationRouter = createTRPCRouter({
 
       const summaryRecord = summary[0];
 
-      // Check if settings have changed since this summary was generated
-      const currentModelId = getSummarizationModelId(userSummarizationModel);
+      // Check if settings have changed since this summary was generated.
+      // promptVersionChanged also gates cache reuse below (a built-in prompt
+      // bump invalidates the cache), so it stays a separate variable.
       const promptVersionChanged = summaryRecord.promptVersion !== CURRENT_PROMPT_VERSION;
-      const modelChanged =
-        summaryRecord.modelId !== null && summaryRecord.modelId !== currentModelId;
-      const settingsChanged = promptVersionChanged || modelChanged;
+      const settingsChanged = isSettingsChanged(summaryRecord);
 
       // Return cached summary if available and not stale (prompt version unchanged),
       // unless the user explicitly requested regeneration
@@ -302,6 +319,8 @@ export const summarizationRouter = createTRPCRouter({
             summaryText: result.summary,
             modelId: result.modelId,
             promptVersion: CURRENT_PROMPT_VERSION,
+            maxWords: currentMaxWords,
+            promptHash: currentPromptHash,
             generatedAt: new Date(),
             error: null,
             errorAt: null,

--- a/tests/unit/summarization-settings.test.ts
+++ b/tests/unit/summarization-settings.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  getMaxWords,
+  hashPrompt,
+  DEFAULT_SUMMARIZATION_PROMPT,
+} from "@/server/services/summarization";
+import { DEFAULT_SUMMARIZATION_MAX_WORDS } from "@/lib/summarization/constants";
+
+describe("getMaxWords", () => {
+  const originalEnv = process.env.SUMMARIZATION_MAX_WORDS;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SUMMARIZATION_MAX_WORDS;
+    } else {
+      process.env.SUMMARIZATION_MAX_WORDS = originalEnv;
+    }
+  });
+
+  it("prefers the user setting when set", () => {
+    process.env.SUMMARIZATION_MAX_WORDS = "50";
+    expect(getMaxWords(200)).toBe(200);
+  });
+
+  it("falls back to the env var when the user setting is unset", () => {
+    process.env.SUMMARIZATION_MAX_WORDS = "75";
+    expect(getMaxWords(null)).toBe(75);
+    expect(getMaxWords(undefined)).toBe(75);
+  });
+
+  it("falls back to the default when nothing is set", () => {
+    delete process.env.SUMMARIZATION_MAX_WORDS;
+    expect(getMaxWords(null)).toBe(DEFAULT_SUMMARIZATION_MAX_WORDS);
+  });
+
+  it("ignores non-positive user values", () => {
+    delete process.env.SUMMARIZATION_MAX_WORDS;
+    expect(getMaxWords(0)).toBe(DEFAULT_SUMMARIZATION_MAX_WORDS);
+    expect(getMaxWords(-10)).toBe(DEFAULT_SUMMARIZATION_MAX_WORDS);
+  });
+});
+
+describe("hashPrompt", () => {
+  it("is stable for the same prompt", () => {
+    expect(hashPrompt("hello {{content}}")).toBe(hashPrompt("hello {{content}}"));
+  });
+
+  it("differs for different custom prompts", () => {
+    expect(hashPrompt("prompt A")).not.toBe(hashPrompt("prompt B"));
+  });
+
+  it("treats no custom prompt as the default prompt", () => {
+    expect(hashPrompt(null)).toBe(hashPrompt(DEFAULT_SUMMARIZATION_PROMPT));
+    expect(hashPrompt(undefined)).toBe(hashPrompt(DEFAULT_SUMMARIZATION_PROMPT));
+    expect(hashPrompt("")).toBe(hashPrompt(DEFAULT_SUMMARIZATION_PROMPT));
+  });
+
+  it("distinguishes a custom prompt from the default", () => {
+    expect(hashPrompt("a custom prompt")).not.toBe(hashPrompt(null));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #824. `settingsChanged` in `summarization.generate` only compared the built-in prompt version and model ID, so changing `summarizationMaxWords` or setting a custom `summarizationPrompt` never surfaced the "settings changed" indicator that prompts regeneration.

## Changes

- **Migration 0078** — add nullable `max_words` / `prompt_hash` columns to `entry_summaries`. Nullable with no default so pre-existing rows read `NULL` and are treated as "unknown" (never reported as changed), avoiding a spurious indicator on every old cached summary.
- **Service** — export `getMaxWords` and add `hashPrompt` (SHA-256 of the effective prompt; no custom prompt hashes as the default, so clearing a custom prompt back to the default is a no-op).
- **Router** — store the effective max words and prompt hash when a summary is generated, and compare both against current settings via a shared `isSettingsChanged` helper used by all three cached-summary return paths. New columns are only compared when present.
- **Tests** — unit tests for `getMaxWords` and `hashPrompt`.

## Testing

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test:unit` ✅ (1978 tests)

Integration/e2e not run locally (no Docker access in this environment); CI will run them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)