### PR TITLE
greader: fetch full subscription list in one query, not a cursor loop

### DIFF
--- a/src/app/api/greader.php/reader/api/0/subscription/list/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/list/route.ts
@@ -20,26 +20,18 @@ export async function GET(request: Request): Promise<Response> {
   const session = await requireAuth(request);
   if (session instanceof Response) return session;
 
-  // Fetch all subscriptions (no pagination — Google Reader clients expect all at once)
-  const allSubscriptions: subscriptionsService.Subscription[] = [];
-  let cursor: string | undefined;
-
-  do {
-    const result = await subscriptionsService.listSubscriptions(db, {
-      userId: session.user.id,
-      cursor,
-      limit: 100,
-    });
-    allSubscriptions.push(...result.subscriptions);
-    cursor = result.nextCursor;
-  } while (cursor);
+  // Google Reader clients expect the whole subscription list at once. Fetch it in
+  // a single query (not a cursor loop) concurrently with the saved-feed lookup.
+  const [allSubscriptions, savedFeedId] = await Promise.all([
+    subscriptionsService.listAllSubscriptions(db, session.user.id),
+    getSavedFeedId(db, session.user.id),
+  ]);
 
   const subscriptions = allSubscriptions.map(formatSubscription);
 
   // Expose saved articles as a synthetic "Saved Articles" subscription (issue
   // #730). Only when the saved feed exists — a user who has never saved anything
   // gets no empty feed.
-  const savedFeedId = await getSavedFeedId(db, session.user.id);
   if (savedFeedId) {
     subscriptions.push(formatSavedSubscription(savedFeedId));
   }

--- a/src/app/api/greader.php/reader/api/0/unread-count/route.ts
+++ b/src/app/api/greader.php/reader/api/0/unread-count/route.ts
@@ -20,29 +20,17 @@ export async function GET(request: Request): Promise<Response> {
   const session = await requireAuth(request);
   if (session instanceof Response) return session;
 
-  // Fetch all subscriptions to get unread counts
-  const allSubscriptions: Array<{ id: string; unreadCount: number; subscribedAt: Date }> = [];
-  let cursor: string | undefined;
-
-  do {
-    const result = await subscriptionsService.listSubscriptions(db, {
-      userId: session.user.id,
-      cursor,
-      limit: 100,
-    });
-    for (const sub of result.subscriptions) {
-      allSubscriptions.push({
-        id: sub.id,
-        unreadCount: sub.unreadCount,
-        subscribedAt: sub.subscribedAt,
-      });
-    }
-    cursor = result.nextCursor;
-  } while (cursor);
+  // Fetch the full subscription list (with per-subscription unread counts) in a
+  // single query, concurrently with the saved-feed lookup.
+  const [allSubscriptions, savedFeedId] = await Promise.all([
+    subscriptionsService.listAllSubscriptions(db, session.user.id),
+    getSavedFeedId(db, session.user.id),
+  ]);
 
   // Include the synthetic "Saved Articles" feed (issue #730) so its unread items
   // are counted alongside subscriptions and folded into the reading-list total.
-  const savedFeedId = await getSavedFeedId(db, session.user.id);
+  // countEntries runs only when a saved feed exists (users who never saved
+  // anything skip the extra aggregate).
   let savedFeed: { feedId: string; unreadCount: number } | undefined;
   if (savedFeedId) {
     const { unread } = await countEntries(db, session.user.id, {

--- a/src/server/services/subscriptions.ts
+++ b/src/server/services/subscriptions.ts
@@ -288,6 +288,30 @@ export async function listSubscriptions(
 }
 
 /**
+ * Lists ALL active subscriptions for a user in a single query (no pagination).
+ *
+ * The Google Reader `subscription/list` and `unread-count` endpoints need the
+ * user's entire subscription set at once. Paging through `listSubscriptions`
+ * (capped at 100/page) issues ⌈N/100⌉ sequential round-trips; this runs the same
+ * base query (per-subscription unread counts + tags) unbounded instead. Ordered
+ * alphabetically to match `listSubscriptions`. Callers already hold the whole
+ * list in memory, so there is no extra memory cost — only fewer round-trips.
+ *
+ * This is deliberately separate from `listSubscriptions` rather than an
+ * unbounded `limit`: the 100 cap is a safety valve for the paginated UI/MCP/tRPC
+ * callers and stays intact for them.
+ */
+export async function listAllSubscriptions(
+  db: typeof dbType,
+  userId: string
+): Promise<Subscription[]> {
+  const results = await buildSubscriptionBaseQuery(db, userId)
+    .where(eq(userFeeds.userId, userId))
+    .orderBy(sql`COALESCE(${userFeeds.title}, '') ASC`, userFeeds.id);
+  return results.map(formatSubscriptionRow);
+}
+
+/**
  * Gets a single subscription by ID.
  */
 export async function getSubscription(

--- a/tests/integration/subscriptions.test.ts
+++ b/tests/integration/subscriptions.test.ts
@@ -13,6 +13,7 @@ import { users, feeds, entries, subscriptions, userEntries } from "../../src/ser
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
+import * as subscriptionsService from "../../src/server/services/subscriptions";
 
 // ============================================================================
 // Test Helpers
@@ -1039,5 +1040,64 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       expect(result.items).toHaveLength(1);
       expect(result.items[0].title).toBe("Ruby Programming Tips");
     });
+  });
+});
+
+describe("listAllSubscriptions", () => {
+  it("returns every subscription in one call, past the 100-per-page cap", async () => {
+    const userId = await createTestUser();
+
+    // More than listSubscriptions' hard cap of 100 so a single unbounded query is
+    // observably different from a capped one. Bulk-insert for speed.
+    const N = 101;
+    const feedRows = Array.from({ length: N }, (_, i) => ({
+      id: generateUuidv7(),
+      type: "web" as const,
+      url: `https://example.com/all-subs/${i}.xml`,
+      title: `Feed ${String(i).padStart(3, "0")}`,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+    await db.insert(feeds).values(feedRows);
+    await db.insert(subscriptions).values(
+      feedRows.map((f) => ({
+        id: generateUuidv7(),
+        userId,
+        feedId: f.id,
+        subscribedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }))
+    );
+
+    const all = await subscriptionsService.listAllSubscriptions(db, userId);
+
+    expect(all).toHaveLength(N);
+    // Ordered alphabetically by title, matching listSubscriptions.
+    const titles = all.map((s) => s.title);
+    expect(titles).toEqual([...titles].sort());
+  });
+
+  it("matches listSubscriptions' rows and shape for a user's subscriptions", async () => {
+    const userId = await createTestUser();
+    const feedA = await createTestFeed({ url: "https://example.com/a.xml", title: "Alpha" });
+    const feedB = await createTestFeed({ url: "https://example.com/b.xml", title: "Beta" });
+    await createTestSubscription(userId, feedA);
+    await createTestSubscription(userId, feedB);
+
+    const all = await subscriptionsService.listAllSubscriptions(db, userId);
+    const paged = await subscriptionsService.listSubscriptions(db, { userId, limit: 100 });
+
+    // Same rows (ids), no pagination cursor semantics to worry about.
+    expect(all.map((s) => s.id).sort()).toEqual(paged.subscriptions.map((s) => s.id).sort());
+    // Same object shape as the paginated variant (id/title/unreadCount/tags present).
+    const alpha = all.find((s) => s.title === "Alpha");
+    expect(alpha).toMatchObject({ title: "Alpha", unreadCount: 0, tags: [] });
+  });
+
+  it("returns an empty array for a user with no subscriptions", async () => {
+    const userId = await createTestUser();
+    const all = await subscriptionsService.listAllSubscriptions(db, userId);
+    expect(all).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

The Google Reader `subscription/list` and `unread-count` endpoints need the user's **entire** subscription set at once, but `listSubscriptions` hard-caps each page at 100. So both routes paged through it in a `do/while` cursor loop — **⌈N/100⌉ sequential DB round-trips** for a user with >100 subscriptions, each page also running the per-subscription unread-count subquery. (Pre-existing; surfaced during the #1068 review.)

## Fix

Add `listAllSubscriptions(db, userId)` — the same base query (`buildSubscriptionBaseQuery`: per-subscription unread counts + tags) run **unbounded, once**. Both routes now fetch the full list in a single query, concurrently with the saved-feed lookup:

- **unread-count**: `(⌈N/100⌉ + 2)` sequential queries → **2 concurrent** (+ one conditional `countEntries` only when a saved feed exists).
- **subscription/list**: `⌈N/100⌉ + 1` → **1** (+ concurrent saved lookup).

The 100-per-page cap on `listSubscriptions` stays intact for the paginated UI / MCP / tRPC callers — this is a separate, deliberately-unbounded function for the two greader "give me everything" endpoints, not a raised cap. No memory change: the routes already accumulated the whole list in memory.

This also folds in the smaller "run the saved-feed queries concurrently instead of sequentially" efficiency note (#4) from the #1068 review.

## Testing

- New integration tests (`tests/integration/subscriptions.test.ts`): `listAllSubscriptions` returns **past the 100-per-page cap** (101 subs), matches `listSubscriptions`' rows/shape, and handles the empty case.
- `pnpm typecheck` ✅
- `pnpm test:integration subscriptions.test` — 500 passed ✅
- `pnpm test:e2e greader-api` — 18 passed (subscription/list, unread-count, saved-articles, mark-all-as-read all exercise the new path) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)