### PR TITLE
Wallabag API: offset pagination, incremental sync, service-layer cleanup

### DIFF
--- a/src/app/api/wallabag/api/entries/exists/route.ts
+++ b/src/app/api/wallabag/api/entries/exists/route.ts
@@ -15,11 +15,8 @@
 import { requireAuth } from "@/server/wallabag/auth";
 import { jsonResponse, errorResponse } from "@/server/wallabag/parse";
 import { uuidToWallabagId } from "@/server/wallabag/format";
-import { normalizeUrl } from "@/lib/url";
-import { eq, and } from "drizzle-orm";
+import * as savedService from "@/server/services/saved";
 import { db } from "@/server/db";
-import { entries, userEntries } from "@/server/db/schema";
-import { getOrCreateSavedFeed } from "@/server/feed/saved-feed";
 
 export const dynamic = "force-dynamic";
 
@@ -35,26 +32,12 @@ export async function GET(request: Request): Promise<Response> {
     return errorResponse("invalid_request", "url parameter is required", 400);
   }
 
-  const normalizedUrl = normalizeUrl(singleUrl);
-  const savedFeedId = await getOrCreateSavedFeed(db, auth.userId);
+  const entryId = await savedService.savedArticleExistsByUrl(db, auth.userId, singleUrl);
 
-  const existing = await db
-    .select({ id: entries.id })
-    .from(entries)
-    .innerJoin(userEntries, eq(userEntries.entryId, entries.id))
-    .where(
-      and(
-        eq(entries.feedId, savedFeedId),
-        eq(entries.guid, normalizedUrl),
-        eq(userEntries.userId, auth.userId)
-      )
-    )
-    .limit(1);
-
-  if (existing.length > 0) {
+  if (entryId) {
     const result: Record<string, unknown> = { exists: true };
     if (returnId) {
-      result.id = uuidToWallabagId(existing[0].id);
+      result.id = uuidToWallabagId(entryId);
     }
     return jsonResponse(result);
   }

--- a/src/app/api/wallabag/api/entries/route.ts
+++ b/src/app/api/wallabag/api/entries/route.ts
@@ -50,8 +50,16 @@ export async function GET(request: Request): Promise<Response> {
   const params = parseEntryListParams(url);
 
   // Scope to saved articles only — the Wallabag API is a read-it-later interface.
-  // The read/starred/since filters are shared by the page query and the count so
-  // the two can't drift.
+  // The read/starred filters are shared by the page query and the count so the
+  // two can't drift.
+  //
+  // NOTE: `since` is intentionally not applied. Wallabag's `since` means "entries
+  // *updated* since" and clients use it to pull archive/star state changes for
+  // delta sync. We have no single indexed "last modified" column — that would be
+  // GREATEST(entry.updated_at, read_changed_at, starred_changed_at) — so mapping
+  // it to publishedAfter (≈ save time) would silently drop read/star deltas and
+  // break multi-device sync. Left unsupported (a wasteful superset) rather than
+  // lossy. See issue #1062.
   const filter = {
     type: "saved" as const,
     showSpam: false,
@@ -59,9 +67,6 @@ export async function GET(request: Request): Promise<Response> {
     readOnly: params.archive === true ? true : undefined,
     starredOnly: params.starred === true ? true : undefined,
     unstarredOnly: params.starred === false ? true : undefined,
-    // Wallabag `since` is a unix timestamp (seconds). Map it to publishedAfter so
-    // clients can sync incrementally instead of re-paging the whole library.
-    publishedAfter: params.since ? new Date(params.since * 1000) : undefined,
   };
 
   // Serve the requested page with a single indexed query via LIMIT/OFFSET, and

--- a/src/app/api/wallabag/api/entries/route.ts
+++ b/src/app/api/wallabag/api/entries/route.ts
@@ -49,61 +49,33 @@ export async function GET(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const params = parseEntryListParams(url);
 
-  // Build list params from Wallabag query params
-  // Scope to saved articles only — the Wallabag API is a read-it-later interface
-  const baseParams: entriesService.ListEntriesParams = {
-    userId: auth.userId,
-    type: "saved",
-    limit: params.perPage,
-    sortOrder: params.order === "asc" ? "oldest" : "newest",
+  // Scope to saved articles only — the Wallabag API is a read-it-later interface.
+  // The read/starred/since filters are shared by the page query and the count so
+  // the two can't drift.
+  const filter = {
+    type: "saved" as const,
     showSpam: false,
-  };
-
-  // Filter by read/archived state
-  if (params.archive === false) {
-    baseParams.unreadOnly = true;
-  } else if (params.archive === true) {
-    baseParams.readOnly = true;
-  }
-
-  // Filter by starred state
-  if (params.starred === true) {
-    baseParams.starredOnly = true;
-  } else if (params.starred === false) {
-    baseParams.unstarredOnly = true;
-  }
-
-  // Get total count for pagination metadata (Wallabag API needs total for offset pagination)
-  const total = await entriesService.countTotalEntries(db, auth.userId, {
-    type: "saved",
     unreadOnly: params.archive === false ? true : undefined,
     readOnly: params.archive === true ? true : undefined,
     starredOnly: params.starred === true ? true : undefined,
     unstarredOnly: params.starred === false ? true : undefined,
-    showSpam: false,
-  });
+    // Wallabag `since` is a unix timestamp (seconds). Map it to publishedAfter so
+    // clients can sync incrementally instead of re-paging the whole library.
+    publishedAfter: params.since ? new Date(params.since * 1000) : undefined,
+  };
 
-  // Simulate page-based pagination by iterating through cursor-based pages.
-  // Skip (page - 1) pages of entries, then return the requested page.
-  let cursor: string | undefined;
-  for (let p = 1; p < params.page; p++) {
-    const skipResult = await entriesService.listEntries(db, {
-      ...baseParams,
-      cursor,
-    });
-    cursor = skipResult.nextCursor;
-    if (!cursor) {
-      // Requested page is beyond available data
-      const baseUrl = `${url.origin}/api/wallabag/api/entries`;
-      return jsonResponse(createPaginatedResponse([], params.page, params.perPage, total, baseUrl));
-    }
-  }
-
-  // Fetch the actual requested page
-  const result = await entriesService.listEntries(db, {
-    ...baseParams,
-    cursor,
-  });
+  // Serve the requested page with a single indexed query via LIMIT/OFFSET, and
+  // fetch the total count in parallel (Wallabag needs it for page metadata).
+  const [result, total] = await Promise.all([
+    entriesService.listEntries(db, {
+      ...filter,
+      userId: auth.userId,
+      limit: params.perPage,
+      offset: (params.page - 1) * params.perPage,
+      sortOrder: params.order === "asc" ? "oldest" : "newest",
+    }),
+    entriesService.countTotalEntries(db, auth.userId, filter),
+  ]);
 
   // If detail is "full", fetch full content in a single bulk query
   let formattedItems;

--- a/src/app/api/wallabag/api/entries/route.ts
+++ b/src/app/api/wallabag/api/entries/route.ts
@@ -50,16 +50,8 @@ export async function GET(request: Request): Promise<Response> {
   const params = parseEntryListParams(url);
 
   // Scope to saved articles only — the Wallabag API is a read-it-later interface.
-  // The read/starred filters are shared by the page query and the count so the
-  // two can't drift.
-  //
-  // NOTE: `since` is intentionally not applied. Wallabag's `since` means "entries
-  // *updated* since" and clients use it to pull archive/star state changes for
-  // delta sync. We have no single indexed "last modified" column — that would be
-  // GREATEST(entry.updated_at, read_changed_at, starred_changed_at) — so mapping
-  // it to publishedAfter (≈ save time) would silently drop read/star deltas and
-  // break multi-device sync. Left unsupported (a wasteful superset) rather than
-  // lossy. See issue #1062.
+  // The read/starred/since filters are shared by the page query and the count so
+  // the two can't drift.
   const filter = {
     type: "saved" as const,
     showSpam: false,
@@ -67,6 +59,11 @@ export async function GET(request: Request): Promise<Response> {
     readOnly: params.archive === true ? true : undefined,
     starredOnly: params.starred === true ? true : undefined,
     unstarredOnly: params.starred === false ? true : undefined,
+    // Wallabag `since` (unix seconds) means "entries *updated* since" — clients
+    // use it to pull new saves AND archive/star state changes for delta sync.
+    // updatedAfter filters on GREATEST(entry.updated_at, user_entries.updated_at),
+    // which captures all three, so this is correct (not a lossy save-time proxy).
+    updatedAfter: params.since ? new Date(params.since * 1000) : undefined,
   };
 
   // Serve the requested page with a single indexed query via LIMIT/OFFSET, and

--- a/src/app/api/wallabag/api/search/route.ts
+++ b/src/app/api/wallabag/api/search/route.ts
@@ -12,7 +12,7 @@
  */
 
 import { requireAuth } from "@/server/wallabag/auth";
-import { jsonResponse, errorResponse } from "@/server/wallabag/parse";
+import { jsonResponse, errorResponse, parseEntryListParams } from "@/server/wallabag/parse";
 import { formatEntryListItem, createPaginatedResponse } from "@/server/wallabag/format";
 import * as entriesService from "@/server/services/entries";
 import { db } from "@/server/db";
@@ -29,39 +29,17 @@ export async function GET(request: Request): Promise<Response> {
     return errorResponse("invalid_request", "term parameter is required", 400);
   }
 
-  const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10) || 1);
-  const perPage = Math.min(
-    Math.max(1, parseInt(url.searchParams.get("perPage") ?? "30", 10) || 30),
-    100
-  );
+  // Reuse the shared page/perPage parsing (clamped identically to the list endpoint).
+  const { page, perPage } = parseEntryListParams(url);
 
-  const searchParams: entriesService.ListEntriesParams = {
+  // Serve the requested page with a single indexed query via LIMIT/OFFSET.
+  const result = await entriesService.listEntries(db, {
     userId: auth.userId,
     query: term,
     type: "saved",
     limit: perPage,
+    offset: (page - 1) * perPage,
     showSpam: false,
-  };
-
-  // Simulate page-based pagination by iterating through cursor-based pages.
-  let cursor: string | undefined;
-  for (let p = 1; p < page; p++) {
-    const skipResult = await entriesService.listEntries(db, {
-      ...searchParams,
-      cursor,
-    });
-    cursor = skipResult.nextCursor;
-    if (!cursor) {
-      // Requested page is beyond available data
-      const baseUrl = `${url.origin}/api/wallabag/api/search`;
-      return jsonResponse(createPaginatedResponse([], page, perPage, 0, baseUrl));
-    }
-  }
-
-  // Fetch the actual requested page
-  const result = await entriesService.listEntries(db, {
-    ...searchParams,
-    cursor,
   });
 
   // Estimate total: for search results we don't have an efficient count query,

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -70,6 +70,7 @@ export interface ListEntriesParams {
   maxLimit?: number; // Override MAX_LIMIT (e.g., for Google Reader API which needs larger batches)
   publishedAfter?: Date; // Only entries published/fetched after this timestamp
   publishedBefore?: Date; // Only entries published/fetched before this timestamp
+  updatedAfter?: Date; // Only entries modified at/after this timestamp (GREATEST(entry.updated_at, user_entries.updated_at); powers Wallabag `since` delta sync)
   showSpam: boolean;
 }
 
@@ -92,6 +93,7 @@ export interface SearchEntriesParams {
   maxLimit?: number;
   publishedAfter?: Date;
   publishedBefore?: Date;
+  updatedAfter?: Date; // Only entries modified at/after this timestamp (see ListEntriesParams.updatedAfter)
   showSpam: boolean;
 }
 
@@ -544,6 +546,15 @@ export async function listEntries(
   if (params.publishedBefore) {
     conditions.push(sql`${visibleEntries.publishedOrFetchedAt} <= ${params.publishedBefore}`);
   }
+  // "Modified since" filter (Wallabag `since` delta sync). visibleEntries.updatedAt is
+  // GREATEST(entry.updated_at, user_entries.updated_at), so this captures new saves,
+  // content refetches, AND read/star state changes — the same value we return as the
+  // entry's updated_at, so the filter and the reported timestamp can't disagree. The
+  // GREATEST spans two tables so no single index covers it; the userId predicate bounds
+  // the scan to one user's rows (the exact set an un-filtered client would re-page).
+  if (params.updatedAfter) {
+    conditions.push(sql`${visibleEntries.updatedAt} >= ${params.updatedAfter}`);
+  }
 
   // Recently Read: exclude entries that were never explicitly read-state-changed
   if (params.sortBy === "readChanged") {
@@ -684,6 +695,9 @@ async function searchEntries(
   }
   if (params.publishedBefore) {
     conditions.push(sql`${visibleEntries.publishedOrFetchedAt} <= ${params.publishedBefore}`);
+  }
+  if (params.updatedAfter) {
+    conditions.push(sql`${visibleEntries.updatedAt} >= ${params.updatedAfter}`);
   }
 
   // Cursor for search results (based on rank)
@@ -1281,6 +1295,7 @@ export async function countTotalEntries(
     readOnly?: boolean;
     starredOnly?: boolean;
     unstarredOnly?: boolean;
+    updatedAfter?: Date;
     showSpam: boolean;
   }
 ): Promise<number> {
@@ -1305,6 +1320,10 @@ export async function countTotalEntries(
   }
 
   conditions.push(...buildEntryFilterConditions(params));
+
+  if (params.updatedAfter) {
+    conditions.push(sql`${visibleEntries.updatedAt} >= ${params.updatedAfter}`);
+  }
 
   // count(DISTINCT id): dedupe entries reachable through overlapping
   // subscription_feeds rows (see countEntries).

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -65,6 +65,7 @@ export interface ListEntriesParams {
   sortOrder?: "newest" | "oldest";
   sortBy?: "published" | "readChanged"; // Which column to sort by (default: published)
   cursor?: string;
+  offset?: number; // Skip this many rows (for page/offset-based compat APIs like Wallabag). Mutually exclusive with cursor.
   limit?: number;
   maxLimit?: number; // Override MAX_LIMIT (e.g., for Google Reader API which needs larger batches)
   publishedAfter?: Date; // Only entries published/fetched after this timestamp
@@ -86,6 +87,7 @@ export interface SearchEntriesParams {
   starredOnly?: boolean;
   unstarredOnly?: boolean;
   cursor?: string;
+  offset?: number; // Skip this many rows (for page/offset-based compat APIs like Wallabag). Mutually exclusive with cursor.
   limit?: number;
   maxLimit?: number;
   publishedAfter?: Date;
@@ -603,7 +605,8 @@ export async function listEntries(
     .innerJoin(feeds, eq(visibleEntries.feedId, feeds.id))
     .where(and(...conditions))
     .orderBy(...orderByClause)
-    .limit(limit + 1);
+    .limit(limit + 1)
+    .offset(params.offset ?? 0);
 
   const hasMore = queryResults.length > limit;
   const resultEntries = hasMore ? queryResults.slice(0, limit) : queryResults;
@@ -709,7 +712,8 @@ async function searchEntries(
     .innerJoin(feeds, eq(visibleEntries.feedId, feeds.id))
     .where(and(...conditions))
     .orderBy(desc(rankColumn), desc(visibleEntries.id))
-    .limit(limit + 1);
+    .limit(limit + 1)
+    .offset(params.offset ?? 0);
 
   const hasMore = queryResults.length > limit;
   const resultEntries = hasMore ? queryResults.slice(0, limit) : queryResults;
@@ -1270,6 +1274,7 @@ export async function countTotalEntries(
     readOnly?: boolean;
     starredOnly?: boolean;
     unstarredOnly?: boolean;
+    publishedAfter?: Date;
     showSpam: boolean;
   }
 ): Promise<number> {
@@ -1294,6 +1299,10 @@ export async function countTotalEntries(
   }
 
   conditions.push(...buildEntryFilterConditions(params));
+
+  if (params.publishedAfter) {
+    conditions.push(sql`${visibleEntries.publishedOrFetchedAt} >= ${params.publishedAfter}`);
+  }
 
   // count(DISTINCT id): dedupe entries reachable through overlapping
   // subscription_feeds rows (see countEntries).

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -491,6 +491,13 @@ export async function listEntries(
   db: typeof dbType,
   params: ListEntriesParams
 ): Promise<{ items: EntryListItem[]; nextCursor?: string }> {
+  // `cursor` and `offset` are two different ways to page and must not be combined:
+  // the cursor predicate would narrow the window and offset would then skip *more*
+  // rows on top of it, silently double-skipping. Callers use one or the other.
+  if (params.cursor && params.offset) {
+    throw new Error("listEntries: `cursor` and `offset` are mutually exclusive");
+  }
+
   // If query is provided, delegate to search implementation
   if (params.query) {
     return searchEntries(db, {
@@ -1274,7 +1281,6 @@ export async function countTotalEntries(
     readOnly?: boolean;
     starredOnly?: boolean;
     unstarredOnly?: boolean;
-    publishedAfter?: Date;
     showSpam: boolean;
   }
 ): Promise<number> {
@@ -1299,10 +1305,6 @@ export async function countTotalEntries(
   }
 
   conditions.push(...buildEntryFilterConditions(params));
-
-  if (params.publishedAfter) {
-    conditions.push(sql`${visibleEntries.publishedOrFetchedAt} >= ${params.publishedAfter}`);
-  }
 
   // count(DISTINCT id): dedupe entries reachable through overlapping
   // subscription_feeds rows (see countEntries).

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -20,7 +20,7 @@ import { extractTextFromHtml } from "@/server/http/html";
 import { sanitizeEntryHtml } from "@/server/html/sanitize";
 import { absolutizeUrls } from "@/server/feed/content-cleaner";
 import { cleanContentInWorker, sanitizeEntryHtmlInWorker } from "@/server/worker-thread/pool";
-import { getOrCreateSavedFeed, SAVED_FEED_TITLE } from "@/server/feed/saved-feed";
+import { getOrCreateSavedFeed, getSavedFeedId, SAVED_FEED_TITLE } from "@/server/feed/saved-feed";
 import { generateSummary } from "@/server/html/strip-html";
 import { withSanitizedEntryContentAsync } from "@/server/html/sanitize-entry";
 import { logger } from "@/lib/logger";
@@ -673,18 +673,55 @@ async function acquireArticleContent(
  * Google Docs, etc.); private Google Docs are supported via the interactive
  * `googleDocsAuth` option.
  */
+/**
+ * Normalizes a URL exactly the way {@link saveArticle} does before storing it as
+ * the entry `guid`: strip fragments (two URLs differing only by `#section` point
+ * to the same article), and for Google Docs remove extraneous query params
+ * except `tab`. Existence checks must use this so they match saved rows.
+ */
+function normalizeSavedUrl(url: string): string {
+  const normalized = normalizeUrl(url);
+  return isGoogleDocsUrl(normalized) ? normalizeGoogleDocsUrl(normalized) : normalized;
+}
+
+/**
+ * Checks whether the user has already saved an article for the given URL,
+ * returning its entry id (or null). Read-only: unlike {@link saveArticle} it
+ * never creates the user's saved feed, so it's safe on probe/exists paths.
+ *
+ * Indexed by the `uq_entries_feed_guid` unique constraint on `(feed_id, guid)`.
+ */
+export async function savedArticleExistsByUrl(
+  db: typeof dbType,
+  userId: string,
+  url: string
+): Promise<string | null> {
+  const savedFeedId = await getSavedFeedId(db, userId);
+  if (!savedFeedId) return null;
+
+  const normalizedUrl = normalizeSavedUrl(url);
+  const existing = await db
+    .select({ id: entries.id })
+    .from(entries)
+    .innerJoin(userEntries, eq(userEntries.entryId, entries.id))
+    .where(
+      and(
+        eq(entries.feedId, savedFeedId),
+        eq(entries.guid, normalizedUrl),
+        eq(userEntries.userId, userId)
+      )
+    )
+    .limit(1);
+
+  return existing[0]?.id ?? null;
+}
+
 export async function saveArticle(
   db: typeof dbType,
   userId: string,
   params: SaveArticleParams
 ): Promise<SaveArticleResult> {
-  // Normalize URL: strip fragments (two URLs differing only by #section point
-  // to the same article). For Google Docs, also remove extraneous query
-  // params except 'tab'.
-  let normalizedUrl = normalizeUrl(params.url);
-  if (isGoogleDocsUrl(normalizedUrl)) {
-    normalizedUrl = normalizeGoogleDocsUrl(normalizedUrl);
-  }
+  const normalizedUrl = normalizeSavedUrl(params.url);
 
   // Get or create the user's saved feed
   const savedFeedId = await getOrCreateSavedFeed(db, userId);

--- a/src/server/wallabag/format.ts
+++ b/src/server/wallabag/format.ts
@@ -90,86 +90,108 @@ function formatDate(date: Date | null): string | null {
 }
 
 /**
+ * The fields that vary between our entry shapes (full entry, list item, saved
+ * article); everything else in a Wallabag entry is derived or constant.
+ */
+interface WallabagEntryInput {
+  id: string;
+  url: string | null;
+  title: string | null;
+  content: string | null;
+  read: boolean;
+  starred: boolean;
+  author: string | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+  publishedAt: Date | null;
+  previewPicture: string | null;
+}
+
+/**
+ * Builds a Wallabag entry from the varying fields, deriving the constant and
+ * computed ones (id hash, archived/starred flags, domain, reading time). This is
+ * the single place the Wallabag entry shape is assembled, so the three format*
+ * helpers below can't drift.
+ */
+function buildWallabagEntry(input: WallabagEntryInput): WallabagEntry {
+  return {
+    id: uuidToWallabagId(input.id),
+    url: input.url,
+    title: input.title,
+    content: input.content,
+    is_archived: input.read ? 1 : 0,
+    is_starred: input.starred ? 1 : 0,
+    is_public: false,
+    tags: [],
+    created_at: formatDate(input.createdAt)!,
+    updated_at: formatDate(input.updatedAt)!,
+    published_at: formatDate(input.publishedAt),
+    published_by: input.author ? [input.author] : null,
+    domain_name: extractDomain(input.url),
+    reading_time: estimateReadingTime(input.content),
+    preview_picture: input.previewPicture,
+    mimetype: "text/html",
+    language: null,
+    uid: input.id,
+    _lion_reader_id: input.id,
+  };
+}
+
+/**
  * Formats a full entry as a Wallabag entry.
  */
 export function formatEntryFull(entry: EntryFull): WallabagEntry {
-  const content = entry.contentCleaned ?? entry.contentOriginal ?? entry.summary ?? null;
-
-  return {
-    id: uuidToWallabagId(entry.id),
+  return buildWallabagEntry({
+    id: entry.id,
     url: entry.url,
     title: entry.title,
-    content,
-    is_archived: entry.read ? 1 : 0,
-    is_starred: entry.starred ? 1 : 0,
-    is_public: false,
-    tags: [],
-    created_at: formatDate(entry.fetchedAt)!,
-    updated_at: formatDate(entry.updatedAt)!,
-    published_at: formatDate(entry.publishedAt),
-    published_by: entry.author ? [entry.author] : null,
-    domain_name: extractDomain(entry.url),
-    reading_time: estimateReadingTime(content),
-    preview_picture: null,
-    mimetype: "text/html",
-    language: null,
-    uid: entry.id,
-    _lion_reader_id: entry.id,
-  };
+    content: entry.contentCleaned ?? entry.contentOriginal ?? entry.summary ?? null,
+    read: entry.read,
+    starred: entry.starred,
+    author: entry.author,
+    createdAt: entry.fetchedAt,
+    updatedAt: entry.updatedAt,
+    publishedAt: entry.publishedAt,
+    previewPicture: null,
+  });
 }
 
 /**
  * Formats a list entry as a Wallabag entry (no full content).
  */
 export function formatEntryListItem(entry: EntryListItem): WallabagEntry {
-  return {
-    id: uuidToWallabagId(entry.id),
+  return buildWallabagEntry({
+    id: entry.id,
     url: entry.url,
     title: entry.title,
     content: entry.summary ?? null,
-    is_archived: entry.read ? 1 : 0,
-    is_starred: entry.starred ? 1 : 0,
-    is_public: false,
-    tags: [],
-    created_at: formatDate(entry.fetchedAt)!,
-    updated_at: formatDate(entry.updatedAt)!,
-    published_at: formatDate(entry.publishedAt),
-    published_by: entry.author ? [entry.author] : null,
-    domain_name: extractDomain(entry.url),
-    reading_time: estimateReadingTime(entry.summary),
-    preview_picture: null,
-    mimetype: "text/html",
-    language: null,
-    uid: entry.id,
-    _lion_reader_id: entry.id,
-  };
+    read: entry.read,
+    starred: entry.starred,
+    author: entry.author,
+    createdAt: entry.fetchedAt,
+    updatedAt: entry.updatedAt,
+    publishedAt: entry.publishedAt,
+    previewPicture: null,
+  });
 }
 
 /**
  * Formats a saved article as a Wallabag entry.
  */
 export function formatSavedArticle(article: SavedArticle): WallabagEntry {
-  return {
-    id: uuidToWallabagId(article.id),
+  return buildWallabagEntry({
+    id: article.id,
     url: article.url,
     title: article.title,
     content: article.contentCleaned ?? article.excerpt ?? null,
-    is_archived: article.read ? 1 : 0,
-    is_starred: article.starred ? 1 : 0,
-    is_public: false,
-    tags: [],
-    created_at: formatDate(article.savedAt)!,
-    updated_at: formatDate(article.savedAt)!,
-    published_at: null,
-    published_by: article.author ? [article.author] : null,
-    domain_name: extractDomain(article.url),
-    reading_time: estimateReadingTime(article.contentCleaned),
-    preview_picture: article.imageUrl,
-    mimetype: "text/html",
-    language: null,
-    uid: article.id,
-    _lion_reader_id: article.id,
-  };
+    read: article.read,
+    starred: article.starred,
+    author: article.author,
+    createdAt: article.savedAt,
+    updatedAt: article.savedAt,
+    publishedAt: null,
+    previewPicture: article.imageUrl,
+  });
 }
 
 // ============================================================================

--- a/tests/e2e/wallabag-api.spec.ts
+++ b/tests/e2e/wallabag-api.spec.ts
@@ -223,6 +223,18 @@ test.describe("Wallabag API happy path", () => {
       expect(existsRes.status()).toBe(200);
       expect((await existsRes.json()).exists).toBe(true);
 
+      // `since` delta sync is wired through the route: since=0 returns everything,
+      // a far-future timestamp returns nothing. (The GREATEST(entry, user_entries)
+      // "modified since" semantics are covered in detail by the integration tests.)
+      const sinceAll = await request.get("/api/wallabag/api/entries?since=0", { headers: auth });
+      expect((await sinceAll.json())._embedded.items.map((e: { id: number }) => e.id)).toContain(
+        saved.id
+      );
+      const sinceFuture = await request.get("/api/wallabag/api/entries?since=9999999999", {
+        headers: auth,
+      });
+      expect((await sinceFuture.json())._embedded.items).toHaveLength(0);
+
       // Delete it.
       const deleteRes = await request.delete(`/api/wallabag/api/entries/${saved.id}`, {
         headers: auth,

--- a/tests/e2e/wallabag-api.spec.ts
+++ b/tests/e2e/wallabag-api.spec.ts
@@ -238,6 +238,71 @@ test.describe("Wallabag API happy path", () => {
       await close();
     }
   });
+
+  test("paginates saved articles with page/perPage (offset)", async ({ request }) => {
+    const { access_token } = await getTokens(request);
+    const auth = { Authorization: `Bearer ${access_token}` };
+
+    // Two distinct saved articles (two servers → two ports → two URLs).
+    const a = await startArticleServer();
+    const b = await startArticleServer();
+    let idA: number | undefined;
+    let idB: number | undefined;
+    try {
+      idA = (
+        await (
+          await request.post("/api/wallabag/api/entries", { headers: auth, form: { url: a.url } })
+        ).json()
+      ).id;
+      idB = (
+        await (
+          await request.post("/api/wallabag/api/entries", { headers: auth, form: { url: b.url } })
+        ).json()
+      ).id;
+
+      // Ground truth: one big page gives the canonical order and total.
+      const allRes = await request.get("/api/wallabag/api/entries?perPage=100&detail=metadata", {
+        headers: auth,
+      });
+      const all = await allRes.json();
+      const orderedIds: number[] = all._embedded.items.map((e: { id: number }) => e.id);
+      expect(orderedIds).toContain(idA);
+      expect(orderedIds).toContain(idB);
+      const total: number = all.total;
+
+      // perPage=1 must page through the SAME order via LIMIT/OFFSET, one item per
+      // page, with pages == total. This is the regression guard for the old
+      // cursor-skip loop (N sequential queries to reach page N).
+      const page1 = await (
+        await request.get("/api/wallabag/api/entries?perPage=1&page=1&detail=metadata", {
+          headers: auth,
+        })
+      ).json();
+      const page2 = await (
+        await request.get("/api/wallabag/api/entries?perPage=1&page=2&detail=metadata", {
+          headers: auth,
+        })
+      ).json();
+
+      expect(page1.total).toBe(total);
+      expect(page1.pages).toBe(total);
+      expect(page1._embedded.items.map((e: { id: number }) => e.id)).toEqual([orderedIds[0]]);
+      expect(page2._embedded.items.map((e: { id: number }) => e.id)).toEqual([orderedIds[1]]);
+
+      // A page beyond the data is empty, not an error.
+      const beyond = await request.get(
+        `/api/wallabag/api/entries?perPage=1&page=${total + 5}&detail=metadata`,
+        { headers: auth }
+      );
+      expect(beyond.status()).toBe(200);
+      expect((await beyond.json())._embedded.items).toHaveLength(0);
+    } finally {
+      if (idA) await request.delete(`/api/wallabag/api/entries/${idA}`, { headers: auth });
+      if (idB) await request.delete(`/api/wallabag/api/entries/${idB}`, { headers: auth });
+      await a.close();
+      await b.close();
+    }
+  });
 });
 
 /**

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
-import { eq } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import {
   users,
@@ -20,7 +20,11 @@ import {
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
-import { markAllEntriesRead, listEntries } from "../../src/server/services/entries";
+import {
+  markAllEntriesRead,
+  markEntriesRead,
+  listEntries,
+} from "../../src/server/services/entries";
 
 // ============================================================================
 // Test Helpers
@@ -329,6 +333,53 @@ describe("Entries", () => {
       expect(page3.items.map((e) => e.id)).toEqual([aId]);
       // Offset past the end yields an empty page (not an error).
       expect(page4.items).toHaveLength(0);
+    });
+  });
+
+  describe("list with updatedAfter (Wallabag `since` delta sync)", () => {
+    it("returns entries whose state OR content changed since the checkpoint", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/feed.xml");
+      await createTestSubscription(userId, feedId);
+
+      // Three entries, all "modified" long ago (both entry.updated_at and
+      // user_entries.updated_at pinned to the same old time).
+      const stateChangedId = await createTestEntry(feedId, { title: "State" });
+      const contentChangedId = await createTestEntry(feedId, { title: "Content" });
+      const untouchedId = await createTestEntry(feedId, { title: "Untouched" });
+      for (const id of [stateChangedId, contentChangedId, untouchedId]) {
+        await createUserEntry(userId, id);
+      }
+
+      const past = new Date("2026-01-01T00:00:00Z");
+      const allIds = [stateChangedId, contentChangedId, untouchedId];
+      await db.update(entries).set({ updatedAt: past }).where(inArray(entries.id, allIds));
+      await db
+        .update(userEntries)
+        .set({ updatedAt: past })
+        .where(and(eq(userEntries.userId, userId), inArray(userEntries.entryId, allIds)));
+
+      // Client's last sync happened after `past`; nothing has changed since, so a
+      // delta sync returns nothing.
+      const checkpoint = new Date("2026-01-02T00:00:00Z");
+      const before = await listEntries(db, { userId, updatedAfter: checkpoint, showSpam: false });
+      expect(before.items).toHaveLength(0);
+
+      // A read-state change bumps user_entries.updated_at (a Wallabag archive), and
+      // a content refetch bumps entries.updated_at — both must surface via the
+      // GREATEST(entry.updated_at, user_entries.updated_at) that updatedAfter filters.
+      await markEntriesRead(db, userId, [{ id: stateChangedId }], true);
+      await db
+        .update(entries)
+        .set({ updatedAt: new Date() })
+        .where(eq(entries.id, contentChangedId));
+
+      const after = await listEntries(db, { userId, updatedAfter: checkpoint, showSpam: false });
+      expect(after.items.map((e) => e.id).sort()).toEqual(
+        [stateChangedId, contentChangedId].sort()
+      );
+      // The untouched entry stays out of the delta.
+      expect(after.items.map((e) => e.id)).not.toContain(untouchedId);
     });
   });
 

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -20,7 +20,7 @@ import {
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
-import { markAllEntriesRead } from "../../src/server/services/entries";
+import { markAllEntriesRead, listEntries } from "../../src/server/services/entries";
 
 // ============================================================================
 // Test Helpers
@@ -292,6 +292,43 @@ describe("Entries", () => {
       expect(result.items).toHaveLength(1);
       expect(result.items[0].id).toBe(starredId);
       expect(result.items[0].starred).toBe(true);
+    });
+  });
+
+  describe("list with offset", () => {
+    it("skips `offset` rows in one query (page/offset pagination for compat APIs)", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/feed.xml");
+      await createTestSubscription(userId, feedId);
+
+      // Three entries with distinct publish times so the newest-first order is
+      // deterministic: newest → oldest is [c, b, a].
+      const aId = await createTestEntry(feedId, {
+        title: "A",
+        publishedAt: new Date("2026-01-01T00:00:00Z"),
+      });
+      const bId = await createTestEntry(feedId, {
+        title: "B",
+        publishedAt: new Date("2026-01-02T00:00:00Z"),
+      });
+      const cId = await createTestEntry(feedId, {
+        title: "C",
+        publishedAt: new Date("2026-01-03T00:00:00Z"),
+      });
+      for (const id of [aId, bId, cId]) await createUserEntry(userId, id);
+
+      // Page size 1: offset 0/1/2 return c/b/a respectively, matching what the
+      // old cursor-skip loop produced but in a single indexed query per page.
+      const page1 = await listEntries(db, { userId, limit: 1, offset: 0, showSpam: false });
+      const page2 = await listEntries(db, { userId, limit: 1, offset: 1, showSpam: false });
+      const page3 = await listEntries(db, { userId, limit: 1, offset: 2, showSpam: false });
+      const page4 = await listEntries(db, { userId, limit: 1, offset: 3, showSpam: false });
+
+      expect(page1.items.map((e) => e.id)).toEqual([cId]);
+      expect(page2.items.map((e) => e.id)).toEqual([bId]);
+      expect(page3.items.map((e) => e.id)).toEqual([aId]);
+      // Offset past the end yields an empty page (not an error).
+      expect(page4.items).toHaveLength(0);
     });
   });
 

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -19,7 +19,7 @@ import { users, entries, userEntries, feeds } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
-import { saveArticle } from "../../src/server/services/saved";
+import { saveArticle, savedArticleExistsByUrl } from "../../src/server/services/saved";
 
 // ============================================================================
 // Test Helpers
@@ -1200,6 +1200,44 @@ describe("Saved Articles API", () => {
       const rows = await db.select({ id: entries.id }).from(entries).where(eq(entries.guid, url));
       expect(rows).toHaveLength(1);
       expect(rows[0].id).toBe(a.id);
+    });
+  });
+
+  describe("savedArticleExistsByUrl", () => {
+    it("returns the entry id for a saved URL and null for an unsaved one", async () => {
+      const userId = await createTestUser();
+      const savedUrl = "https://example.com/saved-exists";
+      const articleId = await createTestSavedArticle(userId, { url: savedUrl });
+
+      // Matches on the normalized URL (fragments are stripped, so a #hash on the
+      // query URL still resolves to the same saved article).
+      expect(await savedArticleExistsByUrl(db, userId, savedUrl)).toBe(articleId);
+      expect(await savedArticleExistsByUrl(db, userId, `${savedUrl}#section`)).toBe(articleId);
+      expect(await savedArticleExistsByUrl(db, userId, "https://example.com/not-saved")).toBeNull();
+    });
+
+    it("is scoped per user", async () => {
+      const userId = await createTestUser();
+      const otherId = await createTestUser("other");
+      const url = "https://example.com/mine";
+      await createTestSavedArticle(userId, { url });
+
+      expect(await savedArticleExistsByUrl(db, userId, url)).not.toBeNull();
+      expect(await savedArticleExistsByUrl(db, otherId, url)).toBeNull();
+    });
+
+    it("is read-only: does not create the saved feed for a user who has none", async () => {
+      const userId = await createTestUser();
+
+      const result = await savedArticleExistsByUrl(db, userId, "https://example.com/whatever");
+
+      expect(result).toBeNull();
+      // The probe must not have created a saved feed as a side effect.
+      const savedFeeds = await db
+        .select({ id: feeds.id })
+        .from(feeds)
+        .where(and(eq(feeds.type, "saved"), eq(feeds.userId, userId)));
+      expect(savedFeeds).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

Performance + duplication cleanup of the Wallabag compat API (`src/app/api/wallabag/**`, `src/server/wallabag/**`).

The headline fix: the entries **and** search list endpoints simulated page-based pagination by iterating through cursor pages — to reach page *N* they ran *N* sequential `listEntries` queries, each fetching a full page of rows only to discard them. A Wallabag mobile app paging through its whole library made this **O(pages²)** round-trips.

## Changes

**Performance**
- Add an `offset` param to `listEntries`/`searchEntries` and serve each Wallabag page with a single indexed `LIMIT/OFFSET` query. Both cursor-skip loops are gone. The list endpoint runs its page query and the count in parallel. `listEntries` throws if `cursor` and `offset` are both passed (they would double-skip).

**Incremental sync (`since`)**
- Support Wallabag's `since` (delta sync) via a new `updatedAfter` filter. Wallabag's `since` means "entries *updated* since" — clients use it to pull new saves **and** archive/star state changes. The `visible_entries` view already exposes `GREATEST(entry.updated_at, user_entries.updated_at) AS updated_at`, and both write paths maintain it (`markEntriesRead`/`updateEntryStarred` bump `user_entries.updated_at`; feed/refetch bumps `entry.updated_at`). So filtering on that column is correct for all of new-save / content-refetch / read / star, and it's the exact value we return as the entry's `updated_at`, so filter and reported timestamp can't disagree.
- No new index: the `GREATEST` spans two tables so no single index covers it, but the `user_id` predicate already bounds the scan to one user's saved articles — the exact set an un-filtered client would otherwise re-page — so it's strictly better than a full resync. A denormalized indexed "last modified" column is a possible future optimization for very large libraries.

**Service layer / correctness**
- Move the `exists` check into a read-only `savedArticleExistsByUrl` service function. It no longer creates the user's saved feed as a side effect of a `GET`, and no longer hand-rolls a join in the route handler. Backed by the `uq_entries_feed_guid` unique index. (Bonus: it now applies Google Docs URL normalization, so probing a saved Google Doc with extra query params reports `exists: true` correctly.)
- Extract the shared save-URL normalization (`normalizeSavedUrl`, incl. Google Docs) so existence checks match saved rows exactly.

**Duplication**
- One filter object feeds both the page query and the count (no more drift between them).
- Search reuses `parseEntryListParams` for `page`/`perPage` clamping.
- The three `formatEntry*` helpers now share a single `buildWallabagEntry` builder.

## Tests
- **Integration**: offset paging in `listEntries`; `updatedAfter` surfaces both a read-state change (`user_entries.updated_at`) and a content refetch (`entry.updated_at`) while excluding untouched entries; `savedArticleExistsByUrl` match/miss, per-user scoping, and the read-only (no feed creation) guarantee.
- **E2E**: `perPage=1` pages through the same order as one big page with correct `total`/`pages`; page past the end returns empty; `since=0` returns everything and a far-future `since` returns nothing (route wiring).
- Full `typecheck`, `lint`, `test:unit`, and the `entries`/`saved-articles` integration + `wallabag-api` e2e suites pass locally.

## Reviewed
A second review pass (Fable model) caught that an earlier draft mapped `since` → save-time (`publishedAfter`), which would have silently dropped read/star deltas; that's what led to the `GREATEST`-based `updatedAfter` implementation here. Other areas (offset math, list/count consistency, read-only exists, `buildWallabagEntry` output) verified clean.

## Follow-ups (out of scope, filed as issues)
- #1061 — `uuidToWallabagId` is a 31-bit hash and can collide (left as-is per request).
- #1062 — `tags` / `sort` / `domain_name` query params are still ignored (need design work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)