### PR TITLE
Return 401 (not 500) for unauthenticated Wallabag/Google Reader requests

### DIFF
--- a/src/app/api/greader.php/reader/api/0/disable-tag/route.ts
+++ b/src/app/api/greader.php/reader/api/0/disable-tag/route.ts
@@ -21,6 +21,7 @@ export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
   const userId = session.user.id;
 
   const params = await parseFormData(request);

--- a/src/app/api/greader.php/reader/api/0/edit-tag/route.ts
+++ b/src/app/api/greader.php/reader/api/0/edit-tag/route.ts
@@ -35,6 +35,7 @@ export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
 
   const params = await parseFormData(request);
 

--- a/src/app/api/greader.php/reader/api/0/mark-all-as-read/route.ts
+++ b/src/app/api/greader.php/reader/api/0/mark-all-as-read/route.ts
@@ -22,6 +22,7 @@ export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
   const userId = session.user.id;
 
   const params = await parseFormData(request);

--- a/src/app/api/greader.php/reader/api/0/rename-tag/route.ts
+++ b/src/app/api/greader.php/reader/api/0/rename-tag/route.ts
@@ -20,6 +20,7 @@ export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
   const userId = session.user.id;
 
   const params = await parseFormData(request);

--- a/src/app/api/greader.php/reader/api/0/stream/contents/[...streamId]/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/contents/[...streamId]/route.ts
@@ -35,6 +35,7 @@ async function handleStreamContents(
   params: Promise<{ streamId: string[] }>
 ): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
   const { streamId: streamIdParts } = await params;
 
   // Reconstruct the stream ID from path segments

--- a/src/app/api/greader.php/reader/api/0/stream/items/contents/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/items/contents/route.ts
@@ -31,6 +31,7 @@ export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
 
   const params = await parseFormData(request);
   let itemIds: bigint[];

--- a/src/app/api/greader.php/reader/api/0/stream/items/ids/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/items/ids/route.ts
@@ -31,6 +31,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET(request: Request): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
 
   const url = new URL(request.url);
   const searchParams = url.searchParams;

--- a/src/app/api/greader.php/reader/api/0/subscription/edit/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/edit/route.ts
@@ -27,6 +27,7 @@ export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
   const userId = session.user.id;
 
   const params = await parseFormData(request);

--- a/src/app/api/greader.php/reader/api/0/subscription/list/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/list/route.ts
@@ -17,6 +17,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET(request: Request): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
 
   // Fetch all subscriptions (no pagination — Google Reader clients expect all at once)
   const allSubscriptions: subscriptionsService.Subscription[] = [];

--- a/src/app/api/greader.php/reader/api/0/subscription/quickadd/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/quickadd/route.ts
@@ -22,6 +22,7 @@ export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
 
   const params = await parseFormData(request);
   const feedUrl = params.get("quickadd");

--- a/src/app/api/greader.php/reader/api/0/tag/list/route.ts
+++ b/src/app/api/greader.php/reader/api/0/tag/list/route.ts
@@ -17,6 +17,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET(request: Request): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
 
   const tagsResult = await tagsService.listTags(db, session.user.id);
 

--- a/src/app/api/greader.php/reader/api/0/token/route.ts
+++ b/src/app/api/greader.php/reader/api/0/token/route.ts
@@ -13,7 +13,8 @@ import { requireAuth, extractAuthToken } from "@/server/google-reader/auth";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request): Promise<Response> {
-  await requireAuth(request);
+  const session = await requireAuth(request);
+  if (session instanceof Response) return session;
 
   // Return the auth token as the action token
   // This is what FreshRSS and Miniflux do

--- a/src/app/api/greader.php/reader/api/0/unread-count/route.ts
+++ b/src/app/api/greader.php/reader/api/0/unread-count/route.ts
@@ -16,6 +16,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET(request: Request): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
 
   // Fetch all subscriptions to get unread counts
   const allSubscriptions: Array<{ id: string; unreadCount: number; subscribedAt: Date }> = [];

--- a/src/app/api/greader.php/reader/api/0/user-info/route.ts
+++ b/src/app/api/greader.php/reader/api/0/user-info/route.ts
@@ -14,6 +14,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET(request: Request): Promise<Response> {
   const session = await requireAuth(request);
+  if (session instanceof Response) return session;
 
   return jsonResponse(formatUserInfo(session.user.id, session.user.email));
 }

--- a/src/app/api/wallabag/api/entries/[entry]/route.ts
+++ b/src/app/api/wallabag/api/entries/[entry]/route.ts
@@ -38,6 +38,7 @@ export async function GET(
   { params }: { params: Promise<{ entry: string }> }
 ): Promise<Response> {
   const auth = await requireAuth(request);
+  if (auth instanceof Response) return auth;
   const { entry: entryParam } = await params;
 
   const entryId = await resolveEntryId(auth.userId, entryParam);
@@ -58,6 +59,7 @@ export async function PATCH(
   { params }: { params: Promise<{ entry: string }> }
 ): Promise<Response> {
   const auth = await requireAuth(request);
+  if (auth instanceof Response) return auth;
   const { entry: entryParam } = await params;
   const body = await parseBody(request);
 
@@ -92,6 +94,7 @@ export async function DELETE(
   { params }: { params: Promise<{ entry: string }> }
 ): Promise<Response> {
   const auth = await requireAuth(request);
+  if (auth instanceof Response) return auth;
   const { entry: entryParam } = await params;
 
   const entryId = await resolveEntryId(auth.userId, entryParam);

--- a/src/app/api/wallabag/api/entries/exists/route.ts
+++ b/src/app/api/wallabag/api/entries/exists/route.ts
@@ -25,6 +25,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await requireAuth(request);
+  if (auth instanceof Response) return auth;
   const url = new URL(request.url);
 
   const singleUrl = url.searchParams.get("url");

--- a/src/app/api/wallabag/api/entries/route.ts
+++ b/src/app/api/wallabag/api/entries/route.ts
@@ -45,6 +45,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await requireAuth(request);
+  if (auth instanceof Response) return auth;
   const url = new URL(request.url);
   const params = parseEntryListParams(url);
 
@@ -129,6 +130,7 @@ export async function GET(request: Request): Promise<Response> {
 
 export async function POST(request: Request): Promise<Response> {
   const auth = await requireAuth(request);
+  if (auth instanceof Response) return auth;
   const body = await parseBody(request);
 
   const articleUrl = body.url;

--- a/src/app/api/wallabag/api/search/route.ts
+++ b/src/app/api/wallabag/api/search/route.ts
@@ -21,6 +21,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await requireAuth(request);
+  if (auth instanceof Response) return auth;
   const url = new URL(request.url);
 
   const term = url.searchParams.get("term");

--- a/src/app/api/wallabag/api/tags/route.ts
+++ b/src/app/api/wallabag/api/tags/route.ts
@@ -14,6 +14,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await requireAuth(request);
+  if (auth instanceof Response) return auth;
 
   const tags = await tagsService.listTags(db, auth.userId);
   return jsonResponse(formatTags(tags));

--- a/src/app/api/wallabag/api/user/route.ts
+++ b/src/app/api/wallabag/api/user/route.ts
@@ -12,6 +12,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET(request: Request): Promise<Response> {
   const auth = await requireAuth(request);
+  if (auth instanceof Response) return auth;
 
   return jsonResponse({
     id: uuidToWallabagId(auth.userId),

--- a/src/server/google-reader/auth.ts
+++ b/src/server/google-reader/auth.ts
@@ -102,12 +102,16 @@ async function authenticateRequest(request: Request): Promise<SessionData | null
 
 /**
  * Validates a Google Reader request and returns the session.
- * Throws a 401 response if not authenticated.
+ *
+ * Returns a 401 `Response` if not authenticated — callers must forward it, e.g.
+ * `const session = await requireAuth(request); if (session instanceof Response) return session;`.
+ * (We return rather than throw because Next.js App Router route handlers don't
+ * convert a thrown `Response` into the HTTP response — it surfaces as a 500.)
  */
-export async function requireAuth(request: Request): Promise<SessionData> {
+export async function requireAuth(request: Request): Promise<SessionData | Response> {
   const session = await authenticateRequest(request);
   if (!session) {
-    throw new Response("Unauthorized", { status: 401 });
+    return new Response("Unauthorized", { status: 401 });
   }
   return session;
 }

--- a/src/server/wallabag/auth.ts
+++ b/src/server/wallabag/auth.ts
@@ -124,12 +124,18 @@ async function authenticateRequest(
 
 /**
  * Validates a Wallabag API request and returns the user data.
- * Throws a 401 response if not authenticated.
+ *
+ * Returns a 401 `Response` if not authenticated — callers must forward it, e.g.
+ * `const auth = await requireAuth(request); if (auth instanceof Response) return auth;`.
+ * (We return rather than throw because Next.js App Router route handlers don't
+ * convert a thrown `Response` into the HTTP response — it surfaces as a 500.)
  */
-export async function requireAuth(request: Request): Promise<{ userId: string; email: string }> {
+export async function requireAuth(
+  request: Request
+): Promise<{ userId: string; email: string } | Response> {
   const auth = await authenticateRequest(request);
   if (!auth) {
-    throw new Response(
+    return new Response(
       JSON.stringify({ error: "invalid_grant", error_description: "Unauthorized" }),
       {
         status: 401,


### PR DESCRIPTION
## Summary

While checking the Wallabag API after the recent scope/permission changes (#870), I found a pre-existing bug affecting **both** the Wallabag and Google Reader compatibility APIs: unauthenticated (or expired/invalid-token) requests returned **HTTP 500 instead of 401**.

**Root cause:** `requireAuth` in both APIs signalled missing auth with `throw new Response(..., { status: 401 })`. Next.js App Router route handlers don't convert a *thrown* `Response` into the HTTP response — it surfaces as an unhandled error → 500. So a client whose token expired got a 500 and no signal that it needed to re-authenticate.

This is **unrelated to #870** — that change never touched these files (it enforces scopes in the tRPC/MCP layers, which these compat APIs bypass). The bug dates back to the original implementations (#649, #659).

## Fix

Make `requireAuth` **return** the 401 `Response` (union return type) instead of throwing, and forward it at each callsite:

```ts
const auth = await requireAuth(request);
if (auth instanceof Response) return auth;
```

The union return type makes completeness **compiler-enforced** — any callsite that forgets the guard fails `typecheck`. 23 callsites across 20 route files updated.

## Verification

Ran both APIs against local services:

- **Before:** unauthenticated `GET /api/wallabag/api/user` → 500
- **After:** all protected Wallabag + Google Reader endpoints → **401** for missing/invalid credentials
- Authenticated happy paths (token grant → user/entries/tags; ClientLogin → user-info) still → **200**
- `pnpm typecheck` + `pnpm lint` clean

## Note on the original question

The Wallabag (and Google Reader) APIs are **not broken by the permission changes**: they call the services layer directly and authenticate via their own `requireAuth`/`validateAccessToken`, so the new tRPC scope enforcement and MCP audience binding don't apply to them. This 401/500 fix is a separate correctness issue found along the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)