### PR TITLE
Enlarge read/unread dot to 44px touch target (#828)

### DIFF
--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -153,17 +153,23 @@ export const EntryListItem = memo(function EntryListItem({
         {/* Read/Unread Indicator */}
         <div className="mt-1.5 shrink-0">
           {onToggleRead ? (
+            // 44px WCAG touch target: pad the small dot out to 44px and cancel
+            // the padding with an equal negative margin so layout is unchanged.
             <button
               type="button"
               onClick={handleToggleRead}
-              className={`block h-2.5 w-2.5 rounded-full transition-colors ${
-                read
-                  ? "hover:border-accent hover:bg-accent-subtle border border-zinc-300 bg-transparent dark:border-zinc-600"
-                  : "bg-accent-muted hover:bg-accent dark:bg-accent dark:hover:bg-accent-hover"
-              }`}
+              className="group -m-[17px] flex items-center justify-center rounded-full p-[17px]"
               aria-label={read ? "Mark as unread" : "Mark as read"}
               title={read ? "Mark as unread" : "Mark as read"}
-            />
+            >
+              <span
+                className={`block h-2.5 w-2.5 rounded-full transition-colors ${
+                  read
+                    ? "group-hover:border-accent group-hover:bg-accent-subtle border border-zinc-300 bg-transparent dark:border-zinc-600"
+                    : "bg-accent-muted group-hover:bg-accent dark:bg-accent dark:group-hover:bg-accent-hover"
+                }`}
+              />
+            </button>
           ) : (
             <span
               className={`block h-2.5 w-2.5 rounded-full ${

--- a/tests/unit/frontend/components/EntryListItem.test.tsx
+++ b/tests/unit/frontend/components/EntryListItem.test.tsx
@@ -156,7 +156,8 @@ describe("EntryListItem", () => {
 
       const button = screen.getByRole("button", { name: "Mark as read" });
       expect(button).toBeInTheDocument();
-      expect(button).toHaveClass("bg-accent-muted");
+      // Color lives on the inner dot span; the button is the 44px touch target.
+      expect(button.querySelector("span")).toHaveClass("bg-accent-muted");
     });
 
     it("shows empty indicator for read entries", () => {
@@ -165,7 +166,8 @@ describe("EntryListItem", () => {
 
       const button = screen.getByRole("button", { name: "Mark as unread" });
       expect(button).toBeInTheDocument();
-      expect(button).toHaveClass("bg-transparent");
+      // Color lives on the inner dot span; the button is the 44px touch target.
+      expect(button.querySelector("span")).toHaveClass("bg-transparent");
     });
 
     it("applies different title styling for read vs unread", () => {


### PR DESCRIPTION
Fixes #828.

## Problem

The read/unread indicator button in `EntryListItem` was only `h-2.5 w-2.5` (10×10px), violating WCAG 2.5.8 (Target Size) and the project's 44px touch-target guideline.

## Fix

The button now pads the small dot out to a 44px hit area and cancels the padding with an equal negative margin (`p-[17px] -m-[17px]`), so the visual dot **and** surrounding layout stay exactly as before. The colored dot moves into an inner `<span>`, and hover styling uses `group-hover` so it responds across the whole 44px touch target.

Two component tests that asserted the color class on the button element were updated to check the inner dot span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)