### PR TITLE
Remove unused exports flagged by knip

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
+  "entry": ["src/server/worker-thread/worker.ts"],
   "ignore": [
     "extension/**",
     "src/lib/stubs/**",

--- a/src/components/ui/icon-button.tsx
+++ b/src/components/ui/icon-button.tsx
@@ -820,30 +820,6 @@ export function CheckCircleIcon({ className = "h-5 w-5" }: IconProps) {
 }
 
 /**
- * Double chevron up icon (for strong upvote)
- */
-export function DoubleChevronUpIcon({ className = "h-4 w-4" }: IconProps) {
-  return (
-    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 9l7-7 7 7" />
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
-    </svg>
-  );
-}
-
-/**
- * Double chevron down icon (for strong downvote)
- */
-export function DoubleChevronDownIcon({ className = "h-4 w-4" }: IconProps) {
-  return (
-    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 15l-7 7-7-7" />
-    </svg>
-  );
-}
-
-/**
  * Key icon (for API tokens)
  */
 export function KeyIcon({ className = "h-4 w-4" }: IconProps) {

--- a/src/lib/events/connection-state.ts
+++ b/src/lib/events/connection-state.ts
@@ -32,7 +32,7 @@ export const INITIAL_RECONNECT_DELAY_MS = 1_000;
 export const MAX_RECONNECT_DELAY_MS = 30_000;
 
 /** Backoff multiplier for exponential backoff. */
-export const BACKOFF_MULTIPLIER = 2;
+const BACKOFF_MULTIPLIER = 2;
 
 /** Polling interval when in fallback mode (30 seconds). */
 export const POLL_INTERVAL_MS = 30_000;

--- a/src/lib/events/schemas.ts
+++ b/src/lib/events/schemas.ts
@@ -162,7 +162,7 @@ const updatedAtWithFallback = z.string().optional();
 // Individual Event Schemas
 // ============================================================================
 
-export const newEntryEventSchema = z.object({
+const newEntryEventSchema = z.object({
   type: z.literal("new_entry"),
   subscriptionId: z.string().nullable(),
   entryId: z.string(),
@@ -184,7 +184,7 @@ export const newEntryEventSchema = z.object({
   entry: newEntryListDataSchema.optional(),
 });
 
-export const entryUpdatedEventSchema = z.object({
+const entryUpdatedEventSchema = z.object({
   type: z.literal("entry_updated"),
   subscriptionId: z.string().nullable(),
   entryId: z.string(),
@@ -193,7 +193,7 @@ export const entryUpdatedEventSchema = z.object({
   metadata: entryMetadataSchema,
 });
 
-export const entryStateChangedEventSchema = z.object({
+const entryStateChangedEventSchema = z.object({
   type: z.literal("entry_state_changed"),
   entryId: z.string(),
   read: z.boolean(),
@@ -205,7 +205,7 @@ export const entryStateChangedEventSchema = z.object({
   updatedAt: z.string(),
 });
 
-export const subscriptionCreatedEventSchema = z.object({
+const subscriptionCreatedEventSchema = z.object({
   type: z.literal("subscription_created"),
   subscriptionId: z.string(),
   feedId: z.string(),
@@ -220,7 +220,7 @@ export const subscriptionCreatedEventSchema = z.object({
   counts: unreadCountsSchema.optional(),
 });
 
-export const subscriptionDeletedEventSchema = z.object({
+const subscriptionDeletedEventSchema = z.object({
   type: z.literal("subscription_deleted"),
   subscriptionId: z.string(),
   timestamp: timestampWithDefault,
@@ -233,7 +233,7 @@ export const subscriptionDeletedEventSchema = z.object({
   counts: unreadCountsSchema.optional(),
 });
 
-export const subscriptionUpdatedEventSchema = z.object({
+const subscriptionUpdatedEventSchema = z.object({
   type: z.literal("subscription_updated"),
   subscriptionId: z.string(),
   tags: z.array(syncTagSchema),
@@ -242,28 +242,28 @@ export const subscriptionUpdatedEventSchema = z.object({
   updatedAt: z.string(),
 });
 
-export const tagCreatedEventSchema = z.object({
+const tagCreatedEventSchema = z.object({
   type: z.literal("tag_created"),
   tag: syncTagSchema,
   timestamp: timestampWithDefault,
   updatedAt: z.string(),
 });
 
-export const tagUpdatedEventSchema = z.object({
+const tagUpdatedEventSchema = z.object({
   type: z.literal("tag_updated"),
   tag: syncTagSchema,
   timestamp: timestampWithDefault,
   updatedAt: z.string(),
 });
 
-export const tagDeletedEventSchema = z.object({
+const tagDeletedEventSchema = z.object({
   type: z.literal("tag_deleted"),
   tagId: z.string(),
   timestamp: timestampWithDefault,
   updatedAt: z.string(),
 });
 
-export const importProgressEventSchema = z
+const importProgressEventSchema = z
   .object({
     type: z.literal("import_progress"),
     importId: z.string(),
@@ -281,7 +281,7 @@ export const importProgressEventSchema = z
     updatedAt: event.updatedAt ?? event.timestamp,
   }));
 
-export const importCompletedEventSchema = z
+const importCompletedEventSchema = z
   .object({
     type: z.literal("import_completed"),
     importId: z.string(),

--- a/src/lib/narration/browser-tts-provider.ts
+++ b/src/lib/narration/browser-tts-provider.ts
@@ -36,7 +36,7 @@ import {
  * - Voice quality varies by browser and OS
  * - Firefox has broken pause/resume (we cancel and restart instead)
  */
-export class BrowserTTSProvider implements TTSProvider {
+class BrowserTTSProvider implements TTSProvider {
   readonly id = "browser" as const;
   readonly name = "Browser Voices";
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -34,9 +34,9 @@ const citext = customType<{ data: string }>({
 // ENUMS
 // ============================================================================
 
-export const feedTypeEnum = pgEnum("feed_type", ["web", "email", "saved"]);
+const feedTypeEnum = pgEnum("feed_type", ["web", "email", "saved"]);
 
-export const websubStateEnum = pgEnum("websub_state", ["pending", "active", "unsubscribed"]);
+const websubStateEnum = pgEnum("websub_state", ["pending", "active", "unsubscribed"]);
 
 // ============================================================================
 // AUTHENTICATION

--- a/src/server/google-reader/auth.ts
+++ b/src/server/google-reader/auth.ts
@@ -93,7 +93,7 @@ export function extractAuthToken(request: Request): string | null {
  * Validates a Google Reader request and returns the authenticated session.
  * Returns null if not authenticated.
  */
-export async function authenticateRequest(request: Request): Promise<SessionData | null> {
+async function authenticateRequest(request: Request): Promise<SessionData | null> {
   const token = extractAuthToken(request);
   if (!token) return null;
 

--- a/src/server/google-reader/format.ts
+++ b/src/server/google-reader/format.ts
@@ -7,7 +7,7 @@
 
 import { uuidToInt64, int64ToLongFormId, subscriptionToStreamId } from "./id";
 import { stateStreamId, labelStreamId } from "./streams";
-import type { EntryFull, EntryListItem } from "@/server/services/entries";
+import type { EntryFull } from "@/server/services/entries";
 import type { Subscription } from "@/server/services/subscriptions";
 import type { ListTagsResult } from "@/server/services/tags";
 
@@ -76,52 +76,6 @@ export function formatEntryAsItem(entry: EntryFull): GoogleReaderItem {
       streamId: entry.subscriptionId ? subscriptionToStreamId(entry.subscriptionId) : "",
       title: entry.feedTitle ?? "",
       htmlUrl: entry.feedUrl ?? entry.url ?? "",
-    },
-    categories,
-  };
-}
-
-/**
- * Formats a list entry (without content) as a Google Reader item.
- * Used when full content is not needed (e.g., stream/items/ids).
- */
-export function formatListEntryAsItem(
-  entry: EntryListItem
-): Omit<GoogleReaderItem, "summary"> & { summary: { direction: string; content: string } } {
-  const itemId = uuidToInt64(entry.id);
-  const publishedTs = entry.publishedAt
-    ? Math.floor(entry.publishedAt.getTime() / 1000)
-    : Math.floor(entry.fetchedAt.getTime() / 1000);
-  const updatedTs = Math.floor(entry.updatedAt.getTime() / 1000);
-  const crawlTimeMs = entry.fetchedAt.getTime().toString();
-
-  const categories: string[] = [];
-  categories.push(stateStreamId("reading-list"));
-  if (entry.read) {
-    categories.push(stateStreamId("read"));
-  }
-  if (entry.starred) {
-    categories.push(stateStreamId("starred"));
-  }
-
-  return {
-    id: int64ToLongFormId(itemId),
-    crawlTimeMsec: crawlTimeMs,
-    timestampUsec: (BigInt(crawlTimeMs) * BigInt(1000)).toString(),
-    published: publishedTs,
-    updated: updatedTs,
-    title: entry.title ?? "",
-    canonical: entry.url ? [{ href: entry.url }] : [],
-    alternate: entry.url ? [{ href: entry.url, type: "text/html" }] : [],
-    summary: {
-      direction: "ltr",
-      content: entry.summary ?? "",
-    },
-    author: entry.author ?? "",
-    origin: {
-      streamId: entry.subscriptionId ? subscriptionToStreamId(entry.subscriptionId) : "",
-      title: entry.feedTitle ?? "",
-      htmlUrl: entry.url ?? "",
     },
     categories,
   };

--- a/src/server/google-reader/id.ts
+++ b/src/server/google-reader/id.ts
@@ -127,37 +127,6 @@ function uuidTimestampMatch(column: typeof entries.id | typeof subscriptions.id,
 }
 
 /**
- * Looks up a UUIDv7 entry ID from a Google Reader int64 ID.
- *
- * Strategy: Extract the 48-bit timestamp to narrow the query to entries
- * created in that millisecond, then match on random bits.
- */
-export async function int64ToUuid(db: typeof dbType, id: bigint): Promise<string | null> {
-  const timestampMs = extractTimestamp(id);
-  const randomBits = extractRandomBits(id);
-
-  // Find entries whose UUIDs fall in this timestamp range
-  // UUIDv7 IDs within the same millisecond will share the same first 12 hex chars
-  const tsHex = timestampMs.toString(16).padStart(12, "0");
-
-  const candidates = await db
-    .select({ id: entries.id })
-    .from(entries)
-    .where(uuidTimestampMatch(entries.id, tsHex))
-    .limit(100);
-
-  // Match on random bits
-  for (const candidate of candidates) {
-    const candidateInt64 = uuidToInt64(candidate.id);
-    if (extractRandomBits(candidateInt64) === randomBits) {
-      return candidate.id;
-    }
-  }
-
-  return null;
-}
-
-/**
  * Batch converts Google Reader int64 IDs to UUIDv7 entry IDs.
  *
  * Groups IDs by timestamp millisecond for efficient batch queries.

--- a/src/server/google-reader/parse.ts
+++ b/src/server/google-reader/parse.ts
@@ -45,53 +45,6 @@ export async function parseFormData(request: Request): Promise<URLSearchParams> 
 }
 
 /**
- * Gets a single string parameter from form data or query params.
- */
-export function getParam(params: URLSearchParams, key: string): string | null {
-  return params.get(key);
-}
-
-/**
- * Gets all values for a parameter (for repeated params like `i=...&i=...`).
- */
-export function getAllParams(params: URLSearchParams, key: string): string[] {
-  return params.getAll(key);
-}
-
-/**
- * Gets a numeric parameter.
- */
-export function getNumParam(params: URLSearchParams, key: string): number | null {
-  const value = params.get(key);
-  if (value === null) return null;
-  const num = parseInt(value, 10);
-  return isNaN(num) ? null : num;
-}
-
-/**
- * Merges query parameters and POST body parameters.
- * POST body params take precedence for duplicate keys.
- * Google Reader API sometimes accepts params in both locations.
- */
-export async function mergeParams(request: Request): Promise<URLSearchParams> {
-  const url = new URL(request.url);
-  const queryParams = url.searchParams;
-
-  if (request.method === "GET") {
-    return queryParams;
-  }
-
-  const bodyParams = await parseFormData(request);
-  const merged = new URLSearchParams(queryParams);
-
-  for (const [key, value] of bodyParams.entries()) {
-    merged.append(key, value);
-  }
-
-  return merged;
-}
-
-/**
  * Parses item IDs from request parameters.
  * Google Reader sends item IDs as repeated `i` parameters.
  * Each ID can be in long hex, short hex, or decimal format.

--- a/src/server/http/html.ts
+++ b/src/server/http/html.ts
@@ -60,18 +60,3 @@ export function escapeHtml(text: string): string {
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#039;");
 }
-
-/**
- * Wraps an HTML fragment in a full document structure.
- *
- * Used by plugins that return content fragments (e.g., from APIs) to ensure
- * consistent document structure for metadata extraction and Readability.
- *
- * @param html - The HTML fragment to wrap
- * @param title - Optional title for the document
- * @returns A complete HTML document
- */
-export function wrapHtmlFragment(html: string, title?: string | null): string {
-  const titleTag = title ? `<title>${escapeHtml(title)}</title>` : "";
-  return `<!DOCTYPE html><html><head>${titleTag}</head><body>${html}</body></html>`;
-}

--- a/src/server/jobs/worker-core.ts
+++ b/src/server/jobs/worker-core.ts
@@ -122,7 +122,7 @@ export interface WorkerStats {
 /**
  * Error thrown when a job exceeds its timeout.
  */
-export class JobTimeoutError extends Error {
+class JobTimeoutError extends Error {
   constructor(
     public readonly jobId: string,
     public readonly timeoutMs: number

--- a/src/server/markdown/index.ts
+++ b/src/server/markdown/index.ts
@@ -141,7 +141,7 @@ function parseFrontmatterLenient(yaml: string): Record<string, string> | null {
  * @param markdown - The Markdown text to convert
  * @returns The HTML representation
  */
-export async function markdownToHtml(markdown: string): Promise<string> {
+async function markdownToHtml(markdown: string): Promise<string> {
   // Configure marked for safe rendering
   marked.setOptions({
     gfm: true, // GitHub Flavored Markdown

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -214,7 +214,7 @@ function extractMetadata(html: string, url: string): PageMetadata {
  * Generates a SHA-256 content hash for saved article.
  * Used for narration deduplication.
  */
-export function generateContentHash(title: string | null, content: string | null): string {
+function generateContentHash(title: string | null, content: string | null): string {
   const titleStr = title ?? "";
   const contentStr = content ?? "";
   const hashInput = `${titleStr}\n${contentStr}`;

--- a/src/server/services/subscriptions.ts
+++ b/src/server/services/subscriptions.ts
@@ -57,7 +57,7 @@ export interface Subscription {
  * Builds the base query for fetching subscriptions using the user_feeds view.
  * Includes unread counts and tags.
  */
-export function buildSubscriptionBaseQuery(db: typeof dbType, userId: string) {
+function buildSubscriptionBaseQuery(db: typeof dbType, userId: string) {
   // Subquery to get unread counts per subscription.
   // Counts through visible_entries (grouped by subscription_id) rather than by
   // entries.feed_id: a subscription can own entries under multiple feed_ids via
@@ -129,7 +129,7 @@ export type SubscriptionQueryRow = Awaited<ReturnType<typeof buildSubscriptionBa
 /**
  * Transforms a subscription query row into the output format.
  */
-export function formatSubscriptionRow(row: SubscriptionQueryRow): Subscription {
+function formatSubscriptionRow(row: SubscriptionQueryRow): Subscription {
   return {
     id: row.id,
     type: row.type,

--- a/src/server/wallabag/auth.ts
+++ b/src/server/wallabag/auth.ts
@@ -102,7 +102,7 @@ export async function refreshTokenGrant(
  * Validates a Wallabag API request using Bearer token.
  * Returns user data if authenticated.
  */
-export async function authenticateRequest(
+async function authenticateRequest(
   request: Request
 ): Promise<{ userId: string; email: string } | null> {
   const authHeader = request.headers.get("authorization");

--- a/src/server/worker-thread/pool.ts
+++ b/src/server/worker-thread/pool.ts
@@ -129,14 +129,3 @@ export async function parseFeedInWorker(content: string): Promise<ParsedFeed> {
   const result = serializedParsedFeedSchema.parse(raw);
   return deserializeParsedFeed(result);
 }
-
-/**
- * Destroy the worker pool. Call during graceful shutdown.
- */
-export async function destroyWorkerPool(): Promise<void> {
-  if (pool) {
-    await pool.destroy();
-    pool = null;
-    logger.info("Worker thread pool destroyed");
-  }
-}

--- a/tests/utils/cache-test-helpers.ts
+++ b/tests/utils/cache-test-helpers.ts
@@ -127,7 +127,7 @@ export const DEFAULT_SUBSCRIPTIONS: SeededSubscription[] = [
   },
 ];
 
-export const DEFAULT_TAGS: SeededTag[] = [
+const DEFAULT_TAGS: SeededTag[] = [
   {
     id: "tag-1",
     name: "Tech",
@@ -146,7 +146,7 @@ export const DEFAULT_TAGS: SeededTag[] = [
   },
 ];
 
-export const DEFAULT_UNCATEGORIZED = { feedCount: 1, unreadCount: 3 };
+const DEFAULT_UNCATEGORIZED = { feedCount: 1, unreadCount: 3 };
 
 export const DEFAULT_ENTRIES: SeededEntry[] = [
   {


### PR DESCRIPTION
Cleans up all **36 "unused export" findings** from `knip` (`pnpm knip`).

## Approach — per-symbol judgment, not blanket deletion

Each finding was checked for internal-vs-external use before deciding:

**Un-exported (used only within their own module → made module-private):**
- The 11 per-event Zod schemas in `events/schemas.ts` (composed into `syncEventSchema` in-file)
- `BACKOFF_MULTIPLIER`, the `feedTypeEnum`/`websubStateEnum` pgEnums, `JobTimeoutError`, `markdownToHtml`, `buildSubscriptionBaseQuery`/`formatSubscriptionRow`
- `saved.ts`'s internal `generateContentHash` (distinct from the used `entry-processor.ts` one)
- `authenticateRequest` in google-reader and wallabag (callers use `requireAuth`, which wraps it)
- The `BrowserTTSProvider` class (public surface is the `getBrowserTTSProvider()` factory)
- `DEFAULT_TAGS`/`DEFAULT_UNCATEGORIZED` test fixtures (used within the test-helper module)

**Deleted (genuinely dead — no internal or external references):**
- `DoubleChevronUpIcon` / `DoubleChevronDownIcon`
- google-reader helpers `formatListEntryAsItem`, `int64ToUuid`, `getParam`/`getAllParams`/`getNumParam`/`mergeParams`
- `wrapHtmlFragment`, `destroyWorkerPool`

Verified no cascade (e.g. `int64ToUuid` was the only caller of nothing exclusive; `extractRandomBits` and `escapeHtml` remain used elsewhere) and removed the now-unused `EntryListItem` import.

**knip config fix (false positive):**
- Registered `src/server/worker-thread/worker.ts` as a knip `entry`. It's spawned by Piscina via a runtime path string, so knip couldn't see it imports `workerRequestSchema`/`serializeParsedFeed` — they were flagged unused but are not.

## Out of scope
Pre-existing knip findings in **other categories** remain (they predate this change and aren't "unused exports"): two standalone ops scripts under `scripts/` (unused *files*) and the `html-entities` dependency. Those are false-positive-prone (scripts are run directly) and left for a separate call.

## Verification
- `pnpm typecheck` ✅ (guarantees nothing references the deleted symbols)
- `pnpm lint` ✅
- `pnpm knip` → **no "Unused exports" section** ✅
- `pnpm test:unit` (2005) ✅ and the touched integration suites (entry-processor, subscriptions, saved-articles, …) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)