### PR TITLE
Add reader:full-access scope; enforce on Wallabag and scope Google Reader sessions

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -207,18 +207,20 @@ Session tokens are 32 random bytes, base64url encoded. We store SHA-256 hash in 
 
 ### Token Scopes & Authorization
 
-Authorization is **fail-closed** for tokens. There are three credential types:
+Authorization is **fail-closed** for tokens. There are four credential types:
 
-- **Browser sessions**: full access. Scopes do not apply (`scopes` is a token-only concept).
+- **Browser sessions**: full access. A normal login session has `scopes = NULL`.
+- **Scoped sessions**: a session with a non-NULL `scopes` array — a restricted bearer credential minted by a session-based compat API (the Google Reader `ClientLogin` mints one with `reader:full-access`). `validateSession` is **fail-closed**: a scoped session is rejected for full-access use (main tRPC/REST, RSC caller, SSE, `/oauth/authorize`) exactly as if invalid, unless the caller passes `allowScoped: true` (only the Google Reader API does, and it then verifies the reader scope). This keeps a leaked Google Reader token from being replayed as a browser session for account management.
 - **API tokens** (`api_tokens`, used by extensions/integrations and the legacy MCP path): restricted to their granted scopes.
-- **OAuth 2.1 access tokens**: audience-bound to the MCP endpoint only (see below).
+- **OAuth 2.1 access tokens**: audience-bound to the MCP endpoint at `/api/mcp` (see below). The Wallabag compat API also validates OAuth access tokens directly, requiring `reader:full-access`.
 
 Available scopes (`API_TOKEN_SCOPES` / `OAUTH_SCOPES`):
 
-| Scope         | Grants                                                                                                             |
-| ------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `mcp`         | The MCP tool surface: entries list/get/mark-read/star/count, subscriptions list/get, tag CRUD, saved delete/upload |
-| `saved:write` | Saving articles (`saved.save`) only                                                                                |
+| Scope                | Grants                                                                                                                                                                                                                           |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mcp`                | The MCP tool surface: entries list/get/mark-read/star/count, subscriptions list/get, tag CRUD, saved delete/upload                                                                                                               |
+| `saved:write`        | Saving articles (`saved.save`) only                                                                                                                                                                                              |
+| `reader:full-access` | Full reader surface (entries, subscriptions, tags, saved articles — not account settings). Minted for the Wallabag and Google Reader compat APIs and enforced by them; OAuth/session-only (not an `API_TOKEN_SCOPES` value yet). |
 
 Enforcement (`src/server/trpc/trpc.ts`):
 

--- a/migrations/0082_session_scopes.sql
+++ b/migrations/0082_session_scopes.sql
@@ -1,0 +1,18 @@
+-- Scoped sessions: let a session carry a restricted set of scopes instead of
+-- being full-access.
+--
+-- Sessions were always full browser-equivalent access. The Google Reader compat
+-- API mints a real session via ClientLogin, so a leaked Google Reader token
+-- could be replayed as a browser session cookie for full account access
+-- (change password, delete account). Adding a nullable scopes column lets
+-- ClientLogin mint a session restricted to reader:full-access.
+--
+-- NULL scopes = full access (a normal browser login) — the fail-closed default,
+-- and what every existing session becomes. A non-NULL array marks the session
+-- as restricted; validateSession rejects such sessions for full-access use
+-- unless the caller explicitly opts in (only the Google Reader API does).
+--
+-- Expand-safe: the column is nullable with no default, so existing rows and old
+-- code (which never sets or reads it) are unaffected.
+
+ALTER TABLE public.sessions ADD COLUMN scopes text[];

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -568,6 +568,13 @@
       "when": 1782951400000,
       "tag": "0081_tags_partial_unique_name",
       "breakpoints": true
+    },
+    {
+      "idx": 81,
+      "version": "7",
+      "when": 1782951500000,
+      "tag": "0082_session_scopes",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -285,6 +285,7 @@ CREATE TABLE public.sessions (
     id uuid NOT NULL,
     user_id uuid NOT NULL,
     token_hash text NOT NULL,
+    scopes text[],
     user_agent text,
     ip_address text,
     created_at timestamp with time zone DEFAULT now() NOT NULL,

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -63,6 +63,7 @@ interface CachedSession {
   revokedAt: string | null;
   createdAt: string;
   lastActiveAt: string;
+  scopes: string[] | null;
   userAgent: string | null;
   ipAddress: string | null;
   userCreatedAt: string;
@@ -130,6 +131,13 @@ export interface CreateSessionParams {
   userAgent?: string;
   /** IP address from request */
   ipAddress?: string;
+  /**
+   * Scopes to restrict this session to. Omit (undefined) for a normal
+   * full-access browser session. Pass an array to mint a restricted session
+   * (e.g. the Google Reader API passes ['reader:full-access']); such sessions
+   * are only usable by callers that opt into scoped sessions.
+   */
+  scopes?: string[];
 }
 
 /**
@@ -161,7 +169,7 @@ export async function createSession(
   dbOrTx: DbOrTx,
   params: CreateSessionParams
 ): Promise<CreateSessionResult> {
-  const { userId, userAgent, ipAddress } = params;
+  const { userId, userAgent, ipAddress, scopes } = params;
 
   const sessionId = generateUuidv7();
   const { token, tokenHash } = generateSessionToken();
@@ -172,6 +180,7 @@ export async function createSession(
     id: sessionId,
     userId,
     tokenHash,
+    scopes: scopes ?? null,
     userAgent,
     ipAddress,
     expiresAt,
@@ -205,6 +214,7 @@ function serializeForCache(data: SessionData): string {
     revokedAt: data.session.revokedAt?.toISOString() ?? null,
     createdAt: data.session.createdAt.toISOString(),
     lastActiveAt: data.session.lastActiveAt.toISOString(),
+    scopes: data.session.scopes,
     userAgent: data.session.userAgent,
     ipAddress: data.session.ipAddress,
     userCreatedAt: data.user.createdAt.toISOString(),
@@ -234,6 +244,7 @@ function deserializeFromCache(data: string): SessionData {
       id: cached.sessionId,
       userId: cached.userId,
       tokenHash: "", // Not needed after validation
+      scopes: cached.scopes ?? null,
       expiresAt: new Date(cached.expiresAt),
       revokedAt: cached.revokedAt ? new Date(cached.revokedAt) : null,
       createdAt: new Date(cached.createdAt),
@@ -269,11 +280,33 @@ function deserializeFromCache(data: string): SessionData {
 }
 
 /**
+ * Options for {@link validateSession}.
+ */
+export interface ValidateSessionOptions {
+  /**
+   * Accept restricted (scoped) sessions. Defaults to `false` — a fail-closed
+   * default so full-access consumers (tRPC context, RSC caller, SSE, OAuth
+   * authorize) automatically reject a scoped session (e.g. a Google Reader
+   * token) as if it were invalid. Only surfaces that understand scoped sessions
+   * (the Google Reader API) should pass `true`, and they must then check the
+   * returned `session.scopes` themselves.
+   */
+  allowScoped?: boolean;
+}
+
+/**
  * Validates a session token and returns the session with user data.
  * Uses Redis cache for fast lookups, falls back to database on cache miss.
  * Returns null if the token is invalid, expired, or revoked.
+ *
+ * By default a restricted (non-NULL `scopes`) session is treated as invalid —
+ * see {@link ValidateSessionOptions.allowScoped}.
  */
-export async function validateSession(token: string): Promise<SessionData | null> {
+export async function validateSession(
+  token: string,
+  options?: ValidateSessionOptions
+): Promise<SessionData | null> {
+  const allowScoped = options?.allowScoped ?? false;
   const tokenHash = hashToken(token);
   const cacheKey = getCacheKey(tokenHash);
   const redis = getRedisClient();
@@ -287,6 +320,10 @@ export async function validateSession(token: string): Promise<SessionData | null
 
         // Verify session is still valid (not expired, not revoked)
         if (data.session.expiresAt > new Date() && data.session.revokedAt === null) {
+          // Reject a restricted session for full-access use (fail closed).
+          if (data.session.scopes !== null && !allowScoped) {
+            return null;
+          }
           // Update last_active_at asynchronously (fire and forget)
           void updateLastActiveAt(data.session.id, data.session.userId);
           return data;
@@ -336,7 +373,8 @@ export async function validateSession(token: string): Promise<SessionData | null
     hasAnthropicApiKey: !!dbResult.user.anthropicApiKey,
   };
 
-  // Cache the result in Redis (if available)
+  // Cache the result in Redis (if available). We cache before applying the
+  // scoped-access policy so a later opt-in caller still benefits from the cache.
   if (redis) {
     try {
       await redis.setex(cacheKey, SESSION_CACHE_TTL_SECONDS, serializeForCache(sessionData));
@@ -344,6 +382,11 @@ export async function validateSession(token: string): Promise<SessionData | null
       // Redis error - continue without caching
       console.error("Failed to cache session:", err);
     }
+  }
+
+  // Reject a restricted session for full-access use (fail closed).
+  if (sessionData.session.scopes !== null && !allowScoped) {
+    return null;
   }
 
   // Update last_active_at asynchronously (fire and forget)

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -117,6 +117,12 @@ export const sessions = pgTable(
       .references(() => users.id, { onDelete: "cascade" }),
     tokenHash: text("token_hash").unique().notNull(), // SHA-256 of session token
 
+    // Scopes restricting this session. NULL = full access (a normal browser
+    // login). A non-NULL array marks a restricted session (e.g. the Google
+    // Reader compat API mints one with ['reader:full-access']); validateSession
+    // rejects such sessions for full-access use unless the caller opts in.
+    scopes: text("scopes").array(),
+
     userAgent: text("user_agent"),
     ipAddress: text("ip_address"),
 

--- a/src/server/google-reader/auth.ts
+++ b/src/server/google-reader/auth.ts
@@ -15,6 +15,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/server/db";
 import { users } from "@/server/db/schema";
 import { createSession, validateSession, type SessionData } from "@/server/auth/session";
+import { OAUTH_SCOPES } from "@/server/oauth/utils";
 
 /**
  * Authenticates a user with email/password and returns session credentials
@@ -53,11 +54,15 @@ export async function clientLogin(
     return null;
   }
 
-  // Create a session (reuses existing session infrastructure)
+  // Create a session (reuses existing session infrastructure), restricted to
+  // the reader surface. Unlike a browser login, a Google Reader token must not
+  // be replayable as a full-access session cookie (account settings, password,
+  // deletion) — the scope confines it to what the Google Reader API exposes.
   const { token } = await createSession(db, {
     userId: foundUser.id,
     userAgent,
     ipAddress,
+    scopes: [OAUTH_SCOPES.READER_FULL_ACCESS],
   });
 
   return { auth: token };
@@ -97,7 +102,18 @@ async function authenticateRequest(request: Request): Promise<SessionData | null
   const token = extractAuthToken(request);
   if (!token) return null;
 
-  return validateSession(token);
+  // Google Reader tokens are scoped sessions, so opt into scoped validation.
+  // Accept a session that is either full access (a browser session, NULL scopes)
+  // or explicitly granted reader:full-access; reject any other restricted scope.
+  const session = await validateSession(token, { allowScoped: true });
+  if (!session) return null;
+
+  const scopes = session.session.scopes;
+  if (scopes !== null && !scopes.includes(OAUTH_SCOPES.READER_FULL_ACCESS)) {
+    return null;
+  }
+
+  return session;
 }
 
 /**

--- a/src/server/oauth/utils.ts
+++ b/src/server/oauth/utils.ts
@@ -31,6 +31,14 @@ const AUTH_CODE_EXPIRY_SECONDS = 600;
 export const OAUTH_SCOPES = {
   MCP: "mcp",
   SAVED_WRITE: "saved:write",
+  /**
+   * Full read/write access to the reader surface: entries, subscriptions, tags,
+   * and saved articles — but NOT account settings, sessions, passwords, API
+   * tokens, or OAuth grant management. Granted to reader-style API clients (the
+   * Wallabag and Google Reader compatibility APIs) so a single scope covers
+   * everything those surfaces need without per-endpoint micro-management.
+   */
+  READER_FULL_ACCESS: "reader:full-access",
 } as const;
 
 export type OAuthScope = (typeof OAUTH_SCOPES)[keyof typeof OAUTH_SCOPES];
@@ -41,6 +49,7 @@ export type OAuthScope = (typeof OAUTH_SCOPES)[keyof typeof OAUTH_SCOPES];
 export const SCOPE_DESCRIPTIONS: Record<OAuthScope, string> = {
   mcp: "Read and manage your feeds and articles",
   "saved:write": "Save articles to your library",
+  "reader:full-access": "Read and manage your feeds, subscriptions, tags, and saved articles",
 };
 
 // ============================================================================

--- a/src/server/trpc/context.ts
+++ b/src/server/trpc/context.ts
@@ -144,6 +144,10 @@ export async function createContext(opts: FetchCreateContextFnOptions): Promise<
         id: apiTokenData.token.id,
         userId: apiTokenData.user.id,
         tokenHash: "",
+        // Token scope enforcement uses `scopes` on the context (below), not this
+        // synthetic session; session.scopes is the scoped-*session* concept,
+        // which doesn't apply to API tokens.
+        scopes: null,
         expiresAt: apiTokenData.token.expiresAt ?? new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
         revokedAt: null,
         createdAt: apiTokenData.token.createdAt,

--- a/src/server/wallabag/auth.ts
+++ b/src/server/wallabag/auth.ts
@@ -19,6 +19,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/server/db";
 import { users } from "@/server/db/schema";
 import { validateAccessToken, createTokens, rotateRefreshToken } from "@/server/oauth/service";
+import { OAUTH_SCOPES } from "@/server/oauth/utils";
 
 /**
  * Wallabag OAuth token response
@@ -61,11 +62,14 @@ export async function passwordGrant(
     return null;
   }
 
-  // Create OAuth tokens using existing infrastructure
+  // Create OAuth tokens using existing infrastructure. The Wallabag surface
+  // covers the full reader API (list/read/mutate/delete entries + tags), so it
+  // is granted reader:full-access rather than the narrow saved:write scope —
+  // and requireAuth enforces that scope on every endpoint (see below).
   const tokens = await createTokens({
     clientId,
     userId: foundUser.id,
-    scopes: ["saved:write"],
+    scopes: [OAUTH_SCOPES.READER_FULL_ACCESS],
   });
 
   return {
@@ -104,7 +108,7 @@ export async function refreshTokenGrant(
  */
 async function authenticateRequest(
   request: Request
-): Promise<{ userId: string; email: string } | null> {
+): Promise<{ userId: string; email: string; scopes: string[] } | null> {
   const authHeader = request.headers.get("authorization");
   if (!authHeader?.startsWith("Bearer ")) {
     return null;
@@ -119,13 +123,21 @@ async function authenticateRequest(
   return {
     userId: tokenData.userId,
     email: tokenData.user.email,
+    scopes: tokenData.scopes,
   };
 }
 
 /**
  * Validates a Wallabag API request and returns the user data.
  *
- * Returns a 401 `Response` if not authenticated — callers must forward it, e.g.
+ * Every Wallabag endpoint exposes the full reader surface (list/read/mutate/
+ * delete entries + tags), so all of them require the `reader:full-access`
+ * scope. A token that authenticates but lacks the scope (e.g. a `saved:write`
+ * save-only credential) is rejected with 403 — this is what prevents a narrow
+ * scope from being replayed for full library access.
+ *
+ * Returns a `Response` (401 unauthenticated / 403 insufficient scope) that
+ * callers must forward, e.g.
  * `const auth = await requireAuth(request); if (auth instanceof Response) return auth;`.
  * (We return rather than throw because Next.js App Router route handlers don't
  * convert a thrown `Response` into the HTTP response — it surfaces as a 500.)
@@ -143,5 +155,17 @@ export async function requireAuth(
       }
     );
   }
-  return auth;
+  if (!auth.scopes.includes(OAUTH_SCOPES.READER_FULL_ACCESS)) {
+    return new Response(
+      JSON.stringify({
+        error: "insufficient_scope",
+        error_description: `This endpoint requires the ${OAUTH_SCOPES.READER_FULL_ACCESS} scope`,
+      }),
+      {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+  return { userId: auth.userId, email: auth.email };
 }

--- a/tests/integration/entries-perf.test.ts
+++ b/tests/integration/entries-perf.test.ts
@@ -67,6 +67,7 @@ function createAuthContext(userId: string): Context {
         id: generateUuidv7(),
         userId,
         tokenHash: "test-hash",
+        scopes: null,
         userAgent: null,
         ipAddress: null,
         createdAt: now,

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -53,6 +53,7 @@ function createAuthContext(userId: string): Context {
         id: generateUuidv7(),
         userId,
         tokenHash: "test-hash",
+        scopes: null,
         userAgent: null,
         ipAddress: null,
         createdAt: now,

--- a/tests/integration/feed-redirect.test.ts
+++ b/tests/integration/feed-redirect.test.ts
@@ -59,6 +59,7 @@ function createAuthContext(userId: string): Context {
         id: generateUuidv7(),
         userId,
         tokenHash: "test-hash",
+        scopes: null,
         userAgent: null,
         ipAddress: null,
         createdAt: now,

--- a/tests/integration/feed-stats.test.ts
+++ b/tests/integration/feed-stats.test.ts
@@ -46,6 +46,7 @@ function createAuthContext(userId: string): Context {
         id: generateUuidv7(),
         userId,
         tokenHash: "test-hash",
+        scopes: null,
         userAgent: null,
         ipAddress: null,
         createdAt: now,

--- a/tests/integration/google-reader-auth.test.ts
+++ b/tests/integration/google-reader-auth.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Integration tests for Google Reader authentication + scoped sessions.
+ *
+ * ClientLogin mints a real session, so historically a Google Reader token was
+ * full browser access — a leaked token could be replayed as a session cookie to
+ * change the password or delete the account. Sessions now carry an optional
+ * scopes array: ClientLogin restricts its session to reader:full-access, and
+ * validateSession rejects scoped sessions for full-access use unless the caller
+ * opts in. Only the Google Reader API opts in.
+ *
+ * See issue #1022.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import * as argon2 from "argon2";
+import { inArray } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createSession, validateSession } from "../../src/server/auth/session";
+import { clientLogin, requireAuth } from "../../src/server/google-reader/auth";
+import { OAUTH_SCOPES } from "../../src/server/oauth/utils";
+
+const createdUserIds: string[] = [];
+const PASSWORD = "correct-horse-battery-staple";
+
+async function createTestUser(): Promise<{ id: string; email: string }> {
+  const id = generateUuidv7();
+  const email = `greader-${id}@test.com`;
+  await db.insert(users).values({
+    id,
+    email,
+    passwordHash: await argon2.hash(PASSWORD),
+    tosAgreedAt: new Date(),
+    privacyPolicyAgreedAt: new Date(),
+    notEuAgreedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  createdUserIds.push(id);
+  return { id, email };
+}
+
+function greaderRequest(token: string): Request {
+  return new Request("https://example.com/api/greader.php/reader/api/0/user-info", {
+    headers: { authorization: `GoogleLogin auth=${token}` },
+  });
+}
+
+afterAll(async () => {
+  if (createdUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+});
+
+describe("Google Reader ClientLogin mints a reader-scoped session", () => {
+  it("issues a token that requireAuth accepts", async () => {
+    const user = await createTestUser();
+    const login = await clientLogin(user.email, PASSWORD);
+    expect(login).not.toBeNull();
+    if (!login) throw new Error("unreachable");
+
+    const result = await requireAuth(greaderRequest(login.auth));
+    expect(result).not.toBeInstanceOf(Response);
+    if (result instanceof Response) throw new Error("unreachable");
+    expect(result.user.id).toBe(user.id);
+    expect(result.session.scopes).toEqual([OAUTH_SCOPES.READER_FULL_ACCESS]);
+  });
+
+  it("mints a session that is NOT usable as a full-access session", async () => {
+    const user = await createTestUser();
+    const login = await clientLogin(user.email, PASSWORD);
+    if (!login) throw new Error("unreachable");
+
+    // Default (full-access) validation rejects the scoped session — this is what
+    // stops a Google Reader token from being replayed as a browser session.
+    expect(await validateSession(login.auth)).toBeNull();
+
+    // Opt-in validation returns it, scoped.
+    const scoped = await validateSession(login.auth, { allowScoped: true });
+    expect(scoped?.session.scopes).toEqual([OAUTH_SCOPES.READER_FULL_ACCESS]);
+  });
+
+  it("returns null for a wrong password", async () => {
+    const user = await createTestUser();
+    expect(await clientLogin(user.email, "wrong-password")).toBeNull();
+  });
+});
+
+describe("Google Reader requireAuth session acceptance", () => {
+  it("accepts a full-access (unscoped) browser session", async () => {
+    const user = await createTestUser();
+    const { token } = await createSession(db, { userId: user.id });
+
+    const result = await requireAuth(greaderRequest(token));
+    expect(result).not.toBeInstanceOf(Response);
+    if (result instanceof Response) throw new Error("unreachable");
+    expect(result.user.id).toBe(user.id);
+  });
+
+  it("rejects a session scoped to something other than reader:full-access", async () => {
+    const user = await createTestUser();
+    const { token } = await createSession(db, {
+      userId: user.id,
+      scopes: [OAUTH_SCOPES.SAVED_WRITE],
+    });
+
+    const result = await requireAuth(greaderRequest(token));
+    expect(result).toBeInstanceOf(Response);
+    if (!(result instanceof Response)) throw new Error("unreachable");
+    expect(result.status).toBe(401);
+  });
+
+  it("returns 401 for a missing token", async () => {
+    const result = await requireAuth(
+      new Request("https://example.com/api/greader.php/reader/api/0/user-info")
+    );
+    expect(result).toBeInstanceOf(Response);
+    if (!(result instanceof Response)) throw new Error("unreachable");
+    expect(result.status).toBe(401);
+  });
+});

--- a/tests/integration/oauth-unlink.test.ts
+++ b/tests/integration/oauth-unlink.test.ts
@@ -55,6 +55,7 @@ function createAuthContext(userId: string): Context {
         id: generateUuidv7(),
         userId,
         tokenHash: "test-hash",
+        scopes: null,
         userAgent: null,
         ipAddress: null,
         createdAt: now,

--- a/tests/integration/opml-import.test.ts
+++ b/tests/integration/opml-import.test.ts
@@ -50,6 +50,7 @@ function createAuthContext(userId: string): Context {
         id: generateUuidv7(),
         userId,
         tokenHash: "test-hash",
+        scopes: null,
         userAgent: null,
         ipAddress: null,
         createdAt: now,

--- a/tests/integration/sanitized-entry-content.test.ts
+++ b/tests/integration/sanitized-entry-content.test.ts
@@ -34,6 +34,7 @@ function createAuthContext(userId: string): Context {
         id: generateUuidv7(),
         userId,
         tokenHash: "test-hash",
+        scopes: null,
         userAgent: null,
         ipAddress: null,
         createdAt: now,

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -53,6 +53,7 @@ function createAuthContext(userId: string): Context {
         id: generateUuidv7(),
         userId,
         tokenHash: "test-hash",
+        scopes: null,
         userAgent: null,
         ipAddress: null,
         createdAt: now,

--- a/tests/integration/subscriptions.test.ts
+++ b/tests/integration/subscriptions.test.ts
@@ -45,6 +45,7 @@ function createAuthContext(userId: string): Context {
         id: generateUuidv7(),
         userId,
         tokenHash: "test-hash",
+        scopes: null,
         userAgent: null,
         ipAddress: null,
         createdAt: now,

--- a/tests/integration/sync-events.test.ts
+++ b/tests/integration/sync-events.test.ts
@@ -47,6 +47,7 @@ function createAuthContext(userId: string): Context {
         id: generateUuidv7(),
         userId,
         tokenHash: "test-hash",
+        scopes: null,
         userAgent: null,
         ipAddress: null,
         createdAt: now,

--- a/tests/integration/tags.test.ts
+++ b/tests/integration/tags.test.ts
@@ -54,6 +54,7 @@ function createAuthContext(userId: string): Context {
         id: generateUuidv7(),
         userId,
         tokenHash: "test-hash",
+        scopes: null,
         userAgent: null,
         ipAddress: null,
         createdAt: now,

--- a/tests/integration/token-scopes.test.ts
+++ b/tests/integration/token-scopes.test.ts
@@ -44,6 +44,7 @@ function buildSession(userId: string): NonNullable<Context["session"]> {
       id: generateUuidv7(),
       userId,
       tokenHash: "test-hash",
+      scopes: null,
       userAgent: null,
       ipAddress: null,
       createdAt: now,

--- a/tests/integration/wallabag-auth.test.ts
+++ b/tests/integration/wallabag-auth.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Integration tests for Wallabag API authentication + scope enforcement.
+ *
+ * The Wallabag surface exposes the full reader API (list/read/mutate/delete
+ * entries + tags), so it mints and requires the `reader:full-access` OAuth
+ * scope. A token that authenticates but lacks that scope (e.g. a `saved:write`
+ * save-only credential, or an `mcp` token) must be rejected with 403 — this is
+ * what stops a narrow scope from being replayed for full library access.
+ *
+ * See issue #1022.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import * as argon2 from "argon2";
+import { inArray } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createTokens, validateAccessToken } from "../../src/server/oauth/service";
+import { requireAuth, passwordGrant } from "../../src/server/wallabag/auth";
+import { OAUTH_SCOPES } from "../../src/server/oauth/utils";
+
+const createdUserIds: string[] = [];
+
+async function createTestUser(password?: string): Promise<{ id: string; email: string }> {
+  const id = generateUuidv7();
+  const email = `wallabag-${id}@test.com`;
+  await db.insert(users).values({
+    id,
+    email,
+    passwordHash: password ? await argon2.hash(password) : "test-hash",
+    tosAgreedAt: new Date(),
+    privacyPolicyAgreedAt: new Date(),
+    notEuAgreedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  createdUserIds.push(id);
+  return { id, email };
+}
+
+async function mintToken(userId: string, scopes: string[]): Promise<string> {
+  const tokens = await createTokens({ clientId: "wallabag", userId, scopes });
+  return tokens.accessToken;
+}
+
+function bearerRequest(token: string | null): Request {
+  const headers: Record<string, string> = {};
+  if (token) headers.authorization = `Bearer ${token}`;
+  return new Request("https://example.com/api/wallabag/api/user", { headers });
+}
+
+afterAll(async () => {
+  if (createdUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+});
+
+describe("Wallabag requireAuth scope enforcement", () => {
+  it("accepts a reader:full-access token", async () => {
+    const user = await createTestUser();
+    const token = await mintToken(user.id, [OAUTH_SCOPES.READER_FULL_ACCESS]);
+
+    const result = await requireAuth(bearerRequest(token));
+
+    expect(result).not.toBeInstanceOf(Response);
+    if (result instanceof Response) throw new Error("unreachable");
+    expect(result.userId).toBe(user.id);
+    expect(result.email).toBe(user.email);
+  });
+
+  it("rejects a saved:write-only token with 403 insufficient_scope", async () => {
+    const user = await createTestUser();
+    const token = await mintToken(user.id, [OAUTH_SCOPES.SAVED_WRITE]);
+
+    const result = await requireAuth(bearerRequest(token));
+
+    expect(result).toBeInstanceOf(Response);
+    if (!(result instanceof Response)) throw new Error("unreachable");
+    expect(result.status).toBe(403);
+    expect(await result.json()).toMatchObject({ error: "insufficient_scope" });
+  });
+
+  it("rejects an mcp-scoped token with 403 (audience/scope confinement)", async () => {
+    const user = await createTestUser();
+    const token = await mintToken(user.id, [OAUTH_SCOPES.MCP]);
+
+    const result = await requireAuth(bearerRequest(token));
+
+    expect(result).toBeInstanceOf(Response);
+    if (!(result instanceof Response)) throw new Error("unreachable");
+    expect(result.status).toBe(403);
+  });
+
+  it("returns 401 for a missing token", async () => {
+    const result = await requireAuth(bearerRequest(null));
+    expect(result).toBeInstanceOf(Response);
+    if (!(result instanceof Response)) throw new Error("unreachable");
+    expect(result.status).toBe(401);
+  });
+
+  it("returns 401 for an invalid token", async () => {
+    const result = await requireAuth(bearerRequest("not-a-real-token"));
+    expect(result).toBeInstanceOf(Response);
+    if (!(result instanceof Response)) throw new Error("unreachable");
+    expect(result.status).toBe(401);
+  });
+});
+
+describe("Wallabag passwordGrant", () => {
+  it("mints a reader:full-access token that requireAuth accepts", async () => {
+    const password = "correct-horse-battery-staple";
+    const user = await createTestUser(password);
+
+    const grant = await passwordGrant(user.email, password, "wallabag");
+    expect(grant).not.toBeNull();
+    if (!grant) throw new Error("unreachable");
+
+    // The minted access token carries reader:full-access...
+    const tokenData = await validateAccessToken(grant.access_token);
+    expect(tokenData?.scopes).toContain(OAUTH_SCOPES.READER_FULL_ACCESS);
+
+    // ...and is accepted by requireAuth.
+    const result = await requireAuth(bearerRequest(grant.access_token));
+    expect(result).not.toBeInstanceOf(Response);
+  });
+
+  it("returns null for a wrong password", async () => {
+    const user = await createTestUser("the-right-password");
+    const grant = await passwordGrant(user.email, "the-wrong-password", "wallabag");
+    expect(grant).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1022. Follows up on #1018.

The Wallabag and Google Reader compat APIs both handed out over-broad credentials:

- **Wallabag** authenticated any OAuth token without checking scope, so a `saved:write` token (consented only for "save articles") could be replayed for full library read/mutate/delete.
- **Google Reader** `ClientLogin` minted a full browser session, so a leaked Google Reader token could be replayed as a session cookie to change the password or delete the account.

Both are fixed with one new broad scope. Two commits:

## Commit 1 — `reader:full-access` + Wallabag enforcement

Adds a `reader:full-access` OAuth scope covering the whole reader surface (entries, subscriptions, tags, saved articles — **not** account settings/sessions/passwords/tokens/OAuth grants). Wallabag's password grant mints it, and `requireAuth` **requires** it on every endpoint — a token that authenticates but lacks the scope gets `403 insufficient_scope`. A single broad scope also lets future reader-style clients reuse it without per-endpoint micro-management, and makes the existing single-entry/tag endpoints (which legitimately span the reader surface) honest. Kept OAuth/session-only for now (not an `API_TOKEN_SCOPES` value).

## Commit 2 — scoped Google Reader sessions

Adds a nullable `sessions.scopes` column (migration 0082). `NULL` = full access (every existing session; the fail-closed default). `ClientLogin` mints a session scoped to `reader:full-access`. `validateSession` gains `allowScoped` (default **false**): a scoped session is rejected for full-access use, so the main tRPC/REST context, the RSC caller, the SSE endpoint, and `/oauth/authorize` all reject a Google Reader token **automatically, with no code change** (fail closed). Only the Google Reader API opts in and then verifies the reader scope; it still accepts a full browser session.

## Why a broad scope (per discussion)

`saved:full-access` would have been too narrow — Wallabag's single-entry and tag endpoints span more than saved articles, and the goal is a reusable reader credential, not per-endpoint grants. `reader:full-access` is a sibling of `mcp`. OAuth tokens (short-lived + refresh) fit Wallabag; sessions (long-lived, no refresh) fit Google Reader clients — hence scoped sessions rather than switching Google Reader to OAuth tokens.

## Compatibility

- Migration is expand-safe (nullable column; old code never sets/reads it).
- Existing **Wallabag** OAuth tokens carry `saved:write` and will get `403` until the client re-runs the password grant (Wallabag clients store credentials and re-authenticate on failure; refresh preserves the old scope, so a re-login is required). Documented in the commit.
- Existing **Google Reader** sessions predate the column, so they stay full-access (`NULL`) until they expire or the client re-logs-in — we can't retroactively identify which sessions came from ClientLogin.

## Tests

New integration suites `tests/integration/wallabag-auth.test.ts` and `tests/integration/google-reader-auth.test.ts` cover scope minting, scope enforcement / `403`, fail-closed session rejection, and full-session acceptance. `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (2005), and `pnpm test:integration` (all) pass. HTTP-surface e2e coverage is tracked separately in #1021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)