### PR TITLE
Fix over-count of global unread counts via visible_entries (#829)

### DIFF
--- a/src/server/services/counts.ts
+++ b/src/server/services/counts.ts
@@ -105,10 +105,19 @@ export function toBulkUnreadCounts(counts: UnreadCounts): NewEntryUnreadCounts {
 /**
  * Global unread counts (all + starred + saved) for a user.
  *
- * read=false is in WHERE (not a FILTER aggregate) so the partial
- * idx_user_entries_unread index drives the scan instead of reading every
- * visible row. Every aggregate is a subset of unread, so this is exactly
- * equivalent to FILTER (WHERE NOT read) over all visible rows.
+ * `count(DISTINCT id)` — not `count(*)` — because `visible_entries` emits one
+ * row per matching `subscription_feeds` row, so an entry reachable through
+ * overlapping subscriptions (redirect/merge history) appears multiple times and
+ * a plain `count(*)` over-counts. DISTINCT dedupes by entry id, matching the
+ * per-tag/uncategorized counts below. Keeping the visibility rule in the view
+ * (rather than re-deriving it here) means it stays defined in exactly one place.
+ *
+ * `read = false` is in WHERE (not a FILTER predicate) so the partial
+ * `idx_user_entries_unread` index can drive the scan; every aggregate is then a
+ * subset of unread. An `EXPLAIN ANALYZE` on a heavy user (50k entries, 45k
+ * unread) confirmed the view's set-based hash joins run once in ~30ms — pushing
+ * the visibility check onto the base tables with a correlated `EXISTS` was ~25x
+ * slower (per-row subplan), so the view scan is the right shape here.
  */
 async function getGlobalUnreadCounts(
   db: typeof dbType,
@@ -116,9 +125,9 @@ async function getGlobalUnreadCounts(
 ): Promise<{ allUnread: number; starredUnread: number; savedUnread: number }> {
   const result = await db
     .select({
-      allUnread: sql<number>`count(*)::int`,
-      starredUnread: sql<number>`count(*) FILTER (WHERE ${visibleEntries.starred})::int`,
-      savedUnread: sql<number>`count(*) FILTER (WHERE ${visibleEntries.type} = 'saved')::int`,
+      allUnread: sql<number>`count(DISTINCT ${visibleEntries.id})::int`,
+      starredUnread: sql<number>`count(DISTINCT ${visibleEntries.id}) FILTER (WHERE ${visibleEntries.starred})::int`,
+      savedUnread: sql<number>`count(DISTINCT ${visibleEntries.id}) FILTER (WHERE ${visibleEntries.type} = 'saved')::int`,
     })
     .from(visibleEntries)
     .where(and(eq(visibleEntries.userId, userId), eq(visibleEntries.read, false)));
@@ -481,22 +490,23 @@ export async function getNewEntryRelatedCounts(
   entryType: "web" | "email" | "saved",
   subscriptionId: string | null
 ): Promise<UnreadCounts> {
-  // Query unread counts for global + starred + saved + subscription in one query.
-  // read=false in WHERE lets the partial idx_user_entries_unread index drive;
-  // every aggregate is a subset of unread, so the remaining FILTERs (starred,
-  // saved, this subscription) are equivalent to the previous AND NOT read form.
+  // Query unread counts for global + starred + saved + subscription in one
+  // scan. read=false in WHERE lets the partial idx_user_entries_unread index
+  // drive; every aggregate is then a subset of unread. count(DISTINCT id)
+  // dedupes entries reachable through overlapping subscription_feeds rows (see
+  // getGlobalUnreadCounts).
   const result = await db
     .select({
       // Global unread counts
-      allUnread: sql<number>`count(*)::int`,
+      allUnread: sql<number>`count(DISTINCT ${visibleEntries.id})::int`,
       // Starred unread counts
-      starredUnread: sql<number>`count(*) FILTER (WHERE ${visibleEntries.starred})::int`,
+      starredUnread: sql<number>`count(DISTINCT ${visibleEntries.id}) FILTER (WHERE ${visibleEntries.starred})::int`,
       // Saved unread counts
-      savedUnread: sql<number>`count(*) FILTER (WHERE ${visibleEntries.type} = 'saved')::int`,
+      savedUnread: sql<number>`count(DISTINCT ${visibleEntries.id}) FILTER (WHERE ${visibleEntries.type} = 'saved')::int`,
       // Subscription count (only computed if subscriptionId provided)
       subscriptionUnread:
         subscriptionId !== null
-          ? sql<number>`count(*) FILTER (WHERE ${visibleEntries.subscriptionId} = ${subscriptionId})::int`
+          ? sql<number>`count(DISTINCT ${visibleEntries.id}) FILTER (WHERE ${visibleEntries.subscriptionId} = ${subscriptionId})::int`
           : sql<number>`0`,
     })
     .from(visibleEntries)
@@ -557,16 +567,10 @@ export async function getSubscriptionDeletionCounts(
   userId: string,
   formerTagIds: string[]
 ): Promise<BulkUnreadCounts> {
-  const globalResult = await db
-    .select({
-      allUnread: sql<number>`count(*) FILTER (WHERE NOT ${visibleEntries.read})::int`,
-      starredUnread: sql<number>`count(*) FILTER (WHERE ${visibleEntries.starred} AND NOT ${visibleEntries.read})::int`,
-      savedUnread: sql<number>`count(*) FILTER (WHERE ${visibleEntries.type} = 'saved' AND NOT ${visibleEntries.read})::int`,
-    })
-    .from(visibleEntries)
-    .where(eq(visibleEntries.userId, userId));
-
-  const globalCounts = globalResult[0] ?? { allUnread: 0, starredUnread: 0, savedUnread: 0 };
+  // Reuse the shared global-count query (see getGlobalUnreadCounts). Must run
+  // AFTER the subscription is soft-deleted so its entries no longer count as
+  // visible.
+  const globalCounts = await getGlobalUnreadCounts(db, userId);
   const baseCounts: BulkUnreadCounts = {
     all: { unread: globalCounts.allUnread },
     starred: { unread: globalCounts.starredUnread },

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -1154,9 +1154,14 @@ export async function countEntries(
   // Apply entry filter conditions (unreadOnly, starredOnly, type, excludeTypes, showSpam)
   conditions.push(...buildEntryFilterConditions(params));
 
+  // count(DISTINCT id), not count(*): visible_entries emits one row per matching
+  // subscription_feeds row, so an entry reachable through overlapping
+  // subscriptions (redirect/merge history) would be counted multiple times.
+  // This keeps the sidebar badge consistent with the counts.ts service, which
+  // dedupes the same way.
   const result = await db
     .select({
-      unread: sql<number>`count(*) FILTER (WHERE ${visibleEntries.read} = false)::int`,
+      unread: sql<number>`count(DISTINCT ${visibleEntries.id}) FILTER (WHERE ${visibleEntries.read} = false)::int`,
     })
     .from(visibleEntries)
     .where(and(...conditions));
@@ -1211,9 +1216,11 @@ export async function countTotalEntries(
 
   conditions.push(...buildEntryFilterConditions(params));
 
+  // count(DISTINCT id): dedupe entries reachable through overlapping
+  // subscription_feeds rows (see countEntries).
   const result = await db
     .select({
-      total: sql<number>`count(*)::int`,
+      total: sql<number>`count(DISTINCT ${visibleEntries.id})::int`,
     })
     .from(visibleEntries)
     .where(and(...conditions));

--- a/tests/integration/counts.test.ts
+++ b/tests/integration/counts.test.ts
@@ -218,6 +218,87 @@ describe("Entry counts service", () => {
       expect(counts.starred).toEqual({ unread: 0 });
     });
 
+    it("does not double-count global unread for entries reachable through multiple subscriptions", async () => {
+      // Regression test: the global "All Articles" count previously scanned the
+      // visible_entries view with count(*), which emits an entry once per
+      // matching subscription_feeds row. entryIdB is reachable through both
+      // sub1 and sub2, so it was counted twice, inflating allUnread to 3 for
+      // what are really 2 distinct unread entries.
+      const userId = await createTestUser();
+      const { entryIdB } = await createOverlappingSubscriptions(userId);
+
+      const counts = await getEntryRelatedCounts(db, userId, entryIdB);
+
+      expect(counts.all).toEqual({ unread: 2 });
+    });
+
+    it("excludes unread entries from unsubscribed feeds from global counts", async () => {
+      // user_entries rows persist after unsubscribe (soft delete), but such
+      // entries are not visible unless starred/saved. The global count must
+      // exclude them.
+      const userId = await createTestUser();
+      const activeFeedId = await createTestFeed("https://active.com/rss");
+      await createTestSubscription(userId, activeFeedId);
+      const activeEntryId = await createTestEntry(activeFeedId, [userId]);
+
+      // A feed the user has unsubscribed from, with an unread (non-starred,
+      // non-saved) entry whose user_entries row still exists.
+      const goneFeedId = await createTestFeed("https://gone.com/rss");
+      const goneSubId = generateUuidv7();
+      await db.insert(subscriptions).values({
+        id: goneSubId,
+        userId,
+        feedId: goneFeedId,
+        subscribedAt: new Date(),
+        unsubscribedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      await db
+        .insert(subscriptionFeeds)
+        .values({ subscriptionId: goneSubId, feedId: goneFeedId, userId })
+        .onConflictDoNothing();
+      await createTestEntry(goneFeedId, [userId]);
+
+      const counts = await getEntryRelatedCounts(db, userId, activeEntryId);
+
+      expect(counts.all).toEqual({ unread: 1 });
+    });
+
+    it("counts starred entries from unsubscribed feeds in global counts", async () => {
+      // Starred entries are always visible, even from a feed the user has
+      // unsubscribed from, so they must still count toward All Articles and
+      // Starred.
+      const userId = await createTestUser();
+      const goneFeedId = await createTestFeed("https://gone-starred.com/rss");
+      const goneSubId = generateUuidv7();
+      await db.insert(subscriptions).values({
+        id: goneSubId,
+        userId,
+        feedId: goneFeedId,
+        subscribedAt: new Date(),
+        unsubscribedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      await db
+        .insert(subscriptionFeeds)
+        .values({ subscriptionId: goneSubId, feedId: goneFeedId, userId })
+        .onConflictDoNothing();
+      const starredEntryId = await createTestEntry(goneFeedId, []);
+      await db.insert(userEntries).values({
+        userId,
+        entryId: starredEntryId,
+        read: false,
+        starred: true,
+      });
+
+      const counts = await getEntryRelatedCounts(db, userId, starredEntryId);
+
+      expect(counts.all).toEqual({ unread: 1 });
+      expect(counts.starred).toEqual({ unread: 1 });
+    });
+
     it("does not count other users' unread entries in tag counts", async () => {
       const userId = await createTestUser("user-a");
       const otherUserId = await createTestUser("user-b");

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -683,6 +683,34 @@ describe("Entries", () => {
 
       expect(result.unread).toBe(2);
     });
+
+    it("does not double-count entries reachable through overlapping subscriptions", async () => {
+      // visible_entries emits one row per matching subscription_feeds row, so an
+      // entry reachable through two subscriptions to the same feed (redirect/
+      // merge history) appears twice. The unread count must dedupe by entry id
+      // so the sidebar badge stays consistent with the counts service.
+      const userId = await createTestUser();
+      const feedA = await createTestFeed("https://a.com/rss");
+      const feedB = await createTestFeed("https://b.com/rss");
+      const subId1 = await createTestSubscription(userId, feedA);
+      await createTestSubscription(userId, feedB);
+      // Extra subscription_feeds row: sub1 also covers feedB (merge history).
+      await db
+        .insert(subscriptionFeeds)
+        .values({ subscriptionId: subId1, feedId: feedB, userId })
+        .onConflictDoNothing();
+
+      const entryA = await createTestEntry(feedA, { title: "A" });
+      const entryB = await createTestEntry(feedB, { title: "B" });
+      await createUserEntry(userId, entryA, { read: false });
+      await createUserEntry(userId, entryB, { read: false }); // reachable via sub1 AND sub2
+
+      const caller = createCaller(createAuthContext(userId));
+      const result = await caller.entries.count({});
+
+      // Two distinct unread entries, not three.
+      expect(result.unread).toBe(2);
+    });
   });
 
   describe("markAllEntriesRead service", () => {


### PR DESCRIPTION
Addresses #829.

## TL;DR

The original premise of #829 — that scanning `visible_entries` for global unread counts is expensive — **did not hold up under measurement**. The view's hash joins are cheap. The only real defect was a **correctness bug**: `count(*)` over `visible_entries` double-counts entries reachable through overlapping `subscription_feeds` rows (feed redirect/merge history). This PR fixes that with `count(DISTINCT id)`, keeping the visibility rule defined solely in the view.

## What changed

- `counts.ts`: `getGlobalUnreadCounts` and `getNewEntryRelatedCounts` use `count(DISTINCT id)`; `getSubscriptionDeletionCounts` reuses the shared helper.
- `entries.ts`: `countEntries` / `countTotalEntries` dedupe the same way, so the page-load/refetch sidebar badge agrees with the mutation/SSE badge (fixes a cross-path inconsistency).
- Tests: global-count dedup, unsubscribed-feed exclusion, starred-from-unsubscribed inclusion (`counts.test.ts`); `countEntries` dedup (`entries.test.ts`).

## Why not the base-table rewrite (which this PR originally proposed)

The first version scanned `user_entries` directly with an `EXISTS` semi-join to bypass the view's joins. A Fable reviewer flagged a cross-path inconsistency and a DRY concern, so I benchmarked with `EXPLAIN ANALYZE` on a synthetic heavy user (200 subs, 50k entries, 45k unread, with an overlapping merge-history subscription):

| Approach | Correct? | Warm exec time |
|---|---|---|
| current master: `count(*)` over view | ❌ over-counts (43,545 vs true 43,317) | ~27 ms |
| base-table scan + `EXISTS` semi-join | ✅ | **~720 ms** 🔴 |
| **`count(DISTINCT id)` over view (this PR)** | ✅ | ~40 ms |

The `EXISTS` sits inside an aggregate `FILTER`, so the planner can't turn it into a set-based semi-join — it runs as a **per-row correlated subplan (43,651 executions)**. The view's joins run once as hash joins (~27ms). So the base-table approach was a ~25x regression; `count(DISTINCT)` fixes correctness at ~the same cost as today **and** keeps the visibility rule in one place (the view), which is the maintainability property we want for this fragile code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)