### PR TITLE
Google Reader: accept stream/contents with no stream id (fix Newsflash setup)

### DIFF
--- a/src/app/api/greader.php/reader/api/0/stream/contents/[[...streamId]]/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/contents/[[...streamId]]/route.ts
@@ -2,12 +2,20 @@
  * Google Reader API: Stream Contents
  *
  * GET/POST /api/greader.php/reader/api/0/stream/contents/{streamId}
+ * GET/POST /api/greader.php/reader/api/0/stream/contents   (streamId omitted)
  *
  * Returns items (entries) for a given stream. The streamId can be:
  * - feed/{int64} — entries from a specific subscription
  * - user/-/state/com.google/reading-list — all entries
  * - user/-/state/com.google/starred — starred entries
  * - user/-/label/{name} — entries in a tag/folder
+ *
+ * When the streamId is omitted entirely (this is an optional catch-all route),
+ * it defaults to the reading-list, matching Google Reader semantics where
+ * `stream/contents` with no stream id returns the reading list. Newsflash's
+ * FreshRSS backend relies on this: its initial sync fetches "latest" articles
+ * by calling `stream/contents` with no stream id, so a required catch-all would
+ * 404 that request and break account setup.
  *
  * Query parameters:
  * - n: number of items (default 20, max 300) — capped lower than the ids stream
@@ -31,16 +39,22 @@ import { isState } from "@/server/google-reader/streams";
 
 export const dynamic = "force-dynamic";
 
+// Google Reader treats `stream/contents` with no stream id as the reading list.
+const DEFAULT_STREAM_ID = "user/-/state/com.google/reading-list";
+
 async function handleStreamContents(
   request: Request,
-  params: Promise<{ streamId: string[] }>
+  params: Promise<{ streamId?: string[] }>
 ): Promise<Response> {
   const session = await requireAuth(request);
   if (session instanceof Response) return session;
   const { streamId: streamIdParts } = await params;
 
-  // Reconstruct the stream ID from path segments
-  const streamIdStr = streamIdParts.join("/");
+  // Reconstruct the stream ID from path segments. On the optional catch-all,
+  // `streamIdParts` is undefined when the streamId is omitted — default it to
+  // the reading list.
+  const streamIdStr =
+    streamIdParts && streamIdParts.length > 0 ? streamIdParts.join("/") : DEFAULT_STREAM_ID;
 
   let parsedStream: StreamId;
   try {
@@ -172,14 +186,14 @@ async function handleStreamContents(
 
 export async function GET(
   request: Request,
-  ctx: { params: Promise<{ streamId: string[] }> }
+  ctx: { params: Promise<{ streamId?: string[] }> }
 ): Promise<Response> {
   return handleStreamContents(request, ctx.params);
 }
 
 export async function POST(
   request: Request,
-  ctx: { params: Promise<{ streamId: string[] }> }
+  ctx: { params: Promise<{ streamId?: string[] }> }
 ): Promise<Response> {
   return handleStreamContents(request, ctx.params);
 }

--- a/tests/e2e/greader-api.spec.ts
+++ b/tests/e2e/greader-api.spec.ts
@@ -171,6 +171,34 @@ test.describe("Google Reader API happy path", () => {
     }
   });
 
+  // Newsflash's FreshRSS backend fetches "latest" articles during its initial
+  // sync by calling stream/contents with *no* stream id. That must resolve to
+  // the reading list, not 404 (which would break account setup). Regression
+  // guard for the optional catch-all route ([[...streamId]]).
+  test("stream/contents with no stream id returns the reading list", async ({ request }) => {
+    const token = await getToken(request);
+
+    const res = await request.post(`${API_BASE}/stream/contents`, { headers: authHeader(token) });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe("user/-/state/com.google/reading-list");
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.items.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("stream/contents with an explicit stream id still works", async ({ request }) => {
+    const token = await getToken(request);
+
+    const res = await request.get(
+      `${API_BASE}/stream/contents/user/-/state/com.google/reading-list`,
+      { headers: authHeader(token) }
+    );
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe("user/-/state/com.google/reading-list");
+    expect(Array.isArray(body.items)).toBe(true);
+  });
+
   test("stream/items/contents returns full items with body for the given ids", async ({
     request,
   }) => {


### PR DESCRIPTION
## Problem

Setting up Lion Reader in **Newsflash** (via its FreshRSS/Google Reader backend) failed during the initial sync.

Newsflash's FreshRSS backend performs three `stream/contents` fetches on first sync. Two pass an explicit stream id (`reading-list`, `starred`), but the **"latest" fetch passes no stream id at all** — it calls `reader/api/0/stream/contents` with an empty path (see [`freshrss/mod.rs:196` `stream_id: None`](https://gitlab.com/news-flash/news_flash/-/blob/master/src/feed_api_implementations/freshrss/mod.rs)).

Our route was a **required** catch-all (`[...streamId]`), so `stream/contents` with no path segment returned **404**, the `try_join!` failed, and account setup broke.

## Fix

Convert the route to an **optional** catch-all (`[[...streamId]]`) and default an omitted stream id to the reading list — matching Google Reader semantics (`stream/contents` with no stream id = reading list).

## Tests

Added two e2e cases to `tests/e2e/greader-api.spec.ts`:
- `stream/contents` with **no** stream id → returns the reading list (regression guard)
- `stream/contents` with an explicit stream id → still works

Full `greader-api` suite (15 tests) passes.

## Notes on the trailing slash

The user noticed Newsflash stores the URL as `.../api/greader.php/` (trailing slash). That itself is **not** the problem: Newsflash builds sub-paths with Rust's `Url::join`, which *requires* the trailing slash to resolve `reader/api/0/...` correctly, and those sub-paths already work on our server. `GET /api/greader.php/` returns a 308 redirect to the non-slash form, which redirect-following clients handle, and Newsflash's reachability check hits the site root `/`, not the greader base.

## Follow-up (not in this PR)

Newsflash's FreshRSS backend also calls `reader/api/0/subscription/import` for **OPML import** (a user-triggered action, not part of setup), which we don't implement yet. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)