### PR TITLE
Fix Read You syncing 0 articles: URL-safe (base64url) Google Reader continuation cursor

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -372,7 +372,11 @@ Cursor-based pagination everywhere:
 
 - Request: `{ cursor?: string, limit?: number }`
 - Response: `{ items: T[], nextCursor?: string }`
-- Cursor is base64-encoded UUIDv7 (gives us ordering)
+- Cursor is base64url-encoded UUIDv7 (gives us ordering). base64url (not standard
+  base64) so the cursor is safe to echo back in a URL query string — it surfaces as
+  the Google Reader `continuation` token, and some clients concatenate query params
+  without URL-encoding, where a `+` from standard base64 would arrive as a space and
+  corrupt the cursor.
 
 ### Rate Limiting
 

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -237,6 +237,10 @@ interface CursorData {
 
 function decodeCursor(cursor: string): CursorData {
   try {
+    // Node's "base64" decoder accepts both the standard (+/=) and URL-safe
+    // (-_) alphabets, so this still decodes cursors we emitted before switching
+    // encodeCursor to base64url, as well as any the client mangled by not
+    // URL-encoding the standard form (e.g. "+" arriving as a space).
     const decoded = Buffer.from(cursor, "base64").toString("utf8");
     const parsed = JSON.parse(decoded) as CursorData;
     if (!parsed.ts || !parsed.id) {
@@ -250,7 +254,12 @@ function decodeCursor(cursor: string): CursorData {
 
 function encodeCursor(ts: string, entryId: string): string {
   const data: CursorData = { ts, id: entryId };
-  return Buffer.from(JSON.stringify(data), "utf8").toString("base64");
+  // base64url (no "+", "/", or "=" padding) so the cursor is safe to place in a
+  // URL query string. It is surfaced as the Google Reader `continuation` token,
+  // and some clients (e.g. Read You) concatenate query params without
+  // URL-encoding — a "+" in standard base64 would decode to a space server-side
+  // and corrupt the cursor, 400ing every page past the first and aborting sync.
+  return Buffer.from(JSON.stringify(data), "utf8").toString("base64url");
 }
 
 // ============================================================================

--- a/tests/e2e/greader-api.spec.ts
+++ b/tests/e2e/greader-api.spec.ts
@@ -237,6 +237,56 @@ test.describe("Google Reader API happy path", () => {
     }
   });
 
+  // Regression guard: the `continuation` token is our base64 list cursor. It is
+  // handed straight back by clients as the `c=` query param, and some (e.g. Read
+  // You) concatenate query params WITHOUT URL-encoding. A standard-base64 cursor
+  // can contain "+", which then arrives as a space and corrupts the cursor —
+  // 400ing every page past the first and aborting the whole sync (0 articles).
+  // The token must be URL-safe (base64url: only [A-Za-z0-9_-], no padding) and
+  // must round-trip even when sent raw/unescaped.
+  test("stream/items/ids continuation is URL-safe and pages when sent unescaped", async ({
+    request,
+  }) => {
+    // Dedicated user so paging with a tiny page size doesn't disturb the shared
+    // seeded user's assertions.
+    const db = getDb();
+    const user = await createPasswordUser(db);
+    const feed = await createSubscribedFeed(db, user.id);
+    for (let i = 0; i < 3; i++) {
+      await createUnreadEntry(db, {
+        feedId: feed.feedId,
+        userId: user.id,
+        title: `Page entry ${i}`,
+      });
+    }
+    const token = await clientLogin(request, user);
+
+    // Page 1 with n=1 forces a continuation across the 3 entries.
+    const page1 = await request.get(
+      `${API_BASE}/stream/items/ids?s=user/-/state/com.google/reading-list&n=1`,
+      { headers: authHeader(token) }
+    );
+    expect(page1.status()).toBe(200);
+    const body1 = await page1.json();
+    expect(body1.itemRefs.length).toBe(1);
+    const continuation: string = body1.continuation;
+    expect(typeof continuation).toBe("string");
+    // The crux: URL-safe alphabet only, no "+", "/", or "=".
+    expect(continuation).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    // Send the continuation raw (unescaped) the way Read You does. Build the URL
+    // by hand so the value isn't re-encoded, mirroring the client's behavior.
+    const page2 = await request.get(
+      `${API_BASE}/stream/items/ids?s=user/-/state/com.google/reading-list&n=1&c=${continuation}`,
+      { headers: authHeader(token) }
+    );
+    expect(page2.status()).toBe(200);
+    const body2 = await page2.json();
+    expect(body2.itemRefs.length).toBe(1);
+    // Page 2 must be a different item than page 1 (cursor advanced, not reset).
+    expect(body2.itemRefs[0].id).not.toBe(body1.itemRefs[0].id);
+  });
+
   test("stream/items/contents rejects an oversized id batch with 400", async ({ request }) => {
     const token = await getToken(request);
 


### PR DESCRIPTION
## Problem

When signing into **Read You** (and likely other Google Reader clients) against our `/api/greader.php` compat API, it authenticates and syncs **feeds and tags**, but syncs **0 articles**.

## Root cause

The entries list cursor (`encodeCursor` in `src/server/services/entries.ts`) was **standard base64**, which can contain `+`, `/`, and `=`. We surface that cursor to Google Reader clients as the `stream/items/ids` **`continuation`** token, and clients hand it straight back as the `c=` query param.

Read You (see [`GoogleReaderAPI.kt`](https://github.com/ReadYouApp/ReadYou)) builds request URLs by **raw string concatenation without URL-encoding**. So a `+` in our base64 cursor arrives at the server as a **space**, corrupting the base64 — `decodeCursor` then throws and the endpoint returns **400**.

Read You's sync fetches unread / starred / read item IDs paged at `n=1000`, unions them, then fetches contents — and it **aborts the entire sync (inserting nothing) if any page request fails**. So any account with **>1000 items in a stream** (very common) synced feeds and tags but ended up with 0 articles. Every retry repeated the failure.

## Fix

- `encodeCursor` now emits **base64url** (only `[A-Za-z0-9_-]`, no padding), which is safe to place in a URL query string unescaped. This matches the subscriptions cursor, which already used base64url — the entries cursor was the lone inconsistency.
- `decodeCursor` keeps the `"base64"` alphabet, which Node decodes for **both** the standard and URL-safe alphabets, so cursors issued before this change (and any a client already holds) still decode.
- Added an e2e regression test that forces pagination (`n=1`), asserts the `continuation` is URL-safe, and confirms page 2 advances correctly when the token is sent **unescaped** the way Read You does.

## Testing

- `pnpm typecheck` ✅
- `pnpm test:e2e greader-api` — 16 passed (incl. new pagination test) ✅
- `pnpm test:integration entries` — 496 passed / 12 pre-existing skips ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)