### PR TITLE
Retention cleanup for orphaned DCR clients (#975)

### DIFF
--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -1338,8 +1338,9 @@ const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
  *
  * Deletes rows that expire but were never deleted anywhere (issue #953):
  * expired sessions, expired OAuth authorization codes / access tokens /
- * refresh tokens, long-revoked credentials, and parked one-time
- * process_opml_import jobs. See src/server/services/retention.ts.
+ * refresh tokens, long-revoked credentials, orphaned Dynamic Client
+ * Registration clients (issue #975), and parked one-time process_opml_import
+ * jobs. See src/server/services/retention.ts.
  */
 export async function handleCleanup(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/server/services/retention.ts
+++ b/src/server/services/retention.ts
@@ -7,12 +7,14 @@
  * so deletion only reclaims space and index bloat, never changes behavior.
  */
 
-import { and, eq, gt, isNull, lt, or } from "drizzle-orm";
+import { and, eq, gt, isNull, lt, notExists, or, sql } from "drizzle-orm";
 import type { Database } from "../db";
 import {
   jobs,
   oauthAccessTokens,
   oauthAuthorizationCodes,
+  oauthClients,
+  oauthConsentGrants,
   oauthRefreshTokens,
   sessions,
 } from "../db/schema";
@@ -40,6 +42,17 @@ const REVOKED_RETENTION_MS = 30 * DAY_MS;
 const PARKED_JOB_THRESHOLD_MS = 180 * DAY_MS;
 
 /**
+ * How long an orphaned Dynamic Client Registration (RFC 7591) client is retained
+ * before deletion. `/oauth/register` is open (no auth) and MCP clients such as
+ * claude.ai re-register on every connect, so most rows never complete an
+ * authorization; without cleanup they accumulate unbounded. A registration older
+ * than this with no live tokens and no active consent grant is dead — the client
+ * would have to re-register to be usable — so it's safe to remove. Kept generous
+ * so a client mid-onboarding (registered, not yet authorized) isn't reaped.
+ */
+const ORPHANED_CLIENT_RETENTION_MS = 30 * DAY_MS;
+
+/**
  * Row counts deleted by a cleanup run, keyed for job metadata/logging.
  */
 export interface RetentionCleanupResult {
@@ -47,17 +60,21 @@ export interface RetentionCleanupResult {
   oauthAuthorizationCodes: number;
   oauthAccessTokens: number;
   oauthRefreshTokens: number;
+  oauthClients: number;
   parkedJobs: number;
 }
 
 /**
- * Deletes expired/revoked credentials and parked one-time jobs.
+ * Deletes expired/revoked credentials, orphaned DCR clients, and parked
+ * one-time jobs.
  */
 export async function runRetentionCleanup(db: Database): Promise<RetentionCleanupResult> {
   const now = Date.now();
+  const nowDate = new Date(now);
   const expiryCutoff = new Date(now - EXPIRY_GRACE_MS);
   const revokedCutoff = new Date(now - REVOKED_RETENTION_MS);
   const parkedCutoff = new Date(now + PARKED_JOB_THRESHOLD_MS);
+  const orphanedClientCutoff = new Date(now - ORPHANED_CLIENT_RETENTION_MS);
 
   const expiredSessions = await db
     .delete(sessions)
@@ -100,11 +117,61 @@ export async function runRetentionCleanup(db: Database): Promise<RetentionCleanu
       )
     );
 
+  // Orphaned Dynamic Client Registration clients (issue #975): every row in
+  // oauth_clients comes from open /oauth/register (CIMD URL clients are resolved
+  // on the fly and never stored). Delete old registrations that never became
+  // usable — no live (non-revoked, unexpired) access or refresh token and no
+  // active consent grant. clientId is a plain text column (no FK), so an active
+  // client is protected by these NOT EXISTS checks, not by referential integrity;
+  // the liveness predicates match resolveClient/token validation exactly so we
+  // never remove a client a future request could still authenticate against.
+  const orphanedClients = await db.delete(oauthClients).where(
+    and(
+      lt(oauthClients.createdAt, orphanedClientCutoff),
+      notExists(
+        db
+          .select({ one: sql`1` })
+          .from(oauthAccessTokens)
+          .where(
+            and(
+              eq(oauthAccessTokens.clientId, oauthClients.clientId),
+              isNull(oauthAccessTokens.revokedAt),
+              gt(oauthAccessTokens.expiresAt, nowDate)
+            )
+          )
+      ),
+      notExists(
+        db
+          .select({ one: sql`1` })
+          .from(oauthRefreshTokens)
+          .where(
+            and(
+              eq(oauthRefreshTokens.clientId, oauthClients.clientId),
+              isNull(oauthRefreshTokens.revokedAt),
+              gt(oauthRefreshTokens.expiresAt, nowDate)
+            )
+          )
+      ),
+      notExists(
+        db
+          .select({ one: sql`1` })
+          .from(oauthConsentGrants)
+          .where(
+            and(
+              eq(oauthConsentGrants.clientId, oauthClients.clientId),
+              isNull(oauthConsentGrants.revokedAt)
+            )
+          )
+      )
+    )
+  );
+
   return {
     sessions: expiredSessions.rowCount ?? 0,
     oauthAuthorizationCodes: expiredAuthCodes.rowCount ?? 0,
     oauthAccessTokens: expiredAccessTokens.rowCount ?? 0,
     oauthRefreshTokens: expiredRefreshTokens.rowCount ?? 0,
+    oauthClients: orphanedClients.rowCount ?? 0,
     parkedJobs: parkedJobs.rowCount ?? 0,
   };
 }

--- a/tests/integration/retention.test.ts
+++ b/tests/integration/retention.test.ts
@@ -12,6 +12,8 @@ import {
   jobs,
   oauthAccessTokens,
   oauthAuthorizationCodes,
+  oauthClients,
+  oauthConsentGrants,
   oauthRefreshTokens,
   sessions,
   users,
@@ -48,15 +50,20 @@ async function createSession(userId: string, expiresAt: Date, revokedAt?: Date):
   return id;
 }
 
-async function createAccessToken(userId: string, expiresAt: Date): Promise<string> {
+async function createAccessToken(
+  userId: string,
+  expiresAt: Date,
+  options: { clientId?: string; revokedAt?: Date } = {}
+): Promise<string> {
   const id = generateUuidv7();
   await db.insert(oauthAccessTokens).values({
     id,
     tokenHash: `hash-${id}`,
-    clientId: TEST_CLIENT_ID,
+    clientId: options.clientId ?? TEST_CLIENT_ID,
     userId,
     scopes: ["mcp"],
     expiresAt,
+    revokedAt: options.revokedAt ?? null,
     createdAt: new Date(),
   });
   return id;
@@ -65,13 +72,18 @@ async function createAccessToken(userId: string, expiresAt: Date): Promise<strin
 async function createRefreshToken(
   userId: string,
   expiresAt: Date,
-  options: { revokedAt?: Date; accessTokenId?: string; replacedById?: string } = {}
+  options: {
+    clientId?: string;
+    revokedAt?: Date;
+    accessTokenId?: string;
+    replacedById?: string;
+  } = {}
 ): Promise<string> {
   const id = generateUuidv7();
   await db.insert(oauthRefreshTokens).values({
     id,
     tokenHash: `hash-${id}`,
-    clientId: TEST_CLIENT_ID,
+    clientId: options.clientId ?? TEST_CLIENT_ID,
     userId,
     scopes: ["mcp"],
     expiresAt,
@@ -79,6 +91,36 @@ async function createRefreshToken(
     accessTokenId: options.accessTokenId ?? null,
     replacedById: options.replacedById ?? null,
     createdAt: new Date(),
+  });
+  return id;
+}
+
+async function createClient(clientId: string, createdAt: Date): Promise<string> {
+  await db.insert(oauthClients).values({
+    id: generateUuidv7(),
+    clientId,
+    name: "Test DCR Client",
+    redirectUris: ["https://example.com/callback"],
+    createdAt,
+    updatedAt: createdAt,
+  });
+  return clientId;
+}
+
+async function createConsentGrant(
+  userId: string,
+  clientId: string,
+  options: { revokedAt?: Date } = {}
+): Promise<string> {
+  const id = generateUuidv7();
+  await db.insert(oauthConsentGrants).values({
+    id,
+    userId,
+    clientId,
+    scopes: ["mcp"],
+    revokedAt: options.revokedAt ?? null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   });
   return id;
 }
@@ -104,6 +146,8 @@ async function cleanupTables(): Promise<void> {
   await db.delete(oauthRefreshTokens);
   await db.delete(oauthAccessTokens);
   await db.delete(oauthAuthorizationCodes);
+  await db.delete(oauthConsentGrants);
+  await db.delete(oauthClients);
   await db.delete(sessions);
   await db.delete(jobs);
   await db.delete(users);
@@ -246,6 +290,58 @@ describe("runRetentionCleanup", () => {
     expect(remaining).not.toContain(parkedId);
   });
 
+  it("deletes orphaned old DCR clients but keeps recent or actively-used ones", async () => {
+    const userId = await createTestUser();
+    const old = new Date(Date.now() - 40 * DAY_MS);
+    const recentDate = new Date(Date.now() - 2 * DAY_MS);
+
+    // Old registration that never completed authorization: deleted.
+    const orphaned = await createClient("dcr-orphaned", old);
+
+    // Recently registered, still mid-onboarding: kept despite no tokens.
+    const recent = await createClient("dcr-recent", recentDate);
+
+    // Old but has a live access token: kept.
+    const withLiveAccess = await createClient("dcr-live-access", old);
+    await createAccessToken(userId, new Date(Date.now() + 60 * 60 * 1000), {
+      clientId: withLiveAccess,
+    });
+
+    // Old but has a live refresh token: kept.
+    const withLiveRefresh = await createClient("dcr-live-refresh", old);
+    await createRefreshToken(userId, new Date(Date.now() + 30 * DAY_MS), {
+      clientId: withLiveRefresh,
+    });
+
+    // Old but has an active consent grant (tokens all expired): kept.
+    const withConsent = await createClient("dcr-consent", old);
+    await createConsentGrant(userId, withConsent);
+
+    // Old with only dead tokens (expired access, revoked refresh) and a revoked
+    // consent grant: nothing live, so deleted.
+    const withDeadGrants = await createClient("dcr-dead", old);
+    await createAccessToken(userId, new Date(Date.now() - 2 * DAY_MS), {
+      clientId: withDeadGrants,
+    });
+    await createRefreshToken(userId, new Date(Date.now() + 30 * DAY_MS), {
+      clientId: withDeadGrants,
+      revokedAt: new Date(Date.now() - DAY_MS),
+    });
+    await createConsentGrant(userId, withDeadGrants, {
+      revokedAt: new Date(Date.now() - DAY_MS),
+    });
+
+    const result = await runRetentionCleanup(db);
+
+    expect(result.oauthClients).toBe(2);
+    const remaining = (await db.select({ clientId: oauthClients.clientId }).from(oauthClients)).map(
+      (r) => r.clientId
+    );
+    expect(remaining.sort()).toEqual([recent, withLiveAccess, withLiveRefresh, withConsent].sort());
+    expect(remaining).not.toContain(orphaned);
+    expect(remaining).not.toContain(withDeadGrants);
+  });
+
   it("returns zero counts when there is nothing to delete", async () => {
     const result = await runRetentionCleanup(db);
     expect(result).toEqual({
@@ -253,6 +349,7 @@ describe("runRetentionCleanup", () => {
       oauthAuthorizationCodes: 0,
       oauthAccessTokens: 0,
       oauthRefreshTokens: 0,
+      oauthClients: 0,
       parkedJobs: 0,
     });
   });


### PR DESCRIPTION
Fixes #975.

## Problem

`/oauth/register` (RFC 7591 Dynamic Client Registration) is open (no auth) and inserts a row into `oauth_clients` per request. MCP clients like claude.ai re-register on **every connect**, so rows accumulate and are never removed — `runRetentionCleanup` had no `oauth_clients` handling. The recently-widened `oauth` rate-limit bucket raises the theoretical per-IP insert ceiling, so the growth is effectively unbounded.

## Change

`runRetentionCleanup` now deletes an `oauth_clients` row only when **all** of the following hold:

- created more than **30 days** ago (`ORPHANED_CLIENT_RETENTION_MS`), AND
- no **live** (non-revoked, unexpired) access token references its `client_id`, AND
- no **live** refresh token references its `client_id`, AND
- no **active** (non-revoked) consent grant references its `client_id`.

The liveness predicates mirror `resolveClient`/token validation exactly, so a client that any future request could still authenticate against is always retained even if old. A registration that never completed authorization, or whose grants have all lapsed, is dead — the client would have to re-register to be usable — so removing it is behavior-preserving.

CIMD URL clients are resolved on the fly and never stored, so every `oauth_clients` row is DCR-created; scoping by live tokens + consent grants (rather than a new column) also protects any future first-party client that is actually in use, per the issue's suggestion.

## Tests

Extended `tests/integration/retention.test.ts`:
- deletes an old orphaned registration and one with only dead tokens + a revoked consent grant,
- keeps a recently-registered client (mid-onboarding), and old clients with a live access token, a live refresh token, or an active consent grant,
- updated the zero-count assertion for the new `oauthClients` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)