### PR TITLE
Integrations settings: link compatible apps, add copy buttons, reorder sections

### DIFF
--- a/src/app/demo/articles/google-reader-api.ts
+++ b/src/app/demo/articles/google-reader-api.ts
@@ -14,7 +14,7 @@ const article: DemoArticle = {
   heroImage: "/demo/google-reader-api.png",
   heroImageAlt:
     "The Lion Reader lion syncing with a phone and a desktop feed reader via two-way arrows.",
-  summaryHtml: `<p>Lion Reader now includes a <strong>Google Reader-compatible API</strong>, allowing you to sync your subscriptions, read state, starred articles, and tags with popular third-party RSS reader apps like Reeder, NetNewsWire, FeedMe, Read You, and NewsFlash. The API uses your existing Lion Reader credentials and requires no additional setup beyond pointing your app at your Lion Reader server.</p>`,
+  summaryHtml: `<p>Lion Reader now includes a <strong>Google Reader-compatible API</strong>, allowing you to sync your subscriptions, read state, starred articles, and tags with popular third-party RSS reader apps like Reeder, NetNewsWire, FocusReader, Read You, and NewsFlash. The API uses your existing Lion Reader credentials and requires no additional setup beyond pointing your app at your Lion Reader server.</p>`,
   contentHtml: `
     <h2>Use Your Favorite RSS App</h2>
 
@@ -27,11 +27,11 @@ const article: DemoArticle = {
     <p>Any app that supports the Google Reader API should work with Lion Reader. Some popular options include:</p>
 
     <ul>
-      <li><strong>Reeder</strong> &mdash; A beautiful RSS reader for iOS and macOS</li>
-      <li><strong>NetNewsWire</strong> &mdash; A free, open-source reader for iOS and macOS</li>
-      <li><strong>FeedMe</strong> &mdash; A popular RSS reader for Android</li>
-      <li><strong>Read You</strong> &mdash; A modern, Material Design reader for Android</li>
-      <li><strong>NewsFlash</strong> &mdash; A GTK4 feed reader for Linux</li>
+      <li><a href="https://reederapp.com/classic/" target="_blank" rel="noopener noreferrer"><strong>Reeder Classic</strong></a> &mdash; A beautiful RSS reader for iOS and macOS</li>
+      <li><a href="https://netnewswire.com/" target="_blank" rel="noopener noreferrer"><strong>NetNewsWire</strong></a> &mdash; A free, open-source reader for iOS and macOS</li>
+      <li><a href="https://play.google.com/store/apps/details?id=allen.town.focus.reader" target="_blank" rel="noopener noreferrer"><strong>FocusReader</strong></a> &mdash; A feature-rich RSS reader for Android</li>
+      <li><a href="https://f-droid.org/packages/me.ash.reader" target="_blank" rel="noopener noreferrer"><strong>Read You</strong></a> &mdash; A modern, Material Design reader for Android</li>
+      <li><a href="https://flathub.org/apps/io.gitlab.news_flash.NewsFlash" target="_blank" rel="noopener noreferrer"><strong>NewsFlash</strong></a> &mdash; A GTK4 feed reader for Linux</li>
     </ul>
 
     <h3>What Syncs</h3>

--- a/src/components/settings/GoogleReaderApiSettings.tsx
+++ b/src/components/settings/GoogleReaderApiSettings.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { CopyButton } from "@/components/ui/copy-button";
 
 export function GoogleReaderApiSettings() {
   const baseUrl = useMemo(() => {
@@ -49,26 +50,59 @@ export function GoogleReaderApiSettings() {
           </p>
           <ul className="ui-text-sm mt-2 list-inside list-disc space-y-1 text-zinc-600 dark:text-zinc-400">
             <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Reeder</strong> (iOS / macOS)
+              <a
+                href="https://reederapp.com/classic/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:text-accent-hover font-medium"
+              >
+                Reeder Classic
+              </a>{" "}
+              (iOS / macOS)
             </li>
             <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">NetNewsWire</strong> (iOS /
-              macOS)
+              <a
+                href="https://netnewswire.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:text-accent-hover font-medium"
+              >
+                NetNewsWire
+              </a>{" "}
+              (iOS / macOS)
             </li>
             <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">FeedMe</strong> (Android)
+              <a
+                href="https://play.google.com/store/apps/details?id=allen.town.focus.reader"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:text-accent-hover font-medium"
+              >
+                FocusReader
+              </a>{" "}
+              (Android)
             </li>
             <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Read You</strong> (Android)
+              <a
+                href="https://f-droid.org/packages/me.ash.reader"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:text-accent-hover font-medium"
+              >
+                Read You
+              </a>{" "}
+              (Android)
             </li>
             <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">FocusReader</strong> (Android)
-            </li>
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">SmartRSS</strong> (Android)
-            </li>
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">NewsFlash</strong> (Linux)
+              <a
+                href="https://flathub.org/apps/io.gitlab.news_flash.NewsFlash"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:text-accent-hover font-medium"
+              >
+                NewsFlash
+              </a>{" "}
+              (Linux)
             </li>
           </ul>
         </div>
@@ -86,6 +120,11 @@ export function GoogleReaderApiSettings() {
               <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
                 {baseUrl}/api/greader.php
               </code>
+              <CopyButton
+                value={`${baseUrl}/api/greader.php`}
+                className="ml-2 px-1.5 py-0.5"
+                title="Copy server URL"
+              />
             </li>
             <li>
               <strong className="text-zinc-900 dark:text-zinc-200">Email:</strong> Your Lion Reader

--- a/src/components/settings/IntegrationsSettings.tsx
+++ b/src/components/settings/IntegrationsSettings.tsx
@@ -7,12 +7,11 @@
 
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Alert } from "@/components/ui/alert";
+import { CodeBlock, CopyButton } from "@/components/ui/copy-button";
 
 export function IntegrationsSettings() {
-  const [copiedSection, setCopiedSection] = useState<string | null>(null);
-
   // Check env var first (available on both server and client), then fall back to window.location.origin
   const baseUrl = useMemo(() => {
     return (
@@ -40,12 +39,6 @@ export function IntegrationsSettings() {
 
   const claudeCodeCommand = `claude mcp add --transport http lionreader ${mcpUrl}`;
 
-  const copyToClipboard = (text: string, section: string) => {
-    navigator.clipboard.writeText(text);
-    setCopiedSection(section);
-    setTimeout(() => setCopiedSection(null), 2000);
-  };
-
   return (
     <section>
       <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">
@@ -72,18 +65,7 @@ export function IntegrationsSettings() {
           <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
             Run this command in your terminal:
           </p>
-          <div className="relative mt-3">
-            <pre className="ui-text-xs overflow-x-auto rounded-md border border-zinc-200 bg-zinc-100 p-3 pr-20 font-mono text-zinc-800 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
-              <code>{claudeCodeCommand}</code>
-            </pre>
-            <button
-              type="button"
-              onClick={() => copyToClipboard(claudeCodeCommand, "claude-code")}
-              className="ui-text-xs absolute top-2 right-2 rounded border border-zinc-300 bg-white px-2 py-1 font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600 dark:hover:text-zinc-100"
-            >
-              {copiedSection === "claude-code" ? "Copied!" : "Copy"}
-            </button>
-          </div>
+          <CodeBlock code={claudeCodeCommand} className="mt-3" />
         </div>
 
         {/* Claude.ai */}
@@ -122,13 +104,11 @@ export function IntegrationsSettings() {
               <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
                 {mcpUrl}
               </code>
-              <button
-                type="button"
-                onClick={() => copyToClipboard(mcpUrl, "claude-ai-url")}
-                className="ui-text-xs ml-2 rounded border border-zinc-300 bg-white px-1.5 py-0.5 font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600 dark:hover:text-zinc-100"
-              >
-                {copiedSection === "claude-ai-url" ? "Copied!" : "Copy"}
-              </button>
+              <CopyButton
+                value={mcpUrl}
+                className="ml-2 px-1.5 py-0.5"
+                title="Copy MCP server URL"
+              />
             </li>
           </ol>
         </div>
@@ -145,18 +125,7 @@ export function IntegrationsSettings() {
             </code>
             :
           </p>
-          <div className="relative mt-3">
-            <pre className="ui-text-xs overflow-x-auto rounded-md border border-zinc-200 bg-zinc-100 p-3 pr-20 font-mono text-zinc-800 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
-              <code>{claudeDesktopConfig}</code>
-            </pre>
-            <button
-              type="button"
-              onClick={() => copyToClipboard(claudeDesktopConfig, "claude-desktop")}
-              className="ui-text-xs absolute top-2 right-2 rounded border border-zinc-300 bg-white px-2 py-1 font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600 dark:hover:text-zinc-100"
-            >
-              {copiedSection === "claude-desktop" ? "Copied!" : "Copy"}
-            </button>
-          </div>
+          <CodeBlock code={claudeDesktopConfig} className="mt-3" />
         </div>
 
         {/* Note about MCP URL */}

--- a/src/components/settings/WallabagApiSettings.tsx
+++ b/src/components/settings/WallabagApiSettings.tsx
@@ -12,6 +12,7 @@ import { useMemo } from "react";
 import { QRCodeSVG } from "qrcode.react";
 import { trpc } from "@/lib/trpc/client";
 import { MobileIcon } from "@/components/ui/icon-button";
+import { CopyButton } from "@/components/ui/copy-button";
 
 export function WallabagApiSettings() {
   const userQuery = trpc.auth.me.useQuery();
@@ -150,25 +151,39 @@ export function WallabagApiSettings() {
               <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
                 {serverUrl}
               </code>
+              <CopyButton
+                value={serverUrl}
+                className="ml-2 px-1.5 py-0.5"
+                title="Copy server URL"
+              />
             </li>
             <li>
               <strong className="text-zinc-900 dark:text-zinc-200">Client ID:</strong>{" "}
               <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
                 wallabag
               </code>
+              <CopyButton value="wallabag" className="ml-2 px-1.5 py-0.5" title="Copy client ID" />
             </li>
             <li>
               <strong className="text-zinc-900 dark:text-zinc-200">Client Secret:</strong>{" "}
               <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
                 wallabag
               </code>
+              <CopyButton
+                value="wallabag"
+                className="ml-2 px-1.5 py-0.5"
+                title="Copy client secret"
+              />
             </li>
             <li>
               <strong className="text-zinc-900 dark:text-zinc-200">Username:</strong>{" "}
               {email ? (
-                <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
-                  {email}
-                </code>
+                <>
+                  <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
+                    {email}
+                  </code>
+                  <CopyButton value={email} className="ml-2 px-1.5 py-0.5" title="Copy username" />
+                </>
               ) : (
                 "Your Lion Reader email address"
               )}

--- a/src/components/settings/pages/IntegrationsSettingsContent.tsx
+++ b/src/components/settings/pages/IntegrationsSettingsContent.tsx
@@ -20,9 +20,6 @@ export default function IntegrationsSettingsContent() {
       {/* Save to Lion Reader (Firefox extension + bookmarklet) */}
       <BookmarkletSettings />
 
-      {/* Discord Bot */}
-      <DiscordBotSettings />
-
       {/* Google Reader API (mobile/desktop client sync) */}
       <GoogleReaderApiSettings />
 
@@ -31,6 +28,9 @@ export default function IntegrationsSettingsContent() {
 
       {/* AI Integrations (MCP) */}
       <IntegrationsSettings />
+
+      {/* Discord Bot */}
+      <DiscordBotSettings />
 
       {/* API Tokens */}
       <ApiTokensSettingsContent />

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -1,0 +1,81 @@
+/**
+ * CopyButton / CodeBlock
+ *
+ * Small reusable "copy to clipboard" button (with transient "Copied!" feedback)
+ * and a code block that pairs a <pre> with a copy button. Used across the
+ * integrations settings sections (Google Reader API, Wallabag API, AI
+ * Integrations, bookmarklet) so the copy affordance stays consistent.
+ */
+
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const BUTTON_CLASSES =
+  "ui-text-xs rounded border border-zinc-300 bg-white font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600 dark:hover:text-zinc-100";
+
+interface CopyButtonProps {
+  /** Text to copy to the clipboard. */
+  value: string;
+  /** Extra classes for positioning/padding (e.g. "absolute top-2 right-2 px-2 py-1"). */
+  className?: string;
+  /** Label shown when idle. */
+  label?: string;
+  /** Label shown briefly after copying. */
+  copiedLabel?: string;
+  /** Accessible label when the button has no visible text alternative. */
+  title?: string;
+}
+
+export function CopyButton({
+  value,
+  className = "px-2 py-1",
+  label = "Copy",
+  copiedLabel = "Copied!",
+  title,
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(value);
+    setCopied(true);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      title={title}
+      className={`${BUTTON_CLASSES} ${className}`}
+    >
+      {copied ? copiedLabel : label}
+    </button>
+  );
+}
+
+interface CodeBlockProps {
+  /** Code/text to display and copy. */
+  code: string;
+  /** Extra classes for the wrapping element. */
+  className?: string;
+}
+
+export function CodeBlock({ code, className = "" }: CodeBlockProps) {
+  return (
+    <div className={`relative ${className}`}>
+      <pre className="ui-text-xs overflow-x-auto rounded-md border border-zinc-200 bg-zinc-100 p-3 pr-20 font-mono text-zinc-800 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
+        <code>{code}</code>
+      </pre>
+      <CopyButton value={code} className="absolute top-2 right-2 px-2 py-1" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Improvements to the **Settings → Integrations** page, per request.

### Google Reader API
- Link each compatible app instead of listing plain names:
  - [Reeder Classic](https://reederapp.com/classic/) (iOS / macOS)
  - [NetNewsWire](https://netnewswire.com/) (iOS / macOS)
  - [FocusReader](https://play.google.com/store/apps/details?id=allen.town.focus.reader) (Android)
  - [Read You](https://f-droid.org/packages/me.ash.reader) (Android)
  - [NewsFlash](https://flathub.org/apps/io.gitlab.news_flash.NewsFlash) (Linux)
- Dropped **FeedMe** and **SmartRSS** (untested), and ordered **FocusReader** before **Read You**.
- Added a copy-to-clipboard button next to the server URL.

### Wallabag API
- Added copy buttons to the manual-setup values (server URL, client ID, client secret, username). App links were already present.

### Copy buttons everywhere
- Added reusable `CopyButton` / `CodeBlock` components in `src/components/ui/` and refactored the AI Integrations section to use them (removing the duplicated copy logic across sections). All API setup examples now have copy buttons.

### Layout
- Moved the **Discord Bot** section below **AI Integrations**.

### Demo
- Kept the Google Reader demo article's app list in sync (same links, FocusReader in, FeedMe out).

`pnpm typecheck` and `pnpm lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)