### PR TITLE
Google Reader: batch stream/items/contents fetch, cap contents pages (#1048)

### DIFF
--- a/src/app/api/greader.php/reader/api/0/stream/contents/[...streamId]/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/contents/[...streamId]/route.ts
@@ -10,7 +10,8 @@
  * - user/-/label/{name} — entries in a tag/folder
  *
  * Query parameters:
- * - n: number of items (default 20, max 1000)
+ * - n: number of items (default 20, max 300) — capped lower than the ids stream
+ *   because each item carries a full (potentially large, sanitized) article body
  * - c: continuation token (cursor)
  * - ot: oldest timestamp (unix seconds) — exclude items older than this
  * - nt: newest timestamp (unix seconds) — exclude items newer than this
@@ -52,7 +53,7 @@ async function handleStreamContents(
   const url = new URL(request.url);
   const searchParams = url.searchParams;
 
-  const count = Math.min(parseInt(searchParams.get("n") ?? "20", 10) || 20, 1000);
+  const count = Math.min(parseInt(searchParams.get("n") ?? "20", 10) || 20, 300);
   const continuation = searchParams.get("c") ?? undefined;
   const sortOrder = searchParams.get("r") === "o" ? "oldest" : "newest";
   const excludeTarget = searchParams.get("xt");
@@ -63,7 +64,7 @@ async function handleStreamContents(
   const listParams: entriesService.ListEntriesParams = {
     userId: session.user.id,
     limit: count,
-    maxLimit: 1000,
+    maxLimit: 300,
     cursor: continuation,
     sortOrder: sortOrder as "newest" | "oldest",
     showSpam: session.user.showSpam,
@@ -133,24 +134,26 @@ async function handleStreamContents(
   // Fetch entries using service layer
   const result = await entriesService.listEntries(db, listParams);
 
-  // Get full content for each entry
-  const items = await Promise.all(
-    result.items.map(async (entry) => {
-      try {
-        const full = await entriesService.getEntry(db, session.user.id, entry.id);
-        return formatEntryAsItem(full);
-      } catch {
-        // If entry can't be fetched with full content, use list data
-        return formatEntryAsItem({
-          ...entry,
-          contentOriginal: null,
-          contentCleaned: null,
-          feedUrl: null,
-          unsubscribeUrl: null,
-        });
-      }
-    })
+  // Get full content in a single bulk query rather than one getEntry per entry.
+  const fullEntries = await entriesService.getEntries(
+    db,
+    session.user.id,
+    result.items.map((e) => e.id)
   );
+  const fullMap = new Map(fullEntries.map((e) => [e.id, e]));
+  const items = result.items.map((entry) => {
+    const full = fullMap.get(entry.id);
+    // If full content isn't available, fall back to list data.
+    return formatEntryAsItem(
+      full ?? {
+        ...entry,
+        contentOriginal: null,
+        contentCleaned: null,
+        feedUrl: null,
+        unsubscribeUrl: null,
+      }
+    );
+  });
 
   const response: Record<string, unknown> = {
     direction: "ltr",

--- a/src/app/api/greader.php/reader/api/0/stream/items/contents/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/items/contents/route.ts
@@ -52,16 +52,13 @@ export async function POST(request: Request): Promise<Response> {
   // Batch resolve int64 IDs to UUIDs
   const uuidMap = await batchInt64ToUuid(db, itemIds);
 
-  // Fetch full entries for resolved UUIDs
-  const items = [];
-  for (const [, uuid] of uuidMap) {
-    try {
-      const entry = await entriesService.getEntry(db, session.user.id, uuid);
-      items.push(formatEntryAsItem(entry));
-    } catch {
-      // Skip entries that can't be found (deleted, not visible to user, etc.)
-    }
-  }
+  // Fetch full entries in a single bulk query (mirrors the Wallabag route)
+  // rather than one getEntry per id. getEntries returns entries in the order of
+  // the given UUIDs and silently skips ones that can't be found (deleted, not
+  // visible to the user, etc.).
+  const uuids = [...uuidMap.values()];
+  const entries = await entriesService.getEntries(db, session.user.id, uuids);
+  const items = entries.map(formatEntryAsItem);
 
   return jsonResponse({
     direction: "ltr",

--- a/tests/e2e/greader-api.spec.ts
+++ b/tests/e2e/greader-api.spec.ts
@@ -170,6 +170,43 @@ test.describe("Google Reader API happy path", () => {
       expect(typeof ref.id).toBe("string");
     }
   });
+
+  test("stream/items/contents returns full items for the given ids in order", async ({
+    request,
+  }) => {
+    const token = await getToken(request);
+
+    // Grab a couple of item ids from the reading list.
+    const idsRes = await request.get(
+      `${API_BASE}/stream/items/ids?s=user/-/state/com.google/reading-list`,
+      { headers: authHeader(token) }
+    );
+    expect(idsRes.status()).toBe(200);
+    const idsBody = await idsRes.json();
+    const ids: string[] = idsBody.itemRefs.map((ref: { id: string }) => ref.id);
+    expect(ids.length).toBeGreaterThanOrEqual(1);
+
+    // POST them to the batch contents endpoint (form-encoded, i=... repeated).
+    const form = new URLSearchParams();
+    for (const id of ids) form.append("i", id);
+    const res = await request.post(`${API_BASE}/stream/items/contents`, {
+      headers: {
+        ...authHeader(token),
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      data: form.toString(),
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.items.length).toBe(ids.length);
+    for (const item of body.items) {
+      expect(typeof item.id).toBe("string");
+      // Full items carry the article body in either `content` (large bodies) or
+      // `summary` (short bodies) — the batch fetch must populate one of them.
+      expect(item.content ?? item.summary).toBeTruthy();
+    }
+  });
 });
 
 /**

--- a/tests/e2e/greader-api.spec.ts
+++ b/tests/e2e/greader-api.spec.ts
@@ -171,7 +171,7 @@ test.describe("Google Reader API happy path", () => {
     }
   });
 
-  test("stream/items/contents returns full items for the given ids in order", async ({
+  test("stream/items/contents returns full items with body for the given ids", async ({
     request,
   }) => {
     const token = await getToken(request);
@@ -202,9 +202,10 @@ test.describe("Google Reader API happy path", () => {
     expect(body.items.length).toBe(ids.length);
     for (const item of body.items) {
       expect(typeof item.id).toBe("string");
-      // Full items carry the article body in either `content` (large bodies) or
-      // `summary` (short bodies) — the batch fetch must populate one of them.
-      expect(item.content ?? item.summary).toBeTruthy();
+      // formatEntryAsItem always emits the body under `summary.content` — the
+      // batch fetch must populate it with the seeded entry's actual content, not
+      // an empty string (which is what a failed/missing body fetch produces).
+      expect(item.summary.content).toContain("Content for GReader entry");
     }
   });
 });


### PR DESCRIPTION
Fixes #1048.

## Problem

The Google Reader `stream/items/contents` route fetched full entries **one-by-one in a loop** (`getEntry` per id) instead of using the existing batch service, turning a large initial sync into hundreds of sequential DB round-trips + sanitize passes in a single request — a latency cliff that can time out a client. The `stream/contents/[...streamId]` route had the same anti-pattern (parallel `getEntry` fan-out) and a very large 1000-item page cap.

## Changes

- **`stream/items/contents`**: rewritten to call `entriesService.getEntries(db, userId, uuids)` — a single `inArray` query returning results in input order, mirroring the Wallabag route. Missing entries are still silently skipped.
- **`stream/contents/[...streamId]`**: converted from its parallel per-entry `getEntry` loop to the same batch service (falling back to list data when full content isn't available), and lowered its page cap (`n` and `maxLimit`) from **1000 → 300** since each item carries a full, potentially large sanitized article body.
- **`stream/items/ids`** cap stays high (10000) — IDs are cheap.
- Added an e2e test exercising the batch `stream/items/contents` endpoint.

## Verification

`pnpm typecheck`, `pnpm lint`, and the Google Reader e2e suite (`pnpm test:e2e:local greader-api`, 12 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)