### PR TITLE
Add created_at to blocked_senders and subscription_feeds (#747)

### DIFF
--- a/migrations/0079_created_at_backfill.sql
+++ b/migrations/0079_created_at_backfill.sql
@@ -1,0 +1,53 @@
+-- Add missing created_at columns to tables that lacked a creation timestamp
+-- (issue #747). Most tables carry both created_at/updated_at, but a few junction
+-- and event tables only had a domain-specific timestamp. This backfills a proper
+-- creation timestamp so "row was created" is distinguishable from later mutations.
+--
+-- Covered here:
+--   * blocked_senders   — had blocked_at (creation-equivalent), no created_at
+--   * subscription_feeds — junction table, had neither
+--
+-- Not covered: user_entries.created_at was added in 0064; entry_score_predictions
+-- was dropped in 0073.
+
+-- ---------------------------------------------------------------------------
+-- blocked_senders: backfill created_at from blocked_at (the row is created when
+-- the sender is blocked, so they coincide for existing rows).
+-- ---------------------------------------------------------------------------
+ALTER TABLE blocked_senders ADD COLUMN created_at timestamptz;
+
+--> statement-breakpoint
+
+UPDATE blocked_senders SET created_at = blocked_at WHERE created_at IS NULL;
+
+--> statement-breakpoint
+
+ALTER TABLE blocked_senders ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE blocked_senders ALTER COLUMN created_at SET DEFAULT NOW();
+
+--> statement-breakpoint
+
+-- ---------------------------------------------------------------------------
+-- subscription_feeds: backfill created_at from the later of the owning
+-- subscription's created_at and the feed's created_at. The junction row is
+-- created when a subscription first covers a feed, so it can't predate either;
+-- redirect-added rows in particular point at a feed newer than the subscription.
+-- Rows with no matching subscription/feed (shouldn't happen) fall back to NOW().
+-- ---------------------------------------------------------------------------
+ALTER TABLE subscription_feeds ADD COLUMN created_at timestamptz;
+
+--> statement-breakpoint
+
+UPDATE subscription_feeds sf
+SET created_at = GREATEST(s.created_at, f.created_at)
+FROM subscriptions s, feeds f
+WHERE s.id = sf.subscription_id AND f.id = sf.feed_id AND sf.created_at IS NULL;
+
+--> statement-breakpoint
+
+UPDATE subscription_feeds SET created_at = NOW() WHERE created_at IS NULL;
+
+--> statement-breakpoint
+
+ALTER TABLE subscription_feeds ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE subscription_feeds ALTER COLUMN created_at SET DEFAULT NOW();

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -547,6 +547,13 @@
       "when": 1782951100000,
       "tag": "0078_entry_summaries_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 78,
+      "version": "7",
+      "when": 1782951200000,
+      "tag": "0079_created_at_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -53,7 +53,8 @@ CREATE TABLE public.blocked_senders (
     sender_email text NOT NULL,
     blocked_at timestamp with time zone DEFAULT now() NOT NULL,
     list_unsubscribe_mailto text,
-    unsubscribe_sent_at timestamp with time zone
+    unsubscribe_sent_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 CREATE TABLE public.entries (
@@ -295,7 +296,8 @@ CREATE TABLE public.sessions (
 CREATE TABLE public.subscription_feeds (
     subscription_id uuid NOT NULL,
     feed_id uuid NOT NULL,
-    user_id uuid NOT NULL
+    user_id uuid NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 CREATE TABLE public.subscription_tags (

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -618,6 +618,8 @@ export const subscriptionFeeds = pgTable(
     userId: uuid("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
+
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
     primaryKey({ columns: [table.subscriptionId, table.feedId] }),
@@ -980,6 +982,7 @@ export const blockedSenders = pgTable(
 
     senderEmail: text("sender_email").notNull(), // Normalized sender email (lowercased, plus codes stripped)
     blockedAt: timestamp("blocked_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 
     // Store unsubscribe info for potential retry
     listUnsubscribeMailto: text("list_unsubscribe_mailto"),


### PR DESCRIPTION
## Summary

Closes #747. Adds the missing `created_at` timestamp columns flagged in the issue so "row was just created" is distinguishable from a later mutation.

Of the tables listed in the issue:
- **user_entries** — already got `created_at` in migration `0064` (Recently Read fix).
- **entry_score_predictions** — dropped in migration `0073`, no longer exists.
- **blocked_senders** — added `created_at`, backfilled from `blocked_at` (row is created when the sender is blocked, so they coincide for existing rows).
- **subscription_feeds** — added `created_at`, backfilled from the owning subscription's `created_at` (falling back to `NOW()` for any orphaned rows).

The "missing only `updated_at`" tables were intentionally left alone — they're immutable or already carry domain-specific timestamps, as the issue notes.

## Changes

- `migrations/0079_created_at_backfill.sql` — new migration (expand-only: adds nullable column, backfills, then sets `NOT NULL` + default). Backward-compatible with the previous release.
- `migrations/meta/_journal.json` — journaled the new migration.
- `migrations/schema.sql` — regenerated.
- `src/server/db/schema.ts` — added the Drizzle columns.

## Testing

- `pnpm typecheck` ✅
- `pnpm test:unit` ✅ (1985 passed, including the migrations-journal check)
- Migration applied cleanly to fresh dev + test databases via `pnpm services`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)