### PR TITLE
Bound dead WebSub hubs: 14-day lease clamp + per-hub push tally (#1034)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -123,6 +123,7 @@ The schema is defined in `migrations/` directory. Key tables:
 - **user_entries** - Per-user read/starred state for entries
 - **jobs** - Background job queue for feed fetching
 - **websub_subscriptions** - WebSub push subscription state
+- **websub_hub_stats** - Per-hub tally of how new articles first reached us (hub push vs. backup poll), for spotting silently-broken hubs
 - **ingest_addresses** - Per-user email addresses for newsletter ingestion
 - **narration_content** - Cached LLM-processed narration text
 - **entry_summaries** - Cached AI-generated article summaries
@@ -272,6 +273,14 @@ The OAuth/MCP endpoints (`.well-known/*`, `/oauth/register`, `/oauth/token`, `/a
 ### Respectful Fetching
 
 Lion Reader respects server Cache-Control headers and applies exponential backoff for failed fetches.
+
+### WebSub Push & Backup Polling
+
+When a feed advertises a hub, we subscribe via WebSub (see [Real-time Updates](#real-time-updates)) and drop the feed to a 24h **backup poll** cadence (`reason: "websub_backup"`), trusting the hub to push new content in real time. A hub can silently stop delivering while we still believe it's active, so two mechanisms bound how long a dead hub can keep a feed stale:
+
+- **Lease clamp** (`MAX_LEASE_SECONDS`, 14 days, `src/server/feed/websub.ts`): we honor at most a 14-day lease regardless of what the hub grants, so we re-verify the subscription — and re-confirm the hub is still delivering — at least that often. We don't request a shorter lease; we just renew earlier. This bounds the quiet-feed case, where a silently-dropped subscription produces no new content to reveal the breakage.
+
+- **Backup-poll push-reliability tally** (`websub_hub_stats`, `src/server/feed/websub-hub-stats.ts`): this handler (`processSuccessfulFetch`) only runs for scheduled/backup polls — hub pushes go through `ingestWebsubNotification` instead — so any **new** entry a backup poll finds on a feed we believed push was covering is a push miss. We tally, per hub URL, how new articles first reached us: `articles_announced_by_hub` (pushed), `articles_announced_by_backup` (a confirmed miss), and `articles_near_miss` (found by backup but published within a 15-min grace window, or with an unknown date — too recent to confidently blame the hub, e.g. a publish-time race). This is purely observational today: nothing reads it to change fetch behavior; it exists so a chronically-broken hub (e.g. Google's `pubsubhubbub.appspot.com`, which accepts pings but never pushes) becomes visible in aggregate and can be dealt with later.
 
 ### SSRF Protection
 

--- a/migrations/0083_websub_hub_stats.sql
+++ b/migrations/0083_websub_hub_stats.sql
@@ -1,0 +1,23 @@
+-- Per-hub push-reliability tally.
+--
+-- A WebSub hub can silently stop delivering while we still believe it's active
+-- (Google's pubsubhubbub.appspot.com does exactly this). We can't act on a
+-- single miss, but tallying per hub how new articles first reached us —
+-- pushed by the hub, vs. first found by the 24h backup poll — lets us later
+-- spot chronically-broken hubs.
+--
+-- articles_near_miss counts backup-poll discoveries that were published too
+-- recently (or with an unknown date) to confidently blame the hub, so they
+-- don't inflate the confirmed-miss count.
+--
+-- Purely observational: nothing reads these columns to change fetch behavior.
+-- Expand-safe: brand-new table, no existing code depends on it.
+
+CREATE TABLE public.websub_hub_stats (
+    hub_url text PRIMARY KEY,
+    articles_announced_by_hub bigint NOT NULL DEFAULT 0,
+    articles_announced_by_backup bigint NOT NULL DEFAULT 0,
+    articles_near_miss bigint NOT NULL DEFAULT 0,
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at timestamp with time zone NOT NULL DEFAULT now()
+);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1782951500000,
       "tag": "0082_session_scopes",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1782951600000,
+      "tag": "0083_websub_hub_stats",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -438,6 +438,15 @@ CREATE VIEW public.visible_entries AS
      LEFT JOIN public.subscriptions s ON ((s.id = sf.subscription_id)))
   WHERE (((s.id IS NOT NULL) AND (s.unsubscribed_at IS NULL)) OR (ue.starred = true) OR (e.type = 'saved'::public.feed_type));
 
+CREATE TABLE public.websub_hub_stats (
+    hub_url text NOT NULL,
+    articles_announced_by_hub bigint DEFAULT 0 NOT NULL,
+    articles_announced_by_backup bigint DEFAULT 0 NOT NULL,
+    articles_near_miss bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
 CREATE TABLE public.websub_subscriptions (
     id uuid NOT NULL,
     feed_id uuid NOT NULL,
@@ -579,6 +588,9 @@ ALTER TABLE ONLY public.users
 
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.websub_hub_stats
+    ADD CONSTRAINT websub_hub_stats_pkey PRIMARY KEY (hub_url);
 
 ALTER TABLE ONLY public.websub_subscriptions
     ADD CONSTRAINT websub_subscriptions_pkey PRIMARY KEY (id);

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,4 +1,5 @@
 import {
+  bigint,
   boolean,
   check,
   customType,
@@ -891,6 +892,39 @@ export const websubSubscriptions = pgTable(
   ]
 );
 
+/**
+ * Per-hub push-reliability tally (keyed by hub URL).
+ *
+ * A WebSub hub can silently stop pushing while we still believe it's active. We
+ * can't take action on a single miss, but aggregating, per hub, how new articles
+ * first reached us lets us later spot chronically-broken hubs (e.g. Google's
+ * pubsubhubbub.appspot.com, which accepts pings but never pushes):
+ *
+ * - `articlesAnnouncedByHub`: a new entry arrived via a hub push notification.
+ * - `articlesAnnouncedByBackup`: a new entry was first discovered by the 24h
+ *   backup poll on a feed we thought push was covering — a confident push miss
+ *   (the entry was published long enough ago that a working hub should have
+ *   pushed it).
+ * - `articlesNearMiss`: a backup poll found a new entry, but it was published
+ *   too recently (or with an unknown date) to confidently blame the hub — it may
+ *   simply not have been pushed yet. Recorded separately so it doesn't inflate
+ *   the miss count.
+ *
+ * Purely observational: nothing reads these to change fetch behavior (yet).
+ */
+export const websubHubStats = pgTable("websub_hub_stats", {
+  hubUrl: text("hub_url").primaryKey(),
+  articlesAnnouncedByHub: bigint("articles_announced_by_hub", { mode: "number" })
+    .notNull()
+    .default(0),
+  articlesAnnouncedByBackup: bigint("articles_announced_by_backup", { mode: "number" })
+    .notNull()
+    .default(0),
+  articlesNearMiss: bigint("articles_near_miss", { mode: "number" }).notNull().default(0),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
 // ============================================================================
 // NARRATION
 // ============================================================================
@@ -1123,6 +1157,8 @@ export type NewSubscriptionTag = typeof subscriptionTags.$inferInsert;
 
 export type WebsubSubscription = typeof websubSubscriptions.$inferSelect;
 export type NewWebsubSubscription = typeof websubSubscriptions.$inferInsert;
+export type WebsubHubStats = typeof websubHubStats.$inferSelect;
+export type NewWebsubHubStats = typeof websubHubStats.$inferInsert;
 
 export type NarrationContent = typeof narrationContent.$inferSelect;
 export type NewNarrationContent = typeof narrationContent.$inferInsert;

--- a/src/server/feed/websub-hub-stats.ts
+++ b/src/server/feed/websub-hub-stats.ts
@@ -1,0 +1,137 @@
+/**
+ * Per-hub WebSub push-reliability tallying.
+ *
+ * A WebSub hub can silently stop pushing while we still believe it's active, so
+ * a feed only refreshes on its 24h backup poll and new posts show up ~a day late.
+ * We don't act on a single miss here, but we record, per hub, how new articles
+ * first reached us so a chronically-broken hub (e.g. Google's
+ * pubsubhubbub.appspot.com, which accepts pings but never pushes) becomes visible
+ * in aggregate and can be dealt with later. See the `websubHubStats` table.
+ *
+ * All writes are best-effort: this is telemetry and must never break feed
+ * processing, so failures are swallowed after logging.
+ */
+
+import { sql } from "drizzle-orm";
+import { db as defaultDb } from "../db";
+import { websubHubStats } from "../db/schema";
+import { logger } from "@/lib/logger";
+
+type DbClient = typeof defaultDb;
+
+/**
+ * Grace period for the backup-poll miss classification: 15 minutes.
+ *
+ * A new entry first found by a backup poll but published within this window may
+ * simply not have been pushed *yet* (publish-time race), so we can't confidently
+ * blame the hub. Such entries are counted as near-misses instead of misses.
+ */
+export const WEBSUB_PUSH_GRACE_PERIOD_MS = 15 * 60 * 1000;
+
+/**
+ * How a batch of backup-poll-discovered new entries splits between confirmed
+ * push misses and ambiguous near-misses.
+ */
+export interface BackupPollClassification {
+  /** New entries old enough that a working hub should have pushed them. */
+  backupMisses: number;
+  /** New entries too recent (or with an unknown publish date) to blame the hub. */
+  nearMisses: number;
+}
+
+/**
+ * Classifies backup-poll-discovered new entries into confirmed misses vs.
+ * near-misses using the publish-time grace period. Pure so it can be unit-tested.
+ *
+ * An entry counts as a confirmed miss only when we know it was published at least
+ * `gracePeriodMs` ago — long enough that a working hub should already have pushed
+ * it. Entries published more recently, or with an unknown publish date (we can't
+ * prove they're old), are counted as near-misses so they don't inflate the miss
+ * count.
+ */
+export function classifyBackupPollEntries(
+  publishedAts: Array<Date | null | undefined>,
+  now: Date,
+  gracePeriodMs: number = WEBSUB_PUSH_GRACE_PERIOD_MS
+): BackupPollClassification {
+  let backupMisses = 0;
+  let nearMisses = 0;
+
+  for (const publishedAt of publishedAts) {
+    if (publishedAt && now.getTime() - publishedAt.getTime() >= gracePeriodMs) {
+      backupMisses++;
+    } else {
+      nearMisses++;
+    }
+  }
+
+  return { backupMisses, nearMisses };
+}
+
+/**
+ * Upserts a per-hub tally, incrementing the given counters atomically.
+ */
+async function incrementHubStats(
+  db: DbClient,
+  hubUrl: string,
+  delta: { byHub?: number; byBackup?: number; nearMiss?: number }
+): Promise<void> {
+  const byHub = delta.byHub ?? 0;
+  const byBackup = delta.byBackup ?? 0;
+  const nearMiss = delta.nearMiss ?? 0;
+
+  try {
+    await db
+      .insert(websubHubStats)
+      .values({
+        hubUrl,
+        articlesAnnouncedByHub: byHub,
+        articlesAnnouncedByBackup: byBackup,
+        articlesNearMiss: nearMiss,
+      })
+      .onConflictDoUpdate({
+        target: websubHubStats.hubUrl,
+        set: {
+          articlesAnnouncedByHub: sql`${websubHubStats.articlesAnnouncedByHub} + ${byHub}`,
+          articlesAnnouncedByBackup: sql`${websubHubStats.articlesAnnouncedByBackup} + ${byBackup}`,
+          articlesNearMiss: sql`${websubHubStats.articlesNearMiss} + ${nearMiss}`,
+          updatedAt: new Date(),
+        },
+      });
+  } catch (error) {
+    // Telemetry must never break feed processing.
+    logger.warn("Failed to update WebSub hub stats", {
+      hubUrl,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Records that `count` new entries reached us via a hub push notification.
+ * No-op for a non-positive count.
+ */
+export async function recordHubAnnouncedEntries(
+  hubUrl: string,
+  count: number,
+  db: DbClient = defaultDb
+): Promise<void> {
+  if (count <= 0) return;
+  await incrementHubStats(db, hubUrl, { byHub: count });
+}
+
+/**
+ * Records new entries first discovered by a backup poll on a feed we believed
+ * push was covering — i.e. entries the hub failed to push. Splits them into
+ * confirmed misses vs. near-misses via the publish-time grace period.
+ */
+export async function recordBackupPollNewEntries(
+  hubUrl: string,
+  publishedAts: Array<Date | null | undefined>,
+  now: Date,
+  db: DbClient = defaultDb
+): Promise<void> {
+  const { backupMisses, nearMisses } = classifyBackupPollEntries(publishedAts, now);
+  if (backupMisses === 0 && nearMisses === 0) return;
+  await incrementHubStats(db, hubUrl, { byBackup: backupMisses, nearMiss: nearMisses });
+}

--- a/src/server/feed/websub-notification.ts
+++ b/src/server/feed/websub-notification.ts
@@ -9,6 +9,7 @@ import { db } from "../db";
 import { feeds, type Feed } from "../db/schema";
 import { parseFeedInWorker } from "../worker-thread/pool";
 import { processEntries } from "./entry-processor";
+import { recordHubAnnouncedEntries } from "./websub-hub-stats";
 import { WEBSUB_BACKUP_POLL_INTERVAL_SECONDS } from "./scheduling";
 import { updateFeedJobNextRun } from "../jobs/queue";
 import { trackWebsubNotificationReceived } from "../metrics/metrics";
@@ -91,6 +92,12 @@ export async function ingestWebsubNotification(feed: Feed, bodyText: string): Pr
       updatedEntries: result.updatedCount,
       unchangedEntries: result.unchangedCount,
     });
+
+    // Credit the hub for any new entries it pushed, so we can later compare this
+    // against entries the backup poll had to discover (see websub-hub-stats.ts).
+    if (result.newCount > 0 && feed.hubUrl) {
+      await recordHubAnnouncedEntries(feed.hubUrl, result.newCount);
+    }
   } catch (error) {
     logger.error("WebSub notification processing failed", {
       feedId,

--- a/src/server/feed/websub.ts
+++ b/src/server/feed/websub.ts
@@ -37,6 +37,22 @@ const HUB_REQUEST_TIMEOUT_MS = 10000;
 const DEFAULT_LEASE_SECONDS = 24 * 60 * 60;
 
 /**
+ * Maximum lease length (seconds) we honor from a hub: 14 days.
+ *
+ * We store `expiresAt = now + lease_seconds` and only re-verify a subscription
+ * when it nears expiry, so a hub granting a very long lease means we'd trust the
+ * subscription — and never re-confirm the hub is still delivering — for that
+ * whole period. A hub can silently stop pushing while still "active" in our DB,
+ * so we cap how long that can last by clamping the honored lease.
+ *
+ * We don't request a shorter lease from the hub (WebSub has no such request); we
+ * just renew earlier than the hub's stated expiry. 14 days sits comfortably above
+ * the common ~10-day hub max, so it rarely fires against well-behaved hubs; it
+ * only bounds our worst-case re-verification cadence.
+ */
+export const MAX_LEASE_SECONDS = 14 * 24 * 60 * 60;
+
+/**
  * Private/local hostnames and IP ranges that can't receive WebSub callbacks.
  */
 const PRIVATE_HOSTNAMES = ["localhost", "127.0.0.1", "0.0.0.0", "::1"];
@@ -483,9 +499,12 @@ async function applyVerificationChallenge(
 
   // Parse lease seconds. Hubs SHOULD send hub.lease_seconds but some don't; fall
   // back to a default so expiresAt is always set and the subscription stays in
-  // the renewal filter's window (see DEFAULT_LEASE_SECONDS).
+  // the renewal filter's window (see DEFAULT_LEASE_SECONDS). Clamp the granted
+  // lease to MAX_LEASE_SECONDS so a hub can't push our re-verification cadence
+  // arbitrarily far out (see MAX_LEASE_SECONDS).
   const parsedLease = leaseSeconds ? parseInt(leaseSeconds, 10) : NaN;
-  const lease = !isNaN(parsedLease) && parsedLease > 0 ? parsedLease : DEFAULT_LEASE_SECONDS;
+  const grantedLease = !isNaN(parsedLease) && parsedLease > 0 ? parsedLease : DEFAULT_LEASE_SECONDS;
+  const lease = Math.min(grantedLease, MAX_LEASE_SECONDS);
   const expiresAt = new Date(Date.now() + lease * 1000);
 
   // Update subscription to active

--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -34,6 +34,7 @@ import {
   deactivateWebsub,
   resolveWebsubAction,
 } from "../feed/websub";
+import { recordBackupPollNewEntries } from "../feed/websub-hub-stats";
 import { getDomainFromUrl } from "../feed/types";
 import type { ParsedCacheHeaders } from "../feed/cache-headers";
 import {
@@ -412,8 +413,22 @@ async function processSuccessfulFetch(
 
   // Fetch full content for new entries if any subscriber has fetchFullContent enabled
   // This is done after processEntries so entries exist in the database
-  const newEntryIds = processResult.entries.filter((e) => e.isNew).map((e) => e.id);
+  const newEntries = processResult.entries.filter((e) => e.isNew);
+  const newEntryIds = newEntries.map((e) => e.id);
   const fullContentResult = await fetchFullContentForNewEntries(feed.id, newEntryIds);
+
+  // Push-reliability telemetry: this handler only runs for scheduled/backup
+  // polls (hub pushes go through ingestWebsubNotification, not here). If push
+  // were working, the hub would already have delivered these entries, so any
+  // new entry a backup poll finds on a feed we believed push was covering is a
+  // push miss. Record it per hub for later analysis (see websub-hub-stats.ts).
+  if ((feed.websubActive ?? false) && feed.hubUrl && newEntries.length > 0) {
+    await recordBackupPollNewEntries(
+      feed.hubUrl,
+      newEntries.map((e) => e.newEntryData?.publishedAt),
+      now
+    );
+  }
 
   // Calculate next fetch time based on cache headers and feed hints
   const nextFetch = calculateNextFetch({

--- a/tests/integration/websub.test.ts
+++ b/tests/integration/websub.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { createHmac } from "crypto";
 import { eq } from "drizzle-orm";
 import { db } from "../../src/server/db";
-import { feeds, entries, websubSubscriptions } from "../../src/server/db/schema";
+import { feeds, entries, websubSubscriptions, websubHubStats } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import {
   generateCallbackSecret,
@@ -20,7 +20,12 @@ import {
   handleVerificationChallengeByFeed,
   verifyHmacSignature,
   verifyHmacSignatureByFeed,
+  MAX_LEASE_SECONDS,
 } from "../../src/server/feed/websub";
+import {
+  recordHubAnnouncedEntries,
+  recordBackupPollNewEntries,
+} from "../../src/server/feed/websub-hub-stats";
 
 // Sample RSS feed content for testing content notifications
 const SAMPLE_RSS_FEED = `<?xml version="1.0" encoding="UTF-8"?>
@@ -82,6 +87,7 @@ describe("WebSub Integration", () => {
   beforeEach(async () => {
     await db.delete(entries);
     await db.delete(websubSubscriptions);
+    await db.delete(websubHubStats);
     await db.delete(feeds);
   });
 
@@ -89,6 +95,7 @@ describe("WebSub Integration", () => {
   afterAll(async () => {
     await db.delete(entries);
     await db.delete(websubSubscriptions);
+    await db.delete(websubHubStats);
     await db.delete(feeds);
   });
 
@@ -222,6 +229,33 @@ describe("WebSub Integration", () => {
       const expiresMs = subscription.expiresAt!.getTime();
       expect(expiresMs).toBeGreaterThanOrEqual(before + 24 * 60 * 60 * 1000);
       expect(expiresMs).toBeLessThanOrEqual(Date.now() + 24 * 60 * 60 * 1000 + 5000);
+    });
+
+    it("clamps a lease longer than the maximum to MAX_LEASE_SECONDS", async () => {
+      // A hub granting a very long lease shouldn't push our re-verification
+      // cadence out arbitrarily far - we clamp it so we re-confirm the hub is
+      // still delivering at least every MAX_LEASE_SECONDS.
+      const feed = await createTestFeed();
+      const topicUrl = "https://example.com/feed-long-lease.xml";
+      await createTestSubscription(feed.id, { topicUrl });
+
+      const before = Date.now();
+      const oneYear = 365 * 24 * 60 * 60;
+      const result = await handleVerificationChallengeByFeed(feed.id, {
+        mode: "subscribe",
+        topic: topicUrl,
+        challenge: "long-lease-challenge",
+        leaseSeconds: String(oneYear),
+      });
+
+      expect(result.success).toBe(true);
+
+      const [subscription] = await db.select().from(websubSubscriptions).limit(1);
+      expect(subscription.state).toBe("active");
+      expect(subscription.leaseSeconds).toBe(MAX_LEASE_SECONDS);
+      const expiresMs = subscription.expiresAt!.getTime();
+      expect(expiresMs).toBeGreaterThanOrEqual(before + MAX_LEASE_SECONDS * 1000);
+      expect(expiresMs).toBeLessThanOrEqual(Date.now() + MAX_LEASE_SECONDS * 1000 + 5000);
     });
 
     it("confirms unsubscribe when we requested it", async () => {
@@ -665,6 +699,54 @@ describe("WebSub Integration", () => {
       expect(await verifyHmacSignature(feed.id, subscription.id, signature, body)).toBe(true);
       // Same secret/body but an unknown subscription ID -> rejected.
       expect(await verifyHmacSignature(feed.id, generateUuidv7(), signature, body)).toBe(false);
+    });
+  });
+
+  // Per-hub push-reliability tallies (websub_hub_stats). These upserts are the
+  // durable record of how new articles first reached us, per hub.
+  describe("websub hub stats", () => {
+    const HUB = "https://hub.example.com/";
+
+    async function getStats(hubUrl: string) {
+      const [row] = await db.select().from(websubHubStats).where(eq(websubHubStats.hubUrl, hubUrl));
+      return row;
+    }
+
+    it("records hub-announced entries and accumulates across calls", async () => {
+      await recordHubAnnouncedEntries(HUB, 3);
+      await recordHubAnnouncedEntries(HUB, 2);
+
+      const row = await getStats(HUB);
+      expect(row.articlesAnnouncedByHub).toBe(5);
+      expect(row.articlesAnnouncedByBackup).toBe(0);
+      expect(row.articlesNearMiss).toBe(0);
+    });
+
+    it("ignores a non-positive hub-announced count", async () => {
+      await recordHubAnnouncedEntries(HUB, 0);
+      expect(await getStats(HUB)).toBeUndefined();
+    });
+
+    it("splits backup-poll entries into confirmed misses and near-misses", async () => {
+      const now = new Date();
+      const old = new Date(now.getTime() - 60 * 60 * 1000); // 1h ago -> miss
+      const recent = new Date(now.getTime() - 60 * 1000); // 1m ago -> near-miss
+      await recordBackupPollNewEntries(HUB, [old, recent, null], now);
+
+      const row = await getStats(HUB);
+      expect(row.articlesAnnouncedByBackup).toBe(1);
+      expect(row.articlesNearMiss).toBe(2); // recent + unknown-date
+      expect(row.articlesAnnouncedByHub).toBe(0);
+    });
+
+    it("keeps hub-announced and backup counters on the same row", async () => {
+      const now = new Date();
+      await recordHubAnnouncedEntries(HUB, 4);
+      await recordBackupPollNewEntries(HUB, [new Date(now.getTime() - 60 * 60 * 1000)], now);
+
+      const row = await getStats(HUB);
+      expect(row.articlesAnnouncedByHub).toBe(4);
+      expect(row.articlesAnnouncedByBackup).toBe(1);
     });
   });
 });

--- a/tests/unit/websub-hub-stats.test.ts
+++ b/tests/unit/websub-hub-stats.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for classifyBackupPollEntries - the pure grace-period split that
+ * decides whether a backup-poll-discovered new entry is a confirmed push miss
+ * or an ambiguous near-miss.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  classifyBackupPollEntries,
+  WEBSUB_PUSH_GRACE_PERIOD_MS,
+} from "../../src/server/feed/websub-hub-stats";
+
+const NOW = new Date("2026-07-06T12:00:00.000Z");
+
+/** A Date `ms` before NOW. */
+function ago(ms: number): Date {
+  return new Date(NOW.getTime() - ms);
+}
+
+describe("classifyBackupPollEntries", () => {
+  it("counts an entry published well before the grace window as a confirmed miss", () => {
+    const result = classifyBackupPollEntries([ago(60 * 60 * 1000)], NOW);
+    expect(result).toEqual({ backupMisses: 1, nearMisses: 0 });
+  });
+
+  it("counts an entry published within the grace window as a near-miss", () => {
+    const result = classifyBackupPollEntries([ago(60 * 1000)], NOW);
+    expect(result).toEqual({ backupMisses: 0, nearMisses: 1 });
+  });
+
+  it("treats an entry exactly at the grace boundary as a confirmed miss", () => {
+    const result = classifyBackupPollEntries([ago(WEBSUB_PUSH_GRACE_PERIOD_MS)], NOW);
+    expect(result).toEqual({ backupMisses: 1, nearMisses: 0 });
+  });
+
+  it("counts an entry one ms inside the grace boundary as a near-miss", () => {
+    const result = classifyBackupPollEntries([ago(WEBSUB_PUSH_GRACE_PERIOD_MS - 1)], NOW);
+    expect(result).toEqual({ backupMisses: 0, nearMisses: 1 });
+  });
+
+  it("treats an unknown publish date as a near-miss (can't prove it's old)", () => {
+    expect(classifyBackupPollEntries([null], NOW)).toEqual({ backupMisses: 0, nearMisses: 1 });
+    expect(classifyBackupPollEntries([undefined], NOW)).toEqual({ backupMisses: 0, nearMisses: 1 });
+  });
+
+  it("treats a future publish date as a near-miss", () => {
+    const future = new Date(NOW.getTime() + 60 * 1000);
+    expect(classifyBackupPollEntries([future], NOW)).toEqual({ backupMisses: 0, nearMisses: 1 });
+  });
+
+  it("tallies a mixed batch", () => {
+    const result = classifyBackupPollEntries(
+      [ago(2 * 60 * 60 * 1000), ago(60 * 1000), null, ago(24 * 60 * 60 * 1000)],
+      NOW
+    );
+    expect(result).toEqual({ backupMisses: 2, nearMisses: 2 });
+  });
+
+  it("returns zeros for an empty batch", () => {
+    expect(classifyBackupPollEntries([], NOW)).toEqual({ backupMisses: 0, nearMisses: 0 });
+  });
+
+  it("honors a custom grace period", () => {
+    const oneHour = 60 * 60 * 1000;
+    // Published 30 min ago: a miss under the default 15-min grace, a near-miss
+    // under a 1-hour grace.
+    expect(classifyBackupPollEntries([ago(30 * 60 * 1000)], NOW)).toEqual({
+      backupMisses: 1,
+      nearMisses: 0,
+    });
+    expect(classifyBackupPollEntries([ago(30 * 60 * 1000)], NOW, oneHour)).toEqual({
+      backupMisses: 0,
+      nearMisses: 1,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1034.

A WebSub hub can silently stop delivering while we still trust it (Google's `pubsubhubbub.appspot.com` does exactly this — accepts publish pings, never pushes). When that happens the feed only refreshes on its 24h backup poll, so new posts show up ~a day late. This adds two complementary mechanisms to bound how long a dead hub can keep a feed stale.

## 1. Clamp the honored lease to 14 days
`applyVerificationChallenge` now clamps `lease = min(granted, MAX_LEASE_SECONDS)` (14 days). We don't request a shorter lease from the hub — we just re-verify the subscription (and re-confirm the hub is still delivering) at least every 14 days. This bounds the **quiet-feed** case, where a silently-dropped subscription produces no new content to reveal the breakage. 14 days sits comfortably above the common ~10-day hub max, so it rarely fires against well-behaved hubs.

## 2. Per-hub push-reliability tally (`websub_hub_stats`)
`processSuccessfulFetch` only runs for scheduled/backup polls — hub pushes go through `ingestWebsubNotification` instead — so any **new** entry a backup poll finds on a feed we believed push was covering is a push miss. We tally, per hub URL, how new articles first reached us:

- `articles_announced_by_hub` — pushed by the hub
- `articles_announced_by_backup` — a **confirmed** miss (published long enough ago that a working hub should have pushed it)
- `articles_near_miss` — found by backup but published within a **15-minute grace window** (publish-time race), or with an unknown date — too recent to confidently blame the hub

This is **purely observational** today: nothing reads it to change fetch behavior. It exists so a chronically-broken hub becomes visible in aggregate and can be dealt with later (e.g. blocking individual hubs).

### Scope note
Per discussion on the issue, the active detection → re-subscription suppression/backoff (the issue's mechanism #2) is deliberately left out of scope — flapping/false-positive handling is hard to get right. This change instead collects the per-hub data needed to make those decisions later, plus lands the trivial, isolated lease clamp.

## Testing
- New unit tests for the pure grace-period split (`classifyBackupPollEntries`)
- New integration tests: lease clamped to `MAX_LEASE_SECONDS`; hub/backup/near-miss counters accumulate correctly on the same row
- `pnpm typecheck`, `pnpm lint`, full unit suite (2023 tests) and the WebSub integration suite pass
- `migrations/schema.sql` regenerated (only the new table added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)