### PR TITLE
Add route-level e2e tests for Wallabag and Google Reader compat APIs (#1021)

### DIFF
--- a/tests/e2e/greader-api.spec.ts
+++ b/tests/e2e/greader-api.spec.ts
@@ -171,3 +171,38 @@ test.describe("Google Reader API happy path", () => {
     }
   });
 });
+
+/**
+ * A Google Reader token is a *scoped* session (`reader:full-access`), minted so
+ * it can't be replayed as a full-access browser session. It must be rejected
+ * (as if invalid) by the main tRPC/REST surface — whether presented as a bearer
+ * token or as the `session` cookie a browser would send — and by the Wallabag
+ * API (which authenticates OAuth access tokens, not sessions). These lock in
+ * that a leaked Google Reader token can't reach account management.
+ */
+test.describe("Google Reader API credential isolation", () => {
+  test("token cannot reach account-management endpoints as a bearer token", async ({ request }) => {
+    const token = await getToken(request);
+    // Session-only account surface (listing the user's active sessions).
+    const res = await request.get("/api/v1/users/me/sessions", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("token cannot be replayed as a browser session cookie", async ({ request }) => {
+    const token = await getToken(request);
+    const res = await request.get("/api/v1/users/me/sessions", {
+      headers: { Cookie: `session=${token}` },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("token cannot be replayed against the Wallabag API", async ({ request }) => {
+    const token = await getToken(request);
+    const res = await request.get("/api/wallabag/api/user", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(401);
+  });
+});

--- a/tests/e2e/greader-api.spec.ts
+++ b/tests/e2e/greader-api.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * Route-level tests for the Google Reader compatibility API
+ * (`src/app/api/greader.php/**`).
+ *
+ * The Google Reader HTTP surface — ClientLogin, GoogleLogin bearer auth,
+ * response formatting, status codes — has no unit/integration coverage. This
+ * suite exercises the real server over HTTP.
+ *
+ * Regression guard for #1018: `requireAuth` used to `throw` a `Response`, which
+ * Next.js App Router surfaces as a 500 instead of the intended 401. These tests
+ * assert 401 (not 500) for every unauthenticated protected endpoint.
+ */
+
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import {
+  getDb,
+  createPasswordUser,
+  createSubscribedFeed,
+  createUnreadEntry,
+  closeTestConnections,
+  type TestPasswordUser,
+  type TestFeed,
+} from "./helpers";
+
+const CLIENT_LOGIN_PATH = "/api/greader.php/accounts/ClientLogin";
+const API_BASE = "/api/greader.php/reader/api/0";
+
+/** Protected GET endpoints that must reject unauthenticated requests with 401. */
+const PROTECTED_GET_ENDPOINTS = [
+  `${API_BASE}/user-info`,
+  `${API_BASE}/unread-count`,
+  `${API_BASE}/subscription/list`,
+  `${API_BASE}/tag/list`,
+  `${API_BASE}/token`,
+  `${API_BASE}/stream/items/ids?s=user/-/state/com.google/reading-list`,
+];
+
+interface SeededUser {
+  user: TestPasswordUser;
+  feed: TestFeed;
+}
+
+let seeded: SeededUser | undefined;
+
+/** A confirmed password user with a subscribed feed + one unread entry. */
+async function getSeeded(): Promise<SeededUser> {
+  if (!seeded) {
+    const db = getDb();
+    const user = await createPasswordUser(db);
+    const feed = await createSubscribedFeed(db, user.id);
+    await createUnreadEntry(db, { feedId: feed.feedId, userId: user.id, title: "GReader entry" });
+    seeded = { user, feed };
+  }
+  return seeded;
+}
+
+/** Runs ClientLogin and returns the `Auth=` token. */
+async function clientLogin(request: APIRequestContext, user: TestPasswordUser): Promise<string> {
+  const res = await request.post(CLIENT_LOGIN_PATH, {
+    form: { Email: user.email, Passwd: user.password },
+  });
+  expect(res.status()).toBe(200);
+  const text = await res.text();
+  const match = text.match(/^Auth=(.+)$/m);
+  expect(match, `ClientLogin response missing Auth token:\n${text}`).not.toBeNull();
+  return match![1];
+}
+
+let sharedToken: string | undefined;
+
+/**
+ * Logs in once and memoizes the auth token. The `expensive` per-IP rate-limit
+ * bucket (capacity 10, refill 1/s) is shared across both compat login
+ * endpoints, so happy-path tests reuse a single token rather than logging in
+ * on every case.
+ */
+async function getToken(request: APIRequestContext): Promise<string> {
+  if (!sharedToken) {
+    const { user } = await getSeeded();
+    sharedToken = await clientLogin(request, user);
+  }
+  return sharedToken;
+}
+
+/** GoogleLogin authorization header for a token. */
+function authHeader(token: string): Record<string, string> {
+  return { Authorization: `GoogleLogin auth=${token}` };
+}
+
+test.afterAll(async () => {
+  await closeTestConnections();
+});
+
+test.describe("Google Reader API auth", () => {
+  test("protected endpoints return 401 (not 500) without a token", async ({ request }) => {
+    for (const endpoint of PROTECTED_GET_ENDPOINTS) {
+      const res = await request.get(endpoint);
+      expect(res.status(), `GET ${endpoint} without auth`).toBe(401);
+    }
+  });
+
+  test("protected endpoints return 401 with a garbage token", async ({ request }) => {
+    for (const endpoint of PROTECTED_GET_ENDPOINTS) {
+      const res = await request.get(endpoint, { headers: authHeader("not-a-real-token") });
+      expect(res.status(), `GET ${endpoint} with garbage token`).toBe(401);
+    }
+  });
+
+  test("ClientLogin with wrong password returns 401", async ({ request }) => {
+    const { user } = await getSeeded();
+    const res = await request.post(CLIENT_LOGIN_PATH, {
+      form: { Email: user.email, Passwd: "wrong-password" },
+    });
+    expect(res.status()).toBe(401);
+    expect(await res.text()).toContain("Error=BadAuthentication");
+  });
+
+  test("ClientLogin for an unknown user returns 401", async ({ request }) => {
+    const res = await request.post(CLIENT_LOGIN_PATH, {
+      form: { Email: "does-not-exist@example.com", Passwd: "whatever" },
+    });
+    expect(res.status()).toBe(401);
+  });
+});
+
+test.describe("Google Reader API happy path", () => {
+  test("ClientLogin issues a token that authorizes user-info", async ({ request }) => {
+    const { user } = await getSeeded();
+    const token = await clientLogin(request, user);
+
+    const res = await request.get(`${API_BASE}/user-info`, { headers: authHeader(token) });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.userEmail).toBe(user.email);
+    expect(body.userName).toBe(user.email);
+  });
+
+  test("token endpoint echoes the auth token", async ({ request }) => {
+    const token = await getToken(request);
+
+    const res = await request.get(`${API_BASE}/token`, { headers: authHeader(token) });
+    expect(res.status()).toBe(200);
+    expect(await res.text()).toBe(token);
+  });
+
+  test("subscription/list returns the user's subscribed feed", async ({ request }) => {
+    const { feed } = await getSeeded();
+    const token = await getToken(request);
+
+    const res = await request.get(`${API_BASE}/subscription/list`, { headers: authHeader(token) });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.subscriptions)).toBe(true);
+    const titles = body.subscriptions.map((s: { title: string }) => s.title);
+    expect(titles).toContain(feed.title);
+  });
+
+  test("stream/items/ids returns item refs for the reading list", async ({ request }) => {
+    const token = await getToken(request);
+
+    const res = await request.get(
+      `${API_BASE}/stream/items/ids?s=user/-/state/com.google/reading-list`,
+      { headers: authHeader(token) }
+    );
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.itemRefs)).toBe(true);
+    expect(body.itemRefs.length).toBeGreaterThanOrEqual(1);
+    for (const ref of body.itemRefs) {
+      expect(typeof ref.id).toBe("string");
+    }
+  });
+});

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -9,6 +9,7 @@
  */
 
 import crypto from "node:crypto";
+import * as argon2 from "argon2";
 import { Pool } from "pg";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { and, eq } from "drizzle-orm";
@@ -91,6 +92,39 @@ export async function createConfirmedUser(db: TestDb): Promise<TestUser> {
   });
 
   return { id, email, sessionToken };
+}
+
+export interface TestPasswordUser {
+  id: string;
+  email: string;
+  password: string;
+}
+
+/**
+ * Creates a confirmed user with a password hash (no session), for exercising
+ * password-based auth flows: the Wallabag OAuth password grant and the Google
+ * Reader ClientLogin endpoint. Mirrors createConfirmedUser's confirmation
+ * columns so requireAuth's signup-confirmation gate passes.
+ */
+export async function createPasswordUser(
+  db: TestDb,
+  password = "correct-horse-battery-staple"
+): Promise<TestPasswordUser> {
+  const now = new Date();
+  const id = generateUuidv7();
+  const email = `e2e-${id}@example.com`;
+
+  await db.insert(schema.users).values({
+    id,
+    email,
+    passwordHash: await argon2.hash(password),
+    emailVerifiedAt: now,
+    tosAgreedAt: now,
+    privacyPolicyAgreedAt: now,
+    notEuAgreedAt: now,
+  });
+
+  return { id, email, password };
 }
 
 /** Sets the session cookie so the browser context is logged in as the user. */

--- a/tests/e2e/wallabag-api.spec.ts
+++ b/tests/e2e/wallabag-api.spec.ts
@@ -241,6 +241,41 @@ test.describe("Wallabag API happy path", () => {
 });
 
 /**
+ * A Wallabag token is an OAuth access token scoped to `reader:full-access`. It
+ * must not be usable outside the Wallabag surface: not on the MCP endpoint (that
+ * needs the `mcp` scope), not on the main tRPC/REST account-management surface
+ * (OAuth tokens aren't accepted there at all), and not on the Google Reader API
+ * (which authenticates sessions, not OAuth tokens). These lock in that a leaked
+ * Wallabag credential can't be replayed to escalate.
+ */
+test.describe("Wallabag API credential isolation", () => {
+  test("token is rejected at the MCP endpoint (lacks the mcp scope)", async ({ request }) => {
+    const { access_token } = await getTokens(request);
+    const res = await request.get("/api/mcp", {
+      headers: { Authorization: `Bearer ${access_token}` },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("token cannot reach account-management endpoints", async ({ request }) => {
+    const { access_token } = await getTokens(request);
+    // Session-only account surface (listing the user's active sessions).
+    const res = await request.get("/api/v1/users/me/sessions", {
+      headers: { Authorization: `Bearer ${access_token}` },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("token cannot be replayed against the Google Reader API", async ({ request }) => {
+    const { access_token } = await getTokens(request);
+    const res = await request.get("/api/greader.php/reader/api/0/user-info", {
+      headers: { Authorization: `Bearer ${access_token}` },
+    });
+    expect(res.status()).toBe(401);
+  });
+});
+
+/**
  * Starts a throwaway HTTP server on a random port serving a single article page,
  * returning its URL and a close function. The app fetches this when saving.
  */

--- a/tests/e2e/wallabag-api.spec.ts
+++ b/tests/e2e/wallabag-api.spec.ts
@@ -1,0 +1,267 @@
+/**
+ * Route-level tests for the Wallabag compatibility API
+ * (`src/app/api/wallabag/**`).
+ *
+ * The Wallabag HTTP surface — OAuth password/refresh grants, bearer-token auth,
+ * response formatting, status codes — has no unit/integration coverage (the
+ * services it calls do, but the routes themselves don't). This suite exercises
+ * the real server over HTTP so regressions in auth handling and status codes
+ * are caught.
+ *
+ * Regression guard for #1018: `requireAuth` used to `throw` a `Response`, which
+ * Next.js App Router surfaces as a 500 instead of the intended 401. These tests
+ * assert 401 (not 500) for every unauthenticated protected endpoint.
+ */
+
+import { createServer, type Server } from "node:http";
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { getDb, createPasswordUser, closeTestConnections, type TestPasswordUser } from "./helpers";
+
+const TOKEN_PATH = "/api/wallabag/oauth/v2/token";
+
+/** Protected GET endpoints that must reject unauthenticated requests with 401. */
+const PROTECTED_GET_ENDPOINTS = [
+  "/api/wallabag/api/user",
+  "/api/wallabag/api/entries",
+  "/api/wallabag/api/tags",
+  "/api/wallabag/api/search",
+  "/api/wallabag/api/entries/exists?url=https://example.com",
+];
+
+let sharedUser: TestPasswordUser | undefined;
+
+/** A confirmed password user, created once and reused across happy-path tests. */
+async function getUser(): Promise<TestPasswordUser> {
+  sharedUser ??= await createPasswordUser(getDb());
+  return sharedUser;
+}
+
+interface TokenPair {
+  access_token: string;
+  refresh_token: string;
+}
+
+let sharedTokens: TokenPair | undefined;
+
+/**
+ * Runs the password grant once and memoizes the token pair. The `expensive`
+ * per-IP rate-limit bucket (capacity 10, refill 1/s) is shared across both
+ * compat login endpoints, so tests must authenticate sparingly rather than
+ * logging in on every case.
+ */
+async function getTokens(request: APIRequestContext): Promise<TokenPair> {
+  if (!sharedTokens) {
+    const user = await getUser();
+    sharedTokens = await passwordGrant(request, user);
+  }
+  return sharedTokens;
+}
+
+/** Runs the password grant and returns the token pair. */
+async function passwordGrant(
+  request: APIRequestContext,
+  user: TestPasswordUser
+): Promise<TokenPair> {
+  const res = await request.post(TOKEN_PATH, {
+    form: {
+      grant_type: "password",
+      client_id: "wallabag",
+      client_secret: "wallabag",
+      username: user.email,
+      password: user.password,
+    },
+  });
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  expect(typeof body.access_token).toBe("string");
+  expect(typeof body.refresh_token).toBe("string");
+  expect(body.token_type).toBe("bearer");
+  return body;
+}
+
+test.afterAll(async () => {
+  await closeTestConnections();
+});
+
+test.describe("Wallabag API auth", () => {
+  test("protected endpoints return 401 (not 500) without a token", async ({ request }) => {
+    for (const endpoint of PROTECTED_GET_ENDPOINTS) {
+      const res = await request.get(endpoint);
+      expect(res.status(), `GET ${endpoint} without auth`).toBe(401);
+    }
+  });
+
+  test("protected endpoints return 401 with a garbage token", async ({ request }) => {
+    for (const endpoint of PROTECTED_GET_ENDPOINTS) {
+      const res = await request.get(endpoint, {
+        headers: { Authorization: "Bearer not-a-real-token" },
+      });
+      expect(res.status(), `GET ${endpoint} with garbage token`).toBe(401);
+    }
+  });
+
+  test("password grant with wrong password returns 401", async ({ request }) => {
+    const user = await getUser();
+    const res = await request.post(TOKEN_PATH, {
+      form: {
+        grant_type: "password",
+        client_id: "wallabag",
+        client_secret: "wallabag",
+        username: user.email,
+        password: "wrong-password",
+      },
+    });
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_grant");
+  });
+
+  test("password grant for an unknown user returns 401", async ({ request }) => {
+    const res = await request.post(TOKEN_PATH, {
+      form: {
+        grant_type: "password",
+        client_id: "wallabag",
+        client_secret: "wallabag",
+        username: "does-not-exist@example.com",
+        password: "whatever",
+      },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("refresh grant with an invalid refresh token returns 401", async ({ request }) => {
+    const res = await request.post(TOKEN_PATH, {
+      form: {
+        grant_type: "refresh_token",
+        client_id: "wallabag",
+        client_secret: "wallabag",
+        refresh_token: "not-a-real-refresh-token",
+      },
+    });
+    expect(res.status()).toBe(401);
+  });
+});
+
+test.describe("Wallabag API happy path", () => {
+  test("password grant issues a working bearer token", async ({ request }) => {
+    const user = await getUser();
+    const { access_token } = await passwordGrant(request, user);
+
+    const res = await request.get("/api/wallabag/api/user", {
+      headers: { Authorization: `Bearer ${access_token}` },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.email).toBe(user.email);
+    expect(body.username).toBe(user.email);
+  });
+
+  test("list and tags endpoints authorize with a token", async ({ request }) => {
+    const { access_token } = await getTokens(request);
+    const auth = { Authorization: `Bearer ${access_token}` };
+
+    const listRes = await request.get("/api/wallabag/api/entries", { headers: auth });
+    expect(listRes.status()).toBe(200);
+    const list = await listRes.json();
+    expect(Array.isArray(list._embedded.items)).toBe(true);
+
+    const tagsRes = await request.get("/api/wallabag/api/tags", { headers: auth });
+    expect(tagsRes.status()).toBe(200);
+    expect(Array.isArray(await tagsRes.json())).toBe(true);
+  });
+
+  test("refresh_token grant returns a fresh token pair", async ({ request }) => {
+    // A dedicated grant, not the shared token: rotating a refresh token revokes
+    // its access token, which would break the other tests that reuse getTokens.
+    const user = await getUser();
+    const { refresh_token } = await passwordGrant(request, user);
+
+    const res = await request.post(TOKEN_PATH, {
+      form: {
+        grant_type: "refresh_token",
+        client_id: "wallabag",
+        client_secret: "wallabag",
+        refresh_token,
+      },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(typeof body.access_token).toBe("string");
+    expect(typeof body.refresh_token).toBe("string");
+  });
+
+  test("save an article, see it in the list, then delete it", async ({ request }) => {
+    const { access_token } = await getTokens(request);
+    const auth = { Authorization: `Bearer ${access_token}` };
+
+    // Serve a tiny article page locally; ALLOW_PRIVATE_NETWORK_FETCH=true in
+    // .env.test lets the app fetch localhost, so this exercises the real save
+    // pipeline (fetch → clean → persist) end to end.
+    const { url, close } = await startArticleServer();
+    try {
+      const saveRes = await request.post("/api/wallabag/api/entries", {
+        headers: auth,
+        form: { url },
+      });
+      expect(saveRes.status()).toBe(200);
+      const saved = await saveRes.json();
+      expect(typeof saved.id).toBe("number");
+      expect(saved.url).toBe(url);
+
+      // The saved article shows up in the entries list.
+      const listRes = await request.get("/api/wallabag/api/entries", { headers: auth });
+      expect(listRes.status()).toBe(200);
+      const list = await listRes.json();
+      const ids = list._embedded.items.map((e: { id: number }) => e.id);
+      expect(ids).toContain(saved.id);
+
+      // exists reports it as present.
+      const existsRes = await request.get(
+        `/api/wallabag/api/entries/exists?url=${encodeURIComponent(url)}`,
+        { headers: auth }
+      );
+      expect(existsRes.status()).toBe(200);
+      expect((await existsRes.json()).exists).toBe(true);
+
+      // Delete it.
+      const deleteRes = await request.delete(`/api/wallabag/api/entries/${saved.id}`, {
+        headers: auth,
+      });
+      expect(deleteRes.status()).toBe(200);
+
+      // Deleting again is a 404 (it's gone).
+      const deleteAgain = await request.delete(`/api/wallabag/api/entries/${saved.id}`, {
+        headers: auth,
+      });
+      expect(deleteAgain.status()).toBe(404);
+    } finally {
+      await close();
+    }
+  });
+});
+
+/**
+ * Starts a throwaway HTTP server on a random port serving a single article page,
+ * returning its URL and a close function. The app fetches this when saving.
+ */
+async function startArticleServer(): Promise<{ url: string; close: () => Promise<void> }> {
+  const server: Server = createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(
+      `<!DOCTYPE html><html><head><title>Wallabag Test Article</title></head>` +
+        `<body><article><h1>Wallabag Test Article</h1>` +
+        `<p>This is a saved article used by the Wallabag e2e save test. ` +
+        `It has enough words for Readability to treat it as real content, ` +
+        `so the save pipeline produces a cleaned body.</p></article></body></html>`
+    );
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to determine article server port");
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}/article`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}


### PR DESCRIPTION
## Summary

Closes #1021.

Neither the Wallabag (`src/app/api/wallabag/**`) nor the Google Reader (`src/app/api/greader.php/**`) compat HTTP surface had any route-level tests. That's why the "500 instead of 401 for unauthenticated requests" bug (fixed in #1018) slipped past `typecheck`/`lint`/unit tests — the services they call are tested, but the HTTP routes' auth handling and status codes weren't exercised by anything.

This adds two e2e specs that hit the real server over HTTP (`tests/e2e/`, real DB), covering the cases the issue asked for.

## What's tested

**Auth regression guard for #1018**
- Every protected endpoint returns **401, not 500**, for missing tokens and for garbage tokens (Wallabag: `user`, `entries`, `tags`, `search`, `entries/exists`; GReader: `user-info`, `unread-count`, `subscription/list`, `tag/list`, `token`, `stream/items/ids`).

**Auth negatives**
- Wrong password → 401 on both token endpoints; unknown user → 401; invalid refresh token → 401.

**Happy paths**
- Wallabag: password grant → bearer token → `user`/`entries`/`tags`; `refresh_token` grant; save an article via `POST /entries` (against a throwaway local HTTP server, so the real fetch → clean → persist pipeline runs), confirm it in the list + `entries/exists`, then delete.
- Google Reader: `ClientLogin` → `Auth=` token → `user-info`; token echo; `subscription/list`; `stream/items/ids`.

## Notes

- Adds `createPasswordUser` to `tests/e2e/helpers.ts` (confirmed user with an argon2 password hash, no session).
- Logins are memoized per user: the shared per-IP `expensive` rate-limit bucket (capacity 10) is exercised by both compat login endpoints, so logging in on every case would trip a 429. The refresh-token test uses its own grant because rotation revokes the access token.
- The save happy-path relies on `ALLOW_PRIVATE_NETWORK_FETCH=true` (set in `.env.test`) so the app can fetch the test's localhost article server.

All 17 new tests pass locally (`pnpm test:e2e:local wallabag-api greader-api`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)