### PR TITLE
Add shared per-account rate limiting to password login paths (#827)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -367,6 +367,8 @@ Cursor-based pagination everywhere:
 
 Token bucket via Redis, per-user. Different buckets for different operations (e.g., search is more limited than reads).
 
+**Password brute-force protection**: every password-accepting path is rate-limited two ways. A per-IP `expensive` bucket (10 burst, 1/sec) caps a single source, and a **shared per-account** `expensive` bucket keyed by normalized (trimmed/lower-cased) email caps total guesses against one account regardless of source IP — so a distributed, IP-rotating brute-force is throttled too. The account key is shared across the tRPC `auth.login` mutation, Google Reader `ClientLogin`, and the Wallabag password grant via `checkAccountRateLimit`/`checkAccountRouteRateLimit` in `src/server/rate-limit/`. The tRPC login consumes the account bucket _before_ the user lookup so attempts against non-existent accounts are throttled identically (no enumeration side channel). The OAuth 2.1 `/oauth/token` endpoint takes no password (only `authorization_code`/`refresh_token` grants), so it has no account key and uses the generous `oauth` bucket.
+
 ### Error Responses
 
 Errors use tRPC's standard error envelope, extended by the `errorFormatter` in

--- a/src/app/api/greader.php/accounts/ClientLogin/route.ts
+++ b/src/app/api/greader.php/accounts/ClientLogin/route.ts
@@ -17,12 +17,13 @@
 
 import { clientLogin } from "@/server/google-reader/auth";
 import { parseFormData, errorResponse } from "@/server/google-reader/parse";
-import { checkRouteRateLimit } from "@/server/rate-limit";
+import { checkRouteRateLimit, checkAccountRouteRateLimit } from "@/server/rate-limit";
 import { extractClientInfo } from "@/server/http/client-ip";
 
 export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
+  // Per-IP limit first (cheap, rejects floods before parsing).
   const rateLimitResponse = await checkRouteRateLimit(request, "expensive");
   if (rateLimitResponse) return rateLimitResponse;
 
@@ -33,6 +34,11 @@ export async function POST(request: Request): Promise<Response> {
   if (!email || !password) {
     return errorResponse("Error=BadAuthentication", 401);
   }
+
+  // Per-account limit: throttles distributed, IP-rotating brute-force against
+  // a single account, shared with the tRPC login and Wallabag paths.
+  const accountRateLimitResponse = await checkAccountRouteRateLimit(email);
+  if (accountRateLimitResponse) return accountRateLimitResponse;
 
   const { userAgent, ipAddress } = extractClientInfo(request.headers);
 

--- a/src/app/api/wallabag/oauth/v2/token/route.ts
+++ b/src/app/api/wallabag/oauth/v2/token/route.ts
@@ -24,11 +24,12 @@
 import { passwordGrant, refreshTokenGrant } from "@/server/wallabag/auth";
 import { parseBody } from "@/server/wallabag/parse";
 import { jsonResponse, errorResponse } from "@/server/wallabag/parse";
-import { checkRouteRateLimit } from "@/server/rate-limit";
+import { checkRouteRateLimit, checkAccountRouteRateLimit } from "@/server/rate-limit";
 
 export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
+  // Per-IP limit first (cheap, rejects floods before parsing).
   const rateLimitResponse = await checkRouteRateLimit(request, "expensive", { json: true });
   if (rateLimitResponse) return rateLimitResponse;
 
@@ -44,6 +45,11 @@ export async function POST(request: Request): Promise<Response> {
     if (!username || !password) {
       return errorResponse("invalid_request", "username and password are required", 400);
     }
+
+    // Per-account limit: throttles distributed, IP-rotating brute-force against
+    // a single account, shared with the tRPC login and Google Reader paths.
+    const accountRateLimitResponse = await checkAccountRouteRateLimit(username, { json: true });
+    if (accountRateLimitResponse) return accountRateLimitResponse;
 
     const result = await passwordGrant(username, password, clientId);
     if (!result) {

--- a/src/server/rate-limit/index.ts
+++ b/src/server/rate-limit/index.ts
@@ -161,6 +161,18 @@ export async function checkRateLimit(
 }
 
 /**
+ * Derives the rate-limit identifier for a per-account (email/username) password
+ * attempt. The email is trimmed and lower-cased so that case or whitespace
+ * variations can't be used to spread attempts across separate buckets.
+ *
+ * @param email - The email/username supplied in the login attempt
+ * @returns Identifier string (namespaced so it can't collide with ip:/user: keys)
+ */
+export function getAccountRateLimitIdentifier(email: string): string {
+  return `email:${email.trim().toLowerCase()}`;
+}
+
+/**
  * Extracts a client identifier from request headers.
  * Uses user ID if authenticated, otherwise falls back to IP address.
  *
@@ -189,6 +201,28 @@ export function getClientIdentifier(userId: string | null, headers: Headers): st
 }
 
 /**
+ * Builds a 429 response for a rejected rate-limit result.
+ */
+function buildRateLimitResponse(
+  result: ConsumeResult,
+  type: RateLimitType,
+  options: { json?: boolean }
+): Response {
+  const config = RATE_LIMIT_CONFIGS[type];
+  const rateLimitHeaders = getRateLimitHeaders(result, config);
+  const body = options.json
+    ? JSON.stringify({ error: "rate_limit_exceeded", error_description: "Rate limit exceeded" })
+    : "Rate limit exceeded";
+  return new Response(body, {
+    status: 429,
+    headers: {
+      ...rateLimitHeaders,
+      "Content-Type": options.json ? "application/json" : "text/plain",
+    },
+  });
+}
+
+/**
  * Checks rate limit for a route handler request and returns a 429 Response if exceeded.
  * Returns null if the request is allowed.
  *
@@ -203,22 +237,44 @@ export async function checkRouteRateLimit(
   options: { json?: boolean } = {}
 ): Promise<Response | null> {
   const identifier = getClientIdentifier(null, request.headers);
-  const config = RATE_LIMIT_CONFIGS[type];
   const result = await checkRateLimit(identifier, type);
 
   if (!result.allowed) {
-    const rateLimitHeaders = getRateLimitHeaders(result, config);
-    const body = options.json
-      ? JSON.stringify({ error: "rate_limit_exceeded", error_description: "Rate limit exceeded" })
-      : "Rate limit exceeded";
-    return new Response(body, {
-      status: 429,
-      headers: {
-        ...rateLimitHeaders,
-        "Content-Type": options.json ? "application/json" : "text/plain",
-      },
-    });
+    return buildRateLimitResponse(result, type, options);
   }
 
+  return null;
+}
+
+/**
+ * Checks the per-account rate limit for a password attempt, keyed by the
+ * normalized email/username using the strict "expensive" bucket.
+ *
+ * This complements the per-IP `checkRouteRateLimit` (and the
+ * `expensivePublicProcedure` middleware) that guard password-accepting
+ * endpoints: a per-IP limit alone does not stop a distributed, IP-rotating
+ * brute-force against a single account. Sharing this account key across every
+ * password path (tRPC login, Google Reader ClientLogin, Wallabag password
+ * grant) bounds total guesses per account regardless of source IP.
+ *
+ * Returns a ConsumeResult; callers turn a disallowed result into their
+ * transport-appropriate error (429 Response / TRPCError).
+ */
+export async function checkAccountRateLimit(email: string): Promise<ConsumeResult> {
+  return checkRateLimit(getAccountRateLimitIdentifier(email), "expensive");
+}
+
+/**
+ * Route-handler variant of {@link checkAccountRateLimit}: returns a 429 Response
+ * if the per-account limit is exceeded, or null if allowed.
+ */
+export async function checkAccountRouteRateLimit(
+  email: string,
+  options: { json?: boolean } = {}
+): Promise<Response | null> {
+  const result = await checkAccountRateLimit(email);
+  if (!result.allowed) {
+    return buildRateLimitResponse(result, "expensive", options);
+  }
   return null;
 }

--- a/src/server/trpc/routers/auth.ts
+++ b/src/server/trpc/routers/auth.ts
@@ -6,8 +6,11 @@
  */
 
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
 import * as argon2 from "argon2";
 import { eq, and, or, gt, exists, isNotNull, sql } from "drizzle-orm";
+
+import { checkAccountRateLimit } from "@/server/rate-limit";
 
 import {
   createTRPCRouter,
@@ -268,6 +271,19 @@ export const authRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { email, password } = input;
+
+      // Per-account limit (in addition to the per-IP `expensivePublicProcedure`
+      // middleware): throttles distributed, IP-rotating brute-force against a
+      // single account. Shared with the Google Reader and Wallabag password
+      // paths. Checked before the user lookup so attempts against non-existent
+      // accounts are throttled identically (no enumeration side channel).
+      const accountLimit = await checkAccountRateLimit(email);
+      if (!accountLimit.allowed) {
+        throw new TRPCError({
+          code: "TOO_MANY_REQUESTS",
+          message: `Rate limit exceeded. Please retry after ${accountLimit.retryAfterSeconds} seconds.`,
+        });
+      }
 
       // Find user by email
       const user = await ctx.db.select().from(users).where(eq(users.email, email)).limit(1);

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -15,7 +15,7 @@ import {
   type RateLimitConfig,
   type ConsumeResult,
 } from "../../src/server/rate-limit/token-bucket";
-import { getClientIdentifier } from "../../src/server/rate-limit";
+import { getClientIdentifier, getAccountRateLimitIdentifier } from "../../src/server/rate-limit";
 
 /**
  * Helper to create a bucket state with defaults.
@@ -333,6 +333,19 @@ describe("getClientIdentifier", () => {
 
   it("returns ip:unknown when no trusted IP header is present", () => {
     expect(getClientIdentifier(null, new Headers())).toBe("ip:unknown");
+  });
+});
+
+describe("getAccountRateLimitIdentifier", () => {
+  it("namespaces the key under email: so it can't collide with ip:/user: keys", () => {
+    expect(getAccountRateLimitIdentifier("user@example.com")).toBe("email:user@example.com");
+  });
+
+  it("lower-cases and trims so case/whitespace variants share one bucket", () => {
+    // Otherwise an attacker could rotate casing to get a fresh bucket per guess.
+    const canonical = getAccountRateLimitIdentifier("user@example.com");
+    expect(getAccountRateLimitIdentifier("User@Example.COM")).toBe(canonical);
+    expect(getAccountRateLimitIdentifier("  user@example.com  ")).toBe(canonical);
   });
 });
 


### PR DESCRIPTION
Fixes #827.

## Background

Commit 4f094c4e (already merged) added a per-IP `expensive` rate limit to the three previously-unprotected password paths (Google Reader `ClientLogin`, Wallabag password grant, OAuth `/oauth/token`). That closes the "bypass login rate limiting from a single source" hole, but the issue also suggested a **shared rate limiter keyed by email** — needed because a per-IP limit alone doesn't stop a distributed, IP-rotating brute-force against a single account.

## Change

Adds a shared per-account rate limiter keyed by the normalized (trimmed/lower-cased) email, using the same `expensive` bucket, across every password-accepting path:

- **tRPC `auth.login`** — checked *before* the user lookup, so attempts against non-existent accounts are throttled identically (no enumeration side channel).
- **Google Reader `ClientLogin`** (`POST /api/greader.php/accounts/ClientLogin`)
- **Wallabag password grant** (`POST /api/wallabag/oauth/v2/token`)

The per-IP check still runs first on the route handlers (cheap flood rejection before body parsing); the per-account check runs once the email is known.

The OAuth 2.1 `/oauth/token` endpoint accepts no password (only `authorization_code`/`refresh_token` grants), so it has no account key and keeps the generous `oauth` bucket — the issue's third bullet was slightly inaccurate on this point.

## Implementation

- New helpers in `src/server/rate-limit/`: `getAccountRateLimitIdentifier` (pure, namespaced `email:<normalized>` so it can't collide with `ip:`/`user:` keys), `checkAccountRateLimit` (→ `ConsumeResult`, for tRPC), and `checkAccountRouteRateLimit` (→ 429 `Response`, for route handlers). Extracted a shared `buildRateLimitResponse` from `checkRouteRateLimit`.
- Unit tests for the normalization (case/whitespace variants share one bucket).
- Documented in `docs/DESIGN.md`.

## Testing

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test:unit` ✅ (1972 passed, incl. new cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)