### PR TITLE
Cleanly switch WebSub hubs + per-subscription callback URLs

### DIFF
--- a/src/app/api/webhooks/websub/[feedId]/[subscriptionId]/route.ts
+++ b/src/app/api/webhooks/websub/[feedId]/[subscriptionId]/route.ts
@@ -1,0 +1,137 @@
+/**
+ * WebSub Callback Endpoint (per-subscription)
+ *
+ * Handles WebSub (PubSubHubbub) callbacks from hubs:
+ * - GET: Verification challenges when subscribing/unsubscribing
+ * - POST: Content notifications when feeds are updated
+ *
+ * URL format: /api/webhooks/websub/:feedId/:subscriptionId
+ *
+ * Including the subscription ID makes each callback resolve to exactly one
+ * subscription row, so a feed with multiple subscription rows (e.g. after
+ * switching hubs) is never ambiguous. The legacy per-feed route ([feedId]) still
+ * serves subscriptions registered before this URL shape existed.
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "@/server/db";
+import { feeds } from "@/server/db/schema";
+import { handleVerificationChallenge, verifyHmacSignature } from "@/server/feed/websub";
+import { ingestWebsubNotification } from "@/server/feed/websub-notification";
+import { logger } from "@/lib/logger";
+import { isValidUuid } from "@/lib/uuidv7";
+
+/**
+ * Route segment config for Next.js
+ */
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/webhooks/websub/:feedId/:subscriptionId
+ *
+ * Handles WebSub verification challenges.
+ *
+ * Query parameters:
+ * - hub.mode: "subscribe" or "unsubscribe"
+ * - hub.topic: The feed URL (topic) we subscribed to
+ * - hub.challenge: A random string we must echo back
+ * - hub.lease_seconds: (optional) How long the subscription lasts
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ feedId: string; subscriptionId: string }> }
+): Promise<Response> {
+  const { feedId, subscriptionId } = await params;
+
+  if (!isValidUuid(feedId) || !isValidUuid(subscriptionId)) {
+    logger.warn("WebSub verification with invalid IDs", { feedId, subscriptionId });
+    return new Response("Invalid callback URL", { status: 400 });
+  }
+
+  const url = new URL(request.url);
+  const params_ = {
+    mode: url.searchParams.get("hub.mode"),
+    topic: url.searchParams.get("hub.topic"),
+    challenge: url.searchParams.get("hub.challenge"),
+    leaseSeconds: url.searchParams.get("hub.lease_seconds"),
+  };
+
+  logger.debug("WebSub verification request received", {
+    feedId,
+    subscriptionId,
+    mode: params_.mode,
+    topic: params_.topic,
+    challenge: params_.challenge ? "[present]" : "[missing]",
+    leaseSeconds: params_.leaseSeconds,
+  });
+
+  const result = await handleVerificationChallenge(feedId, subscriptionId, params_);
+
+  if (result.success && result.challenge) {
+    return new Response(result.challenge, {
+      status: 200,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+
+  logger.warn("WebSub verification failed", { feedId, subscriptionId, error: result.error });
+  return new Response(result.error || "Verification failed", {
+    status: 404,
+    headers: { "Content-Type": "text/plain" },
+  });
+}
+
+/**
+ * POST /api/webhooks/websub/:feedId/:subscriptionId
+ *
+ * Handles WebSub content notifications.
+ *
+ * Headers:
+ * - Content-Type: The feed format (application/rss+xml, application/atom+xml, etc.)
+ * - X-Hub-Signature: HMAC signature for verification (e.g., "sha256=abc123...")
+ *
+ * Body: The feed content (RSS/Atom/JSON)
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ feedId: string; subscriptionId: string }> }
+): Promise<Response> {
+  const { feedId, subscriptionId } = await params;
+
+  logger.info("WebSub notification received", {
+    feedId,
+    subscriptionId,
+    contentType: request.headers.get("content-type"),
+    hasSignature: !!request.headers.get("x-hub-signature"),
+  });
+
+  if (!isValidUuid(feedId) || !isValidUuid(subscriptionId)) {
+    logger.warn("WebSub notification with invalid IDs", { feedId, subscriptionId });
+    return new Response("Invalid callback URL", { status: 400 });
+  }
+
+  const bodyText = await request.text();
+
+  const signature = request.headers.get("x-hub-signature");
+  const isValid = await verifyHmacSignature(feedId, subscriptionId, signature, bodyText);
+
+  if (!isValid) {
+    logger.warn("WebSub notification with invalid signature", {
+      feedId,
+      subscriptionId,
+      signature: signature ? "[present]" : "[missing]",
+    });
+    return new Response("Invalid signature", { status: 403 });
+  }
+
+  const [feed] = await db.select().from(feeds).where(eq(feeds.id, feedId)).limit(1);
+  if (!feed) {
+    logger.warn("WebSub notification for unknown feed", { feedId, subscriptionId });
+    return new Response("Feed not found", { status: 404 });
+  }
+
+  await ingestWebsubNotification(feed, bodyText);
+
+  // Always return 200 to acknowledge receipt
+  return new Response("OK", { status: 200 });
+}

--- a/src/app/api/webhooks/websub/[feedId]/route.ts
+++ b/src/app/api/webhooks/websub/[feedId]/route.ts
@@ -1,22 +1,23 @@
 /**
- * WebSub Callback Endpoint
+ * Legacy WebSub Callback Endpoint (per-feed)
  *
- * Handles WebSub (PubSubHubbub) callbacks from hubs:
+ * Handles WebSub (PubSubHubbub) callbacks that were registered with the old
+ * per-feed callback URL, before per-subscription callback URLs were introduced:
  * - GET: Verification challenges when subscribing/unsubscribing
  * - POST: Content notifications when feeds are updated
  *
  * URL format: /api/webhooks/websub/:feedId
+ *
+ * New and renewed subscriptions register /api/webhooks/websub/:feedId/:subscriptionId
+ * (see the [subscriptionId] route). This route stays until every subscription has
+ * renewed onto the per-subscription URL, then it can be removed.
  */
 
 import { eq } from "drizzle-orm";
 import { db } from "@/server/db";
 import { feeds } from "@/server/db/schema";
-import { handleVerificationChallenge, verifyHmacSignature } from "@/server/feed/websub";
-import { parseFeedInWorker } from "@/server/worker-thread/pool";
-import { processEntries } from "@/server/feed/entry-processor";
-import { WEBSUB_BACKUP_POLL_INTERVAL_SECONDS } from "@/server/feed/scheduling";
-import { updateFeedJobNextRun } from "@/server/jobs/queue";
-import { trackWebsubNotificationReceived } from "@/server/metrics/metrics";
+import { handleVerificationChallengeByFeed, verifyHmacSignatureByFeed } from "@/server/feed/websub";
+import { ingestWebsubNotification } from "@/server/feed/websub-notification";
 import { logger } from "@/lib/logger";
 import { isValidUuid } from "@/lib/uuidv7";
 
@@ -28,15 +29,7 @@ export const dynamic = "force-dynamic";
 /**
  * GET /api/webhooks/websub/:feedId
  *
- * Handles WebSub verification challenges.
- * The hub sends a GET request with query parameters to verify
- * that we requested the subscription.
- *
- * Query parameters:
- * - hub.mode: "subscribe" or "unsubscribe"
- * - hub.topic: The feed URL (topic) we subscribed to
- * - hub.challenge: A random string we must echo back
- * - hub.lease_seconds: (optional) How long the subscription lasts
+ * Handles WebSub verification challenges for legacy per-feed subscriptions.
  */
 export async function GET(
   request: Request,
@@ -44,70 +37,47 @@ export async function GET(
 ): Promise<Response> {
   const { feedId } = await params;
 
-  // Validate feedId format
   if (!isValidUuid(feedId)) {
     logger.warn("WebSub verification with invalid feedId", { feedId });
     return new Response("Invalid feed ID", { status: 400 });
   }
 
-  // Extract query parameters
   const url = new URL(request.url);
-  const mode = url.searchParams.get("hub.mode");
-  const topic = url.searchParams.get("hub.topic");
-  const challenge = url.searchParams.get("hub.challenge");
-  const leaseSeconds = url.searchParams.get("hub.lease_seconds");
+  const params_ = {
+    mode: url.searchParams.get("hub.mode"),
+    topic: url.searchParams.get("hub.topic"),
+    challenge: url.searchParams.get("hub.challenge"),
+    leaseSeconds: url.searchParams.get("hub.lease_seconds"),
+  };
 
-  logger.debug("WebSub verification request received", {
+  logger.debug("WebSub verification request received (legacy per-feed)", {
     feedId,
-    mode,
-    topic,
-    challenge: challenge ? "[present]" : "[missing]",
-    leaseSeconds,
+    mode: params_.mode,
+    topic: params_.topic,
+    challenge: params_.challenge ? "[present]" : "[missing]",
+    leaseSeconds: params_.leaseSeconds,
   });
 
-  // Handle the verification
-  const result = await handleVerificationChallenge(feedId, {
-    mode,
-    topic,
-    challenge,
-    leaseSeconds,
-  });
+  const result = await handleVerificationChallengeByFeed(feedId, params_);
 
   if (result.success && result.challenge) {
-    // Return the challenge to confirm the subscription
     return new Response(result.challenge, {
       status: 200,
-      headers: {
-        "Content-Type": "text/plain",
-      },
+      headers: { "Content-Type": "text/plain" },
     });
   }
 
-  // Verification failed - return 404 to reject the subscription
-  logger.warn("WebSub verification failed", {
-    feedId,
-    error: result.error,
-  });
-
+  logger.warn("WebSub verification failed", { feedId, error: result.error });
   return new Response(result.error || "Verification failed", {
     status: 404,
-    headers: {
-      "Content-Type": "text/plain",
-    },
+    headers: { "Content-Type": "text/plain" },
   });
 }
 
 /**
  * POST /api/webhooks/websub/:feedId
  *
- * Handles WebSub content notifications.
- * The hub sends a POST request with the feed content when it's updated.
- *
- * Headers:
- * - Content-Type: The feed format (application/rss+xml, application/atom+xml, etc.)
- * - X-Hub-Signature: HMAC signature for verification (e.g., "sha256=abc123...")
- *
- * Body: The feed content (RSS/Atom/JSON)
+ * Handles WebSub content notifications for legacy per-feed subscriptions.
  */
 export async function POST(
   request: Request,
@@ -115,24 +85,21 @@ export async function POST(
 ): Promise<Response> {
   const { feedId } = await params;
 
-  logger.info("WebSub notification received", {
+  logger.info("WebSub notification received (legacy per-feed)", {
     feedId,
     contentType: request.headers.get("content-type"),
     hasSignature: !!request.headers.get("x-hub-signature"),
   });
 
-  // Validate feedId format
   if (!isValidUuid(feedId)) {
     logger.warn("WebSub notification with invalid feedId", { feedId });
     return new Response("Invalid feed ID", { status: 400 });
   }
 
-  // Get the raw body for signature verification
   const bodyText = await request.text();
 
-  // Verify HMAC signature
   const signature = request.headers.get("x-hub-signature");
-  const isValid = await verifyHmacSignature(feedId, signature, bodyText);
+  const isValid = await verifyHmacSignatureByFeed(feedId, signature, bodyText);
 
   if (!isValid) {
     logger.warn("WebSub notification with invalid signature", {
@@ -142,100 +109,14 @@ export async function POST(
     return new Response("Invalid signature", { status: 403 });
   }
 
-  // Check if feed exists
   const [feed] = await db.select().from(feeds).where(eq(feeds.id, feedId)).limit(1);
-
   if (!feed) {
     logger.warn("WebSub notification for unknown feed", { feedId });
     return new Response("Feed not found", { status: 404 });
   }
 
-  // Track WebSub notification received metric
-  trackWebsubNotificationReceived();
-
-  // Parse the pushed feed content
-  let parsedFeed;
-  try {
-    parsedFeed = await parseFeedInWorker(bodyText);
-  } catch (error) {
-    logger.warn("WebSub notification with invalid feed content", {
-      feedId,
-      error: error instanceof Error ? error.message : "Unknown error",
-    });
-    // Return 200 to avoid the hub retrying with bad content
-    return new Response("OK", { status: 200 });
-  }
-
-  // Process entries from the pushed content
-  const now = new Date();
-  try {
-    const result = await processEntries(feedId, feed.type, parsedFeed, {
-      fetchedAt: now,
-      feedUrl: feed.url ?? undefined,
-      // Matches the feeds.title update below so new_entry events carry the
-      // same title a later entries.list refetch would return.
-      feedTitle: parsedFeed.title || feed.title,
-    });
-
-    // Update feed timestamps
-    await db
-      .update(feeds)
-      .set({
-        lastFetchedAt: now,
-        updatedAt: now,
-        // Update metadata if available
-        title: parsedFeed.title || feed.title,
-        description: parsedFeed.description || feed.description,
-        siteUrl: parsedFeed.siteUrl || feed.siteUrl,
-      })
-      .where(eq(feeds.id, feedId));
-
-    logger.info("WebSub notification processed", {
-      feedId,
-      newEntries: result.newCount,
-      updatedEntries: result.updatedCount,
-      unchangedEntries: result.unchangedCount,
-    });
-
-    // Schedule backup polling with a longer interval since WebSub is active.
-    // This ensures we still get updates even if WebSub stops working.
-    await scheduleBackupPoll(feedId);
-  } catch (error) {
-    logger.error("WebSub notification processing failed", {
-      feedId,
-      error: error instanceof Error ? error.message : "Unknown error",
-    });
-    // Return 200 to acknowledge receipt even if processing failed
-    // The hub doesn't need to retry - we have the content
-
-    // Still schedule backup polling in case of errors
-    await scheduleBackupPoll(feedId);
-  }
+  await ingestWebsubNotification(feed, bodyText);
 
   // Always return 200 to acknowledge receipt
   return new Response("OK", { status: 200 });
-}
-
-/**
- * Schedules a backup polling job for a feed.
- * Uses a longer interval than normal since WebSub is active.
- * Updates the existing job's next_run_at rather than creating a new job.
- */
-async function scheduleBackupPoll(feedId: string): Promise<void> {
-  const nextRunAt = new Date(Date.now() + WEBSUB_BACKUP_POLL_INTERVAL_SECONDS * 1000);
-
-  try {
-    await updateFeedJobNextRun(feedId, nextRunAt);
-
-    logger.debug("Scheduled WebSub backup poll", {
-      feedId,
-      nextRunAt: nextRunAt.toISOString(),
-    });
-  } catch (error) {
-    // Don't let scheduling errors affect the response
-    logger.warn("Failed to schedule WebSub backup poll", {
-      feedId,
-      error: error instanceof Error ? error.message : "Unknown error",
-    });
-  }
 }

--- a/src/server/feed/websub-notification.ts
+++ b/src/server/feed/websub-notification.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared processing for WebSub content notifications (the POST body a hub pushes
+ * when a feed updates). Used by both the per-subscription callback route and the
+ * legacy per-feed callback route so the ingest path stays in one place.
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { feeds, type Feed } from "../db/schema";
+import { parseFeedInWorker } from "../worker-thread/pool";
+import { processEntries } from "./entry-processor";
+import { WEBSUB_BACKUP_POLL_INTERVAL_SECONDS } from "./scheduling";
+import { updateFeedJobNextRun } from "../jobs/queue";
+import { trackWebsubNotificationReceived } from "../metrics/metrics";
+import { logger } from "@/lib/logger";
+
+/**
+ * Schedules a backup polling job for a feed after a WebSub notification.
+ * Uses a longer interval than normal since WebSub is active, so we still get
+ * updates if WebSub stops working. Updates the existing job's next_run_at.
+ */
+async function scheduleBackupPoll(feedId: string): Promise<void> {
+  const nextRunAt = new Date(Date.now() + WEBSUB_BACKUP_POLL_INTERVAL_SECONDS * 1000);
+
+  try {
+    await updateFeedJobNextRun(feedId, nextRunAt);
+    logger.debug("Scheduled WebSub backup poll", {
+      feedId,
+      nextRunAt: nextRunAt.toISOString(),
+    });
+  } catch (error) {
+    // Don't let scheduling errors affect the response
+    logger.warn("Failed to schedule WebSub backup poll", {
+      feedId,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+}
+
+/**
+ * Parses a pushed WebSub notification body and processes its entries into the
+ * given feed, then schedules a backup poll. Best-effort: never throws, so the
+ * route can always acknowledge the hub with 200 (a retry wouldn't help — we
+ * already have the content, or it was unparseable).
+ *
+ * The caller is responsible for authenticating the notification (HMAC) and
+ * loading the feed before calling this.
+ */
+export async function ingestWebsubNotification(feed: Feed, bodyText: string): Promise<void> {
+  const feedId = feed.id;
+  trackWebsubNotificationReceived();
+
+  // Parse the pushed feed content
+  let parsedFeed;
+  try {
+    parsedFeed = await parseFeedInWorker(bodyText);
+  } catch (error) {
+    logger.warn("WebSub notification with invalid feed content", {
+      feedId,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    // Nothing to process; don't schedule a backup poll off garbage content.
+    return;
+  }
+
+  const now = new Date();
+  try {
+    const result = await processEntries(feedId, feed.type, parsedFeed, {
+      fetchedAt: now,
+      feedUrl: feed.url ?? undefined,
+      // Matches the feeds.title update below so new_entry events carry the
+      // same title a later entries.list refetch would return.
+      feedTitle: parsedFeed.title || feed.title,
+    });
+
+    // Update feed timestamps and any refreshed metadata
+    await db
+      .update(feeds)
+      .set({
+        lastFetchedAt: now,
+        updatedAt: now,
+        title: parsedFeed.title || feed.title,
+        description: parsedFeed.description || feed.description,
+        siteUrl: parsedFeed.siteUrl || feed.siteUrl,
+      })
+      .where(eq(feeds.id, feedId));
+
+    logger.info("WebSub notification processed", {
+      feedId,
+      newEntries: result.newCount,
+      updatedEntries: result.updatedCount,
+      unchangedEntries: result.unchangedCount,
+    });
+  } catch (error) {
+    logger.error("WebSub notification processing failed", {
+      feedId,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    // Fall through to schedule the backup poll so the feed still refreshes.
+  }
+
+  await scheduleBackupPoll(feedId);
+}

--- a/src/server/feed/websub.ts
+++ b/src/server/feed/websub.ts
@@ -216,15 +216,21 @@ function getWebsubCallbackBaseUrl(): string | null {
 /**
  * Generates a WebSub callback URL for a specific feed.
  *
+ * The subscription ID is part of the path so a hub's verification/notification
+ * callbacks map to exactly one subscription row. Without it (the old per-feed
+ * URL), a feed that switched hubs — leaving an old and a new subscription row —
+ * produced callbacks that were ambiguous by feed alone.
+ *
  * @param feedId - The feed ID
+ * @param subscriptionId - The WebSub subscription ID
  * @returns The callback URL or null if WebSub is not available
  */
-function generateCallbackUrl(feedId: string): string | null {
+function generateCallbackUrl(feedId: string, subscriptionId: string): string | null {
   const baseUrl = getWebsubCallbackBaseUrl();
   if (!baseUrl) {
     return null;
   }
-  return `${baseUrl}/api/webhooks/websub/${feedId}`;
+  return `${baseUrl}/api/webhooks/websub/${feedId}/${subscriptionId}`;
 }
 
 /**
@@ -275,11 +281,6 @@ export async function subscribeToHub(feed: Feed): Promise<SubscribeToHubResult> 
     return { success: false, error: "WebSub is not available (no public callback URL)" };
   }
 
-  const callbackUrl = generateCallbackUrl(feed.id);
-  if (!callbackUrl) {
-    return { success: false, error: "Could not generate callback URL" };
-  }
-
   // Use selfUrl as topic if available, otherwise fall back to feed URL
   const topicUrl = feed.selfUrl || feed.url;
   if (!topicUrl) {
@@ -288,7 +289,9 @@ export async function subscribeToHub(feed: Feed): Promise<SubscribeToHubResult> 
 
   const secret = generateCallbackSecret();
 
-  // Check if subscription already exists for this feed + hub combination
+  // Check if subscription already exists for this feed + hub combination.
+  // Reusing the row keeps the subscription ID (and thus the callback URL) stable
+  // across renewals; a hub switch goes through deactivate + a fresh row instead.
   const existing = await db
     .select()
     .from(websubSubscriptions)
@@ -297,11 +300,17 @@ export async function subscribeToHub(feed: Feed): Promise<SubscribeToHubResult> 
     )
     .limit(1);
 
-  let subscriptionId: string;
+  // The subscription ID must be known before building the callback URL, since it
+  // is part of the path.
+  const subscriptionId = existing.length > 0 ? existing[0].id : generateUuidv7();
+
+  const callbackUrl = generateCallbackUrl(feed.id, subscriptionId);
+  if (!callbackUrl) {
+    return { success: false, error: "Could not generate callback URL" };
+  }
 
   if (existing.length > 0) {
     // Update existing subscription with new secret
-    subscriptionId = existing[0].id;
     await db
       .update(websubSubscriptions)
       .set({
@@ -320,7 +329,6 @@ export async function subscribeToHub(feed: Feed): Promise<SubscribeToHubResult> 
     });
   } else {
     // Create new pending subscription
-    subscriptionId = generateUuidv7();
     await db.insert(websubSubscriptions).values({
       id: subscriptionId,
       feedId: feed.id,
@@ -429,40 +437,26 @@ export interface VerificationResult {
 }
 
 /**
- * Handles a WebSub verification callback from a hub.
- *
- * The hub sends a GET request with query parameters to verify
- * that we want to receive notifications.
- *
- * @param feedId - The feed ID from the callback URL
- * @param params - Query parameters from the hub
- * @returns Verification result with challenge or error
- *
- * @example
- * // In your API route handler:
- * const result = await handleVerificationChallenge(feedId, {
- *   mode: searchParams.get("hub.mode"),
- *   topic: searchParams.get("hub.topic"),
- *   challenge: searchParams.get("hub.challenge"),
- *   leaseSeconds: searchParams.get("hub.lease_seconds"),
- * });
- *
- * if (result.success) {
- *   return new Response(result.challenge, { status: 200 });
- * } else {
- *   return new Response(result.error, { status: 404 });
- * }
+ * Query parameters a hub sends on a verification callback.
  */
-export async function handleVerificationChallenge(
-  feedId: string,
-  params: {
-    mode: string | null;
-    topic: string | null;
-    challenge: string | null;
-    leaseSeconds: string | null;
-  }
+export interface VerificationParams {
+  mode: string | null;
+  topic: string | null;
+  challenge: string | null;
+  leaseSeconds: string | null;
+}
+
+/**
+ * Applies a verification callback to an already-resolved subscription row:
+ * validates the params + topic, then activates (subscribe) or confirms teardown
+ * (unsubscribe). Shared by the per-subscription and legacy per-feed entry points.
+ */
+async function applyVerificationChallenge(
+  subscription: WebsubSubscription,
+  params: VerificationParams
 ): Promise<VerificationResult> {
   const { mode, topic, challenge, leaseSeconds } = params;
+  const feedId = subscription.feedId;
 
   // Validate required parameters
   if (!mode || !topic || !challenge) {
@@ -471,21 +465,6 @@ export async function handleVerificationChallenge(
 
   if (mode !== "subscribe" && mode !== "unsubscribe") {
     return { success: false, error: `Unsupported mode: ${mode}` };
-  }
-
-  // Find the subscription for this feed. A hub switch leaves the old (now
-  // unsubscribed) row alongside the new pending one, so order by newest first:
-  // a verification always concerns the most recent subscription attempt.
-  const [subscription] = await db
-    .select()
-    .from(websubSubscriptions)
-    .where(eq(websubSubscriptions.feedId, feedId))
-    .orderBy(desc(websubSubscriptions.createdAt))
-    .limit(1);
-
-  if (!subscription) {
-    logger.warn("WebSub verification for unknown subscription", { feedId, topic });
-    return { success: false, error: "Subscription not found" };
   }
 
   // Verify the topic matches what we subscribed to
@@ -539,6 +518,73 @@ export async function handleVerificationChallenge(
 }
 
 /**
+ * Handles a WebSub verification callback for a specific subscription.
+ *
+ * This is the primary entry point: the callback URL carries both the feed ID and
+ * the subscription ID (`/api/webhooks/websub/:feedId/:subscriptionId`), so the
+ * callback resolves to exactly one subscription row — no ambiguity when a feed
+ * has multiple subscription rows (e.g. after switching hubs).
+ *
+ * @param feedId - The feed ID from the callback URL
+ * @param subscriptionId - The subscription ID from the callback URL
+ * @param params - Query parameters from the hub
+ * @returns Verification result with challenge or error
+ */
+export async function handleVerificationChallenge(
+  feedId: string,
+  subscriptionId: string,
+  params: VerificationParams
+): Promise<VerificationResult> {
+  const [subscription] = await db
+    .select()
+    .from(websubSubscriptions)
+    .where(and(eq(websubSubscriptions.id, subscriptionId), eq(websubSubscriptions.feedId, feedId)))
+    .limit(1);
+
+  if (!subscription) {
+    logger.warn("WebSub verification for unknown subscription", {
+      feedId,
+      subscriptionId,
+      topic: params.topic,
+    });
+    return { success: false, error: "Subscription not found" };
+  }
+
+  return applyVerificationChallenge(subscription, params);
+}
+
+/**
+ * Handles a WebSub verification callback that arrived at the legacy per-feed
+ * callback URL (`/api/webhooks/websub/:feedId`), used by subscriptions registered
+ * before per-subscription callback URLs. Resolves the subscription by feed,
+ * preferring the newest row since a hub switch can leave more than one.
+ *
+ * Transitional: once all subscriptions have renewed onto per-subscription URLs,
+ * this and the legacy route can be removed.
+ */
+export async function handleVerificationChallengeByFeed(
+  feedId: string,
+  params: VerificationParams
+): Promise<VerificationResult> {
+  const [subscription] = await db
+    .select()
+    .from(websubSubscriptions)
+    .where(eq(websubSubscriptions.feedId, feedId))
+    .orderBy(desc(websubSubscriptions.createdAt))
+    .limit(1);
+
+  if (!subscription) {
+    logger.warn("WebSub verification for unknown subscription", {
+      feedId,
+      topic: params.topic,
+    });
+    return { success: false, error: "Subscription not found" };
+  }
+
+  return applyVerificationChallenge(subscription, params);
+}
+
+/**
  * Handles an unsubscribe verification callback from a hub.
  *
  * Per W3C WebSub spec Section 5.3, we only confirm unsubscribes that we
@@ -589,45 +635,15 @@ async function handleUnsubscribeVerification(
 }
 
 /**
- * Verifies the HMAC signature of a WebSub content notification.
- *
- * The hub signs the request body using the shared secret with HMAC-SHA256
- * (or other algorithms) and includes the signature in the X-Hub-Signature header.
- *
- * @param feedId - The feed ID from the callback URL
- * @param signature - The X-Hub-Signature header value (e.g., "sha256=abc123...")
- * @param body - The raw request body as a Buffer or string
- * @returns true if the signature is valid, false otherwise
- *
- * @example
- * const signatureHeader = req.headers.get("x-hub-signature");
- * const body = await req.text();
- *
- * if (!verifyHmacSignature(feedId, signatureHeader, body)) {
- *   return new Response("Invalid signature", { status: 403 });
- * }
+ * Computes whether an X-Hub-Signature matches a body under a subscription's
+ * shared secret. Shared by the per-subscription and legacy per-feed entry points.
  */
-export async function verifyHmacSignature(
-  feedId: string,
-  signature: string | null,
+function computeSignatureValid(
+  subscription: WebsubSubscription,
+  signature: string,
   body: Buffer | string
-): Promise<boolean> {
-  if (!signature) {
-    logger.warn("WebSub notification missing signature", { feedId });
-    return false;
-  }
-
-  // Find the subscription
-  const [subscription] = await db
-    .select()
-    .from(websubSubscriptions)
-    .where(and(eq(websubSubscriptions.feedId, feedId), eq(websubSubscriptions.state, "active")))
-    .limit(1);
-
-  if (!subscription) {
-    logger.warn("WebSub notification for unknown/inactive subscription", { feedId });
-    return false;
-  }
+): boolean {
+  const feedId = subscription.feedId;
 
   // Parse signature format: "algorithm=hex_digest"
   const [algorithm, expectedDigest] = signature.split("=");
@@ -658,6 +674,84 @@ export async function verifyHmacSignature(
     });
     return false;
   }
+}
+
+/**
+ * Verifies the HMAC signature of a WebSub content notification for a specific
+ * subscription (primary entry point; callback carries feed + subscription IDs).
+ *
+ * The hub signs the request body using the shared secret with HMAC-SHA256
+ * (or other algorithms) and includes the signature in the X-Hub-Signature header.
+ *
+ * @param feedId - The feed ID from the callback URL
+ * @param subscriptionId - The subscription ID from the callback URL
+ * @param signature - The X-Hub-Signature header value (e.g., "sha256=abc123...")
+ * @param body - The raw request body as a Buffer or string
+ * @returns true if the signature is valid, false otherwise
+ */
+export async function verifyHmacSignature(
+  feedId: string,
+  subscriptionId: string,
+  signature: string | null,
+  body: Buffer | string
+): Promise<boolean> {
+  if (!signature) {
+    logger.warn("WebSub notification missing signature", { feedId, subscriptionId });
+    return false;
+  }
+
+  const [subscription] = await db
+    .select()
+    .from(websubSubscriptions)
+    .where(
+      and(
+        eq(websubSubscriptions.id, subscriptionId),
+        eq(websubSubscriptions.feedId, feedId),
+        eq(websubSubscriptions.state, "active")
+      )
+    )
+    .limit(1);
+
+  if (!subscription) {
+    logger.warn("WebSub notification for unknown/inactive subscription", {
+      feedId,
+      subscriptionId,
+    });
+    return false;
+  }
+
+  return computeSignatureValid(subscription, signature, body);
+}
+
+/**
+ * Verifies the HMAC signature of a WebSub content notification that arrived at
+ * the legacy per-feed callback URL. Resolves the active subscription by feed.
+ *
+ * Transitional: removable once all subscriptions have migrated to
+ * per-subscription callback URLs.
+ */
+export async function verifyHmacSignatureByFeed(
+  feedId: string,
+  signature: string | null,
+  body: Buffer | string
+): Promise<boolean> {
+  if (!signature) {
+    logger.warn("WebSub notification missing signature", { feedId });
+    return false;
+  }
+
+  const [subscription] = await db
+    .select()
+    .from(websubSubscriptions)
+    .where(and(eq(websubSubscriptions.feedId, feedId), eq(websubSubscriptions.state, "active")))
+    .limit(1);
+
+  if (!subscription) {
+    logger.warn("WebSub notification for unknown/inactive subscription", { feedId });
+    return false;
+  }
+
+  return computeSignatureValid(subscription, signature, body);
 }
 
 /**

--- a/src/server/feed/websub.ts
+++ b/src/server/feed/websub.ts
@@ -8,7 +8,7 @@
  */
 
 import { randomBytes, createHmac, timingSafeEqual } from "crypto";
-import { eq, and, lt } from "drizzle-orm";
+import { eq, and, lt, desc } from "drizzle-orm";
 import { fetchWithSsrfProtection } from "../http/ssrf";
 import { readResponseBufferWithSizeLimit } from "../http/fetch";
 import { db } from "../db";
@@ -140,6 +140,62 @@ export function canUseWebSub(): boolean {
     // Invalid URL
     return false;
   }
+}
+
+/**
+ * The action a feed fetch should take on the feed's WebSub subscription, based
+ * on how the feed's advertised hub URL changed since the last fetch.
+ *
+ * - `subscribe` - feed advertises a hub and we're not subscribed yet
+ * - `resubscribe` - feed advertises a *different* hub than the one we're
+ *   subscribed to (publisher switched hubs); tear down the old subscription and
+ *   subscribe to the new hub
+ * - `deactivate` - feed no longer advertises a hub; drop back to polling
+ * - `none` - nothing to do (no hub, WebSub unavailable, or already subscribed to
+ *   the same hub — lease renewal is handled separately)
+ */
+export type WebsubAction = "subscribe" | "resubscribe" | "deactivate" | "none";
+
+/**
+ * Decides what to do with a feed's WebSub subscription given the hub URL seen in
+ * the latest fetch versus the previously stored state. Pure function so the
+ * decision can be unit-tested without a DB or HTTP.
+ *
+ * The `resubscribe` case is the one that keeps a publisher's hub switch from
+ * silently breaking push: without it, a feed that changes its `rel="hub"` while
+ * `websubActive` is already true would keep a dangling subscription pointed at
+ * the old (often dead) hub and never subscribe to the new one until the lease
+ * happened to expire.
+ */
+export function resolveWebsubAction(params: {
+  /** Hub URL stored on the feed before this fetch. */
+  previousHubUrl: string | null;
+  /** Whether the feed was already actively subscribed via WebSub. */
+  previousWebsubActive: boolean;
+  /** Hub URL advertised in the current fetch (null if none). */
+  newHubUrl: string | null;
+  /** Whether WebSub is usable at all (public callback URL configured). */
+  canUseWebSub: boolean;
+}): WebsubAction {
+  const { previousHubUrl, previousWebsubActive, newHubUrl, canUseWebSub } = params;
+
+  // Feed advertises no hub - tear down any active subscription, else nothing.
+  if (!newHubUrl) {
+    return previousWebsubActive ? "deactivate" : "none";
+  }
+
+  // Feed has a hub but we can't receive callbacks - stay on polling.
+  if (!canUseWebSub) {
+    return "none";
+  }
+
+  // Not subscribed yet - subscribe fresh.
+  if (!previousWebsubActive) {
+    return "subscribe";
+  }
+
+  // Already active: only act if the publisher switched to a different hub.
+  return previousHubUrl !== newHubUrl ? "resubscribe" : "none";
 }
 
 /**
@@ -417,11 +473,14 @@ export async function handleVerificationChallenge(
     return { success: false, error: `Unsupported mode: ${mode}` };
   }
 
-  // Find the subscription for this feed
+  // Find the subscription for this feed. A hub switch leaves the old (now
+  // unsubscribed) row alongside the new pending one, so order by newest first:
+  // a verification always concerns the most recent subscription attempt.
   const [subscription] = await db
     .select()
     .from(websubSubscriptions)
     .where(eq(websubSubscriptions.feedId, feedId))
+    .orderBy(desc(websubSubscriptions.createdAt))
     .limit(1);
 
   if (!subscription) {

--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -32,6 +32,7 @@ import {
   canUseWebSub,
   subscribeToHub,
   deactivateWebsub,
+  resolveWebsubAction,
 } from "../feed/websub";
 import { getDomainFromUrl } from "../feed/types";
 import type { ParsedCacheHeaders } from "../feed/cache-headers";
@@ -469,8 +470,27 @@ async function processSuccessfulFetch(
   // Handle WebSub subscription changes
   const websubMetadata: Record<string, unknown> = {};
 
-  if (newHubUrl && !feed.websubActive && canUseWebSub()) {
-    // Feed has a hub URL but WebSub isn't active - try to subscribe
+  const websubAction = resolveWebsubAction({
+    previousHubUrl: feed.hubUrl,
+    previousWebsubActive: feed.websubActive ?? false,
+    newHubUrl,
+    canUseWebSub: canUseWebSub(),
+  });
+
+  if (websubAction === "subscribe" || websubAction === "resubscribe") {
+    // On a hub switch, tear down the stale subscription to the old hub first so
+    // we don't leave a dangling active row pointed at a hub that will never
+    // deliver again. deactivateWebsub also clears websubActive, so it stays
+    // false until the new hub verifies our subscription.
+    if (websubAction === "resubscribe") {
+      await deactivateWebsub(feed.id);
+      websubMetadata.websubHubChanged = true;
+      logger.info("WebSub hub URL changed - resubscribing to new hub", {
+        feedId: feed.id,
+        previousHubUrl: feed.hubUrl,
+        newHubUrl,
+      });
+    }
     const updatedFeed: Feed = {
       ...feed,
       hubUrl: newHubUrl,
@@ -491,7 +511,7 @@ async function processSuccessfulFetch(
         error: subscribeResult.error,
       });
     }
-  } else if (!newHubUrl && feed.websubActive) {
+  } else if (websubAction === "deactivate") {
     // Feed had WebSub active but hub URL is now gone - deactivate
     await deactivateWebsub(feed.id);
     websubMetadata.websubDeactivated = true;

--- a/tests/integration/websub.test.ts
+++ b/tests/integration/websub.test.ts
@@ -17,7 +17,9 @@ import { generateUuidv7 } from "../../src/lib/uuidv7";
 import {
   generateCallbackSecret,
   handleVerificationChallenge,
+  handleVerificationChallengeByFeed,
   verifyHmacSignature,
+  verifyHmacSignatureByFeed,
 } from "../../src/server/feed/websub";
 
 // Sample RSS feed content for testing content notifications
@@ -103,12 +105,15 @@ describe("WebSub Integration", () => {
     });
   });
 
-  describe("handleVerificationChallenge", () => {
+  // Core verification behavior, exercised through the legacy per-feed entry point
+  // (handleVerificationChallengeByFeed). The per-subscription entry point shares
+  // the same core and is covered separately below.
+  describe("handleVerificationChallengeByFeed (legacy per-feed)", () => {
     it("returns error when required parameters are missing", async () => {
       const feed = await createTestFeed();
       await createTestSubscription(feed.id, { topicUrl: feed.url ?? "" });
 
-      const result = await handleVerificationChallenge(feed.id, {
+      const result = await handleVerificationChallengeByFeed(feed.id, {
         mode: null,
         topic: null,
         challenge: null,
@@ -123,7 +128,7 @@ describe("WebSub Integration", () => {
       const feed = await createTestFeed();
       await createTestSubscription(feed.id, { topicUrl: feed.url ?? "" });
 
-      const result = await handleVerificationChallenge(feed.id, {
+      const result = await handleVerificationChallengeByFeed(feed.id, {
         mode: "invalid",
         topic: feed.url ?? "",
         challenge: "test-challenge-123",
@@ -137,7 +142,7 @@ describe("WebSub Integration", () => {
     it("returns error when subscription not found", async () => {
       const nonExistentId = generateUuidv7();
 
-      const result = await handleVerificationChallenge(nonExistentId, {
+      const result = await handleVerificationChallengeByFeed(nonExistentId, {
         mode: "subscribe",
         topic: "https://example.com/feed.xml",
         challenge: "test-challenge-123",
@@ -152,7 +157,7 @@ describe("WebSub Integration", () => {
       const feed = await createTestFeed();
       await createTestSubscription(feed.id, { topicUrl: "https://example.com/correct-feed.xml" });
 
-      const result = await handleVerificationChallenge(feed.id, {
+      const result = await handleVerificationChallengeByFeed(feed.id, {
         mode: "subscribe",
         topic: "https://example.com/wrong-feed.xml",
         challenge: "test-challenge-123",
@@ -169,7 +174,7 @@ describe("WebSub Integration", () => {
       await createTestSubscription(feed.id, { topicUrl });
 
       const challenge = "random-challenge-string-456";
-      const result = await handleVerificationChallenge(feed.id, {
+      const result = await handleVerificationChallengeByFeed(feed.id, {
         mode: "subscribe",
         topic: topicUrl,
         challenge,
@@ -198,7 +203,7 @@ describe("WebSub Integration", () => {
 
       const challenge = "test-challenge-no-lease";
       const before = Date.now();
-      const result = await handleVerificationChallenge(feed.id, {
+      const result = await handleVerificationChallengeByFeed(feed.id, {
         mode: "subscribe",
         topic: topicUrl,
         challenge,
@@ -232,7 +237,7 @@ describe("WebSub Integration", () => {
       await db.update(feeds).set({ websubActive: true }).where(eq(feeds.id, feed.id));
 
       const challenge = "unsubscribe-challenge-123";
-      const result = await handleVerificationChallenge(feed.id, {
+      const result = await handleVerificationChallengeByFeed(feed.id, {
         mode: "unsubscribe",
         topic: topicUrl,
         challenge,
@@ -272,7 +277,7 @@ describe("WebSub Integration", () => {
       await db.update(feeds).set({ websubActive: true }).where(eq(feeds.id, feed.id));
 
       const challenge = "hub-unsubscribe-challenge";
-      const result = await handleVerificationChallenge(feed.id, {
+      const result = await handleVerificationChallengeByFeed(feed.id, {
         mode: "unsubscribe",
         topic: topicUrl,
         challenge,
@@ -302,7 +307,7 @@ describe("WebSub Integration", () => {
         unsubscribeRequestedAt: new Date(),
       });
 
-      const result = await handleVerificationChallenge(feed.id, {
+      const result = await handleVerificationChallengeByFeed(feed.id, {
         mode: "unsubscribe",
         topic: "https://example.com/wrong-feed.xml",
         challenge: "challenge",
@@ -314,12 +319,13 @@ describe("WebSub Integration", () => {
     });
   });
 
-  describe("verifyHmacSignature", () => {
+  // Core HMAC behavior, exercised through the legacy per-feed entry point.
+  describe("verifyHmacSignatureByFeed (legacy per-feed)", () => {
     it("returns false when signature is missing", async () => {
       const feed = await createTestFeed();
       await createTestSubscription(feed.id, { state: "active" });
 
-      const isValid = await verifyHmacSignature(feed.id, null, "test body");
+      const isValid = await verifyHmacSignatureByFeed(feed.id, null, "test body");
 
       expect(isValid).toBe(false);
     });
@@ -333,14 +339,14 @@ describe("WebSub Integration", () => {
       hmac.update(body);
       const signature = `sha256=${hmac.digest("hex")}`;
 
-      const isValid = await verifyHmacSignature(feed.id, signature, body);
+      const isValid = await verifyHmacSignatureByFeed(feed.id, signature, body);
 
       expect(isValid).toBe(false);
     });
 
     it("returns false when subscription does not exist", async () => {
       const nonExistentId = generateUuidv7();
-      const isValid = await verifyHmacSignature(nonExistentId, "sha256=abc123", "test body");
+      const isValid = await verifyHmacSignatureByFeed(nonExistentId, "sha256=abc123", "test body");
 
       expect(isValid).toBe(false);
     });
@@ -349,7 +355,11 @@ describe("WebSub Integration", () => {
       const feed = await createTestFeed();
       await createTestSubscription(feed.id, { state: "active" });
 
-      const isValid = await verifyHmacSignature(feed.id, "invalid-signature-format", "test body");
+      const isValid = await verifyHmacSignatureByFeed(
+        feed.id,
+        "invalid-signature-format",
+        "test body"
+      );
 
       expect(isValid).toBe(false);
     });
@@ -362,7 +372,7 @@ describe("WebSub Integration", () => {
       const wrongSignature =
         "sha256=0000000000000000000000000000000000000000000000000000000000000000";
 
-      const isValid = await verifyHmacSignature(feed.id, wrongSignature, "test body");
+      const isValid = await verifyHmacSignatureByFeed(feed.id, wrongSignature, "test body");
 
       expect(isValid).toBe(false);
     });
@@ -376,7 +386,7 @@ describe("WebSub Integration", () => {
       hmac.update(body);
       const signature = `sha256=${hmac.digest("hex")}`;
 
-      const isValid = await verifyHmacSignature(feed.id, signature, body);
+      const isValid = await verifyHmacSignatureByFeed(feed.id, signature, body);
 
       expect(isValid).toBe(true);
     });
@@ -390,7 +400,7 @@ describe("WebSub Integration", () => {
       hmac.update(body);
       const signature = `sha1=${hmac.digest("hex")}`;
 
-      const isValid = await verifyHmacSignature(feed.id, signature, body);
+      const isValid = await verifyHmacSignatureByFeed(feed.id, signature, body);
 
       expect(isValid).toBe(true);
     });
@@ -404,7 +414,7 @@ describe("WebSub Integration", () => {
       hmac.update(body);
       const signature = `sha256=${hmac.digest("hex")}`;
 
-      const isValid = await verifyHmacSignature(feed.id, signature, body);
+      const isValid = await verifyHmacSignatureByFeed(feed.id, signature, body);
 
       expect(isValid).toBe(true);
     });
@@ -425,7 +435,7 @@ describe("WebSub Integration", () => {
 
       // 2. Hub sends verification challenge
       const challenge = "verification-challenge-xyz";
-      const result = await handleVerificationChallenge(feed.id, {
+      const result = await handleVerificationChallengeByFeed(feed.id, {
         mode: "subscribe",
         topic: topicUrl,
         challenge,
@@ -451,7 +461,7 @@ describe("WebSub Integration", () => {
       hmac.update(body);
       const signature = `sha256=${hmac.digest("hex")}`;
 
-      const isValid = await verifyHmacSignature(feed.id, signature, body);
+      const isValid = await verifyHmacSignatureByFeed(feed.id, signature, body);
       expect(isValid).toBe(true);
     });
 
@@ -466,7 +476,7 @@ describe("WebSub Integration", () => {
       });
 
       // Verify first subscription
-      await handleVerificationChallenge(feed.id, {
+      await handleVerificationChallengeByFeed(feed.id, {
         mode: "subscribe",
         topic: topicUrl,
         challenge: "challenge-1",
@@ -484,7 +494,7 @@ describe("WebSub Integration", () => {
         .set({ state: "pending", leaseSeconds: null, expiresAt: null });
 
       // Verify again with different lease
-      await handleVerificationChallenge(feed.id, {
+      await handleVerificationChallengeByFeed(feed.id, {
         mode: "subscribe",
         topic: topicUrl,
         challenge: "challenge-2",
@@ -496,11 +506,11 @@ describe("WebSub Integration", () => {
       expect(second.leaseSeconds).toBe(7200);
     });
 
-    it("hub switch: verification activates the new hub row, not the stale one", async () => {
-      // Simulates a publisher switching hubs: the feed fetch deactivated the old
-      // subscription (leaving an unsubscribed row) and created a fresh pending row
-      // for the new hub. Both rows share the feed and topic, so the callback GET
-      // is ambiguous by feedId alone - the newest row must win.
+    it("legacy hub switch: verification activates the new hub row, not the stale one", async () => {
+      // Legacy per-feed callback path: a publisher switched hubs, so the feed has
+      // an old (unsubscribed) row and a new (pending) row sharing feed + topic.
+      // The per-feed callback is ambiguous, so the newest row must win. (The
+      // per-subscription callback below resolves this exactly, without ordering.)
       const feed = await createTestFeed();
       const topicUrl = feed.url ?? "https://example.com/feed.xml";
 
@@ -522,7 +532,7 @@ describe("WebSub Integration", () => {
       });
 
       const challenge = "hub-b-challenge";
-      const result = await handleVerificationChallenge(feed.id, {
+      const result = await handleVerificationChallengeByFeed(feed.id, {
         mode: "subscribe",
         topic: topicUrl,
         challenge,
@@ -552,8 +562,109 @@ describe("WebSub Integration", () => {
       const body = "content from hub b";
       const hmac = createHmac("sha256", newSecret);
       hmac.update(body);
-      const isValid = await verifyHmacSignature(feed.id, `sha256=${hmac.digest("hex")}`, body);
+      const isValid = await verifyHmacSignatureByFeed(
+        feed.id,
+        `sha256=${hmac.digest("hex")}`,
+        body
+      );
       expect(isValid).toBe(true);
+    });
+  });
+
+  // Primary path: callbacks carry both feed and subscription IDs, so they resolve
+  // to exactly one row - no feed-scoped ordering needed even with multiple rows.
+  describe("per-subscription callbacks", () => {
+    it("verification activates the exact subscription named in the callback", async () => {
+      const feed = await createTestFeed();
+      const topicUrl = feed.url ?? "https://example.com/feed.xml";
+
+      // Two pending rows for the same feed + topic (e.g. a prior subscribe that
+      // never verified, plus a fresh one). Only the one named in the URL activates.
+      const { subscription: other } = await createTestSubscription(feed.id, {
+        hubUrl: "https://hub-a.example.com/",
+        topicUrl,
+        state: "pending",
+      });
+      const { subscription: target } = await createTestSubscription(feed.id, {
+        hubUrl: "https://hub-b.example.com/",
+        topicUrl,
+        state: "pending",
+      });
+
+      const challenge = "target-challenge";
+      const result = await handleVerificationChallenge(feed.id, target.id, {
+        mode: "subscribe",
+        topic: topicUrl,
+        challenge,
+        leaseSeconds: "3600",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.challenge).toBe(challenge);
+
+      const [activatedTarget] = await db
+        .select()
+        .from(websubSubscriptions)
+        .where(eq(websubSubscriptions.id, target.id));
+      expect(activatedTarget.state).toBe("active");
+
+      // The other row is untouched, even though it's for the same feed + topic.
+      const [untouched] = await db
+        .select()
+        .from(websubSubscriptions)
+        .where(eq(websubSubscriptions.id, other.id));
+      expect(untouched.state).toBe("pending");
+    });
+
+    it("returns not found when the subscription ID is unknown", async () => {
+      const feed = await createTestFeed();
+      const topicUrl = feed.url ?? "https://example.com/feed.xml";
+      await createTestSubscription(feed.id, { topicUrl, state: "pending" });
+
+      const result = await handleVerificationChallenge(feed.id, generateUuidv7(), {
+        mode: "subscribe",
+        topic: topicUrl,
+        challenge: "c",
+        leaseSeconds: "3600",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Subscription not found");
+    });
+
+    it("returns not found when the subscription belongs to a different feed", async () => {
+      const feedA = await createTestFeed();
+      const feedB = await createTestFeed();
+      const topicUrl = feedA.url ?? "https://example.com/feed.xml";
+      const { subscription } = await createTestSubscription(feedA.id, {
+        topicUrl,
+        state: "pending",
+      });
+
+      // Right subscription ID, wrong feed ID in the path -> rejected.
+      const result = await handleVerificationChallenge(feedB.id, subscription.id, {
+        mode: "subscribe",
+        topic: topicUrl,
+        challenge: "c",
+        leaseSeconds: "3600",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Subscription not found");
+    });
+
+    it("verifies HMAC only for the named active subscription", async () => {
+      const feed = await createTestFeed();
+      const { subscription, secret } = await createTestSubscription(feed.id, { state: "active" });
+
+      const body = SAMPLE_RSS_FEED;
+      const hmac = createHmac("sha256", secret);
+      hmac.update(body);
+      const signature = `sha256=${hmac.digest("hex")}`;
+
+      expect(await verifyHmacSignature(feed.id, subscription.id, signature, body)).toBe(true);
+      // Same secret/body but an unknown subscription ID -> rejected.
+      expect(await verifyHmacSignature(feed.id, generateUuidv7(), signature, body)).toBe(false);
     });
   });
 });

--- a/tests/integration/websub.test.ts
+++ b/tests/integration/websub.test.ts
@@ -495,5 +495,65 @@ describe("WebSub Integration", () => {
       expect(second.state).toBe("active");
       expect(second.leaseSeconds).toBe(7200);
     });
+
+    it("hub switch: verification activates the new hub row, not the stale one", async () => {
+      // Simulates a publisher switching hubs: the feed fetch deactivated the old
+      // subscription (leaving an unsubscribed row) and created a fresh pending row
+      // for the new hub. Both rows share the feed and topic, so the callback GET
+      // is ambiguous by feedId alone - the newest row must win.
+      const feed = await createTestFeed();
+      const topicUrl = feed.url ?? "https://example.com/feed.xml";
+
+      // Old subscription to hub A, torn down during the switch.
+      const { subscription: oldSub } = await createTestSubscription(feed.id, {
+        hubUrl: "https://hub-a.example.com/",
+        topicUrl,
+        state: "unsubscribed",
+        unsubscribeRequestedAt: new Date(),
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      });
+
+      // New pending subscription to hub B, created after the switch.
+      const { secret: newSecret, subscription: newSub } = await createTestSubscription(feed.id, {
+        hubUrl: "https://hub-b.example.com/",
+        topicUrl,
+        state: "pending",
+        createdAt: new Date("2026-01-02T00:00:00Z"),
+      });
+
+      const challenge = "hub-b-challenge";
+      const result = await handleVerificationChallenge(feed.id, {
+        mode: "subscribe",
+        topic: topicUrl,
+        challenge,
+        leaseSeconds: "3600",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.challenge).toBe(challenge);
+
+      // The new (hub B) row is now active; the old (hub A) row stays unsubscribed.
+      const [activatedNew] = await db
+        .select()
+        .from(websubSubscriptions)
+        .where(eq(websubSubscriptions.id, newSub.id));
+      expect(activatedNew.state).toBe("active");
+
+      const [staleOld] = await db
+        .select()
+        .from(websubSubscriptions)
+        .where(eq(websubSubscriptions.id, oldSub.id));
+      expect(staleOld.state).toBe("unsubscribed");
+
+      // Feed is active, and only the new hub's secret verifies notifications.
+      const [updatedFeed] = await db.select().from(feeds).where(eq(feeds.id, feed.id)).limit(1);
+      expect(updatedFeed.websubActive).toBe(true);
+
+      const body = "content from hub b";
+      const hmac = createHmac("sha256", newSecret);
+      hmac.update(body);
+      const isValid = await verifyHmacSignature(feed.id, `sha256=${hmac.digest("hex")}`, body);
+      expect(isValid).toBe(true);
+    });
   });
 });

--- a/tests/unit/websub-action.test.ts
+++ b/tests/unit/websub-action.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for resolveWebsubAction - the pure decision that maps a feed's
+ * previous WebSub state + the hub URL seen in the latest fetch to an action.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveWebsubAction } from "../../src/server/feed/websub";
+
+const HUB_A = "https://hub-a.example.com/";
+const HUB_B = "https://hub-b.example.com/";
+
+describe("resolveWebsubAction", () => {
+  it("subscribes when a hub appears and we're not active", () => {
+    expect(
+      resolveWebsubAction({
+        previousHubUrl: null,
+        previousWebsubActive: false,
+        newHubUrl: HUB_A,
+        canUseWebSub: true,
+      })
+    ).toBe("subscribe");
+  });
+
+  it("does nothing when there's no hub and we were never active", () => {
+    expect(
+      resolveWebsubAction({
+        previousHubUrl: null,
+        previousWebsubActive: false,
+        newHubUrl: null,
+        canUseWebSub: true,
+      })
+    ).toBe("none");
+  });
+
+  it("deactivates when the hub disappears while active", () => {
+    expect(
+      resolveWebsubAction({
+        previousHubUrl: HUB_A,
+        previousWebsubActive: true,
+        newHubUrl: null,
+        canUseWebSub: true,
+      })
+    ).toBe("deactivate");
+  });
+
+  it("does nothing when active and the hub is unchanged", () => {
+    expect(
+      resolveWebsubAction({
+        previousHubUrl: HUB_A,
+        previousWebsubActive: true,
+        newHubUrl: HUB_A,
+        canUseWebSub: true,
+      })
+    ).toBe("none");
+  });
+
+  it("resubscribes when the publisher switches to a different hub", () => {
+    expect(
+      resolveWebsubAction({
+        previousHubUrl: HUB_A,
+        previousWebsubActive: true,
+        newHubUrl: HUB_B,
+        canUseWebSub: true,
+      })
+    ).toBe("resubscribe");
+  });
+
+  it("does not resubscribe on a hub change when WebSub is unavailable", () => {
+    // canUseWebSub false means we can't receive callbacks at all - stay on polling
+    // rather than tearing down and failing to re-establish.
+    expect(
+      resolveWebsubAction({
+        previousHubUrl: HUB_A,
+        previousWebsubActive: true,
+        newHubUrl: HUB_B,
+        canUseWebSub: false,
+      })
+    ).toBe("none");
+  });
+
+  it("does not subscribe when a hub appears but WebSub is unavailable", () => {
+    expect(
+      resolveWebsubAction({
+        previousHubUrl: null,
+        previousWebsubActive: false,
+        newHubUrl: HUB_A,
+        canUseWebSub: false,
+      })
+    ).toBe("none");
+  });
+
+  it("still deactivates when the hub disappears even if WebSub is unavailable", () => {
+    // We can always tear down local state; deactivation doesn't need a callback URL.
+    expect(
+      resolveWebsubAction({
+        previousHubUrl: HUB_A,
+        previousWebsubActive: true,
+        newHubUrl: null,
+        canUseWebSub: false,
+      })
+    ).toBe("deactivate");
+  });
+
+  it("subscribes when a hub is present but a prior subscription went inactive", () => {
+    // e.g. a previous renewal failed and marked websubActive false; the hub is
+    // still advertised, so we should try again.
+    expect(
+      resolveWebsubAction({
+        previousHubUrl: HUB_A,
+        previousWebsubActive: false,
+        newHubUrl: HUB_A,
+        canUseWebSub: true,
+      })
+    ).toBe("subscribe");
+  });
+});


### PR DESCRIPTION
## Problem

Two related WebSub issues surfaced while diagnosing slow updates on a WebSub-enabled feed:

1. **Hub switches never took effect.** The fetch handler only subscribed when `newHubUrl && !feed.websubActive` — keyed on the boolean, not on the hub URL *changing*. A feed already `websubActive` that changed its `<link rel="hub">` kept a dangling subscription pointed at the **old** (often dead) hub and never subscribed to the new one until the lease happened to expire. So switching off a dead hub wouldn't help for days.

2. **Callbacks were ambiguous by feed.** The callback URL was per-feed (`/api/webhooks/websub/:feedId`), but a feed can have multiple subscription rows (after a hub switch). A verification/notification callback couldn't be mapped to a specific row without guessing.

## Fix

**Hub switching** (`resolveWebsubAction`)
- Pure decision function → `subscribe` / `resubscribe` / `deactivate` / `none`, unit-tested exhaustively.
- On `resubscribe`, the handler tears down the stale subscription (clearing `websubActive`) before subscribing to the new hub.

**Per-subscription callback URLs** — the real disambiguator (the WebSub spec intends the callback URL to identify the subscription)
- Callback is now `/api/webhooks/websub/:feedId/:subscriptionId`, so every callback resolves to exactly one row — no ordering/state heuristics.
- `generateCallbackUrl` takes the subscription ID; `subscribeToHub` computes the (renewal-stable) ID before building the URL.
- Verification and HMAC each split into a shared core + a **primary** lookup keyed by `(feedId, subscriptionId)` and a **legacy** by-feed lookup. Notification ingest moved to a shared `websub-notification` module so both routes reuse it.
- **Expand/contract:** the legacy `[feedId]` route stays so subscriptions registered before this change keep receiving callbacks until their next renewal re-registers the per-subscription URL. Removable in a later release.

## Tests
- `tests/unit/websub-action.test.ts` — every branch of `resolveWebsubAction`.
- `tests/integration/websub.test.ts` — existing core verification/HMAC tests run through the legacy entry points; a new **per-subscription** block covers exact row resolution among multiple rows, unknown/mismatched IDs, and HMAC binding; plus a legacy hub-switch disambiguation test.
- `pnpm typecheck`, unit (2014 passed), and full integration suite (463 passed) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)