### PR TITLE
Google Reader: cap stream/items/contents id batch with a 400 backstop

### DIFF
--- a/src/app/api/greader.php/reader/api/0/stream/items/contents/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/items/contents/route.ts
@@ -13,6 +13,12 @@
  * - Long hex: tag:google.com,2005:reader/item/000000000000001F
  * - Short hex: 000000000000001F
  * - Decimal: 31
+ *
+ * The client supplies the id list explicitly (there is no server-side cursor to
+ * paginate it), so callers are expected to batch: page ids via stream/items/ids
+ * and post them in bounded chunks. We enforce an upper bound with a 400 rather
+ * than assembling an unbounded number of full (potentially large, sanitized)
+ * article bodies into one response — a runaway request should split, not stall.
  */
 
 import { requireAuth } from "@/server/google-reader/auth";
@@ -29,6 +35,13 @@ import { db } from "@/server/db";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Maximum item ids accepted per request. Generous (well-behaved clients batch
+ * far smaller — typically 50–250), but bounded so a single call can't ask the
+ * server to assemble tens of thousands of full article bodies at once.
+ */
+const MAX_ITEM_IDS = 1000;
+
 export async function POST(request: Request): Promise<Response> {
   const session = await requireAuth(request);
   if (session instanceof Response) return session;
@@ -39,6 +52,13 @@ export async function POST(request: Request): Promise<Response> {
     itemIds = parseItemIds(params);
   } catch {
     return errorResponse("Invalid item ID format", 400);
+  }
+
+  if (itemIds.length > MAX_ITEM_IDS) {
+    return errorResponse(
+      `Too many item ids: ${itemIds.length} requested, maximum ${MAX_ITEM_IDS} per request. Split into smaller batches.`,
+      400
+    );
   }
 
   if (itemIds.length === 0) {

--- a/tests/e2e/greader-api.spec.ts
+++ b/tests/e2e/greader-api.spec.ts
@@ -208,6 +208,24 @@ test.describe("Google Reader API happy path", () => {
       expect(item.summary.content).toContain("Content for GReader entry");
     }
   });
+
+  test("stream/items/contents rejects an oversized id batch with 400", async ({ request }) => {
+    const token = await getToken(request);
+
+    // Post more ids than the per-request cap (1000). The values don't need to
+    // resolve — the cap is enforced before any lookup.
+    const form = new URLSearchParams();
+    for (let i = 0; i < 1001; i++) form.append("i", String(i + 1));
+    const res = await request.post(`${API_BASE}/stream/items/contents`, {
+      headers: {
+        ...authHeader(token),
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      data: form.toString(),
+    });
+    expect(res.status()).toBe(400);
+    expect(await res.text()).toContain("Too many item ids");
+  });
 });
 
 /**


### PR DESCRIPTION
Follow-up to #1049 (issue #1048).

## Background

While fixing the N+1 in `stream/items/contents` (#1049), the code review flagged a residual asymmetry: `stream/contents/[...streamId]` is capped at 300 items per page, but `stream/items/contents` accepts an **unbounded** client-supplied id list (`parseItemIds` has no limit). A client can pull 10,000 ids from `stream/items/ids` (that endpoint's cap) and POST all of them here, asking the server to assemble that many full, sanitized (potentially ~700KB) article bodies into a single response.

## Why a cap instead of pagination

Pagination isn't meaningful for this endpoint. `stream/contents` paginates because the **server** owns the result set and hands back a continuation cursor. `stream/items/contents` is the inverse — the **client** owns the explicit id list, and the Google Reader protocol defines no continuation field for it. The natural batching boundary already lives on the ids side: conforming clients page `stream/items/ids` (which *does* have a cursor) and post the ids in bounded chunks.

So the right backstop is to reject an oversized batch and let the client split it.

## Change

- Cap `stream/items/contents` at **1000 ids per request** — generous (well-behaved clients batch 50–250), enforced *before* any DB lookup.
- Return `400` with a plain-text message (`Too many item ids: N requested, maximum 1000 per request. Split into smaller batches.`) so a runaway request splits rather than stalls.
- Added an e2e test asserting the `400`.

## Verification

`pnpm typecheck`, `pnpm lint`, and the Google Reader e2e suite (`pnpm test:e2e:local greader-api`, 13 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)