### PR TITLE
Testing hygiene: real hook tests + no-focused-tests lint (#957)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,21 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import vitest from "@vitest/eslint-plugin";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  // Guard against accidentally committed focused tests (`it.only`/`describe.only`),
+  // which silently skip every other test in a file. Playwright's `forbidOnly` covers
+  // e2e; this covers the vitest unit/integration suites.
+  {
+    files: ["tests/**/*.{ts,tsx}"],
+    plugins: { vitest },
+    rules: {
+      "vitest/no-focused-tests": ["error", { fixable: false }],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/sanitize-html": "^2.16.1",
+    "@vitest/eslint-plugin": "^1.6.20",
     "dotenv-cli": "^11.0.0",
     "esbuild": "^0.28.1",
     "eslint": "^9.39.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@types/sanitize-html':
         specifier: ^2.16.1
         version: 2.16.1
+      '@vitest/eslint-plugin':
+        specifier: ^1.6.20
+        version: 1.6.20(@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(jsdom@29.1.1)(vite@7.3.2(@types/node@26.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       dotenv-cli:
         specifier: ^11.0.0
         version: 11.0.0
@@ -1284,89 +1287,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1473,42 +1492,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -1567,24 +1593,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -1882,41 +1912,49 @@ packages:
     resolution: {integrity: sha512-Cwm6A071ww60QouJ9LoHAwBgEoZzHQ0Qaqk2E7WLfBdiQN9mLXIDhnrpn04hlRElRPhLiu/dtg+o5PPLvaINXQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.17.1':
     resolution: {integrity: sha512-+hwlE2v3m0r3sk93SchJL1uyaKcPjf+NGO/TD2DZUDo+chXx7FfaEj0nUMewigSt7oZ2sQN9Z4NJOtUa75HE5Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.17.1':
     resolution: {integrity: sha512-bO+rsaE5Ox8cFyeL5Ct5tzot1TnQpFa/Wmu5k+hqBYSH2dNVDGoi0NizBN5QV8kOIC6O5MZr81UG4yW/2FyDTA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.17.1':
     resolution: {integrity: sha512-B/P+hxKQ1oX4YstI9Lyh4PGzqB87Ddqj/A4iyRBbPdXTcxa+WW3oRLx1CsJKLmHPdDk461Hmbghq1Bm3pl+8Aw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.17.1':
     resolution: {integrity: sha512-ulp2H3bFXzd/th2maH+QNKj5qgOhJ3v9Yspdf1svTw3CDOuuTl6sRKsWQ7MUw0vnkSNvQndtflBwVXgzZvURsQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.17.1':
     resolution: {integrity: sha512-LAXYVe3rKk09Zo9YKF2ZLBcH8sz8Oj+JIyiUxiHtq0hiYLMsN6dOpCf2hzQEjPAmsSEA/hdC1PVKeXo+oma8mQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.17.1':
     resolution: {integrity: sha512-3RAhxipMKE8RCSPn7O//sj440i+cYTgYbapLeOoDvQEt6R1QcJjTsFgI4iz99FhVj3YbPxlZmcLB5VW+ipyRTA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.17.1':
     resolution: {integrity: sha512-wpjMEubGU8r9VjZTLdZR3aPHaBqTl8Jl8F4DBbgNoZ+yhkhQD1/MGvY70v2TLnAI6kAHSvcqgfvaqKDa2iWsPQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.17.1':
     resolution: {integrity: sha512-XIE4w17RYAVIgx+9Gs3deTREq5tsmalbatYOOBGNdH7n0DfTE600c7wYXsp7ANc3BPDXsInnOzXDEPCvO1F6cg==}
@@ -2106,136 +2144,163 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.6.1':
     resolution: {integrity: sha512-DNGZvZDO5YF7jN5fX8ZqmGLjZEXIJRdJEdTFMhiyXqyXubBa0WVLDWSNlQ5JR2PNgDbEV1VQowhVRUh+74D+RA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -2516,24 +2581,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -2670,9 +2739,6 @@ packages:
   '@types/node@26.0.0':
     resolution: {integrity: sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==}
 
-  '@types/node@26.1.0':
-    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
-
   '@types/pg-pool@2.0.7':
     resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
 
@@ -2803,41 +2869,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2858,6 +2932,22 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@vitest/eslint-plugin@1.6.20':
+    resolution: {integrity: sha512-xRwWHFG0Utp6hXtbGiWk4VdKXCGdExD8kbWrrmFEiG5dk8anOJ+vbWbeOa8EbkocKQRTsx7JAWETccZiBgFp/Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': '*'
+      eslint: '>=8.57.0'
+      typescript: '>=5.0.0'
+      vitest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      typescript:
+        optional: true
+      vitest:
+        optional: true
 
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
@@ -3167,8 +3257,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  baseline-browser-mapping@2.10.42:
-    resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
+  baseline-browser-mapping@2.10.40:
+    resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -3255,8 +3345,8 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
-  caniuse-lite@1.0.30001800:
-    resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -3657,8 +3747,8 @@ packages:
   electron-to-chromium@1.5.357:
     resolution: {integrity: sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==}
 
-  electron-to-chromium@1.5.387:
-    resolution: {integrity: sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==}
+  electron-to-chromium@1.5.380:
+    resolution: {integrity: sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -3712,9 +3802,6 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
-
-  es-module-lexer@2.3.0:
-    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -4622,24 +4709,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5089,10 +5180,6 @@ packages:
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
-
-  picomatch@4.0.5:
-    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pidtree@0.6.0:
@@ -8633,10 +8720,6 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
-  '@types/node@26.1.0':
-    dependencies:
-      undici-types: 8.3.0
-
   '@types/pg-pool@2.0.7':
     dependencies:
       '@types/pg': 8.20.0
@@ -8826,6 +8909,18 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(jsdom@29.1.1)(vite@7.3.2(@types/node@26.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 9.39.2(jiti@2.7.0)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      typescript: 6.0.3
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(jsdom@29.1.1)(vite@7.3.2(@types/node@26.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -9181,7 +9276,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.30: {}
 
-  baseline-browser-mapping@2.10.42: {}
+  baseline-browser-mapping@2.10.40: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -9246,9 +9341,9 @@ snapshots:
 
   browserslist@4.28.4:
     dependencies:
-      baseline-browser-mapping: 2.10.42
-      caniuse-lite: 1.0.30001800
-      electron-to-chromium: 1.5.387
+      baseline-browser-mapping: 2.10.40
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.380
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
@@ -9281,7 +9376,7 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
-  caniuse-lite@1.0.30001800: {}
+  caniuse-lite@1.0.30001799: {}
 
   chai@6.2.2: {}
 
@@ -9580,7 +9675,7 @@ snapshots:
 
   electron-to-chromium@1.5.357: {}
 
-  electron-to-chromium@1.5.387: {}
+  electron-to-chromium@1.5.380: {}
 
   emoji-regex@10.6.0: {}
 
@@ -9687,8 +9782,6 @@ snapshots:
       math-intrinsics: 1.1.0
 
   es-module-lexer@2.1.0: {}
-
-  es-module-lexer@2.3.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -10110,10 +10203,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
-
-  fdir@6.5.0(picomatch@4.0.5):
-    optionalDependencies:
-      picomatch: 4.0.5
 
   fetch-blob@3.2.0:
     dependencies:
@@ -10630,7 +10719,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 26.0.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -11250,8 +11339,6 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
-
-  picomatch@4.0.5: {}
 
   pidtree@0.6.0: {}
 
@@ -12228,8 +12315,8 @@ snapshots:
   vite@7.3.2(@types/node@26.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.16
       rollup: 4.62.2
       tinyglobby: 0.2.17
@@ -12309,7 +12396,7 @@ snapshots:
       browserslist: 4.28.4
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.1
-      es-module-lexer: 2.3.0
+      es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/tests/unit/frontend/hooks/useEntryMutations.test.ts
+++ b/tests/unit/frontend/hooks/useEntryMutations.test.ts
@@ -3,300 +3,233 @@
  */
 
 /**
- * Unit tests for useEntryMutations hook.
+ * Unit tests for useEntryMutations.
  *
- * Tests the entry mutation functions and their behavior.
- * Cache operations are tested separately in cache/operations.test.ts.
+ * These render the real hook inside the real tRPC + React Query provider (via
+ * `renderHookWithTrpc`), backed by a mock network link. That means the actual
+ * mutations fire and the real cache is updated — we assert on the tRPC inputs
+ * the hook sends and on the resulting cache state, not on compile-time types.
  *
- * Note: Testing React hooks that use tRPC mutations requires complex mocking.
- * These tests focus on verifiable behavior patterns rather than full integration.
+ * The lower-level cache operations these mutations call are covered separately
+ * in tests/unit/frontend/cache/operations.test.ts.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { act, cleanup, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+import { useEntryMutations } from "@/lib/hooks/useEntryMutations";
+import type { BulkUnreadCounts, UnreadCounts } from "@/lib/cache/operations";
+import { renderHookWithTrpc } from "../../../utils/component-test-helpers";
 
-describe("useEntryMutations", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    cleanup();
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const fixedDate = new Date("2026-07-05T00:00:00.000Z");
+
+function bulkCounts(overrides: Partial<BulkUnreadCounts> = {}): BulkUnreadCounts {
+  return {
+    all: { unread: 0 },
+    starred: { unread: 0 },
+    saved: { unread: 0 },
+    subscriptions: [],
+    tags: [],
+    ...overrides,
+  };
+}
+
+function singleCounts(overrides: Partial<UnreadCounts> = {}): UnreadCounts {
+  return {
+    all: { unread: 0 },
+    starred: { unread: 0 },
+    ...overrides,
+  };
+}
+
+describe("useEntryMutations markRead", () => {
+  it("calls entries.markRead with the given ids and read status", async () => {
+    const markRead = vi.fn((input: { entries: { id: string }[]; read: boolean }) => ({
+      entries: input.entries.map((e) => ({
+        id: e.id,
+        read: input.read,
+        starred: false,
+        updatedAt: fixedDate,
+      })),
+      counts: bulkCounts(),
+    }));
+
+    const { result, callsFor } = renderHookWithTrpc(() => useEntryMutations(), {
+      handlers: { "entries.markRead": (input) => markRead(input as never) },
+    });
+
+    act(() => {
+      result.current.markRead(["e1", "e2"], true);
+    });
+
+    await waitFor(() => expect(callsFor("entries.markRead")).toHaveLength(1));
+
+    const input = callsFor("entries.markRead")[0].input as {
+      entries: { id: string; changedAt: Date }[];
+      read: boolean;
+    };
+    expect(input.read).toBe(true);
+    expect(input.entries.map((e) => e.id)).toEqual(["e1", "e2"]);
+    expect(input.entries[0].changedAt).toBeInstanceOf(Date);
   });
 
-  afterEach(() => {
-    cleanup();
-    vi.resetModules();
+  it("toggleRead sends the negation of the current read status for a single entry", async () => {
+    const { result, callsFor } = renderHookWithTrpc(() => useEntryMutations(), {
+      handlers: {
+        "entries.markRead": (input) => {
+          const typed = input as { entries: { id: string }[]; read: boolean };
+          return {
+            entries: typed.entries.map((e) => ({
+              id: e.id,
+              read: typed.read,
+              starred: false,
+              updatedAt: fixedDate,
+            })),
+            counts: bulkCounts(),
+          };
+        },
+      },
+    });
+
+    act(() => {
+      result.current.toggleRead("e1", false);
+    });
+
+    await waitFor(() => expect(callsFor("entries.markRead")).toHaveLength(1));
+    const input = callsFor("entries.markRead")[0].input as {
+      entries: { id: string }[];
+      read: boolean;
+    };
+    expect(input.read).toBe(true);
+    expect(input.entries).toEqual([expect.objectContaining({ id: "e1" })]);
   });
 
-  describe("type definitions", () => {
-    it("exports EntryType type", async () => {
-      // Type exists if this doesn't throw at compile time
-      type EntryType = import("@/lib/hooks/useEntryMutations").EntryType;
-      const value: EntryType = "web";
-      expect(value).toBe("web");
+  it("shows a toast when the mutation fails", async () => {
+    const { result } = renderHookWithTrpc(() => useEntryMutations(), {
+      handlers: {
+        "entries.markRead": () => {
+          throw new Error("boom");
+        },
+      },
     });
 
-    it("exports MarkAllReadOptions interface", async () => {
-      // Verify the interface shape through usage
-      const options: import("@/lib/hooks/useEntryMutations").MarkAllReadOptions = {
-        subscriptionId: "sub-1",
-        tagId: "tag-1",
-        uncategorized: true,
-        starredOnly: false,
-        type: "web",
-      };
-      expect(options.subscriptionId).toBe("sub-1");
+    act(() => {
+      result.current.markRead(["e1"], true);
     });
 
-    it("exports UseEntryMutationsResult interface", async () => {
-      // Verify the interface includes expected properties
-      type Result = import("@/lib/hooks/useEntryMutations").UseEntryMutationsResult;
-
-      // This test verifies the type shape at compile time
-      const mockResult: Result = {
-        markRead: vi.fn(),
-        toggleRead: vi.fn(),
-        markAllRead: vi.fn(),
-        star: vi.fn(),
-        unstar: vi.fn(),
-        toggleStar: vi.fn(),
-        isPending: false,
-        isMarkReadPending: false,
-        isMarkAllReadPending: false,
-        isStarPending: false,
-      };
-
-      expect(mockResult.markRead).toBeDefined();
-      expect(mockResult.toggleRead).toBeDefined();
-      expect(mockResult.markAllRead).toBeDefined();
-      expect(mockResult.star).toBeDefined();
-      expect(mockResult.unstar).toBeDefined();
-      expect(mockResult.toggleStar).toBeDefined();
-      expect(typeof mockResult.isPending).toBe("boolean");
-      expect(typeof mockResult.isMarkReadPending).toBe("boolean");
-      expect(typeof mockResult.isMarkAllReadPending).toBe("boolean");
-      expect(typeof mockResult.isStarPending).toBe("boolean");
-    });
-  });
-
-  describe("MarkAllReadOptions", () => {
-    it("allows all fields to be optional", () => {
-      const options: import("@/lib/hooks/useEntryMutations").MarkAllReadOptions = {};
-      expect(options).toEqual({});
-    });
-
-    it("allows subscriptionId filter", () => {
-      const options: import("@/lib/hooks/useEntryMutations").MarkAllReadOptions = {
-        subscriptionId: "sub-123",
-      };
-      expect(options.subscriptionId).toBe("sub-123");
-    });
-
-    it("allows tagId filter", () => {
-      const options: import("@/lib/hooks/useEntryMutations").MarkAllReadOptions = {
-        tagId: "tag-456",
-      };
-      expect(options.tagId).toBe("tag-456");
-    });
-
-    it("allows uncategorized filter", () => {
-      const options: import("@/lib/hooks/useEntryMutations").MarkAllReadOptions = {
-        uncategorized: true,
-      };
-      expect(options.uncategorized).toBe(true);
-    });
-
-    it("allows starredOnly filter", () => {
-      const options: import("@/lib/hooks/useEntryMutations").MarkAllReadOptions = {
-        starredOnly: true,
-      };
-      expect(options.starredOnly).toBe(true);
-    });
-
-    it("allows type filter with web value", () => {
-      const options: import("@/lib/hooks/useEntryMutations").MarkAllReadOptions = {
-        type: "web",
-      };
-      expect(options.type).toBe("web");
-    });
-
-    it("allows type filter with email value", () => {
-      const options: import("@/lib/hooks/useEntryMutations").MarkAllReadOptions = {
-        type: "email",
-      };
-      expect(options.type).toBe("email");
-    });
-
-    it("allows type filter with saved value", () => {
-      const options: import("@/lib/hooks/useEntryMutations").MarkAllReadOptions = {
-        type: "saved",
-      };
-      expect(options.type).toBe("saved");
-    });
-
-    it("allows combining multiple filters", () => {
-      const options: import("@/lib/hooks/useEntryMutations").MarkAllReadOptions = {
-        subscriptionId: "sub-1",
-        starredOnly: true,
-        type: "web",
-      };
-      expect(options.subscriptionId).toBe("sub-1");
-      expect(options.starredOnly).toBe(true);
-      expect(options.type).toBe("web");
-    });
-  });
-
-  describe("EntryType", () => {
-    it("accepts web value", () => {
-      const entryType: import("@/lib/hooks/useEntryMutations").EntryType = "web";
-      expect(entryType).toBe("web");
-    });
-
-    it("accepts email value", () => {
-      const entryType: import("@/lib/hooks/useEntryMutations").EntryType = "email";
-      expect(entryType).toBe("email");
-    });
-
-    it("accepts saved value", () => {
-      const entryType: import("@/lib/hooks/useEntryMutations").EntryType = "saved";
-      expect(entryType).toBe("saved");
-    });
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Failed to update read status"));
   });
 });
 
-describe("useEntryMutations behavior", () => {
-  /**
-   * Note: Full integration testing of useEntryMutations requires a running
-   * tRPC client which needs significant mocking infrastructure. The cache
-   * operations themselves are tested in cache/operations.test.ts.
-   *
-   * These tests document the expected behavior:
-   *
-   * 1. markRead(ids, read) should call entries.markRead.mutate({ ids, read })
-   * 2. toggleRead(entryId, currentlyRead) should call markRead with [entryId] and !currentlyRead
-   * 3. markAllRead(options) should call entries.markAllRead.mutate(options)
-   * 4. star(entryId) should call entries.star.mutate({ id: entryId })
-   * 5. unstar(entryId) should call entries.unstar.mutate({ id: entryId })
-   * 6. toggleStar(entryId, currentlyStarred):
-   *    - If currentlyStarred: calls unstar mutation
-   *    - If !currentlyStarred: calls star mutation
-   * 7. isPending is true when any mutation is pending
-   * 8. isMarkReadPending is true when markRead mutation is pending
-   * 9. isMarkAllReadPending is true when markAllRead mutation is pending
-   * 10. isStarPending is true when star or unstar mutation is pending
-   *
-   * On success:
-   * - markRead calls handleEntriesMarkedRead with returned entries
-   * - markAllRead invalidates entries.list, subscriptions.list, tags.list, and starred count
-   * - star calls handleEntryStarred
-   * - unstar calls handleEntryUnstarred
-   *
-   * On error:
-   * - All mutations show a toast error message
-   */
+describe("useEntryMutations markAllRead", () => {
+  it("calls entries.markAllRead with the provided filter options", async () => {
+    const { result, callsFor } = renderHookWithTrpc(() => useEntryMutations(), {
+      handlers: { "entries.markAllRead": () => ({ success: true }) },
+    });
 
-  it("documents expected markRead behavior", () => {
-    // markRead should:
-    // 1. Accept array of IDs and boolean read status
-    // 2. Call entries.markRead mutation
-    // 3. On success: call handleEntriesMarkedRead with response entries
-    // 4. On error: show toast error "Failed to update read status"
-    expect(true).toBe(true);
+    act(() => {
+      result.current.markAllRead({ subscriptionId: "sub-1", type: "web" });
+    });
+
+    await waitFor(() => expect(callsFor("entries.markAllRead")).toHaveLength(1));
+    const input = callsFor("entries.markAllRead")[0].input as {
+      subscriptionId?: string;
+      type?: string;
+      changedAt: Date;
+    };
+    expect(input.subscriptionId).toBe("sub-1");
+    expect(input.type).toBe("web");
+    expect(input.changedAt).toBeInstanceOf(Date);
   });
 
-  it("documents expected toggleRead behavior", () => {
-    // toggleRead should:
-    // 1. Accept single entryId and current read status
-    // 2. Call markRead mutation with [entryId] and !currentlyRead
-    // This is a convenience wrapper around markRead
-    expect(true).toBe(true);
-  });
+  it("shows a toast when markAllRead fails", async () => {
+    const { result } = renderHookWithTrpc(() => useEntryMutations(), {
+      handlers: {
+        "entries.markAllRead": () => {
+          throw new Error("boom");
+        },
+      },
+    });
 
-  it("documents expected markAllRead behavior", () => {
-    // markAllRead should:
-    // 1. Accept optional filter options (subscriptionId, tagId, etc.)
-    // 2. Call entries.markAllRead mutation
-    // 3. On success: invalidate entries.list, subscriptions.list, tags.list, starred count
-    // 4. On error: show toast error "Failed to mark all as read"
-    expect(true).toBe(true);
-  });
+    act(() => {
+      result.current.markAllRead();
+    });
 
-  it("documents expected star behavior", () => {
-    // star should:
-    // 1. Accept entryId
-    // 2. Call entries.star mutation with { id: entryId }
-    // 3. On success: call handleEntryStarred with entry id and read status
-    // 4. On error: show toast error "Failed to star entry"
-    expect(true).toBe(true);
-  });
-
-  it("documents expected unstar behavior", () => {
-    // unstar should:
-    // 1. Accept entryId
-    // 2. Call entries.unstar mutation with { id: entryId }
-    // 3. On success: call handleEntryUnstarred with entry id and read status
-    // 4. On error: show toast error "Failed to unstar entry"
-    expect(true).toBe(true);
-  });
-
-  it("documents expected toggleStar behavior", () => {
-    // toggleStar should:
-    // 1. Accept entryId and current starred status
-    // 2. If currentlyStarred: call unstar mutation
-    // 3. If !currentlyStarred: call star mutation
-    // This is a convenience wrapper
-    expect(true).toBe(true);
-  });
-
-  it("documents expected pending state behavior", () => {
-    // Pending states:
-    // - isPending: true when any of the four mutations is pending
-    // - isMarkReadPending: true when markRead mutation is pending
-    // - isMarkAllReadPending: true when markAllRead mutation is pending
-    // - isStarPending: true when star OR unstar mutation is pending
-    expect(true).toBe(true);
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Failed to mark all as read"));
   });
 });
 
-describe("cache integration", () => {
-  /**
-   * The cache operations called by useEntryMutations are tested in
-   * tests/unit/frontend/cache/operations.test.ts
-   *
-   * This documents which operations are called by which mutations:
-   */
+describe("useEntryMutations star/unstar", () => {
+  it("star calls entries.setStarred with starred: true", async () => {
+    const { result, callsFor } = renderHookWithTrpc(() => useEntryMutations(), {
+      handlers: {
+        "entries.setStarred": (input) => {
+          const typed = input as { id: string; starred: boolean };
+          return {
+            entry: { id: typed.id, read: false, starred: typed.starred, updatedAt: fixedDate },
+            counts: singleCounts(),
+          };
+        },
+      },
+    });
 
-  it("markRead mutation uses handleEntriesMarkedRead", () => {
-    // handleEntriesMarkedRead updates:
-    // - entries.get cache for each entry
-    // - subscriptions.list unread counts
-    // - tags.list unread counts
-    // - entries.count for starred entries
-    // - entries.count for saved entries (if type is saved)
-    // - entries.list (removes entries if filtering by unread)
-    expect(true).toBe(true);
+    act(() => {
+      result.current.star("e1");
+    });
+
+    await waitFor(() => expect(callsFor("entries.setStarred")).toHaveLength(1));
+    const input = callsFor("entries.setStarred")[0].input as {
+      id: string;
+      starred: boolean;
+      changedAt: Date;
+    };
+    expect(input).toEqual(
+      expect.objectContaining({ id: "e1", starred: true, changedAt: expect.any(Date) })
+    );
   });
 
-  it("markAllRead mutation invalidates caches", () => {
-    // markAllRead invalidates (because we don't know which entries were affected):
-    // - entries.list (all filters)
-    // - subscriptions.list
-    // - tags.list
-    // - entries.count with starredOnly: true
-    expect(true).toBe(true);
+  it("toggleStar unstars an entry that is currently starred", async () => {
+    const { result, callsFor } = renderHookWithTrpc(() => useEntryMutations(), {
+      handlers: {
+        "entries.setStarred": (input) => {
+          const typed = input as { id: string; starred: boolean };
+          return {
+            entry: { id: typed.id, read: false, starred: typed.starred, updatedAt: fixedDate },
+            counts: singleCounts(),
+          };
+        },
+      },
+    });
+
+    act(() => {
+      result.current.toggleStar("e1", true);
+    });
+
+    await waitFor(() => expect(callsFor("entries.setStarred")).toHaveLength(1));
+    const input = callsFor("entries.setStarred")[0].input as { starred: boolean };
+    expect(input.starred).toBe(false);
   });
 
-  it("star mutation uses handleEntryStarred", () => {
-    // handleEntryStarred updates:
-    // - entries.get cache to set starred: true
-    // - entries.count with starredOnly: true (total +1, unread +1 if entry is unread)
-    // - entries.list to add entry to starred list
-    expect(true).toBe(true);
-  });
+  it("shows a star-specific toast when the mutation fails", async () => {
+    const { result } = renderHookWithTrpc(() => useEntryMutations(), {
+      handlers: {
+        "entries.setStarred": () => {
+          throw new Error("boom");
+        },
+      },
+    });
 
-  it("unstar mutation uses handleEntryUnstarred", () => {
-    // handleEntryUnstarred updates:
-    // - entries.get cache to set starred: false
-    // - entries.count with starredOnly: true (total -1, unread -1 if entry is unread)
-    // - entries.list to remove entry from starred list
-    expect(true).toBe(true);
+    act(() => {
+      result.current.star("e1");
+    });
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Failed to star entry"));
   });
 });

--- a/tests/unit/frontend/hooks/useEntryMutations.test.ts
+++ b/tests/unit/frontend/hooks/useEntryMutations.test.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { act, cleanup, waitFor } from "@testing-library/react";
 import { toast } from "sonner";
+import { trpc } from "@/lib/trpc/client";
 import { useEntryMutations } from "@/lib/hooks/useEntryMutations";
 import type { BulkUnreadCounts, UnreadCounts } from "@/lib/cache/operations";
 import { renderHookWithTrpc } from "../../../utils/component-test-helpers";
@@ -61,12 +62,13 @@ describe("useEntryMutations markRead", () => {
       counts: bulkCounts(),
     }));
 
-    const { result, callsFor } = renderHookWithTrpc(() => useEntryMutations(), {
-      handlers: { "entries.markRead": (input) => markRead(input as never) },
-    });
+    const { result, callsFor } = renderHookWithTrpc(
+      () => ({ mutations: useEntryMutations(), utils: trpc.useUtils() }),
+      { handlers: { "entries.markRead": (input) => markRead(input as never) } }
+    );
 
     act(() => {
-      result.current.markRead(["e1", "e2"], true);
+      result.current.mutations.markRead(["e1", "e2"], true);
     });
 
     await waitFor(() => expect(callsFor("entries.markRead")).toHaveLength(1));
@@ -80,26 +82,72 @@ describe("useEntryMutations markRead", () => {
     expect(input.entries[0].changedAt).toBeInstanceOf(Date);
   });
 
-  it("toggleRead sends the negation of the current read status for a single entry", async () => {
-    const { result, callsFor } = renderHookWithTrpc(() => useEntryMutations(), {
-      handlers: {
-        "entries.markRead": (input) => {
-          const typed = input as { entries: { id: string }[]; read: boolean };
-          return {
-            entries: typed.entries.map((e) => ({
-              id: e.id,
-              read: typed.read,
-              starred: false,
-              updatedAt: fixedDate,
-            })),
-            counts: bulkCounts(),
-          };
-        },
-      },
+  it("applies the server's absolute counts to the cache on success", async () => {
+    // Distinctive non-zero counts so a no-op/broken onSuccess (React Query
+    // swallows onSuccess throws) can't pass — the cache would stay undefined.
+    const counts = bulkCounts({
+      all: { unread: 5 },
+      starred: { unread: 3 },
+      saved: { unread: 2 },
     });
 
+    const { result, callsFor } = renderHookWithTrpc(
+      () => ({ mutations: useEntryMutations(), utils: trpc.useUtils() }),
+      {
+        handlers: {
+          "entries.markRead": (input) => {
+            const typed = input as { entries: { id: string }[]; read: boolean };
+            return {
+              entries: typed.entries.map((e) => ({
+                id: e.id,
+                read: typed.read,
+                starred: false,
+                updatedAt: fixedDate,
+              })),
+              counts,
+            };
+          },
+        },
+      }
+    );
+
     act(() => {
-      result.current.toggleRead("e1", false);
+      result.current.mutations.markRead(["e1"], true);
+    });
+
+    await waitFor(() => expect(callsFor("entries.markRead")).toHaveLength(1));
+    await waitFor(() =>
+      expect(result.current.utils.entries.count.getData({})).toEqual({ unread: 5 })
+    );
+    expect(result.current.utils.entries.count.getData({ starredOnly: true })).toEqual({
+      unread: 3,
+    });
+    expect(result.current.utils.entries.count.getData({ type: "saved" })).toEqual({ unread: 2 });
+  });
+
+  it("toggleRead sends the negation of the current read status for a single entry", async () => {
+    const { result, callsFor } = renderHookWithTrpc(
+      () => ({ mutations: useEntryMutations(), utils: trpc.useUtils() }),
+      {
+        handlers: {
+          "entries.markRead": (input) => {
+            const typed = input as { entries: { id: string }[]; read: boolean };
+            return {
+              entries: typed.entries.map((e) => ({
+                id: e.id,
+                read: typed.read,
+                starred: false,
+                updatedAt: fixedDate,
+              })),
+              counts: bulkCounts(),
+            };
+          },
+        },
+      }
+    );
+
+    act(() => {
+      result.current.mutations.toggleRead("e1", false);
     });
 
     await waitFor(() => expect(callsFor("entries.markRead")).toHaveLength(1));
@@ -167,21 +215,24 @@ describe("useEntryMutations markAllRead", () => {
 });
 
 describe("useEntryMutations star/unstar", () => {
-  it("star calls entries.setStarred with starred: true", async () => {
-    const { result, callsFor } = renderHookWithTrpc(() => useEntryMutations(), {
-      handlers: {
-        "entries.setStarred": (input) => {
-          const typed = input as { id: string; starred: boolean };
-          return {
-            entry: { id: typed.id, read: false, starred: typed.starred, updatedAt: fixedDate },
-            counts: singleCounts(),
-          };
+  it("star calls entries.setStarred with starred: true and applies counts on success", async () => {
+    const { result, callsFor } = renderHookWithTrpc(
+      () => ({ mutations: useEntryMutations(), utils: trpc.useUtils() }),
+      {
+        handlers: {
+          "entries.setStarred": (input) => {
+            const typed = input as { id: string; starred: boolean };
+            return {
+              entry: { id: typed.id, read: false, starred: typed.starred, updatedAt: fixedDate },
+              counts: singleCounts({ all: { unread: 4 }, starred: { unread: 7 } }),
+            };
+          },
         },
-      },
-    });
+      }
+    );
 
     act(() => {
-      result.current.star("e1");
+      result.current.mutations.star("e1");
     });
 
     await waitFor(() => expect(callsFor("entries.setStarred")).toHaveLength(1));
@@ -193,6 +244,14 @@ describe("useEntryMutations star/unstar", () => {
     expect(input).toEqual(
       expect.objectContaining({ id: "e1", starred: true, changedAt: expect.any(Date) })
     );
+
+    // onSuccess ran setCounts against the real cache with the server's numbers.
+    await waitFor(() =>
+      expect(result.current.utils.entries.count.getData({ starredOnly: true })).toEqual({
+        unread: 7,
+      })
+    );
+    expect(result.current.utils.entries.count.getData({})).toEqual({ unread: 4 });
   });
 
   it("toggleStar unstars an entry that is currently starred", async () => {

--- a/tests/utils/component-test-helpers.tsx
+++ b/tests/utils/component-test-helpers.tsx
@@ -22,7 +22,12 @@ import type { ReactElement, ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TRPCClientError, type TRPCLink } from "@trpc/client";
 import { observable } from "@trpc/server/observable";
-import { render, type RenderResult } from "@testing-library/react";
+import {
+  render,
+  renderHook,
+  type RenderResult,
+  type RenderHookResult,
+} from "@testing-library/react";
 import { vi } from "vitest";
 import { trpc } from "@/lib/trpc/client";
 import type { AppRouter } from "@/server/trpc/root";
@@ -134,13 +139,17 @@ export interface RenderWithTrpcResult extends RenderResult {
 }
 
 /**
- * Renders `ui` inside a real tRPC + React Query provider whose network layer is
- * the mock link built from `options.handlers`.
+ * Builds the real tRPC + React Query provider wrapper whose network layer is the
+ * mock link resolving procedures from `options.handlers`. Shared by
+ * `renderWithTrpc` (components) and `renderHookWithTrpc` (hooks) so both exercise
+ * the same real client wiring.
  */
-export function renderWithTrpc(
-  ui: ReactElement,
-  options: RenderWithTrpcOptions = {}
-): RenderWithTrpcResult {
+function createTrpcWrapper(options: RenderWithTrpcOptions = {}): {
+  Wrapper: (props: { children: ReactNode }) => ReactElement;
+  queryClient: QueryClient;
+  calls: RecordedCall[];
+  callsFor: (path: string) => RecordedCall[];
+} {
   const handlers = options.handlers ?? {};
   const calls: RecordedCall[] = [];
 
@@ -162,12 +171,48 @@ export function renderWithTrpc(
     );
   }
 
-  const result = render(ui, { wrapper: Wrapper });
-
   return {
-    ...result,
+    Wrapper,
     queryClient,
     calls,
     callsFor: (path: string) => calls.filter((c) => c.path === path),
   };
+}
+
+/**
+ * Renders `ui` inside a real tRPC + React Query provider whose network layer is
+ * the mock link built from `options.handlers`.
+ */
+export function renderWithTrpc(
+  ui: ReactElement,
+  options: RenderWithTrpcOptions = {}
+): RenderWithTrpcResult {
+  const { Wrapper, queryClient, calls, callsFor } = createTrpcWrapper(options);
+  const result = render(ui, { wrapper: Wrapper });
+
+  return { ...result, queryClient, calls, callsFor };
+}
+
+export interface RenderHookWithTrpcResult<TResult> extends RenderHookResult<TResult, unknown> {
+  /** The QueryClient backing the render — inspect or seed its cache directly. */
+  queryClient: QueryClient;
+  /** Every tRPC operation the hook issued, in order. */
+  calls: RecordedCall[];
+  /** Convenience: the recorded calls for a given procedure path. */
+  callsFor: (path: string) => RecordedCall[];
+}
+
+/**
+ * Renders a hook inside the same real tRPC + React Query provider as
+ * `renderWithTrpc`, so hooks that call `trpc.useUtils()`/`useMutation` run
+ * against real client wiring with a mock network link.
+ */
+export function renderHookWithTrpc<TResult>(
+  hook: () => TResult,
+  options: RenderWithTrpcOptions = {}
+): RenderHookWithTrpcResult<TResult> {
+  const { Wrapper, queryClient, calls, callsFor } = createTrpcWrapper(options);
+  const result = renderHook(hook, { wrapper: Wrapper });
+
+  return { ...result, queryClient, calls, callsFor };
 }


### PR DESCRIPTION
Closes the two remaining open testing items from #957. (The docs-hygiene and internal-mock items were already resolved in #968/#969.)

## Changes

### Replace low-value `useEntryMutations.test.ts`
The old file asserted compile-time types at runtime (`expect(value).toBe("web")`) and had `expect(true).toBe(true)` placeholder tests that could never meaningfully fail — the file itself admitted this.

It now renders the real hook through a new **`renderHookWithTrpc`** helper and asserts real behavior:
- `markRead`/`toggleRead` send the correct `entries.markRead` input (ids + read status, negated for toggle)
- `markAllRead` forwards filter options to `entries.markAllRead`
- `star`/`toggleStar` send `entries.setStarred` with the right `starred` value
- Each mutation surfaces its specific error toast on failure

`renderHookWithTrpc` shares the exact real tRPC + React Query wiring already used by `renderWithTrpc` (extracted into a `createTrpcWrapper` helper), backed by the same terminating mock link — no internal mocks.

### Add `vitest/no-focused-tests`
Added `@vitest/eslint-plugin` and enabled `vitest/no-focused-tests` (scoped to `tests/`, autofix disabled) so a committed `it.only`/`describe.only` fails `pnpm lint`. This mirrors Playwright's `forbidOnly` for the vitest unit/integration suites. No focused tests exist today.

## Verification
- `pnpm test:unit` — 1979 passed
- `pnpm typecheck` — clean
- `pnpm lint` — clean; verified the rule flags an injected `it.only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)