### PR TITLE
Distinguish 404 from transient errors in subscription/tag views (#937)

### DIFF
--- a/src/components/entries/UnifiedEntriesContent.tsx
+++ b/src/components/entries/UnifiedEntriesContent.tsx
@@ -276,15 +276,24 @@ function UnifiedEntriesContentInner() {
     refetchOnWindowFocus: false,
   });
 
-  // Fetch subscription data for validation
+  // Fetch subscription data for validation. A genuinely missing subscription
+  // throws NOT_FOUND, which we render as a NotFoundCard below; any other error
+  // is transient and rethrown to the ErrorBoundary (retryable) instead of
+  // showing a misleading "not found" message.
   const subscriptionQuery = trpc.subscriptions.get.useQuery(
     { id: routeInfo.subscriptionId ?? "" },
-    { enabled: !!routeInfo.subscriptionId }
+    {
+      enabled: !!routeInfo.subscriptionId,
+      throwOnError: (error) => error.data?.code !== "NOT_FOUND",
+    }
   );
 
-  // Fetch tag data for validation and empty message customization
+  // Fetch tag data for validation and empty message customization. tags.list
+  // returns a list, so a missing tag is "loaded but absent" (handled below);
+  // real fetch errors surface to the ErrorBoundary.
   const tagsQuery = trpc.tags.list.useQuery(undefined, {
     enabled: !!routeInfo.tagId,
+    throwOnError: true,
   });
 
   // Update empty messages with actual tag name if available
@@ -373,8 +382,9 @@ function UnifiedEntriesContentInner() {
     return () => setOpenEntryId(previousEntryId);
   }, [previousEntryId, setOpenEntryId]);
 
-  // Show error if subscription query completed but subscription not found
-  if (routeInfo.subscriptionId && !subscriptionQuery.isLoading && !subscriptionQuery.data) {
+  // Show "not found" only for a genuine NOT_FOUND; transient errors are
+  // rethrown to the ErrorBoundary by throwOnError above.
+  if (routeInfo.subscriptionId && subscriptionQuery.error?.data?.code === "NOT_FOUND") {
     return (
       <NotFoundCard
         title="Subscription not found"
@@ -383,11 +393,12 @@ function UnifiedEntriesContentInner() {
     );
   }
 
-  // Show error if tag query completed but tag not found
+  // Show error if the tag list loaded but doesn't contain this tag. Fetch
+  // errors are handled by throwOnError above, not this branch.
   if (
     routeInfo.tagId &&
-    !tagsQuery.isLoading &&
-    !tagsQuery.data?.items.find((t) => t.id === routeInfo.tagId)
+    tagsQuery.data &&
+    !tagsQuery.data.items.find((t) => t.id === routeInfo.tagId)
   ) {
     return (
       <NotFoundCard title="Tag not found" message="The tag you're looking for doesn't exist." />

--- a/tests/unit/frontend/components/UnifiedEntriesContent.test.tsx
+++ b/tests/unit/frontend/components/UnifiedEntriesContent.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Component integration tests for UnifiedEntriesContent's not-found guards.
+ *
+ * Subscription and tag views must distinguish a *genuinely missing* resource
+ * (show a NotFoundCard) from a *transient* fetch failure (surface a retryable
+ * error via the ErrorBoundary) — see issue #937. These tests drive the real
+ * tRPC wiring through the mock-link harness and assert:
+ *   - subscriptions.get throwing NOT_FOUND -> "Subscription not found",
+ *   - subscriptions.get throwing a non-NOT_FOUND error -> ErrorBoundary (not
+ *     the misleading "not found" message),
+ *   - tags.list loading without the tag -> "Tag not found",
+ *   - tags.list failing -> ErrorBoundary (not "Tag not found").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { TRPCClientError } from "@trpc/client";
+import { UnifiedEntriesContent } from "@/components/entries/UnifiedEntriesContent";
+import { AppearanceProvider } from "@/lib/appearance/AppearanceProvider";
+import { KeyboardShortcutsProvider } from "@/components/keyboard/KeyboardShortcutsProvider";
+import {
+  renderWithTrpc,
+  stubMemoryLocalStorage,
+  type ProcedureHandlers,
+} from "../../../utils/component-test-helpers";
+
+/**
+ * The validation queries only error *after* an async tick, so on first render
+ * the full entry-list subtree mounts briefly; it reads appearance/keyboard
+ * context, so both providers must wrap the render.
+ */
+function renderUnified(handlers: ProcedureHandlers) {
+  return renderWithTrpc(<UnifiedEntriesContent />, {
+    handlers,
+    wrapper: (children) => (
+      <AppearanceProvider>
+        <KeyboardShortcutsProvider>{children}</KeyboardShortcutsProvider>
+      </AppearanceProvider>
+    ),
+  });
+}
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+// UnifiedEntriesContent derives its route (and view preferences) from the URL
+// via next/navigation. Point it at a specific pathname per test.
+const mockPathname = vi.fn(() => "/all");
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname(),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+/** A tRPC error carrying `data.code`, as the real client would surface it. */
+function trpcError(code: string, message: string): TRPCClientError<never> {
+  return new TRPCClientError(message, {
+    result: { error: { data: { code } } },
+  } as never);
+}
+
+/** entries.list fires unconditionally on mount; give it an empty page. */
+function baseHandlers(overrides: ProcedureHandlers = {}): ProcedureHandlers {
+  return {
+    "entries.list": () => ({ items: [], nextCursor: undefined }),
+    ...overrides,
+  };
+}
+
+describe("UnifiedEntriesContent not-found guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubMemoryLocalStorage();
+    mockPathname.mockReturnValue("/all");
+  });
+
+  it("shows 'Subscription not found' when subscriptions.get throws NOT_FOUND", async () => {
+    mockPathname.mockReturnValue("/subscription/sub-1");
+    renderUnified(
+      baseHandlers({
+        "subscriptions.get": () => {
+          throw trpcError("NOT_FOUND", "Subscription not found");
+        },
+      })
+    );
+
+    expect(await screen.findByText("Subscription not found")).toBeInTheDocument();
+  });
+
+  it("surfaces a transient subscriptions.get error to the ErrorBoundary, not a not-found message", async () => {
+    mockPathname.mockReturnValue("/subscription/sub-1");
+    renderUnified(
+      baseHandlers({
+        "subscriptions.get": () => {
+          throw trpcError("INTERNAL_SERVER_ERROR", "boom");
+        },
+      })
+    );
+
+    // Retryable error UI, not the misleading "not found" card.
+    expect(await screen.findByText("Failed to load entries")).toBeInTheDocument();
+    expect(screen.queryByText("Subscription not found")).not.toBeInTheDocument();
+  });
+
+  it("shows 'Tag not found' when tags.list loads without the requested tag", async () => {
+    mockPathname.mockReturnValue("/tag/tag-missing");
+    renderUnified(
+      baseHandlers({
+        "tags.list": () => ({
+          items: [{ id: "tag-other", name: "Other", color: "#fff", feedCount: 0, unreadCount: 0 }],
+          uncategorized: { feedCount: 0, unreadCount: 0 },
+        }),
+      })
+    );
+
+    expect(await screen.findByText("Tag not found")).toBeInTheDocument();
+  });
+
+  it("surfaces a transient tags.list error to the ErrorBoundary, not a not-found message", async () => {
+    mockPathname.mockReturnValue("/tag/tag-1");
+    renderUnified(
+      baseHandlers({
+        "tags.list": () => {
+          throw trpcError("INTERNAL_SERVER_ERROR", "boom");
+        },
+      })
+    );
+
+    expect(await screen.findByText("Failed to load entries")).toBeInTheDocument();
+    expect(screen.queryByText("Tag not found")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #937. The "not found" guards in `UnifiedEntriesContent` keyed off the **absence of query data** rather than the actual error, so a transient/network failure of `subscriptions.get` or `tags.list` rendered a misleading `NotFoundCard` ("Subscription not found" / "Tag not found") with no retry affordance instead of a retryable error state.

## Changes

- **`subscriptions.get`**: only render `NotFoundCard` when the query errors with `NOT_FOUND`; any other error is rethrown to the `ErrorBoundary` via `throwOnError`, giving users a retryable error UI.
- **`tags.list`**: returns a list, so a missing tag is genuinely "loaded but absent" (still shows `NotFoundCard`). Real fetch errors now surface to the `ErrorBoundary` via `throwOnError` instead of being misread as "tag not found".

## Tests

Adds `tests/unit/frontend/components/UnifiedEntriesContent.test.tsx` covering both routes:
- real `NOT_FOUND` → `NotFoundCard`
- transient error → `ErrorBoundary` (and *not* the not-found message)

Verified the two transient-error tests fail against the pre-fix code and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)