### PR TITLE
Add og:image:width/height to preview images

### DIFF
--- a/src/app/demo/articles/CLAUDE.md
+++ b/src/app/demo/articles/CLAUDE.md
@@ -90,6 +90,9 @@ optipng -quiet -o5 out.png    # ~1.6 MB -> ~90 KB
 ```
 
 - **1200×630** is the social/OG frame and is plenty sharp for the reading column too.
+  Keep this exact size: the `og:image:width`/`height` tags are emitted from the
+  `OG_IMAGE_WIDTH`/`OG_IMAGE_HEIGHT` constants in `src/lib/metadata.ts`, so a hero
+  at a different size would advertise wrong dimensions to crawlers.
 - **128 colors** is the sweet spot for this flat art (no banding on the outlines).
   Eyeball 64 if you want it smaller, but stay at 128 if 64 bands the outlines.
 - Put the final file in `public/demo/<article-id>.png`.

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,13 +1,23 @@
 import type { Metadata } from "next";
 
+/**
+ * All preview/OG images — the shared social card and every demo article hero —
+ * are generated at this fixed size (see src/app/demo/articles/CLAUDE.md).
+ * Emitting og:image:width/height lets crawlers reserve the card's space up front
+ * (no layout shift, and some clients require dimensions to render a large card).
+ */
+export const OG_IMAGE_WIDTH = 1200;
+export const OG_IMAGE_HEIGHT = 630;
+
 export const defaultOpenGraph: Metadata["openGraph"] = {
-  images: [{ url: "/social-preview.png" }],
+  images: [{ url: "/social-preview.png", width: OG_IMAGE_WIDTH, height: OG_IMAGE_HEIGHT }],
 };
 
 /**
  * Build openGraph metadata for a page, overriding the default social image when
  * an `image` is provided (e.g. a demo article's hero doubles as its OG image).
- * Relative URLs resolve against `metadataBase` (set in the root layout).
+ * Relative URLs resolve against `metadataBase` (set in the root layout). The
+ * image is assumed to be OG_IMAGE_WIDTH×OG_IMAGE_HEIGHT.
  */
 export function pageOpenGraph(
   title: string,
@@ -18,6 +28,6 @@ export function pageOpenGraph(
     ...defaultOpenGraph,
     title,
     description,
-    ...(image ? { images: [{ url: image }] } : {}),
+    ...(image ? { images: [{ url: image, width: OG_IMAGE_WIDTH, height: OG_IMAGE_HEIGHT }] } : {}),
   };
 }


### PR DESCRIPTION
## What
Emit `og:image:width` / `og:image:height` (1200×630) for preview/social images so crawlers can reserve the card's space up front — avoids layout shift, and some clients require dimensions before rendering a large summary card.

- Add `OG_IMAGE_WIDTH` / `OG_IMAGE_HEIGHT` constants in `src/lib/metadata.ts` and attach them to the image entry in both `defaultOpenGraph` (root layout + un-illustrated demo articles → `social-preview.png`) and `pageOpenGraph` (per-article heroes).
- Both existing images are exactly 1200×630 (verified `public/social-preview.png` and `public/demo/text-to-speech.png`), matching the documented demo-hero spec.
- Note the fixed-size dependency in `src/app/demo/articles/CLAUDE.md` so future heroes stay 1200×630.

## Verified
Curled the running dev server — both cases emit correctly:

- Article with hero → `og:image` `/demo/text-to-speech.png` + `og:image:width` 1200 + `og:image:height` 630
- Article without hero → fallback `/social-preview.png` + width 1200 + height 630

`pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)