### PR TITLE
Expose saved articles via the Google Reader API (#730)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -361,7 +361,7 @@ Routers are organized by resource:
 Besides the browser tRPC endpoint (`/api/trpc`), the same routers/services back several HTTP surfaces under `src/app/api/`:
 
 - **REST API** (`/api/v1/*`): generated from tRPC procedures' `openapi` meta via `trpc-to-openapi`; the OpenAPI 3.0 spec is served at `/api/openapi`. Includes the SSE stream at `/api/v1/events`.
-- **Google Reader API** (`/api/greader.php/*`): compatibility layer for Google Reader clients.
+- **Google Reader API** (`/api/greader.php/*`): compatibility layer for Google Reader clients. Saved (read-it-later) articles have no subscription row, so they are exposed to Google Reader clients as a synthetic uncategorized "Saved Articles" subscription keyed by the saved feed's own id (`feed/{int64(savedFeedId)}`) — see issue #730. `resolveFeedStream` maps that stream id back to `type='saved'`, `formatEntryAsItem` gives saved items that feed as their `origin.streamId`, and `subscription/list` + `unread-count` include the synthetic feed. A subscription (not a folder) avoids the folder-name-uniqueness edge cases a synthetic folder would create.
 - **Wallabag API** (`/api/wallabag/*`): compatibility layer for Wallabag read-it-later clients.
 - **MCP** (`/api/mcp`): see [MCP Server](#mcp-server).
 - **Webhooks** (`/api/webhooks/*`): Mailgun inbound email, WebSub hub callbacks.

--- a/src/app/api/greader.php/reader/api/0/mark-all-as-read/route.ts
+++ b/src/app/api/greader.php/reader/api/0/mark-all-as-read/route.ts
@@ -13,7 +13,7 @@
 import { requireAuth } from "@/server/google-reader/auth";
 import { parseFormData, textResponse, errorResponse } from "@/server/google-reader/parse";
 import { parseStreamId } from "@/server/google-reader/streams";
-import { feedStreamIdToSubscriptionUuid } from "@/server/google-reader/id";
+import { resolveFeedStream } from "@/server/google-reader/id";
 import { resolveTagByName } from "@/server/google-reader/tags";
 import { db } from "@/server/db";
 import { markAllEntriesRead } from "@/server/services/entries";
@@ -46,18 +46,18 @@ export async function POST(request: Request): Promise<Response> {
   // Translate GReader stream into shared service params
   switch (parsedStream.type) {
     case "feed": {
-      const subscriptionId = await feedStreamIdToSubscriptionUuid(
-        db,
-        userId,
-        parsedStream.subscriptionInt64
-      );
-      if (!subscriptionId) {
+      const resolved = await resolveFeedStream(db, userId, parsedStream.subscriptionInt64);
+      if (!resolved) {
         return textResponse("OK");
       }
 
+      // The saved feed has no subscription; mark all saved entries read via the
+      // type filter (issue #730), mirroring stream/contents' resolution.
       await markAllEntriesRead(db, {
         userId,
-        subscriptionId,
+        ...(resolved.kind === "saved"
+          ? { type: "saved" as const }
+          : { subscriptionId: resolved.subscriptionId }),
         before: beforeDate,
       });
       break;

--- a/src/app/api/greader.php/reader/api/0/stream/contents/[[...streamId]]/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/contents/[[...streamId]]/route.ts
@@ -31,7 +31,7 @@ import { requireAuth } from "@/server/google-reader/auth";
 import { jsonResponse, errorResponse } from "@/server/google-reader/parse";
 import { parseStreamId, type StreamId } from "@/server/google-reader/streams";
 import { formatEntryAsItem } from "@/server/google-reader/format";
-import { feedStreamIdToSubscriptionUuid } from "@/server/google-reader/id";
+import { resolveFeedStream } from "@/server/google-reader/id";
 import { resolveTagByName } from "@/server/google-reader/tags";
 import * as entriesService from "@/server/services/entries";
 import { db } from "@/server/db";
@@ -103,15 +103,15 @@ async function handleStreamContents(
   // Resolve stream ID to filter params
   switch (parsedStream.type) {
     case "feed": {
-      const subscriptionId = await feedStreamIdToSubscriptionUuid(
-        db,
-        session.user.id,
-        parsedStream.subscriptionInt64
-      );
-      if (!subscriptionId) {
+      const resolved = await resolveFeedStream(db, session.user.id, parsedStream.subscriptionInt64);
+      if (!resolved) {
         return errorResponse("Subscription not found", 404);
       }
-      listParams.subscriptionId = subscriptionId;
+      if (resolved.kind === "saved") {
+        listParams.type = "saved";
+      } else {
+        listParams.subscriptionId = resolved.subscriptionId;
+      }
       break;
     }
     case "state": {

--- a/src/app/api/greader.php/reader/api/0/stream/items/ids/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/items/ids/route.ts
@@ -20,8 +20,8 @@
 import { requireAuth } from "@/server/google-reader/auth";
 import { jsonResponse, errorResponse } from "@/server/google-reader/parse";
 import { parseStreamId } from "@/server/google-reader/streams";
-import { uuidToInt64 } from "@/server/google-reader/id";
-import { feedStreamIdToSubscriptionUuid } from "@/server/google-reader/id";
+import { uuidToInt64, feedStreamId } from "@/server/google-reader/id";
+import { resolveFeedStream } from "@/server/google-reader/id";
 import { resolveTagByName } from "@/server/google-reader/tags";
 import { isState } from "@/server/google-reader/streams";
 import * as entriesService from "@/server/services/entries";
@@ -83,15 +83,15 @@ export async function GET(request: Request): Promise<Response> {
 
   switch (parsedStream.type) {
     case "feed": {
-      const subscriptionId = await feedStreamIdToSubscriptionUuid(
-        db,
-        session.user.id,
-        parsedStream.subscriptionInt64
-      );
-      if (!subscriptionId) {
+      const resolved = await resolveFeedStream(db, session.user.id, parsedStream.subscriptionInt64);
+      if (!resolved) {
         return errorResponse("Subscription not found", 404);
       }
-      listParams.subscriptionId = subscriptionId;
+      if (resolved.kind === "saved") {
+        listParams.type = "saved";
+      } else {
+        listParams.subscriptionId = resolved.subscriptionId;
+      }
       break;
     }
     case "state": {
@@ -146,11 +146,16 @@ export async function GET(request: Request): Promise<Response> {
 
   const itemRefs = result.items.map((entry) => {
     const int64Id = uuidToInt64(entry.id);
+    // Saved articles have no subscription; address them by their saved-feed id
+    // (issue #730) so the ref points at the synthetic "Saved Articles" feed.
+    const directStreamId = entry.subscriptionId
+      ? feedStreamId(entry.subscriptionId)
+      : entry.type === "saved"
+        ? feedStreamId(entry.feedId)
+        : null;
     return {
       id: int64Id.toString(),
-      directStreamIds: entry.subscriptionId
-        ? [`feed/${uuidToInt64(entry.subscriptionId).toString()}`]
-        : [],
+      directStreamIds: directStreamId ? [directStreamId] : [],
       timestampUsec: (entry.fetchedAt.getTime() * 1000).toString(),
     };
   });

--- a/src/app/api/greader.php/reader/api/0/subscription/list/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/list/route.ts
@@ -9,8 +9,9 @@
 
 import { requireAuth } from "@/server/google-reader/auth";
 import { jsonResponse } from "@/server/google-reader/parse";
-import { formatSubscription } from "@/server/google-reader/format";
+import { formatSubscription, formatSavedSubscription } from "@/server/google-reader/format";
 import * as subscriptionsService from "@/server/services/subscriptions";
+import { getSavedFeedId } from "@/server/feed/saved-feed";
 import { db } from "@/server/db";
 
 export const dynamic = "force-dynamic";
@@ -33,7 +34,15 @@ export async function GET(request: Request): Promise<Response> {
     cursor = result.nextCursor;
   } while (cursor);
 
-  return jsonResponse({
-    subscriptions: allSubscriptions.map(formatSubscription),
-  });
+  const subscriptions = allSubscriptions.map(formatSubscription);
+
+  // Expose saved articles as a synthetic "Saved Articles" subscription (issue
+  // #730). Only when the saved feed exists — a user who has never saved anything
+  // gets no empty feed.
+  const savedFeedId = await getSavedFeedId(db, session.user.id);
+  if (savedFeedId) {
+    subscriptions.push(formatSavedSubscription(savedFeedId));
+  }
+
+  return jsonResponse({ subscriptions });
 }

--- a/src/app/api/greader.php/reader/api/0/unread-count/route.ts
+++ b/src/app/api/greader.php/reader/api/0/unread-count/route.ts
@@ -10,6 +10,8 @@ import { requireAuth } from "@/server/google-reader/auth";
 import { jsonResponse } from "@/server/google-reader/parse";
 import { formatUnreadCounts } from "@/server/google-reader/format";
 import * as subscriptionsService from "@/server/services/subscriptions";
+import { countEntries } from "@/server/services/entries";
+import { getSavedFeedId } from "@/server/feed/saved-feed";
 import { db } from "@/server/db";
 
 export const dynamic = "force-dynamic";
@@ -38,5 +40,17 @@ export async function GET(request: Request): Promise<Response> {
     cursor = result.nextCursor;
   } while (cursor);
 
-  return jsonResponse(formatUnreadCounts(allSubscriptions));
+  // Include the synthetic "Saved Articles" feed (issue #730) so its unread items
+  // are counted alongside subscriptions and folded into the reading-list total.
+  const savedFeedId = await getSavedFeedId(db, session.user.id);
+  let savedFeed: { feedId: string; unreadCount: number } | undefined;
+  if (savedFeedId) {
+    const { unread } = await countEntries(db, session.user.id, {
+      type: "saved",
+      showSpam: session.user.showSpam,
+    });
+    savedFeed = { feedId: savedFeedId, unreadCount: unread };
+  }
+
+  return jsonResponse(formatUnreadCounts(allSubscriptions, savedFeed));
 }

--- a/src/server/google-reader/format.ts
+++ b/src/server/google-reader/format.ts
@@ -122,7 +122,7 @@ export function formatSubscription(sub: Subscription): GoogleReaderSubscription 
   const int64Id = uuidToInt64(sub.id);
 
   return {
-    id: `feed/${int64Id.toString()}`,
+    id: feedStreamId(sub.id),
     title: sub.title ?? "",
     categories: sub.tags.map((tag) => ({
       id: labelStreamId(tag.name),
@@ -147,7 +147,7 @@ export function formatSavedSubscription(savedFeedId: string): GoogleReaderSubscr
   const int64Id = uuidToInt64(savedFeedId);
 
   return {
-    id: `feed/${int64Id.toString()}`,
+    id: feedStreamId(savedFeedId),
     title: SAVED_FEED_TITLE,
     categories: [],
     sortid: int64Id.toString(16).padStart(16, "0"),
@@ -227,9 +227,8 @@ export function formatUnreadCounts(
   let totalUnread = 0;
   for (const sub of subscriptions) {
     if (sub.unreadCount > 0) {
-      const int64Id = uuidToInt64(sub.id);
       unreadcounts.push({
-        id: `feed/${int64Id.toString()}`,
+        id: feedStreamId(sub.id),
         count: sub.unreadCount,
         newestItemTimestampUsec: (sub.subscribedAt.getTime() * 1000).toString(),
       });

--- a/src/server/google-reader/format.ts
+++ b/src/server/google-reader/format.ts
@@ -5,8 +5,9 @@
  * by Google Reader clients.
  */
 
-import { uuidToInt64, int64ToLongFormId, subscriptionToStreamId } from "./id";
+import { uuidToInt64, int64ToLongFormId, subscriptionToStreamId, feedStreamId } from "./id";
 import { stateStreamId, labelStreamId } from "./streams";
+import { SAVED_FEED_TITLE } from "@/server/feed/saved-feed";
 import type { EntryFull } from "@/server/services/entries";
 import type { Subscription } from "@/server/services/subscriptions";
 import type { ListTagsResult } from "@/server/services/tags";
@@ -73,12 +74,30 @@ export function formatEntryAsItem(entry: EntryFull): GoogleReaderItem {
     },
     author: entry.author ?? "",
     origin: {
-      streamId: entry.subscriptionId ? subscriptionToStreamId(entry.subscriptionId) : "",
+      // Saved articles have no subscription; address them by their saved-feed id
+      // (exposed as the synthetic "Saved Articles" subscription — issue #730) so
+      // clients attach them to a known feed instead of dropping an empty origin.
+      streamId: originStreamId(entry),
       title: entry.feedTitle ?? "",
       htmlUrl: entry.feedUrl ?? entry.url ?? "",
     },
     categories,
   };
+}
+
+/**
+ * The `origin.streamId` for an item. Regular entries use their subscription's
+ * stream id; saved articles (no subscription) use their saved-feed id, matching
+ * the synthetic subscription emitted by `formatSavedSubscription`.
+ */
+function originStreamId(entry: EntryFull): string {
+  if (entry.subscriptionId) {
+    return subscriptionToStreamId(entry.subscriptionId);
+  }
+  if (entry.type === "saved") {
+    return feedStreamId(entry.feedId);
+  }
+  return "";
 }
 
 // ============================================================================
@@ -113,6 +132,28 @@ export function formatSubscription(sub: Subscription): GoogleReaderSubscription 
     firstitemmsec: sub.subscribedAt.getTime().toString(),
     url: sub.url ?? "",
     htmlUrl: sub.siteUrl ?? sub.url ?? "",
+    iconUrl: "",
+  };
+}
+
+/**
+ * Formats the per-user saved-articles feed as a synthetic Google Reader
+ * subscription (issue #730). Saved articles have no real subscription row, so
+ * they are exposed as an uncategorized "Saved Articles" feed keyed by the saved
+ * feed's own id. No categories (uncategorized) avoids the folder-name-uniqueness
+ * edge cases a synthetic folder would introduce.
+ */
+export function formatSavedSubscription(savedFeedId: string): GoogleReaderSubscription {
+  const int64Id = uuidToInt64(savedFeedId);
+
+  return {
+    id: `feed/${int64Id.toString()}`,
+    title: SAVED_FEED_TITLE,
+    categories: [],
+    sortid: int64Id.toString(16).padStart(16, "0"),
+    firstitemmsec: "0",
+    url: "",
+    htmlUrl: "",
     iconUrl: "",
   };
 }
@@ -168,9 +209,15 @@ interface GoogleReaderUnreadCount {
 
 /**
  * Formats unread counts per subscription for the Google Reader unread-count endpoint.
+ *
+ * `savedFeed`, when present, adds the synthetic "Saved Articles" feed (issue
+ * #730) as its own line and folds its unread into the reading-list total —
+ * keeping the total consistent with saved articles appearing in the reading-list
+ * stream.
  */
 export function formatUnreadCounts(
-  subscriptions: Array<{ id: string; unreadCount: number; subscribedAt: Date }>
+  subscriptions: Array<{ id: string; unreadCount: number; subscribedAt: Date }>,
+  savedFeed?: { feedId: string; unreadCount: number }
 ): {
   max: number;
   unreadcounts: GoogleReaderUnreadCount[];
@@ -188,6 +235,15 @@ export function formatUnreadCounts(
       });
       totalUnread += sub.unreadCount;
     }
+  }
+
+  if (savedFeed && savedFeed.unreadCount > 0) {
+    unreadcounts.push({
+      id: feedStreamId(savedFeed.feedId),
+      count: savedFeed.unreadCount,
+      newestItemTimestampUsec: Date.now().toString() + "000",
+    });
+    totalUnread += savedFeed.unreadCount;
   }
 
   // Add total unread count for reading-list

--- a/src/server/google-reader/id.ts
+++ b/src/server/google-reader/id.ts
@@ -25,6 +25,7 @@
 import { eq, and, gte, lte, sql } from "drizzle-orm";
 import type { db as dbType } from "@/server/db";
 import { entries, subscriptions } from "@/server/db/schema";
+import { getSavedFeedId } from "@/server/feed/saved-feed";
 
 /**
  * Converts a UUIDv7 string to a signed 63-bit integer (as bigint).
@@ -225,11 +226,22 @@ export async function batchInt64ToUuid(
 }
 
 /**
+ * Builds a Google Reader feed stream ID ("feed/{int64}") from any feed-like
+ * UUID. Regular feeds are addressed by their *subscription* UUID (the
+ * subscription-centric model), while the per-user saved-articles feed has no
+ * subscription and is addressed by its own `feeds.id`. Both are just UUIDv7s
+ * projected to a 63-bit int, so the same encoding works for either.
+ */
+export function feedStreamId(uuid: string): string {
+  return `feed/${uuidToInt64(uuid).toString()}`;
+}
+
+/**
  * Converts a subscription UUIDv7 to a Google Reader feed stream ID.
  * Format: "feed/{int64}"
  */
 export function subscriptionToStreamId(subscriptionId: string): string {
-  return `feed/${uuidToInt64(subscriptionId).toString()}`;
+  return feedStreamId(subscriptionId);
 }
 
 /**
@@ -265,6 +277,40 @@ export async function feedStreamIdToSubscriptionUuid(
     if (extractRandomBits(candidateInt64) === randomBits) {
       return candidate.id;
     }
+  }
+
+  return null;
+}
+
+/**
+ * A resolved `feed/{int64}` stream: either a real subscription or the user's
+ * synthetic saved-articles feed (which has no subscription row and is exposed
+ * to Google Reader clients as an uncategorized "Saved Articles" subscription —
+ * see issue #730).
+ */
+export type FeedStreamResolution =
+  | { kind: "subscription"; subscriptionId: string }
+  | { kind: "saved"; feedId: string };
+
+/**
+ * Resolves a `feed/{int64}` stream ID to either a subscription or the user's
+ * saved-articles feed. Tries subscriptions first (the common case); if none
+ * matches, checks whether the int64 is the saved feed's own id. Returns null
+ * when it matches nothing the user owns.
+ */
+export async function resolveFeedStream(
+  db: typeof dbType,
+  userId: string,
+  streamId: bigint
+): Promise<FeedStreamResolution | null> {
+  const subscriptionId = await feedStreamIdToSubscriptionUuid(db, userId, streamId);
+  if (subscriptionId) {
+    return { kind: "subscription", subscriptionId };
+  }
+
+  const savedFeedId = await getSavedFeedId(db, userId);
+  if (savedFeedId && uuidToInt64(savedFeedId) === streamId) {
+    return { kind: "saved", feedId: savedFeedId };
   }
 
   return null;

--- a/tests/e2e/greader-api.spec.ts
+++ b/tests/e2e/greader-api.spec.ts
@@ -17,6 +17,7 @@ import {
   createPasswordUser,
   createSubscribedFeed,
   createUnreadEntry,
+  createSavedArticle,
   closeTestConnections,
   type TestPasswordUser,
   type TestFeed,
@@ -285,6 +286,70 @@ test.describe("Google Reader API happy path", () => {
     expect(body2.itemRefs.length).toBe(1);
     // Page 2 must be a different item than page 1 (cursor advanced, not reset).
     expect(body2.itemRefs[0].id).not.toBe(body1.itemRefs[0].id);
+  });
+
+  // Saved articles (read-it-later) have no subscription row, so they used to
+  // surface with an empty origin.streamId and no entry in subscription/list —
+  // Google Reader clients dropped them (issue #730). They must now appear as a
+  // synthetic uncategorized "Saved Articles" subscription and carry that feed as
+  // their origin everywhere.
+  test("saved articles are exposed as a synthetic Saved Articles subscription", async ({
+    request,
+  }) => {
+    const db = getDb();
+    const user = await createPasswordUser(db);
+    const { entry: saved } = await createSavedArticle(db, { userId: user.id, title: "Saved One" });
+    const token = await clientLogin(request, user);
+
+    // 1. subscription/list includes an uncategorized "Saved Articles" feed.
+    const subsRes = await request.get(`${API_BASE}/subscription/list`, {
+      headers: authHeader(token),
+    });
+    expect(subsRes.status()).toBe(200);
+    const subsBody = await subsRes.json();
+    const savedSub = subsBody.subscriptions.find(
+      (s: { title: string }) => s.title === "Saved Articles"
+    );
+    expect(savedSub, "Saved Articles subscription present").toBeTruthy();
+    expect(savedSub.id).toMatch(/^feed\/\d+$/);
+    expect(savedSub.categories).toEqual([]);
+    const savedStreamId: string = savedSub.id;
+
+    // 2. The saved article is fetchable via its feed stream, with a real origin.
+    const contentsRes = await request.get(`${API_BASE}/stream/contents/${savedStreamId}`, {
+      headers: authHeader(token),
+    });
+    expect(contentsRes.status()).toBe(200);
+    const contentsBody = await contentsRes.json();
+    const item = contentsBody.items.find((i: { title: string }) => i.title === saved.title);
+    expect(item, "saved article returned by its feed stream").toBeTruthy();
+    expect(item.origin.streamId).toBe(savedStreamId);
+    expect(item.summary.content).toContain("Content for Saved One");
+
+    // 3. The saved article appears in the reading list with the saved feed as its
+    //    directStreamIds (not an empty origin).
+    const idsRes = await request.get(
+      `${API_BASE}/stream/items/ids?s=user/-/state/com.google/reading-list`,
+      { headers: authHeader(token) }
+    );
+    expect(idsRes.status()).toBe(200);
+    const idsBody = await idsRes.json();
+    const savedRef = idsBody.itemRefs.find((r: { directStreamIds: string[] }) =>
+      r.directStreamIds.includes(savedStreamId)
+    );
+    expect(savedRef, "saved article present in reading list with real origin").toBeTruthy();
+
+    // 4. unread-count counts the saved feed and folds it into the reading-list total.
+    const countRes = await request.get(`${API_BASE}/unread-count`, { headers: authHeader(token) });
+    expect(countRes.status()).toBe(200);
+    const countBody = await countRes.json();
+    const savedCount = countBody.unreadcounts.find((c: { id: string }) => c.id === savedStreamId);
+    expect(savedCount, "saved feed unread count present").toBeTruthy();
+    expect(savedCount.count).toBeGreaterThanOrEqual(1);
+    const readingListCount = countBody.unreadcounts.find(
+      (c: { id: string }) => c.id === "user/-/state/com.google/reading-list"
+    );
+    expect(readingListCount.count).toBeGreaterThanOrEqual(1);
   });
 
   test("stream/items/contents rejects an oversized id batch with 400", async ({ request }) => {

--- a/tests/e2e/greader-api.spec.ts
+++ b/tests/e2e/greader-api.spec.ts
@@ -352,6 +352,44 @@ test.describe("Google Reader API happy path", () => {
     expect(readingListCount.count).toBeGreaterThanOrEqual(1);
   });
 
+  // mark-all-as-read on the synthetic saved feed must actually mark saved
+  // articles read (it used to no-op because the saved feed has no subscription).
+  test("mark-all-as-read marks the Saved Articles feed read", async ({ request }) => {
+    const db = getDb();
+    const user = await createPasswordUser(db);
+    await createSavedArticle(db, { userId: user.id, title: "Mark Me Read" });
+    const token = await clientLogin(request, user);
+
+    // Resolve the synthetic saved feed's stream id from subscription/list.
+    const subsBody = await (
+      await request.get(`${API_BASE}/subscription/list`, { headers: authHeader(token) })
+    ).json();
+    const savedStreamId: string = subsBody.subscriptions.find(
+      (s: { title: string }) => s.title === "Saved Articles"
+    ).id;
+
+    // Precondition: the saved feed has an unread count.
+    const before = await (
+      await request.get(`${API_BASE}/unread-count`, { headers: authHeader(token) })
+    ).json();
+    expect(
+      before.unreadcounts.find((c: { id: string }) => c.id === savedStreamId)?.count
+    ).toBeGreaterThanOrEqual(1);
+
+    // Mark the whole saved feed read.
+    const markRes = await request.post(`${API_BASE}/mark-all-as-read`, {
+      headers: { ...authHeader(token), "content-type": "application/x-www-form-urlencoded" },
+      data: new URLSearchParams({ s: savedStreamId }).toString(),
+    });
+    expect(markRes.status()).toBe(200);
+
+    // The saved feed no longer appears in unread-count (count dropped to 0).
+    const after = await (
+      await request.get(`${API_BASE}/unread-count`, { headers: authHeader(token) })
+    ).json();
+    expect(after.unreadcounts.find((c: { id: string }) => c.id === savedStreamId)).toBeUndefined();
+  });
+
   test("stream/items/contents rejects an oversized id batch with 400", async ({ request }) => {
     const token = await getToken(request);
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -239,6 +239,73 @@ export async function createUnreadEntry(
   };
 }
 
+/**
+ * Creates the user's saved-articles feed (type='saved', no subscription) and a
+ * saved entry in it, plus the user_entries row that makes it visible (unread).
+ * Mirrors the shape produced by the saved-articles service. Returns the saved
+ * feed id and the entry.
+ */
+export async function createSavedArticle(
+  db: TestDb,
+  params: { userId: string; title: string }
+): Promise<{ savedFeedId: string; entry: TestEntry }> {
+  const { userId, title } = params;
+
+  // One saved feed per user (unique index on (user_id) WHERE type='saved').
+  const savedFeedId = generateUuidv7();
+  const inserted = await db
+    .insert(schema.feeds)
+    .values({ id: savedFeedId, type: "saved", userId, title: "Saved Articles" })
+    .onConflictDoNothing()
+    .returning({ id: schema.feeds.id });
+  const feedId =
+    inserted[0]?.id ??
+    (
+      await db
+        .select({ id: schema.feeds.id })
+        .from(schema.feeds)
+        .where(and(eq(schema.feeds.type, "saved"), eq(schema.feeds.userId, userId)))
+        .limit(1)
+    )[0].id;
+
+  const id = generateUuidv7();
+  const now = new Date();
+  const content = `<p>Content for ${title}</p>`;
+  const url = `https://example.com/e2e/saved/${id}`;
+  const [entry] = await db
+    .insert(schema.entries)
+    .values({
+      id,
+      feedId,
+      type: "saved",
+      guid: url,
+      url,
+      title,
+      contentOriginal: content,
+      contentCleaned: content,
+      summary: `Summary for ${title}`,
+      publishedAt: null,
+      fetchedAt: now,
+      contentHash: crypto.createHash("sha256").update(content).digest("hex"),
+    })
+    .returning();
+
+  await db.insert(schema.userEntries).values({ userId, entryId: id, publishedOrFetchedAt: now });
+
+  return {
+    savedFeedId: feedId,
+    entry: {
+      id,
+      title,
+      updatedAt: entry.updatedAt,
+      url,
+      summary: entry.summary ?? "",
+      publishedAt: now,
+      fetchedAt: now,
+    },
+  };
+}
+
 /** Marks an entry read directly in the database, returning the update timestamp. */
 export async function markEntryRead(db: TestDb, userId: string, entryId: string): Promise<Date> {
   const now = new Date();


### PR DESCRIPTION
Closes #730.

## Problem

Saved (read-it-later) articles never showed up in Google Reader native apps. They live in a per-user `feeds` row (`type='saved'`, one per user) with **no `subscriptions` row**, so:

- `formatEntryAsItem` emitted `origin.streamId = ""` for them, and
- they were absent from `subscription/list` and `unread-count`.

They were actually already in the `reading-list` stream (no type filter excludes them), but with an empty/unknown origin feed, so clients (Read You does `origin.streamId.ofFeedStreamIdToId()!!`) orphaned or dropped them.

## Approach

Expose the saved feed as a **synthetic, uncategorized "Saved Articles" subscription**, keyed by the saved feed's own id: `feed/{int64(savedFeedId)}`. The saved feed already has a stable UUID, so it already has a stable, collision-free Google Reader id under the existing scheme — no schema change, no new storage.

A **subscription (not a folder)** deliberately sidesteps the folder-name-uniqueness edge case raised in the issue, and subscription titles needn't be unique. Full-consistency semantics: the saved feed behaves like any uncategorized subscription — its unread items appear in All items and the reading-list total, exactly as standard Google Reader clients expect (no client special-casing).

## Changes

- **`id.ts`**: `feedStreamId(uuid)` helper + `resolveFeedStream()` (tries subscriptions first, then the user's saved feed). `stream/contents` and `stream/items/ids` use it; a saved stream resolves to `listParams.type = 'saved'`.
- **`format.ts`**: `formatEntryAsItem` gives saved items the saved feed as their `origin.streamId`; new `formatSavedSubscription()`; `formatUnreadCounts()` takes the saved feed and folds it into the reading-list total.
- **`subscription/list`**: appends the synthetic feed (only when the saved feed exists — a user who never saved anything gets no empty feed).
- **`unread-count`**: counts unread saved articles as their own line.
- **`stream/items/ids`**: saved refs carry the saved feed in `directStreamIds`.
- `subscription/edit` degrades gracefully for the synthetic feed (no subscription row → edit 404, unsubscribe no-op), so clients can't delete the saved feed.

## Testing

- New `greader-api` e2e test: the saved feed appears in `subscription/list` (uncategorized), the article is fetchable via its feed stream **with a real origin**, appears in the reading list with `directStreamIds` set, and is counted by `unread-count`. Adds a `createSavedArticle` e2e helper.
- `pnpm typecheck` ✅
- `pnpm test:e2e greader-api` — 17 passed ✅
- `pnpm test:unit google-reader` — 2073 passed ✅

## Note / product decision baked in

Because reading-list = the union of all subscriptions in Google Reader, presenting saved articles as a subscription means **unread saved articles now show in the client's All items and unread totals** (chosen deliberately for standard, no-special-casing semantics). If you'd rather keep the read-it-later pile out of the main unread, that would mean stripping `type='saved'` from the reading-list stream/counts — happy to switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)