### PR TITLE
Reset entry-list scroll to top on list→list navigation (#1013)

### DIFF
--- a/src/components/app/AppRouter.tsx
+++ b/src/components/app/AppRouter.tsx
@@ -17,6 +17,7 @@ import { UnifiedSettingsContent } from "@/components/settings/UnifiedSettingsCon
 import { SubscribeContent } from "@/components/subscribe/SubscribeContent";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { useEntryListRefreshOnNavigate } from "@/lib/hooks/useEntryListRefreshOnNavigate";
+import { useEntryListScrollResetOnNavigate } from "@/lib/hooks/useEntryListScrollResetOnNavigate";
 
 /**
  * Loading skeleton for page transitions.
@@ -45,6 +46,10 @@ function AppRouterContent() {
   // Central navigation-triggered refresh for entry lists (must live in this
   // always-mounted shell — see the hook's doc comment).
   useEntryListRefreshOnNavigate();
+
+  // Reset the entry-list scroll to the top on list→list navigation (same
+  // always-mounted-shell requirement — see the hook's doc comment).
+  useEntryListScrollResetOnNavigate();
 
   // Settings pages
   if (pathname.startsWith("/settings")) {

--- a/src/lib/hooks/useEntryListScrollResetOnNavigate.ts
+++ b/src/lib/hooks/useEntryListScrollResetOnNavigate.ts
@@ -1,0 +1,49 @@
+/**
+ * useEntryListScrollResetOnNavigate Hook
+ *
+ * Resets the entry-list scroll container to the top when the user navigates to
+ * a different list. In-app navigation is shallow (`pushState` + AppRouter
+ * re-deriving from `usePathname()`), so the browser never resets scroll the way
+ * a full navigation would; the scroll container keeps its offset across the list
+ * swap and a fresh list would otherwise open scrolled to wherever the previous
+ * one was.
+ *
+ * Keyed on the pathname, exactly like `useEntryListRefreshOnNavigate`: the
+ * pathname is the "list identity". The open entry lives in the `?entry=` search
+ * param (useEntryUrlState), so opening/closing an entry — or moving between a
+ * list and an entry in it — never changes the pathname and never resets scroll
+ * (the list stays put under the reader, so closing an entry lands back where you
+ * were; the reader itself scrolls its own nested container). Only a genuine list
+ * change (sidebar link, All ↔ Starred, subscription/tag swap) resets.
+ *
+ * Runs in a layout effect so the reset happens before paint (no visible jump).
+ *
+ * Must be mounted in a component that stays mounted across all client-side
+ * navigation (AppRouter) so it observes every list change, and within the
+ * ScrollContainerProvider so `useScrollContainer` resolves the `<main>` element.
+ *
+ * If/when per-article reading-position restore (#406) lands, that restores the
+ * *reader's* scroll; this resets the *list's* scroll — separate containers,
+ * separate behaviors.
+ */
+
+"use client";
+
+import { useLayoutEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { useScrollContainer } from "@/components/layout/ScrollContainerContext";
+
+export function useEntryListScrollResetOnNavigate(): void {
+  const pathname = usePathname();
+  const scrollContainerRef = useScrollContainer();
+  const prevPathnameRef = useRef(pathname);
+
+  useLayoutEffect(() => {
+    if (prevPathnameRef.current === pathname) return;
+    prevPathnameRef.current = pathname;
+    const scrollContainer = scrollContainerRef?.current;
+    // scrollTo (a method call) rather than assigning `.scrollTop`, which the
+    // react-hooks/immutability lint rule flags as mutating a hook value.
+    scrollContainer?.scrollTo({ top: 0 });
+  }, [pathname, scrollContainerRef]);
+}

--- a/src/lib/hooks/useEntryListScrollResetOnNavigate.ts
+++ b/src/lib/hooks/useEntryListScrollResetOnNavigate.ts
@@ -14,7 +14,10 @@
  * list and an entry in it — never changes the pathname and never resets scroll
  * (the list stays put under the reader, so closing an entry lands back where you
  * were; the reader itself scrolls its own nested container). Only a genuine list
- * change (sidebar link, All ↔ Starred, subscription/tag swap) resets.
+ * change (sidebar link, All ↔ Starred, subscription/tag swap) resets. Browser
+ * back/forward *between two lists* also changes the pathname and so resets to
+ * the top (the app has no popstate scroll restoration); that's consistent with
+ * the refresh hook and fine until reading-position restore (#406) lands.
  *
  * Runs in a layout effect so the reset happens before paint (no visible jump).
  *

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -31,6 +31,16 @@ function mainScrollTop(page: Page): Promise<number> {
   return page.locator("main").evaluate((el) => el.scrollTop);
 }
 
+/**
+ * Maximum scrollTop of the main container (scrollHeight - clientHeight). > 0
+ * means the list overflows its container, so a non-zero scroll position is
+ * actually reachable there — which is what makes a later `scrollTop === 0`
+ * assertion meaningful rather than trivially true for a list too short to scroll.
+ */
+function mainMaxScroll(page: Page): Promise<number> {
+  return page.locator("main").evaluate((el) => el.scrollHeight - el.clientHeight);
+}
+
 test("resets the entry-list scroll to the top on list→list navigation", async ({
   page,
   baseURL,
@@ -39,18 +49,17 @@ test("resets the entry-list scroll to the top on list→list navigation", async 
   const user = await createConfirmedUser(db);
   const feed = await createSubscribedFeed(db, user.id);
 
-  // Enough entries that both All and Starred overflow the viewport (so a
-  // non-zero scroll position is possible on each and scrollTop === 0 is a
-  // meaningful assertion, not just "the new list happened to be short").
+  // Star every entry so BOTH All and Starred are long lists (~40 rows). They
+  // must each be taller than the pre-scroll offset used below, otherwise a
+  // scrollTop === 0 on the target list could be trivially satisfied by the list
+  // being too short to hold that offset (see the scrollHeight guards below).
   for (let i = 0; i < 40; i++) {
     const entry = await createUnreadEntry(db, {
       feedId: feed.feedId,
       userId: user.id,
       title: `Post ${String(i).padStart(2, "0")}`,
     });
-    if (i % 2 === 0) {
-      await starEntry(db, user.id, entry.id);
-    }
+    await starEntry(db, user.id, entry.id);
   }
 
   await loginAs(page.context(), user, baseURL!);
@@ -63,10 +72,13 @@ test("resets the entry-list scroll to the top on list→list navigation", async 
   await expect.poll(() => mainScrollTop(page)).toBeGreaterThan(0);
 
   await page.getByRole("link", { name: /^Starred/ }).click();
-  // Starred is also a scrollable list (half the posts are starred); it must
-  // open at the top rather than inheriting All's scroll offset. Post 38 is the
-  // newest starred entry.
-  await expect(page.locator('[aria-label*="article: Post 38"]')).toBeVisible();
+  // Starred is also a long list; it must open at the top rather than inheriting
+  // All's scroll offset. All posts are starred, so Post 39 is at the top here too.
+  await expect(page.locator('[aria-label*="article: Post 39"]')).toBeVisible();
+  // Guard against the assertion passing trivially: the target list must overflow
+  // (maxScroll > 0) so that, without the reset, the reused <main> container would
+  // have kept a non-zero scrollTop (clamped to this list's maxScroll).
+  await expect.poll(() => mainMaxScroll(page)).toBeGreaterThan(0);
   await expect.poll(() => mainScrollTop(page)).toBe(0);
 
   // Scroll Starred down, then navigate back to All: the same <main> container
@@ -76,6 +88,7 @@ test("resets the entry-list scroll to the top on list→list navigation", async 
 
   await page.getByRole("link", { name: /All Items/ }).click();
   await expect(page.locator('[aria-label*="article: Post 39"]')).toBeVisible();
+  await expect.poll(() => mainMaxScroll(page)).toBeGreaterThan(0);
   await expect.poll(() => mainScrollTop(page)).toBe(0);
 });
 
@@ -108,14 +121,17 @@ test("does not reset the entry-list scroll when opening and closing an entry", a
   // Open the entry sitting at the viewport center. Picking one already on-screen
   // means the click doesn't scroll the list (which clicking an off-screen entry
   // would), so the pre-open scroll offset is preserved for the comparison below.
-  const centerLabel = await page.evaluate(() => {
+  // Locate by the stable data-entry-id, not the aria-label: opening marks the
+  // entry read, which flips its aria-label ("Unread article: …" → "Read article:
+  // …") and would break an aria-label-based locator after close.
+  const centerEntryId = await page.evaluate(() => {
     const main = document.querySelector("main")!;
     const rect = main.getBoundingClientRect();
     const el = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
-    return el?.closest("[aria-label*='article:']")?.getAttribute("aria-label") ?? null;
+    return el?.closest("[data-entry-id]")?.getAttribute("data-entry-id") ?? null;
   });
-  expect(centerLabel).not.toBeNull();
-  const centerEntry = page.locator(`[aria-label="${centerLabel}"]`);
+  expect(centerEntryId).not.toBeNull();
+  const centerEntry = page.locator(`[data-entry-id="${centerEntryId}"]`);
   await centerEntry.click();
   await expect(centerEntry).toBeHidden();
 

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * E2E tests for client-side navigation behavior.
+ *
+ * In-app navigation is shallow (`pushState` + AppRouter re-deriving from
+ * `usePathname()`), so there's no browser-native scroll reset. These tests
+ * pin the behaviors that need to be reproduced by hand:
+ *
+ * - list→list navigation resets the entry-list scroll container to the top
+ *   (issue #1013), while
+ * - opening/closing an entry (a `?entry=` search-param change, same pathname)
+ *   does NOT reset it — the list stays put under the reader.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import {
+  getDb,
+  createConfirmedUser,
+  createSubscribedFeed,
+  createUnreadEntry,
+  starEntry,
+  loginAs,
+  closeTestConnections,
+} from "./helpers";
+
+test.afterAll(async () => {
+  await closeTestConnections();
+});
+
+/** Current scrollTop of the main entry-list scroll container. */
+function mainScrollTop(page: Page): Promise<number> {
+  return page.locator("main").evaluate((el) => el.scrollTop);
+}
+
+test("resets the entry-list scroll to the top on list→list navigation", async ({
+  page,
+  baseURL,
+}) => {
+  const db = getDb();
+  const user = await createConfirmedUser(db);
+  const feed = await createSubscribedFeed(db, user.id);
+
+  // Enough entries that both All and Starred overflow the viewport (so a
+  // non-zero scroll position is possible on each and scrollTop === 0 is a
+  // meaningful assertion, not just "the new list happened to be short").
+  for (let i = 0; i < 40; i++) {
+    const entry = await createUnreadEntry(db, {
+      feedId: feed.feedId,
+      userId: user.id,
+      title: `Post ${String(i).padStart(2, "0")}`,
+    });
+    if (i % 2 === 0) {
+      await starEntry(db, user.id, entry.id);
+    }
+  }
+
+  await loginAs(page.context(), user, baseURL!);
+  await page.goto("/all");
+  // Lists render newest-first, so the highest-numbered post is at the top.
+  await expect(page.locator('[aria-label*="article: Post 39"]')).toBeVisible();
+
+  // Scroll the All list down, then switch to Starred.
+  await page.locator("main").evaluate((el) => el.scrollTo(0, 1500));
+  await expect.poll(() => mainScrollTop(page)).toBeGreaterThan(0);
+
+  await page.getByRole("link", { name: /^Starred/ }).click();
+  // Starred is also a scrollable list (half the posts are starred); it must
+  // open at the top rather than inheriting All's scroll offset. Post 38 is the
+  // newest starred entry.
+  await expect(page.locator('[aria-label*="article: Post 38"]')).toBeVisible();
+  await expect.poll(() => mainScrollTop(page)).toBe(0);
+
+  // Scroll Starred down, then navigate back to All: the same <main> container
+  // kept its offset across the earlier swap, so returning must reset it too.
+  await page.locator("main").evaluate((el) => el.scrollTo(0, 1500));
+  await expect.poll(() => mainScrollTop(page)).toBeGreaterThan(0);
+
+  await page.getByRole("link", { name: /All Items/ }).click();
+  await expect(page.locator('[aria-label*="article: Post 39"]')).toBeVisible();
+  await expect.poll(() => mainScrollTop(page)).toBe(0);
+});
+
+test("does not reset the entry-list scroll when opening and closing an entry", async ({
+  page,
+  baseURL,
+}) => {
+  const db = getDb();
+  const user = await createConfirmedUser(db);
+  const feed = await createSubscribedFeed(db, user.id);
+
+  for (let i = 0; i < 40; i++) {
+    await createUnreadEntry(db, {
+      feedId: feed.feedId,
+      userId: user.id,
+      title: `Post ${String(i).padStart(2, "0")}`,
+    });
+  }
+
+  await loginAs(page.context(), user, baseURL!);
+  await page.goto("/all");
+  // Lists render newest-first, so the highest-numbered post is at the top.
+  await expect(page.locator('[aria-label*="article: Post 39"]')).toBeVisible();
+
+  // Scroll the list well off the top. Opening/closing an entry only changes the
+  // ?entry= search param (same pathname), so the list scroll must NOT reset.
+  await page.locator("main").evaluate((el) => el.scrollTo(0, 1000));
+  await expect.poll(() => mainScrollTop(page)).toBeGreaterThan(0);
+
+  // Open the entry sitting at the viewport center. Picking one already on-screen
+  // means the click doesn't scroll the list (which clicking an off-screen entry
+  // would), so the pre-open scroll offset is preserved for the comparison below.
+  const centerLabel = await page.evaluate(() => {
+    const main = document.querySelector("main")!;
+    const rect = main.getBoundingClientRect();
+    const el = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    return el?.closest("[aria-label*='article:']")?.getAttribute("aria-label") ?? null;
+  });
+  expect(centerLabel).not.toBeNull();
+  const centerEntry = page.locator(`[aria-label="${centerLabel}"]`);
+  await centerEntry.click();
+  await expect(centerEntry).toBeHidden();
+
+  // Close the entry (back). The list stays scrolled — it is not reset to the
+  // top (closing re-centers the last-viewed entry, so the exact offset differs,
+  // but it must remain a non-zero, mid-list position).
+  await page.getByRole("button", { name: /back to list/i }).click();
+  await expect(centerEntry).toBeVisible();
+  await expect.poll(() => mainScrollTop(page)).toBeGreaterThan(0);
+});


### PR DESCRIPTION
Fixes #1013.

## Problem

Navigating from one entry list to another (All → Starred, or between subscriptions/tags via the sidebar) didn't reset the scroll position — the new list opened scrolled to wherever the previous list was. Because in-app navigation is shallow (`pushState` + `AppRouter` re-deriving from `usePathname()`), there's no browser-native scroll reset, and the `<main>` scroll container kept its offset across the list swap.

## Fix

Add `useEntryListScrollResetOnNavigate`, mounted alongside `useEntryListRefreshOnNavigate` in the always-mounted `AppRouter` shell. It keys on the **pathname** (the "list identity"), exactly like the refresh hook:

- Opening/closing an entry lives in the `?entry=` search param, so it never changes the pathname and never resets scroll — the list stays put under the reader (read entries stay where they were), and the reader scrolls its own nested container.
- Only a genuine list change (sidebar link, All ↔ Starred, subscription/tag swap) resets, and it does so in a layout effect so there's no visible jump.
- Uses `scrollTo({ top: 0 })` rather than assigning `.scrollTop` (the latter trips the `react-hooks/immutability` lint rule).

This resets the **list's** scroll and is orthogonal to per-article reading-position restore (#406), which would restore the **reader's** scroll — separate containers, separate behaviors.

## Tests

New `tests/e2e/navigation.spec.ts`:

1. **list→list navigation resets to top** — seeds 40 entries (half starred) so both All and Starred overflow the viewport; scrolls All down, switches to Starred, asserts `main.scrollTop === 0`; then scrolls Starred down, returns to All, asserts `=== 0` again (proving the persistent `<main>` container is reset on return, not just that a short list happened to fit).
2. **open/close does not reset** — scrolls the list off the top, opens the entry at the viewport center and closes it, asserts the list is still scrolled (`> 0`), i.e. not reset to top.

Both pass locally (`pnpm test:e2e:local`). Typecheck, lint, and knip are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)