### PR TITLE
Fix realtime cache correctness, SSE lifecycle & MCP parity (#955)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -299,12 +299,12 @@ Blocked ranges cover loopback, RFC 1918 private, carrier-grade NAT, link-local (
 
 Per-feed channels for scalability - servers only receive events they care about:
 
-| Channel Pattern        | Events                                                                                                                                                                            |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `feed:{feedId}:events` | `new_entry`, `entry_updated`                                                                                                                                                      |
-| `user:{userId}:events` | `subscription_created`, `subscription_updated`, `subscription_deleted`, `entry_state_changed`, `tag_created`, `tag_updated`, `tag_deleted`, `import_progress`, `import_completed` |
+| Channel Pattern        | Events                                                                                                                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `feed:{feedId}:events` | `new_entry`, `entry_updated`                                                                                                                                                                            |
+| `user:{userId}:events` | `subscription_created`, `subscription_updated`, `subscription_deleted`, `entry_state_changed`, `tag_created`, `tag_updated`, `tag_deleted`, `import_progress`, `import_completed`, `saved_feed_created` |
 
-When a user subscribes to a new feed, the SSE connection dynamically subscribes to that feed's channel.
+When a user subscribes to a new feed, the SSE connection dynamically subscribes to that feed's channel. `saved_feed_created` is a server-internal signal (not forwarded to the client): it fires when a user's saved-articles feed is first created so already-open connections subscribe to its channel and the first saved article broadcasts live rather than only after the next reconnect.
 
 ### Connection Efficiency
 
@@ -405,6 +405,7 @@ Business logic is extracted into reusable service functions in `src/server/servi
 | `entry-filters.ts` | `buildEntryFeedFilter`, `buildEntryFilterConditions`, `buildTaggedFeedIdsSubquery` - shared filter construction                                                                                    |
 | `narration.ts`     | Text-to-speech operations                                                                                                                                                                          |
 | `full-content.ts`  | `fetchFullContent`, `fetchAndStoreFullContent` - fetch, sanitize, and persist full article content                                                                                                 |
+| `entry-events.ts`  | `publishMarkReadStateChanges`, `publishStarredStateChange` - shared `entry_state_changed` publishing so tRPC and MCP mark-read/star stay in sync                                                   |
 | `summarization.ts` | AI-powered article summarization                                                                                                                                                                   |
 | `users.ts`         | `deleteUser` - account deletion                                                                                                                                                                    |
 | `retention.ts`     | `runRetentionCleanup` - data retention background job                                                                                                                                              |

--- a/src/app/api/v1/events/route.ts
+++ b/src/app/api/v1/events/route.ts
@@ -256,6 +256,12 @@ export async function GET(req: Request): Promise<Response> {
       // Expose cleanup to the stream's cancel() callback below.
       cleanupRef = cleanup;
 
+      // Increment the active-connections gauge here, strictly paired with the
+      // decrement in cleanup(): every early return past this point (including a
+      // failed Redis setup) runs cleanup(), so the gauge can't drift. The
+      // already-aborted bail-out above returns before this and never increments.
+      incrementSSEConnections();
+
       /**
        * Sends data to the stream, handling any errors
        */
@@ -460,6 +466,7 @@ export async function GET(req: Request): Promise<Response> {
         // This should never happen since we checked Redis health above,
         // but handle it gracefully just in case
         if (!subscription) {
+          cleanup();
           controller.error(new Error("Redis subscriber unavailable"));
           return;
         }
@@ -500,9 +507,6 @@ export async function GET(req: Request): Promise<Response> {
           send(formatSSEHeartbeat());
           trackSSEEventSent("heartbeat");
         }, HEARTBEAT_INTERVAL_MS);
-
-        // Increment active SSE connections counter
-        incrementSSEConnections();
 
         // Send an initial heartbeat to confirm the connection. (The client
         // detects "connected" from the EventSource open event, and tracks sync

--- a/src/app/api/v1/events/route.ts
+++ b/src/app/api/v1/events/route.ts
@@ -200,9 +200,27 @@ export async function GET(req: Request): Promise<Response> {
   // Get the user-specific events channel
   const userEventsChannel = getUserEventsChannel(userId);
 
+  // Holds the active connection's cleanup so the stream's cancel() callback can
+  // release Redis channels even when no abort event fires (some runtimes cancel
+  // the stream without aborting req.signal).
+  let cleanupRef: (() => void) | null = null;
+
   // Create readable stream for SSE
   const stream = new ReadableStream({
     start(controller) {
+      // If the request was already aborted before start() ran, the abort event
+      // fired before we could register a listener and will never fire again.
+      // Bail out before subscribing/incrementing so we don't leak the
+      // ref-counted Redis channels (or skew the connection gauge).
+      if (req.signal.aborted) {
+        try {
+          controller.close();
+        } catch {
+          // Controller may already be closed
+        }
+        return;
+      }
+
       const encoder = new TextEncoder();
       let subscription: PubSubSubscription | null = null;
       let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
@@ -235,6 +253,9 @@ export async function GET(req: Request): Promise<Response> {
         }
       }
 
+      // Expose cleanup to the stream's cancel() callback below.
+      cleanupRef = cleanup;
+
       /**
        * Sends data to the stream, handling any errors
        */
@@ -263,6 +284,25 @@ export async function GET(req: Request): Promise<Response> {
           console.error(`Failed to subscribe to feed channel ${feedId}:`, err);
           subscribedFeedChannels.delete(channel);
           feedSubscriptionMap.delete(feedId);
+        });
+      }
+
+      /**
+       * Subscribes to a saved feed's event channel. Saved feeds have no
+       * subscription row, so (unlike subscribeToFeed) no feedSubscriptionMap
+       * entry is added — feed events for it resolve to a null subscriptionId,
+       * matching how the saved feed is wired up at connect time.
+       */
+      function subscribeToSavedFeed(feedId: string): void {
+        if (isCleanedUp || !subscription) return;
+
+        const channel = getFeedEventsChannel(feedId);
+        if (subscribedFeedChannels.has(channel)) return;
+
+        subscribedFeedChannels.add(channel);
+        subscription.subscribe(channel).catch((err) => {
+          console.error(`Failed to subscribe to saved feed channel ${feedId}:`, err);
+          subscribedFeedChannels.delete(channel);
         });
       }
 
@@ -324,6 +364,14 @@ export async function GET(req: Request): Promise<Response> {
             subscribeToFeed(event.feedId, event.subscriptionId);
           } else if (event.type === "subscription_deleted") {
             unsubscribeFromFeed(event.feedId);
+          } else if (event.type === "saved_feed_created") {
+            // The saved feed was created after this connection opened; subscribe
+            // to its channel so the first saved article is delivered live.
+            // Saved feeds have no subscription (subscriptionId stays null), so we
+            // add the channel directly rather than via subscribeToFeed.
+            subscribeToSavedFeed(event.feedId);
+            // Server-internal signal — nothing for the client to handle.
+            return;
           }
 
           // All user events are forwarded to the client
@@ -456,14 +504,10 @@ export async function GET(req: Request): Promise<Response> {
         // Increment active SSE connections counter
         incrementSSEConnections();
 
-        // Send initial connected event with cursor for client sync tracking
-        const initialCursor = new Date().toISOString();
-        send(
-          `event: connected\nid: ${initialCursor}\ndata: ${JSON.stringify({ cursor: initialCursor })}\n\n`
-        );
-        trackSSEEventSent("connected");
-
-        // Send initial heartbeat to confirm connection
+        // Send an initial heartbeat to confirm the connection. (The client
+        // detects "connected" from the EventSource open event, and tracks sync
+        // cursors from the events themselves, so no separate cursor event is
+        // sent.)
         send(formatSSEHeartbeat());
         trackSSEEventSent("heartbeat");
       } catch (err) {
@@ -475,6 +519,12 @@ export async function GET(req: Request): Promise<Response> {
           // Controller may already be closed
         }
       }
+    },
+    cancel() {
+      // The consumer cancelled the stream (client disconnect). Release the
+      // ref-counted Redis channels immediately instead of waiting for the next
+      // heartbeat enqueue to fail (up to HEARTBEAT_INTERVAL_MS later).
+      cleanupRef?.();
     },
   });
 

--- a/src/components/layout/RealtimeProvider.tsx
+++ b/src/components/layout/RealtimeProvider.tsx
@@ -48,8 +48,7 @@ interface RealtimeProviderProps {
  * export default function AppLayout({ children }) {
  *   // Initial cursors - null values for fresh sync
  *   const initialCursors: SyncCursors = {
- *     entries: null, entryStates: null, subscriptions: null,
- *     removedSubscriptions: null, tags: null
+ *     entries: null, subscriptions: null, tags: null
  *   };
  *   return (
  *     <RealtimeProvider initialCursors={initialCursors}>

--- a/src/components/ui/client-link.tsx
+++ b/src/components/ui/client-link.tsx
@@ -31,7 +31,8 @@ export interface ClientLinkProps extends Omit<
  * Use this instead of Next.js `<Link>` for navigation within the app.
  * It uses pushState directly, avoiding SSR fetches and prefetching.
  *
- * Supports cmd/ctrl+click to open in a new tab.
+ * Modifier/middle clicks, and `target`/`download` anchors, fall through to the
+ * browser (new tab / new window / download) instead of being intercepted.
  *
  * @example
  * ```tsx

--- a/src/lib/cache/entry-cache.ts
+++ b/src/lib/cache/entry-cache.ts
@@ -358,8 +358,8 @@ const INSERT_SUPPORTED_FILTER_KEYS = new Set([
  * Inserts a new entry into the cached entry lists it belongs to, in sorted
  * position, so it appears live without a refetch (new_entry SSE/sync events).
  *
- * Uses the same filter matching as updateEntriesInAffectedListCaches to skip
- * unrelated caches. Tag/uncategorized membership is derived from the cached
+ * Uses the same filter matching (shouldUpdateEntryListCache) as the read/starred
+ * list updates to skip unrelated caches. Tag/uncategorized membership is derived from the cached
  * subscription (the client's authority on which tags a subscription has —
  * per-entry correct on both the live SSE and catch-up sync paths, unlike the
  * event's counts, whose tag list is a batch-wide union on the catch-up path).

--- a/src/lib/cache/entry-cache.ts
+++ b/src/lib/cache/entry-cache.ts
@@ -81,76 +81,11 @@ export function updateEntriesInListCache(
 }
 
 /**
- * Entry context for targeted cache updates.
- */
-export interface EntryContext {
-  id: string;
-  subscriptionId: string | null;
-  type: "web" | "email" | "saved";
-  starred: boolean;
-}
-
-/**
  * Affected scope info for targeted cache updates.
  */
 export interface AffectedScope {
   tagIds: Set<string>;
   hasUncategorized: boolean;
-}
-
-/**
- * Updates entries in only the affected cached entry lists.
- * Uses the entry context and affected scope to skip unrelated caches.
- *
- * @param queryClient - React Query client for cache access
- * @param entries - Entries with their context
- * @param updates - Fields to update (read, starred)
- * @param scope - Affected tags and uncategorized flag from server response
- */
-export function updateEntriesInAffectedListCaches(
-  queryClient: QueryClient,
-  entries: EntryContext[],
-  updates: Partial<{ read: boolean }>,
-  scope: AffectedScope
-): void {
-  if (entries.length === 0) return;
-
-  const entryIdSet = new Set(entries.map((e) => e.id));
-  const subscriptionIds = new Set(entries.map((e) => e.subscriptionId).filter(Boolean) as string[]);
-  const entryTypes = new Set(entries.map((e) => e.type));
-  const hasStarred = entries.some((e) => e.starred);
-
-  // Get all cached entry list queries
-  const infiniteQueries = queryClient.getQueriesData<InfiniteData>({
-    queryKey: [["entries", "list"]],
-  });
-
-  for (const [queryKey, data] of infiniteQueries) {
-    if (!data?.pages) continue;
-
-    // Extract filters from query key
-    const keyMeta = queryKey[1] as TRPCQueryKey | undefined;
-    const filters: EntryListFilters = keyMeta?.input ?? {};
-
-    // Check if this cache could contain any of the affected entries
-    if (!shouldUpdateEntryListCache(filters, subscriptionIds, entryTypes, hasStarred, scope)) {
-      continue;
-    }
-
-    // Update entries in this cache
-    queryClient.setQueryData(queryKey, {
-      ...data,
-      pages: data.pages.map((page) => ({
-        ...page,
-        items: page.items.map((entry) => {
-          if (entryIdSet.has(entry.id)) {
-            return { ...entry, ...updates };
-          }
-          return entry;
-        }),
-      })),
-    });
-  }
 }
 
 /**

--- a/src/lib/cache/operations.ts
+++ b/src/lib/cache/operations.ts
@@ -12,7 +12,11 @@
 
 import type { QueryClient } from "@tanstack/react-query";
 import type { TRPCClientUtils } from "@/lib/trpc/client";
-import { updateEntriesReadStatus, updateEntryStarredStatus } from "./entry-cache";
+import {
+  updateEntriesReadStatus,
+  updateEntryStarredStatus,
+  findEntryInListCache,
+} from "./entry-cache";
 import {
   addSubscriptionToCache,
   removeSubscriptionFromCache,
@@ -353,22 +357,28 @@ export function setCounts(
 }
 
 /**
- * Sets absolute counts from bulk mutation response.
- * Used by markRead mutation that returns BulkUnreadCounts.
+ * Sets absolute counts from a bulk mutation response (markRead) or a
+ * count-bearing realtime event. `saved` is optional: markRead always provides
+ * it, but web/email events omit it and the write is skipped in that case.
  *
  * @param utils - tRPC utils for cache access
- * @param counts - Absolute counts from server
+ * @param counts - Absolute counts from server (saved optional)
  * @param queryClient - React Query client for updating infinite query caches
  */
 export function setBulkCounts(
   utils: TRPCClientUtils,
-  counts: BulkUnreadCounts,
+  counts: EntryRelatedCounts,
   queryClient?: QueryClient
 ): void {
   // Set global counts
   utils.entries.count.setData({}, counts.all);
   utils.entries.count.setData({ starredOnly: true }, counts.starred);
-  utils.entries.count.setData({ type: "saved" }, counts.saved);
+  // Only write the saved count when we actually have one. Events that omit it
+  // (web/email) and an empty cache leave it undefined; writing a fabricated
+  // { unread: 0 } would seed a "fresh" saved count that a later mount trusts.
+  if (counts.saved) {
+    utils.entries.count.setData({ type: "saved" }, counts.saved);
+  }
 
   // Build subscription updates map for efficient batch update
   const subscriptionUpdates = new Map(counts.subscriptions.map((s) => [s.id, s.unread]));
@@ -422,12 +432,13 @@ export function setEntryRelatedCounts(
   counts: EntryRelatedCounts,
   queryClient?: QueryClient
 ): void {
+  // Fill in `saved` from the current cache when the event omits it so
+  // setBulkCounts doesn't clobber an existing saved count. If neither the event
+  // nor the cache has a value, leave it undefined — setBulkCounts then skips the
+  // write rather than fabricating a { unread: 0 } that a later mount serves as
+  // fresh.
   const currentSaved = utils.entries.count.getData({ type: "saved" });
-  setBulkCounts(
-    utils,
-    { ...counts, saved: counts.saved ?? currentSaved ?? { unread: 0 } },
-    queryClient
-  );
+  setBulkCounts(utils, { ...counts, saved: counts.saved ?? currentSaved }, queryClient);
 }
 
 /**
@@ -604,11 +615,20 @@ export async function applyOptimisticReadUpdate(
   // - If a fetch completes with stale read status, onSuccess will correct it immediately
   // - The race condition window is small (between onMutate and onSuccess)
 
-  // Snapshot the previous state for rollback
+  // Snapshot the previous state for rollback. Prefer entries.get, but fall back
+  // to the list cache: entries acted on from the list view often have no
+  // entries.get entry, and defaulting the previous value to `false` would make
+  // a failed mark-unread of a read entry "roll back" to unread (the state the
+  // failed mutation wanted), silently diverging from the server.
   const previousEntries = new Map<string, { read: boolean } | undefined>();
   for (const entryId of entryIds) {
     const data = utils.entries.get.getData({ id: entryId });
-    previousEntries.set(entryId, data?.entry ? { read: data.entry.read } : undefined);
+    if (data?.entry) {
+      previousEntries.set(entryId, { read: data.entry.read });
+    } else {
+      const listEntry = findEntryInListCache(queryClient, entryId);
+      previousEntries.set(entryId, listEntry ? { read: listEntry.read } : undefined);
+    }
   }
 
   // Optimistically update the cache immediately

--- a/src/lib/hooks/useEntryMutations.ts
+++ b/src/lib/hooks/useEntryMutations.ts
@@ -1,13 +1,13 @@
 /**
  * useEntryMutations Hook
  *
- * Provides entry mutations (markRead, star, unstar, setScore) with optimistic updates.
+ * Provides entry mutations (markRead, star, unstar) with optimistic updates.
  * Consolidates mutation logic from page components.
  *
  * Uses optimistic updates for immediate UI feedback:
  * - Read/starred status updates appear instantly in the UI
  * - If the server request fails, changes are rolled back automatically
- * - Server response is used to update counts and scores after success
+ * - Server response is used to update counts after success
  *
  * Tracks pending mutations per entry with timestamp-based state merging:
  * - Multiple mutations can run in parallel for the same entry
@@ -29,12 +29,7 @@ import {
   applyOptimisticReadUpdate,
   applyOptimisticStarredUpdate,
 } from "@/lib/cache/operations";
-import {
-  updateEntriesReadStatus,
-  updateEntryStarredStatus,
-  updateEntriesInListCache,
-  updateEntriesInAffectedListCaches,
-} from "@/lib/cache/entry-cache";
+import { updateEntriesReadStatus, updateEntryStarredStatus } from "@/lib/cache/entry-cache";
 
 /**
  * Entry type for routing.
@@ -240,7 +235,13 @@ export function useEntryMutations(): UseEntryMutationsResult {
   };
 
   /**
-   * Apply winning state to cache if it's newer than current cache state.
+   * Apply winning state to both entries.get AND the entry lists, but only if
+   * it's newer than the current cache state.
+   *
+   * The list caches must go through this same guard: writing them
+   * unconditionally from each mutation's own response lets two rapid conflicting
+   * mutations that complete out of order leave the list at the older state even
+   * though entries.get resolved to the newer one.
    */
   const applyWinningStateToCache = (entryId: string, winningState: MutationResultState) => {
     // Get current cache state to compare timestamps
@@ -253,8 +254,9 @@ export function useEntryMutations(): UseEntryMutationsResult {
       return;
     }
 
-    // Update the cache with winning state
-    updateEntriesReadStatus(utils, [entryId], winningState.read);
+    // Update entries.get and every entry list (passing queryClient targets the
+    // list caches too).
+    updateEntriesReadStatus(utils, [entryId], winningState.read, queryClient);
     updateEntryStarredStatus(utils, entryId, winningState.starred, queryClient);
   };
 
@@ -296,22 +298,11 @@ export function useEntryMutations(): UseEntryMutationsResult {
         const { allComplete, winningState } = recordMutationResult(entry.id, result);
 
         if (allComplete && winningState) {
+          // Updates entries.get and the entry lists together, guarded by the
+          // winning-state timestamp (see applyWinningStateToCache).
           applyWinningStateToCache(entry.id, winningState);
         }
       }
-
-      // Update list caches with read status from server response
-      const scope = {
-        tagIds: new Set(data.counts.tags.map((t) => t.id)),
-        hasUncategorized: data.counts.uncategorized !== undefined,
-      };
-      // All entries in a markRead batch have the same read value
-      updateEntriesInAffectedListCaches(
-        queryClient,
-        data.entries,
-        { read: data.entries[0]?.read ?? false },
-        scope
-      );
 
       // Update counts (always apply, not dependent on timestamp)
       setBulkCounts(utils, data.counts, queryClient);
@@ -395,11 +386,10 @@ export function useEntryMutations(): UseEntryMutationsResult {
       const { allComplete, winningState } = recordMutationResult(data.entry.id, result);
 
       if (allComplete && winningState) {
+        // Updates entries.get and the entry lists together, guarded by the
+        // winning-state timestamp (see applyWinningStateToCache).
         applyWinningStateToCache(data.entry.id, winningState);
       }
-
-      // Update list cache with starred status
-      updateEntriesInListCache(queryClient, [data.entry.id], { starred: data.entry.starred });
 
       // Update counts (always apply)
       setCounts(utils, data.counts, queryClient);

--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -73,11 +73,12 @@ export interface UseRealtimeUpdatesResult {
 }
 
 /**
- * Named SSE events forwarded to the shared sync-event handler.
- * "connected" is the initial cursor event from the server.
+ * Named SSE events forwarded to the shared sync-event handler. These are
+ * exactly the members of `syncEventSchema`; the connection state itself
+ * (open/error) is tracked via the EventSource's own onopen/onerror, not a
+ * data event.
  */
 const SSE_EVENT_NAMES = [
-  "connected",
   "new_entry",
   "entry_updated",
   "entry_state_changed",

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -58,7 +58,12 @@ export function extractParamsFromPathname(
 
 /**
  * Click handler for client-side navigation without SSR.
- * Allows cmd/ctrl+click to open in new tab.
+ *
+ * Falls through to the browser's default handling (no preventDefault) for any
+ * click the browser would treat specially, so we don't hijack:
+ * - modifier clicks (cmd/ctrl/shift/alt → new tab / new window / download),
+ * - non-primary mouse buttons (middle-click → new tab),
+ * - anchors with an explicit `target` (e.g. `_blank`) or `download` attribute.
  *
  * @example
  * ```tsx
@@ -72,8 +77,12 @@ export function handleClientNav(
   href: string,
   callback?: () => void
 ): void {
-  // Allow cmd/ctrl+click for new tab
-  if (e.metaKey || e.ctrlKey) return;
+  if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+
+  // Respect anchors that intentionally open elsewhere or download.
+  const target = e.currentTarget.getAttribute("target");
+  if ((target && target !== "_self") || e.currentTarget.hasAttribute("download")) return;
+
   e.preventDefault();
   clientPush(href);
   callback?.();

--- a/src/server/feed/saved-feed.ts
+++ b/src/server/feed/saved-feed.ts
@@ -9,6 +9,7 @@ import { eq, and } from "drizzle-orm";
 import type { Database } from "../db";
 import { feeds } from "../db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
+import { publishSavedFeedCreated } from "@/server/redis/pubsub";
 
 /** Title given to every per-user saved-articles feed. */
 export const SAVED_FEED_TITLE = "Saved Articles";
@@ -28,7 +29,10 @@ export async function getOrCreateSavedFeed(db: Database, userId: string): Promis
   const feedId = generateUuidv7();
   const now = new Date();
 
-  await db
+  // ON CONFLICT DO NOTHING + RETURNING yields the inserted row only when we
+  // actually created the feed (empty on conflict), so we can tell first creation
+  // from a subsequent call without a separate query.
+  const inserted = await db
     .insert(feeds)
     .values({
       id: feedId,
@@ -56,9 +60,20 @@ export async function getOrCreateSavedFeed(db: Database, userId: string): Promis
       createdAt: now,
       updatedAt: now,
     })
-    .onConflictDoNothing();
+    .onConflictDoNothing()
+    .returning({ id: feeds.id });
 
-  // Fetch the feed ID (either just inserted or already existed)
+  if (inserted.length > 0) {
+    // First creation: tell already-open SSE connections to subscribe to this
+    // feed's channel so the first saved article broadcasts live. Fire and
+    // forget — SSE is best-effort and must not block the save.
+    void publishSavedFeedCreated(userId, inserted[0].id).catch(() => {
+      // Ignore publish errors - SSE is best-effort
+    });
+    return inserted[0].id;
+  }
+
+  // Already existed: fetch the existing feed ID.
   const result = await db
     .select({ id: feeds.id })
     .from(feeds)

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -21,6 +21,10 @@ import * as countsService from "@/server/services/counts";
 import * as subscriptionsService from "@/server/services/subscriptions";
 import * as savedService from "@/server/services/saved";
 import * as tagsService from "@/server/services/tags";
+import {
+  publishMarkReadStateChanges,
+  publishStarredStateChange,
+} from "@/server/services/entry-events";
 
 // ============================================================================
 // Types
@@ -267,6 +271,11 @@ function buildTools(): Tool[] {
           params.read
         );
         const counts = await countsService.getBulkEntryRelatedCounts(db, userId, entries);
+
+        // Publish entry_state_changed for multi-tab/device sync, mirroring the
+        // tRPC entries.markRead mutation. Fire and forget.
+        publishMarkReadStateChanges(userId, entries, counts);
+
         return { entries, counts };
       },
     },
@@ -278,7 +287,19 @@ function buildTools(): Tool[] {
       inputSchema: toInputSchema(starEntriesArgs),
       handler: async (db, userId, args) => {
         const params = parseArgs(starEntriesArgs, args);
-        return entriesService.updateEntryStarred(db, userId, params.entryId, params.starred);
+        const entry = await entriesService.updateEntryStarred(
+          db,
+          userId,
+          params.entryId,
+          params.starred
+        );
+
+        // Publish entry_state_changed for multi-tab/device sync, mirroring the
+        // tRPC entries.setStarred mutation. Fire and forget.
+        const counts = await countsService.getEntryRelatedCounts(db, userId, params.entryId);
+        publishStarredStateChange(userId, entry, counts);
+
+        return entry;
       },
     },
 

--- a/src/server/redis/pubsub.ts
+++ b/src/server/redis/pubsub.ts
@@ -141,6 +141,16 @@ const userEventSchema = z.discriminatedUnion("type", [
     timestamp: z.string(),
     updatedAt: z.string(),
   }),
+  // Server-internal signal that a user's saved-articles feed was just created.
+  // It tells already-open SSE connections to subscribe to the new feed's channel
+  // so the first saved article is broadcast live (the saved feed didn't exist
+  // when the connection was established). Not forwarded to the client.
+  z.object({
+    type: z.literal("saved_feed_created"),
+    userId: z.string(),
+    feedId: z.string(),
+    timestamp: z.string(),
+  }),
 ]);
 
 // ============================================================================
@@ -171,6 +181,7 @@ type EntryStateChangedEvent = Extract<UserEvent, { type: "entry_state_changed" }
 type TagCreatedEvent = Extract<UserEvent, { type: "tag_created" }>;
 type TagUpdatedEvent = Extract<UserEvent, { type: "tag_updated" }>;
 type TagDeletedEvent = Extract<UserEvent, { type: "tag_deleted" }>;
+type SavedFeedCreatedEvent = Extract<UserEvent, { type: "saved_feed_created" }>;
 
 /**
  * Returns the channel name for feed-specific events.
@@ -645,6 +656,31 @@ export async function publishTagDeleted(
     tagId,
     timestamp: new Date().toISOString(),
     updatedAt: updatedAt.toISOString(),
+  };
+  const channel = getUserEventsChannel(userId);
+  return client.publish(channel, JSON.stringify(event));
+}
+
+/**
+ * Publishes a saved_feed_created event when a user's saved-articles feed is
+ * first created. Lets already-open SSE connections subscribe to the new feed's
+ * channel so the very first saved article broadcasts live instead of only after
+ * the next reconnect. Not forwarded to the client.
+ *
+ * @param userId - The ID of the user whose saved feed was created
+ * @param feedId - The ID of the newly created saved feed
+ * @returns The number of subscribers that received the message (0 if Redis unavailable)
+ */
+export async function publishSavedFeedCreated(userId: string, feedId: string): Promise<number> {
+  const client = getPublisherClient();
+  if (!client) {
+    return 0;
+  }
+  const event: SavedFeedCreatedEvent = {
+    type: "saved_feed_created",
+    userId,
+    feedId,
+    timestamp: new Date().toISOString(),
   };
   const channel = getUserEventsChannel(userId);
   return client.publish(channel, JSON.stringify(event));

--- a/src/server/services/entry-events.ts
+++ b/src/server/services/entry-events.ts
@@ -1,0 +1,65 @@
+/**
+ * Entry State Change Events
+ *
+ * Shared "publish entry_state_changed after a mutation" logic so the tRPC
+ * routers and the MCP tools stay in sync. Both surfaces mark entries read and
+ * star/unstar via the same services, so both must emit the same SSE events for
+ * multi-tab/device sync — extracting this here keeps the mcp-scoped endpoints
+ * mirroring the MCP tools exactly (see DESIGN.md).
+ *
+ * All publishing is fire-and-forget: SSE is best-effort and must never block or
+ * fail the mutation response.
+ */
+
+import { publishEntryStateChanged } from "@/server/redis/pubsub";
+import {
+  toBulkUnreadCounts,
+  type BulkUnreadCounts,
+  type UnreadCounts,
+} from "@/server/services/counts";
+import type { EntryState, MarkReadEntryState } from "@/server/services/entries";
+
+/**
+ * Publishes an entry_state_changed event for each entry affected by a bulk
+ * markRead, carrying the absolute counts so other tabs set them directly.
+ */
+export function publishMarkReadStateChanges(
+  userId: string,
+  entries: MarkReadEntryState[],
+  counts: BulkUnreadCounts
+): void {
+  for (const entry of entries) {
+    void publishEntryStateChanged(
+      userId,
+      entry.id,
+      entry.read,
+      entry.starred,
+      entry.updatedAt,
+      counts
+    ).catch(() => {
+      // Ignore publish errors - SSE is best-effort
+    });
+  }
+}
+
+/**
+ * Publishes an entry_state_changed event after a single-entry star/unstar,
+ * normalizing the single-entry UnreadCounts into the array-shaped counts the
+ * event (and the client's setBulkCounts) expects.
+ */
+export function publishStarredStateChange(
+  userId: string,
+  entry: EntryState,
+  counts: UnreadCounts
+): void {
+  void publishEntryStateChanged(
+    userId,
+    entry.id,
+    entry.read,
+    entry.starred,
+    entry.updatedAt,
+    toBulkUnreadCounts(counts)
+  ).catch(() => {
+    // Ignore publish errors - SSE is best-effort
+  });
+}

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -25,7 +25,10 @@ import * as fullContentService from "@/server/services/full-content";
 import * as entriesService from "@/server/services/entries";
 import * as countsService from "@/server/services/counts";
 import { getSubscriptionFeedIds } from "@/server/services/entry-filters";
-import { publishEntryStateChanged } from "@/server/redis/pubsub";
+import {
+  publishMarkReadStateChanges,
+  publishStarredStateChange,
+} from "@/server/services/entry-events";
 
 // Endpoints exposed via the MCP tool surface; accessible to tokens with the `mcp` scope.
 const mcpProcedure = scopedProtectedProcedure(API_TOKEN_SCOPES.MCP);
@@ -396,18 +399,7 @@ export const entriesRouter = createTRPCRouter({
       // Publish entry state change events for multi-tab/device sync.
       // Include absolute counts so other tabs can set them directly.
       // Fire and forget - don't block the response.
-      for (const entry of entriesResult) {
-        publishEntryStateChanged(
-          userId,
-          entry.id,
-          entry.read,
-          entry.starred,
-          entry.updatedAt,
-          counts
-        ).catch(() => {
-          // Ignore publish errors - SSE is best-effort
-        });
-      }
+      publishMarkReadStateChanges(userId, entriesResult, counts);
 
       return {
         success: true,
@@ -523,18 +515,8 @@ export const entriesRouter = createTRPCRouter({
       const counts = await countsService.getEntryRelatedCounts(ctx.db, userId, input.id);
 
       // Publish entry state change event for multi-tab/device sync.
-      // Normalize UnreadCounts to the same shape as BulkUnreadCounts for the event.
       // Fire and forget - don't block the response.
-      publishEntryStateChanged(userId, entry.id, entry.read, entry.starred, entry.updatedAt, {
-        all: counts.all,
-        starred: counts.starred,
-        ...(counts.saved ? { saved: counts.saved } : {}),
-        subscriptions: counts.subscription ? [counts.subscription] : [],
-        tags: counts.tags ?? [],
-        uncategorized: counts.uncategorized,
-      }).catch(() => {
-        // Ignore publish errors - SSE is best-effort
-      });
+      publishStarredStateChange(userId, entry, counts);
 
       return { entry, counts };
     }),

--- a/tests/unit/frontend/cache/operations.test.ts
+++ b/tests/unit/frontend/cache/operations.test.ts
@@ -19,6 +19,8 @@ import type { TRPCClientUtils } from "@/lib/trpc/client";
 import {
   handleSubscriptionCreated,
   handleSubscriptionDeleted,
+  setEntryRelatedCounts,
+  applyOptimisticReadUpdate,
   type SubscriptionData,
 } from "@/lib/cache/operations";
 import {
@@ -276,5 +278,96 @@ describe("handleSubscriptionDeleted", () => {
     handleSubscriptionDeleted(utils, "sub-1");
 
     expect(getSubscriptionLookupMap().size).toBe(0);
+  });
+});
+
+describe("setEntryRelatedCounts saved-count handling", () => {
+  let queryClient: QueryClient;
+  let utils: TRPCClientUtils;
+
+  beforeEach(() => {
+    _resetSubscriptionLookupMap();
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    utils = createRealTrpcUtils(queryClient);
+  });
+
+  const baseCounts = {
+    all: { unread: 3 },
+    starred: { unread: 1 },
+    subscriptions: [],
+    tags: [],
+  };
+
+  it("does not fabricate a saved count when the event omits it and none is cached", () => {
+    // A web/email event omits `saved`; with nothing cached there is no value to
+    // preserve. Writing a { unread: 0 } here would seed a "fresh" saved count
+    // that a later Saved-view mount would trust instead of fetching.
+    setEntryRelatedCounts(utils, baseCounts, queryClient);
+
+    expect(utils.entries.count.getData({ type: "saved" })).toBeUndefined();
+  });
+
+  it("preserves an existing cached saved count when the event omits it", () => {
+    setUtilsData(utils.entries.count, { type: "saved" }, { unread: 4 });
+
+    setEntryRelatedCounts(utils, baseCounts, queryClient);
+
+    expect(utils.entries.count.getData({ type: "saved" })).toEqual({ unread: 4 });
+  });
+
+  it("writes the saved count when the event provides one", () => {
+    setEntryRelatedCounts(utils, { ...baseCounts, saved: { unread: 7 } }, queryClient);
+
+    expect(utils.entries.count.getData({ type: "saved" })).toEqual({ unread: 7 });
+  });
+});
+
+describe("applyOptimisticReadUpdate previous-state snapshot", () => {
+  let queryClient: QueryClient;
+  let utils: TRPCClientUtils;
+
+  beforeEach(() => {
+    _resetSubscriptionLookupMap();
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    utils = createRealTrpcUtils(queryClient);
+  });
+
+  function seedListEntry(entry: { id: string; read: boolean; starred: boolean }): void {
+    queryClient.setQueryData([["entries", "list"], { input: { limit: 25 }, type: "infinite" }], {
+      pages: [{ items: [entry], nextCursor: undefined }],
+      pageParams: [undefined],
+    });
+  }
+
+  it("falls back to the list cache for the previous read state when entries.get is absent", async () => {
+    // Entry acted on from the list view: it lives in entries.list but has no
+    // entries.get cache entry. The rollback snapshot must capture its real read
+    // state (true) so a failed mark-unread rolls back to read, not to the state
+    // the failed mutation wanted.
+    seedListEntry({ id: "e1", read: true, starred: false });
+
+    const context = await applyOptimisticReadUpdate(utils, queryClient, ["e1"], false);
+
+    expect(context.previousEntries.get("e1")).toEqual({ read: true });
+  });
+
+  it("prefers the entries.get value when it exists", async () => {
+    setUtilsData(
+      utils.entries.get,
+      { id: "e1" },
+      { entry: { id: "e1", read: true, starred: false, updatedAt: new Date() } }
+    );
+    // A stale list copy with a different value must not win over entries.get.
+    seedListEntry({ id: "e1", read: false, starred: false });
+
+    const context = await applyOptimisticReadUpdate(utils, queryClient, ["e1"], false);
+
+    expect(context.previousEntries.get("e1")).toEqual({ read: true });
+  });
+
+  it("records undefined when the entry is in no cache", async () => {
+    const context = await applyOptimisticReadUpdate(utils, queryClient, ["e1"], false);
+
+    expect(context.previousEntries.get("e1")).toBeUndefined();
   });
 });

--- a/tests/unit/frontend/hooks/useEntryMutations.test.ts
+++ b/tests/unit/frontend/hooks/useEntryMutations.test.ts
@@ -125,6 +125,55 @@ describe("useEntryMutations markRead", () => {
     expect(result.current.utils.entries.count.getData({ type: "saved" })).toEqual({ unread: 2 });
   });
 
+  it("updates the entries.list cache with the winning read state on success", async () => {
+    // The list cache is written through the winning-state guard (not
+    // unconditionally from each response), so a successful markRead must still
+    // reach entries.list. Regression guard for that path.
+    const { result, queryClient, callsFor } = renderHookWithTrpc(
+      () => ({ mutations: useEntryMutations(), utils: trpc.useUtils() }),
+      {
+        handlers: {
+          "entries.markRead": (input) => {
+            const typed = input as { entries: { id: string }[]; read: boolean };
+            return {
+              entries: typed.entries.map((e) => ({
+                id: e.id,
+                subscriptionId: "sub-1",
+                read: typed.read,
+                starred: false,
+                type: "web" as const,
+                updatedAt: fixedDate,
+              })),
+              counts: bulkCounts(),
+            };
+          },
+        },
+      }
+    );
+
+    queryClient.setQueryData([["entries", "list"], { input: { limit: 25 }, type: "infinite" }], {
+      pages: [
+        {
+          items: [{ id: "e1", read: false, starred: false, subscriptionId: "sub-1" }],
+          nextCursor: undefined,
+        },
+      ],
+      pageParams: [undefined],
+    });
+
+    act(() => {
+      result.current.mutations.markRead(["e1"], true);
+    });
+
+    await waitFor(() => expect(callsFor("entries.markRead")).toHaveLength(1));
+    await waitFor(() => {
+      const data = queryClient.getQueryData<{
+        pages: Array<{ items: Array<{ id: string; read: boolean }> }>;
+      }>([["entries", "list"], { input: { limit: 25 }, type: "infinite" }]);
+      expect(data?.pages[0].items[0].read).toBe(true);
+    });
+  });
+
   it("toggleRead sends the negation of the current read status for a single entry", async () => {
     const { result, callsFor } = renderHookWithTrpc(
       () => ({ mutations: useEntryMutations(), utils: trpc.useUtils() }),

--- a/tests/unit/frontend/navigation.test.ts
+++ b/tests/unit/frontend/navigation.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Unit tests for client-side navigation helpers.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { MouseEvent } from "react";
+import { handleClientNav } from "@/lib/navigation";
+
+interface FakeEventOptions {
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  button?: number;
+  target?: string | null;
+  download?: boolean;
+}
+
+function makeEvent(opts: FakeEventOptions = {}): {
+  event: MouseEvent<HTMLAnchorElement>;
+  preventDefault: ReturnType<typeof vi.fn>;
+} {
+  const preventDefault = vi.fn();
+  const anchor = {
+    getAttribute: (name: string) => (name === "target" ? (opts.target ?? null) : null),
+    hasAttribute: (name: string) => name === "download" && !!opts.download,
+  };
+  const event = {
+    metaKey: opts.metaKey ?? false,
+    ctrlKey: opts.ctrlKey ?? false,
+    shiftKey: opts.shiftKey ?? false,
+    altKey: opts.altKey ?? false,
+    button: opts.button ?? 0,
+    currentTarget: anchor,
+    preventDefault,
+  } as unknown as MouseEvent<HTMLAnchorElement>;
+  return { event, preventDefault };
+}
+
+describe("handleClientNav", () => {
+  beforeEach(() => {
+    window.history.pushState(null, "", "/start");
+  });
+
+  it("navigates via pushState on a plain primary click", () => {
+    const { event, preventDefault } = makeEvent();
+    const callback = vi.fn();
+
+    handleClientNav(event, "/all", callback);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(window.location.pathname).toBe("/all");
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it.each([
+    ["meta", { metaKey: true }],
+    ["ctrl", { ctrlKey: true }],
+    ["shift", { shiftKey: true }],
+    ["alt", { altKey: true }],
+    ["middle-click", { button: 1 }],
+  ])("falls through to the browser for %s clicks", (_label, opts) => {
+    const { event, preventDefault } = makeEvent(opts);
+    const callback = vi.fn();
+
+    handleClientNav(event, "/all", callback);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe("/start");
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("falls through for anchors with target=_blank", () => {
+    const { event, preventDefault } = makeEvent({ target: "_blank" });
+
+    handleClientNav(event, "/all");
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe("/start");
+  });
+
+  it("still navigates for target=_self", () => {
+    const { event, preventDefault } = makeEvent({ target: "_self" });
+
+    handleClientNav(event, "/all");
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(window.location.pathname).toBe("/all");
+  });
+
+  it("falls through for download anchors", () => {
+    const { event, preventDefault } = makeEvent({ download: true });
+
+    handleClientNav(event, "/file");
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe("/start");
+  });
+});


### PR DESCRIPTION
Fixes the outstanding items from #955. The two highest-value items (stale-list navigation via `useEntryListRefreshOnNavigate` and the FRONTEND_STATE.md rewrite) were already resolved by later work; this PR covers the rest.

## Correctness
- **markRead optimistic rollback** now snapshots the previous read state from the **list cache** (`findEntryInListCache`) when `entries.get` is absent. Entries acted on from the list view often have no `entries.get` entry, so the old `?? false` default made a failed **mark-unread** of a read entry "roll back" to unread — the state the failed mutation wanted. Mirrors `applyOptimisticStarredUpdate`'s fallback.
- **Fabricated `{unread: 0}` saved count** removed: `setBulkCounts` now skips the saved write when neither the event nor the cache has a value (previously seeded a fresh `{unread: 0}` that a later Saved-view mount trusted).
- **List caches now go through the winning-state timestamp guard.** `applyWinningStateToCache` updates `entries.get` **and** the lists together; the old unconditional list writes let two rapid conflicting mutations completing out of order leave the list stale. Removed the now-dead `updateEntriesInAffectedListCaches` / `EntryContext`.

## SSE lifecycle
- **Dead `connected` event removed** (it was never a member of `syncEventSchema`, so its cursor was always dropped) along with its misleading comment. The client detects connection from the EventSource `open` event.
- **SSE route abort race + `cancel()`**: bail out if `req.signal` is already aborted before `start()` runs, and add a `ReadableStream` `cancel()` callback so the ref-counted Redis channels are released immediately on disconnect instead of up to a heartbeat later.
- **First saved article now broadcasts to already-open tabs**: `getOrCreateSavedFeed` publishes a server-internal `saved_feed_created` user event on first creation; the SSE route subscribes the open connection to the new saved-feed channel.

## markAllRead / MCP parity
- Extracted the shared `entry_state_changed` publishing into `services/entry-events.ts`. **MCP `mark_entries_read` / `star_entries` now publish** the same events as their tRPC mirrors (previously they didn't, contradicting DESIGN.md's "mirror the tools exactly" claim).

## Doc/comment rot
- Fixed `RealtimeProvider` five-cursor docstring → the actual three-field `SyncCursors`, and the `useEntryMutations` `setScore` header.
- `handleClientNav` now falls through for **shift/alt/middle clicks** and `target`/`download` anchors (new-window/download were being hijacked).

## Deferred (documented for follow-up)
- **`entries.markAllRead` SSE broadcast**: mirroring `markRead` per-entry would publish thousands of events for a bulk mark-all-read; this needs a dedicated bulk event design and is left as a follow-up. Cross-tab staleness still resolves on the next sync poll / navigation.
- **Scroll reset on list→list navigation**: tracked separately in #406.

## Tests
- New unit tests for the saved-count skip, the markRead rollback list-cache fallback, the winning-state list-cache write, and `handleClientNav` modifier/target/download handling.
- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (2005 passing) all green; `test:integration:local` for saved-articles / sync-events / entries / mcp all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)