### PR TITLE
Drop demo hero attr-escaping (trusted content cleanup)

### DIFF
--- a/src/app/demo/data.ts
+++ b/src/app/demo/data.ts
@@ -197,22 +197,18 @@ export function getDemoSubscription(subscriptionId: string): DemoSubscription | 
   return subscriptionsById.get(subscriptionId);
 }
 
-function escapeHtmlAttr(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
 /**
  * Build the hero <figure> for an article, or "" when it has no heroImage.
  * The reader (reader-prose) styles the <img> automatically (rounded + shadow).
+ *
+ * heroImage/heroImageAlt are trusted, hard-coded values from the article files
+ * (same trust level as the surrounding contentHtml, which is also emitted raw),
+ * so they're interpolated without escaping — keep alt text quote-free.
  */
 function heroFigureHtml(entry: DemoEntry): string {
   if (!entry.heroImage) return "";
   const alt = entry.heroImageAlt ?? `${entry.title ?? "Article"} illustration`;
-  return `<figure><img src="${escapeHtmlAttr(entry.heroImage)}" alt="${escapeHtmlAttr(alt)}" /></figure>\n`;
+  return `<figure><img src="${entry.heroImage}" alt="${alt}" /></figure>\n`;
 }
 
 /** Get EntryArticle props for a demo entry */


### PR DESCRIPTION
Follow-up cleanup to #1024 (code-review finding).

## What
The demo article hero `<figure>` is built in `getDemoEntryArticleProps` from `heroImage`/`heroImageAlt`. Those are **hard-coded literals in the article files**, rendered on the **trusted demo path** (the surrounding `contentHtml` is already emitted raw, unsanitized). The `escapeHtmlAttr` helper I added in #1024 was defense against a non-threat, and it introduced a **third copy** of the codebase's HTML-escape logic (alongside `src/server/http/html.ts` and `src/server/plugins/github.ts`).

Notably it couldn't even reuse the existing `escapeHtml` from `html.ts`: that module imports `linkedom`, and `data.ts` gets pulled into `"use client"` bundles (`DemoRouter`, etc.), so importing it would drag a DOM lib client-side.

## Change
Remove `escapeHtmlAttr` and interpolate the trusted values directly, with a comment to keep alt text quote-free.

- **No behavior change** — the one wired article's alt text has no special characters, so the emitted HTML is byte-identical.
- `pnpm typecheck` passes; no remaining references to the removed helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)