### PR TITLE
Actually close unlinkProvider TOCTOU race with a user row lock (#825)

### DIFF
--- a/src/server/trpc/routers/auth.ts
+++ b/src/server/trpc/routers/auth.ts
@@ -7,7 +7,7 @@
 
 import { z } from "zod";
 import * as argon2 from "argon2";
-import { eq, and, or, gt, exists, isNotNull, sql } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 
 import {
   createTRPCRouter,
@@ -1216,43 +1216,51 @@ export const authRouter = createTRPCRouter({
       const { provider } = input;
       const userId = ctx.session.user.id;
 
-      // Atomic delete with safety check: only unlink if the user has a
-      // password OR has more than one linked OAuth account. A single
-      // statement avoids the TOCTOU race where concurrent requests could
-      // both pass a separate check-then-delete and lock the user out.
-      const deleted = await ctx.db
-        .delete(oauthAccounts)
-        .where(
-          and(
-            eq(oauthAccounts.userId, userId),
-            eq(oauthAccounts.provider, provider),
-            or(
-              exists(
-                ctx.db
-                  .select({ v: sql`1` })
-                  .from(users)
-                  .where(and(eq(users.id, userId), isNotNull(users.passwordHash)))
-              ),
-              gt(ctx.db.$count(oauthAccounts, eq(oauthAccounts.userId, userId)), 1)
-            )
-          )
-        )
-        .returning({ id: oauthAccounts.id });
+      await ctx.db.transaction(async (tx) => {
+        // Serialize concurrent unlinks for this user by taking a row lock
+        // on the user. Without it, two requests unlinking *different*
+        // providers (e.g. Google in one tab, Apple in another) target
+        // different oauth_accounts rows, so neither blocks the other. A
+        // single atomic DELETE with an embedded count check does not close
+        // this race either: under READ COMMITTED the count subquery reads a
+        // snapshot and takes no lock on the other provider's row, so both
+        // requests observe two linked accounts, both pass the check, and
+        // both delete — leaving the user with zero auth methods (#825).
+        await tx.execute(sql`SELECT 1 FROM ${users} WHERE ${users.id} = ${userId} FOR UPDATE`);
 
-      // If nothing was deleted and the account exists, it means the
-      // safety check prevented it (last auth method).
-      // If the account doesn't exist, treat as success (idempotent).
-      if (deleted.length === 0) {
-        const accountExists = await ctx.db
+        // Idempotent: unlinking an already-unlinked provider succeeds
+        // without error rather than 404-ing.
+        const account = await tx
           .select({ id: oauthAccounts.id })
           .from(oauthAccounts)
           .where(and(eq(oauthAccounts.userId, userId), eq(oauthAccounts.provider, provider)))
           .limit(1);
 
-        if (accountExists.length > 0) {
+        if (account.length === 0) {
+          return;
+        }
+
+        // Safety check: refuse to remove the user's only remaining auth
+        // method. The FOR UPDATE lock above guarantees this count and the
+        // delete below can't interleave with another unlink for this user.
+        const user = await tx
+          .select({ passwordHash: users.passwordHash })
+          .from(users)
+          .where(eq(users.id, userId))
+          .limit(1);
+
+        const hasPassword = !!user[0]?.passwordHash;
+        const linkedAccountsCount = await tx.$count(
+          oauthAccounts,
+          eq(oauthAccounts.userId, userId)
+        );
+
+        if (!hasPassword && linkedAccountsCount <= 1) {
           throw errors.cannotUnlinkOnlyAuth();
         }
-      }
+
+        await tx.delete(oauthAccounts).where(eq(oauthAccounts.id, account[0].id));
+      });
 
       return { success: true };
     }),

--- a/tests/integration/oauth-unlink.test.ts
+++ b/tests/integration/oauth-unlink.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Integration tests for auth.unlinkProvider.
+ *
+ * See issue #825: unlinking was a check-then-delete that could race. Two
+ * concurrent requests unlinking *different* providers for a password-less
+ * user could both observe two linked accounts, both pass the "don't remove
+ * the only auth method" check, and both delete — locking the user out. The
+ * unlink now runs inside a transaction that takes a FOR UPDATE lock on the
+ * user row, serializing concurrent unlinks so at least one account always
+ * survives.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users, oauthAccounts } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createCaller } from "../../src/server/trpc/root";
+import type { Context } from "../../src/server/trpc/context";
+
+const createdUserIds: string[] = [];
+
+async function createTestUser(hasPassword: boolean): Promise<string> {
+  const userId = generateUuidv7();
+  const now = new Date();
+  await db.insert(users).values({
+    id: userId,
+    email: `unlink-${userId}@test.com`,
+    passwordHash: hasPassword ? "test-hash" : null,
+    tosAgreedAt: now,
+    privacyPolicyAgreedAt: now,
+    notEuAgreedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  createdUserIds.push(userId);
+  return userId;
+}
+
+async function linkProvider(userId: string, provider: string): Promise<void> {
+  await db.insert(oauthAccounts).values({
+    id: generateUuidv7(),
+    userId,
+    provider,
+    providerAccountId: `${provider}-${userId}`,
+  });
+}
+
+function createAuthContext(userId: string): Context {
+  const now = new Date();
+  return {
+    db,
+    session: {
+      session: {
+        id: generateUuidv7(),
+        userId,
+        tokenHash: "test-hash",
+        userAgent: null,
+        ipAddress: null,
+        createdAt: now,
+        expiresAt: new Date(Date.now() + 3600000),
+        revokedAt: null,
+        lastActiveAt: now,
+      },
+      user: {
+        id: userId,
+        email: `${userId}@test.com`,
+        emailVerifiedAt: null,
+        tosAgreedAt: now,
+        privacyPolicyAgreedAt: now,
+        notEuAgreedAt: now,
+        passwordHash: null,
+        inviteId: null,
+        showSpam: false,
+        lastActiveAt: null,
+        groqApiKey: null,
+        anthropicApiKey: null,
+        summarizationModel: null,
+        summarizationMaxWords: null,
+        summarizationPrompt: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      hasGroqApiKey: false,
+      hasAnthropicApiKey: false,
+    },
+    apiToken: null,
+    authType: "session",
+    scopes: [],
+    sessionToken: "test-token",
+    headers: new Headers(),
+  };
+}
+
+afterAll(async () => {
+  if (createdUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+});
+
+describe("auth.unlinkProvider", () => {
+  it("unlinks one provider when the user has others", async () => {
+    const userId = await createTestUser(false);
+    await linkProvider(userId, "google");
+    await linkProvider(userId, "apple");
+    const caller = createCaller(createAuthContext(userId));
+
+    await caller.auth.unlinkProvider({ provider: "google" });
+
+    const remaining = await db
+      .select({ provider: oauthAccounts.provider })
+      .from(oauthAccounts)
+      .where(eq(oauthAccounts.userId, userId));
+    expect(remaining.map((r) => r.provider)).toEqual(["apple"]);
+  });
+
+  it("refuses to unlink the only auth method (no password, one provider)", async () => {
+    const userId = await createTestUser(false);
+    await linkProvider(userId, "google");
+    const caller = createCaller(createAuthContext(userId));
+
+    await expect(caller.auth.unlinkProvider({ provider: "google" })).rejects.toThrow();
+
+    const remaining = await db.$count(oauthAccounts, eq(oauthAccounts.userId, userId));
+    expect(remaining).toBe(1);
+  });
+
+  it("allows unlinking the last provider when the user has a password", async () => {
+    const userId = await createTestUser(true);
+    await linkProvider(userId, "google");
+    const caller = createCaller(createAuthContext(userId));
+
+    await caller.auth.unlinkProvider({ provider: "google" });
+
+    const remaining = await db.$count(oauthAccounts, eq(oauthAccounts.userId, userId));
+    expect(remaining).toBe(0);
+  });
+
+  it("is idempotent when the provider is already unlinked", async () => {
+    const userId = await createTestUser(true);
+    await linkProvider(userId, "google");
+    const caller = createCaller(createAuthContext(userId));
+
+    const result = await caller.auth.unlinkProvider({ provider: "apple" });
+    expect(result).toEqual({ success: true });
+    // The linked provider is untouched.
+    const remaining = await db.$count(oauthAccounts, eq(oauthAccounts.userId, userId));
+    expect(remaining).toBe(1);
+  });
+
+  it("keeps at least one auth method when two providers are unlinked concurrently (#825)", async () => {
+    const userId = await createTestUser(false);
+    await linkProvider(userId, "google");
+    await linkProvider(userId, "apple");
+
+    // Two concurrent unlinks of *different* providers, as if from two tabs.
+    // The FOR UPDATE lock serializes them: the first to acquire the lock
+    // succeeds; the second re-reads the (now single) remaining account and
+    // is blocked by the "only auth method" guard.
+    const caller = createCaller(createAuthContext(userId));
+    const results = await Promise.allSettled([
+      caller.auth.unlinkProvider({ provider: "google" }),
+      caller.auth.unlinkProvider({ provider: "apple" }),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled").length;
+    const rejected = results.filter((r) => r.status === "rejected").length;
+    expect(fulfilled).toBe(1);
+    expect(rejected).toBe(1);
+
+    // Critically: the user is not locked out — exactly one provider remains.
+    const remaining = await db.$count(oauthAccounts, eq(oauthAccounts.userId, userId));
+    expect(remaining).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Issue #825 flagged a TOCTOU race in `auth.unlinkProvider`: a password-less user with two OAuth providers linked could unlink both simultaneously (e.g. Google in one tab, Apple in another) and end up with **zero auth methods** — locked out.

The prior fix for #825 (commit `40a7d89f`) replaced the check-then-delete with a single atomic `DELETE ... WHERE ... (has_password OR count(*) > 1)`. **That does not actually close the race.** Under Postgres's default READ COMMITTED isolation, the `count(*)` subquery reads a snapshot and takes **no lock** on the *other* provider's row. Two concurrent DELETEs targeting *different* rows never block each other, so both observe two linked accounts, both pass the guard, and both delete.

## Fix

Run the unlink inside a transaction that first takes `SELECT 1 FROM users WHERE id = ... FOR UPDATE`. This serializes concurrent unlinks for the same user: the first to acquire the lock deletes its provider; the second blocks until the first commits, then re-reads the now-single remaining account and is correctly stopped by the "only auth method" guard.

The idempotent-on-already-unlinked behavior (returns success instead of 404) is preserved.

## Tests

New integration test `tests/integration/oauth-unlink.test.ts` covers:
- unlinking one provider when others remain
- the only-auth-method guard (no password, one provider)
- the password escape hatch (last provider removable when a password exists)
- idempotency when the provider is already unlinked
- **the concurrent two-provider race**: exactly one request succeeds, one fails, and one account always survives

All 5 pass against a real Postgres. `pnpm typecheck` and `pnpm lint` are clean.

Closes #825.

— Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)