### PR TITLE
Google Reader: accept ClientLogin params from query string (FeedMe compat)

### DIFF
--- a/src/server/google-reader/parse.ts
+++ b/src/server/google-reader/parse.ts
@@ -8,20 +8,42 @@
 import { parseItemId } from "./id";
 
 /**
- * Parses form-encoded POST body or URL query parameters.
- * Google Reader API uses application/x-www-form-urlencoded for POST bodies.
+ * Parses request parameters, accepting them from the URL query string OR the
+ * form-encoded body, mirroring the original Google Reader API (and FreshRSS's
+ * `greader.php`, which reads PHP `$_REQUEST` — GET and POST merged).
+ *
+ * Some clients put parameters in the query string even on a POST: FeedMe, for
+ * example, sends `POST /accounts/ClientLogin?Email=…&Passwd=…` with an empty
+ * body. Reading only the body would 401 those clients, so we start from the
+ * query params and layer body params on top (body wins on key conflicts).
  */
 export async function parseFormData(request: Request): Promise<URLSearchParams> {
+  const params = new URLSearchParams(new URL(request.url).searchParams);
+
   if (request.method === "GET") {
-    return new URL(request.url).searchParams;
+    return params;
   }
 
+  const bodyParams = await parseBody(request);
+
+  // Body overrides query on conflicting keys (e.g. repeated `i` item IDs come
+  // from the body); delete-then-append so we don't accumulate both sides.
+  for (const key of new Set(bodyParams.keys())) {
+    params.delete(key);
+    for (const value of bodyParams.getAll(key)) {
+      params.append(key, value);
+    }
+  }
+
+  return params;
+}
+
+/**
+ * Parses the request body as form data (url-encoded or multipart). Returns an
+ * empty set for a body-less/unparseable request.
+ */
+async function parseBody(request: Request): Promise<URLSearchParams> {
   const contentType = request.headers.get("content-type") ?? "";
-
-  if (contentType.includes("application/x-www-form-urlencoded")) {
-    const text = await request.text();
-    return new URLSearchParams(text);
-  }
 
   if (contentType.includes("multipart/form-data")) {
     const formData = await request.formData();
@@ -34,10 +56,10 @@ export async function parseFormData(request: Request): Promise<URLSearchParams> 
     return params;
   }
 
-  // Fall back to trying to parse as form data
+  // Default to url-encoded (the Google Reader content type), also covering the
+  // "no content type" case some clients send.
   try {
-    const text = await request.text();
-    return new URLSearchParams(text);
+    return new URLSearchParams(await request.text());
   } catch (err) {
     console.error("Failed to parse request body as form data:", err);
     return new URLSearchParams();

--- a/src/server/sentry.ts
+++ b/src/server/sentry.ts
@@ -15,12 +15,20 @@
 import * as Sentry from "@sentry/nextjs";
 import type { ErrorEvent } from "@sentry/nextjs";
 
-// Query params whose values are credentials/secrets and must never reach Sentry.
+// Query params whose values are credentials/PII and must never reach Sentry.
 // Some clients pass these in the URL even on a POST — notably FeedMe sends the
 // Google Reader `Passwd` (and `Email`) on the ClientLogin URL — so any captured
-// request data would otherwise carry a plaintext password. Case-insensitive to
-// cover both `Passwd` (Google Reader) and `password`/`client_secret` (OAuth).
-const SENSITIVE_QUERY_PARAMS = ["passwd", "password", "email", "client_secret", "t"];
+// request data would otherwise carry a plaintext password. Matched
+// case-insensitively to cover `Passwd` (Google Reader) and
+// `password`/`client_secret` (OAuth).
+const SENSITIVE_QUERY_PARAMS = ["passwd", "password", "email", "client_secret"];
+
+// The Google Reader write/session token is passed as `T` in the URL by some
+// clients — worth redacting. Matched CASE-SENSITIVELY (uppercase only) so it
+// does not also clobber the lowercase `t=` param, which this API uses for
+// non-secret tag names (disable-tag) and feed titles (subscription/edit); those
+// stay visible in Sentry for debugging.
+const SENSITIVE_TOKEN_PARAM = "T";
 
 /**
  * Redacts sensitive values from an event's captured request URL and query
@@ -30,11 +38,13 @@ export function redactSensitiveRequestParams(event: ErrorEvent): void {
   const request = event.request;
   if (!request) return;
 
-  const redact = (value: string): string => {
-    // Matches `?key=…` / `&key=…` (in a full URL) and `key=…` (bare query string).
-    const pattern = new RegExp(`((?:^|[?&])(?:${SENSITIVE_QUERY_PARAMS.join("|")})=)[^&#]*`, "gi");
-    return value.replace(pattern, "$1[REDACTED]");
-  };
+  // Boundary `(?:^|[?&])` requires the name to start the param, so `email` does
+  // not match `…&someemail=` and `T` does not match `&nt=`/`&xt=`/etc.
+  const ciPattern = new RegExp(`((?:^|[?&])(?:${SENSITIVE_QUERY_PARAMS.join("|")})=)[^&#]*`, "gi");
+  const tokenPattern = new RegExp(`((?:^|[?&])${SENSITIVE_TOKEN_PARAM}=)[^&#]*`, "g");
+
+  const redact = (value: string): string =>
+    value.replace(ciPattern, "$1[REDACTED]").replace(tokenPattern, "$1[REDACTED]");
 
   if (typeof request.url === "string") {
     request.url = redact(request.url);

--- a/src/server/sentry.ts
+++ b/src/server/sentry.ts
@@ -13,6 +13,36 @@
  */
 
 import * as Sentry from "@sentry/nextjs";
+import type { ErrorEvent } from "@sentry/nextjs";
+
+// Query params whose values are credentials/secrets and must never reach Sentry.
+// Some clients pass these in the URL even on a POST — notably FeedMe sends the
+// Google Reader `Passwd` (and `Email`) on the ClientLogin URL — so any captured
+// request data would otherwise carry a plaintext password. Case-insensitive to
+// cover both `Passwd` (Google Reader) and `password`/`client_secret` (OAuth).
+const SENSITIVE_QUERY_PARAMS = ["passwd", "password", "email", "client_secret", "t"];
+
+/**
+ * Redacts sensitive values from an event's captured request URL and query
+ * string, in place. Preserves the parameter name so the shape is still visible.
+ */
+export function redactSensitiveRequestParams(event: ErrorEvent): void {
+  const request = event.request;
+  if (!request) return;
+
+  const redact = (value: string): string => {
+    // Matches `?key=…` / `&key=…` (in a full URL) and `key=…` (bare query string).
+    const pattern = new RegExp(`((?:^|[?&])(?:${SENSITIVE_QUERY_PARAMS.join("|")})=)[^&#]*`, "gi");
+    return value.replace(pattern, "$1[REDACTED]");
+  };
+
+  if (typeof request.url === "string") {
+    request.url = redact(request.url);
+  }
+  if (typeof request.query_string === "string") {
+    request.query_string = redact(request.query_string);
+  }
+}
 
 /**
  * Initializes Sentry if SENTRY_DSN is set. Safe to call more than once
@@ -54,6 +84,10 @@ export function initSentry(): void {
           return null;
         }
       }
+
+      // Strip credentials some clients pass in the URL (e.g. FeedMe's Google
+      // Reader `Passwd`) so plaintext passwords never reach Sentry.
+      redactSensitiveRequestParams(event);
 
       return event;
     },

--- a/tests/unit/google-reader-parse.test.ts
+++ b/tests/unit/google-reader-parse.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for Google Reader request parsing.
+ *
+ * Clients disagree on where to put parameters: FocusReader/newsboat send them in
+ * the form body, while FeedMe sends them in the URL query string even on a POST
+ * (`POST /accounts/ClientLogin?Email=…&Passwd=…` with an empty body). The
+ * original Google Reader API and FreshRSS accept either (PHP `$_REQUEST`), so
+ * parseFormData merges query + body with the body winning on conflicts.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseFormData, parseItemIds } from "../../src/server/google-reader/parse";
+
+function postRequest(url: string, body?: string, contentType?: string): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: contentType ? { "content-type": contentType } : undefined,
+    body,
+  });
+}
+
+const FORM = "application/x-www-form-urlencoded";
+
+describe("parseFormData", () => {
+  it("reads params from the URL query string on a POST (FeedMe-style, empty body)", async () => {
+    const req = postRequest("https://x.test/accounts/ClientLogin?Email=a%40b.com&Passwd=secret");
+    const params = await parseFormData(req);
+    expect(params.get("Email")).toBe("a@b.com");
+    expect(params.get("Passwd")).toBe("secret");
+  });
+
+  it("reads params from a url-encoded body (FocusReader-style)", async () => {
+    const req = postRequest(
+      "https://x.test/accounts/ClientLogin",
+      "Email=a%40b.com&Passwd=secret",
+      FORM
+    );
+    const params = await parseFormData(req);
+    expect(params.get("Email")).toBe("a@b.com");
+    expect(params.get("Passwd")).toBe("secret");
+  });
+
+  it("lets the body win over the query string on conflicting keys", async () => {
+    const req = postRequest(
+      "https://x.test/accounts/ClientLogin?Passwd=fromQuery",
+      "Passwd=fromBody",
+      FORM
+    );
+    const params = await parseFormData(req);
+    expect(params.get("Passwd")).toBe("fromBody");
+    // Exactly one value — we don't accumulate both sides.
+    expect(params.getAll("Passwd")).toEqual(["fromBody"]);
+  });
+
+  it("keeps a query param the body does not override", async () => {
+    const req = postRequest("https://x.test/reader/api/0/edit-tag?T=token", "i=123&a=read", FORM);
+    const params = await parseFormData(req);
+    expect(params.get("T")).toBe("token");
+    expect(params.get("i")).toBe("123");
+    expect(params.get("a")).toBe("read");
+  });
+
+  it("returns query params for a GET", async () => {
+    const req = new Request("https://x.test/reader/api/0/stream/items/ids?s=reading-list&n=5");
+    const params = await parseFormData(req);
+    expect(params.get("s")).toBe("reading-list");
+    expect(params.get("n")).toBe("5");
+  });
+
+  it("parses multipart body params", async () => {
+    const form = new FormData();
+    form.set("Email", "a@b.com");
+    form.set("Passwd", "secret");
+    const req = new Request("https://x.test/accounts/ClientLogin", { method: "POST", body: form });
+    const params = await parseFormData(req);
+    expect(params.get("Email")).toBe("a@b.com");
+    expect(params.get("Passwd")).toBe("secret");
+  });
+
+  it("merges repeated item IDs, preferring the body's set when present", async () => {
+    // Body carries the `i` list (the normal contents transport); a stray query
+    // `i` must not leak in alongside it.
+    const req = postRequest(
+      "https://x.test/reader/api/0/stream/items/contents?i=999",
+      "i=1&i=2&i=3",
+      FORM
+    );
+    const params = await parseFormData(req);
+    expect(parseItemIds(params)).toEqual([BigInt(1), BigInt(2), BigInt(3)]);
+  });
+});

--- a/tests/unit/google-reader-parse.test.ts
+++ b/tests/unit/google-reader-parse.test.ts
@@ -88,4 +88,12 @@ describe("parseFormData", () => {
     const params = await parseFormData(req);
     expect(parseItemIds(params)).toEqual([BigInt(1), BigInt(2), BigInt(3)]);
   });
+
+  it("honors a query-only item ID when the body carries none", async () => {
+    // Mirrors PHP $_REQUEST (GET+POST merge): if the body has no `i`, the query
+    // `i` is used. Harmless — parseItemIds → getEntry is fully user-scoped.
+    const req = postRequest("https://x.test/reader/api/0/stream/items/contents?i=42", "", FORM);
+    const params = await parseFormData(req);
+    expect(parseItemIds(params)).toEqual([BigInt(42)]);
+  });
 });

--- a/tests/unit/sentry-redact.test.ts
+++ b/tests/unit/sentry-redact.test.ts
@@ -52,6 +52,26 @@ describe("redactSensitiveRequestParams", () => {
     );
   });
 
+  it("redacts the uppercase T write-token but keeps the lowercase t tag/title param", () => {
+    // `T` = Google Reader write/session token (secret); lowercase `t` = tag name
+    // (disable-tag) / feed title (subscription/edit), which must stay visible.
+    const event = eventWith({ query_string: "T=sessionsecret&t=my-tag-name&s=reading-list" });
+    redactSensitiveRequestParams(event);
+    expect(event.request?.query_string).toBe("T=[REDACTED]&t=my-tag-name&s=reading-list");
+  });
+
+  it("does not match sensitive names embedded in other param names", () => {
+    // `nt`/`xt`/`ot` (timestamp/exclude params) must not be caught by the `T`
+    // rule, and `someemail` must not be caught by `email`.
+    const event = eventWith({
+      url: "https://x.test/reader/api/0/stream/items/ids?ot=1&nt=2&xt=read&someemail=x",
+    });
+    redactSensitiveRequestParams(event);
+    expect(event.request?.url).toBe(
+      "https://x.test/reader/api/0/stream/items/ids?ot=1&nt=2&xt=read&someemail=x"
+    );
+  });
+
   it("does not throw when there is no request context", () => {
     const event = eventWith(undefined);
     expect(() => redactSensitiveRequestParams(event)).not.toThrow();

--- a/tests/unit/sentry-redact.test.ts
+++ b/tests/unit/sentry-redact.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for Sentry request-param redaction.
+ *
+ * Some Google Reader clients pass credentials in the URL query string even on a
+ * POST (FeedMe sends `Passwd` on the ClientLogin URL). Sentry can capture that
+ * URL as request data, so redactSensitiveRequestParams must strip the values
+ * before an event is sent.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { ErrorEvent } from "@sentry/nextjs";
+import { redactSensitiveRequestParams } from "../../src/server/sentry";
+
+function eventWith(request: ErrorEvent["request"]): ErrorEvent {
+  return { type: undefined, request } as ErrorEvent;
+}
+
+describe("redactSensitiveRequestParams", () => {
+  it("redacts the Google Reader Passwd (and Email) in a captured URL", () => {
+    const event = eventWith({
+      url: "https://lionreader.com/api/greader.php/accounts/ClientLogin?Email=a%40b.com&Passwd=hunter2",
+    });
+    redactSensitiveRequestParams(event);
+    expect(event.request?.url).toBe(
+      "https://lionreader.com/api/greader.php/accounts/ClientLogin?Email=[REDACTED]&Passwd=[REDACTED]"
+    );
+  });
+
+  it("redacts sensitive params in a bare query_string", () => {
+    const event = eventWith({ query_string: "Passwd=hunter2&s=reading-list" });
+    redactSensitiveRequestParams(event);
+    expect(event.request?.query_string).toBe("Passwd=[REDACTED]&s=reading-list");
+  });
+
+  it("is case-insensitive and covers OAuth secrets", () => {
+    const event = eventWith({
+      url: "https://x.test/oauth/token?password=p&CLIENT_SECRET=s&code=keep",
+    });
+    redactSensitiveRequestParams(event);
+    expect(event.request?.url).toBe(
+      "https://x.test/oauth/token?password=[REDACTED]&CLIENT_SECRET=[REDACTED]&code=keep"
+    );
+  });
+
+  it("leaves non-sensitive params untouched", () => {
+    const event = eventWith({
+      url: "https://x.test/reader/api/0/stream/items/ids?s=reading-list&n=1000",
+    });
+    redactSensitiveRequestParams(event);
+    expect(event.request?.url).toBe(
+      "https://x.test/reader/api/0/stream/items/ids?s=reading-list&n=1000"
+    );
+  });
+
+  it("does not throw when there is no request context", () => {
+    const event = eventWith(undefined);
+    expect(() => redactSensitiveRequestParams(event)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

Google Reader clients disagree on where to put request parameters. **FocusReader** (and newsboat) send them in the form body; **FeedMe** sends them in the **URL query string even on a POST** — `POST /accounts/ClientLogin?Email=…&Passwd=…` with an empty body. `parseFormData` read only the body, so FeedMe got a spurious `BadAuthentication` (401) with correct credentials.

Verified live against a dev server seeded with a test account: FocusReader logged in and synced 8 articles; FeedMe 401'd. The dev request log showed the smoking gun:

```
POST /api/greader.php/accounts/ClientLogin?Email=reader%40example.com&Passwd=lionreader  401
```

The original Google Reader API and FreshRSS's `greader.php` accept params from either place (PHP `$_REQUEST` merges GET + POST).

## Fix

- **`parseFormData`** now merges query-string and body params, with the **body winning** on key conflicts (so the repeated `i` item-ID list still comes from the body). Verified end-to-end: FeedMe-style query creds → 200, body creds still → 200, body overrides query, bad creds still → 401.
- **Redaction:** because clients may now put a password in the query string — where Sentry could capture it as request data — `redactSensitiveRequestParams` scrubs `Passwd`/`password`/`Email`/`client_secret`/`T` from the Sentry event's `request.url` and `query_string` in `beforeSend`. (Fly's edge access logs are outside our code — noted as an infra follow-up.)

## Tests

New unit tests:
- `tests/unit/google-reader-parse.test.ts` — query vs body precedence, GET, multipart, repeated item IDs.
- `tests/unit/sentry-redact.test.ts` — redaction of sensitive params, case-insensitivity, non-sensitive params untouched, no-request safety.

`pnpm typecheck` clean; 12/12 new tests pass.

## Not included

Found separately while scale-testing and filed as issues (unrelated to this auth bug): #1047 (`uuidToInt64` collisions drop entries at scale) and #1048 (`stream/items/contents` N+1 selects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)