### PR TITLE
greader: consolidate saved-feed synthetic subscription into a shared layer (#1069)

### DIFF
--- a/src/app/api/greader.php/reader/api/0/mark-all-as-read/route.ts
+++ b/src/app/api/greader.php/reader/api/0/mark-all-as-read/route.ts
@@ -13,7 +13,7 @@
 import { requireAuth } from "@/server/google-reader/auth";
 import { parseFormData, textResponse, errorResponse } from "@/server/google-reader/parse";
 import { parseStreamId } from "@/server/google-reader/streams";
-import { resolveFeedStream } from "@/server/google-reader/id";
+import { resolveFeedStreamFilter } from "@/server/google-reader/subscriptions";
 import { resolveTagByName } from "@/server/google-reader/tags";
 import { db } from "@/server/db";
 import { markAllEntriesRead } from "@/server/services/entries";
@@ -46,20 +46,14 @@ export async function POST(request: Request): Promise<Response> {
   // Translate GReader stream into shared service params
   switch (parsedStream.type) {
     case "feed": {
-      const resolved = await resolveFeedStream(db, userId, parsedStream.subscriptionInt64);
-      if (!resolved) {
+      const filter = await resolveFeedStreamFilter(db, userId, parsedStream.subscriptionInt64);
+      if (!filter) {
         return textResponse("OK");
       }
 
-      // The saved feed has no subscription; mark all saved entries read via the
-      // type filter (issue #730), mirroring stream/contents' resolution.
-      await markAllEntriesRead(db, {
-        userId,
-        ...(resolved.kind === "saved"
-          ? { type: "saved" as const }
-          : { subscriptionId: resolved.subscriptionId }),
-        before: beforeDate,
-      });
+      // `filter` is the saved-feed type filter or a real subscription id (issue
+      // #730), resolved identically to the stream/contents endpoints.
+      await markAllEntriesRead(db, { userId, ...filter, before: beforeDate });
       break;
     }
     case "state": {

--- a/src/app/api/greader.php/reader/api/0/stream/contents/[[...streamId]]/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/contents/[[...streamId]]/route.ts
@@ -31,7 +31,7 @@ import { requireAuth } from "@/server/google-reader/auth";
 import { jsonResponse, errorResponse } from "@/server/google-reader/parse";
 import { parseStreamId, type StreamId } from "@/server/google-reader/streams";
 import { formatEntryAsItem } from "@/server/google-reader/format";
-import { resolveFeedStream } from "@/server/google-reader/id";
+import { resolveFeedStreamFilter } from "@/server/google-reader/subscriptions";
 import { resolveTagByName } from "@/server/google-reader/tags";
 import * as entriesService from "@/server/services/entries";
 import { db } from "@/server/db";
@@ -103,15 +103,15 @@ async function handleStreamContents(
   // Resolve stream ID to filter params
   switch (parsedStream.type) {
     case "feed": {
-      const resolved = await resolveFeedStream(db, session.user.id, parsedStream.subscriptionInt64);
-      if (!resolved) {
+      const filter = await resolveFeedStreamFilter(
+        db,
+        session.user.id,
+        parsedStream.subscriptionInt64
+      );
+      if (!filter) {
         return errorResponse("Subscription not found", 404);
       }
-      if (resolved.kind === "saved") {
-        listParams.type = "saved";
-      } else {
-        listParams.subscriptionId = resolved.subscriptionId;
-      }
+      Object.assign(listParams, filter);
       break;
     }
     case "state": {

--- a/src/app/api/greader.php/reader/api/0/stream/items/ids/route.ts
+++ b/src/app/api/greader.php/reader/api/0/stream/items/ids/route.ts
@@ -20,8 +20,9 @@
 import { requireAuth } from "@/server/google-reader/auth";
 import { jsonResponse, errorResponse } from "@/server/google-reader/parse";
 import { parseStreamId } from "@/server/google-reader/streams";
-import { uuidToInt64, feedStreamId } from "@/server/google-reader/id";
-import { resolveFeedStream } from "@/server/google-reader/id";
+import { uuidToInt64 } from "@/server/google-reader/id";
+import { entryFeedStreamId } from "@/server/google-reader/format";
+import { resolveFeedStreamFilter } from "@/server/google-reader/subscriptions";
 import { resolveTagByName } from "@/server/google-reader/tags";
 import { isState } from "@/server/google-reader/streams";
 import * as entriesService from "@/server/services/entries";
@@ -83,15 +84,15 @@ export async function GET(request: Request): Promise<Response> {
 
   switch (parsedStream.type) {
     case "feed": {
-      const resolved = await resolveFeedStream(db, session.user.id, parsedStream.subscriptionInt64);
-      if (!resolved) {
+      const filter = await resolveFeedStreamFilter(
+        db,
+        session.user.id,
+        parsedStream.subscriptionInt64
+      );
+      if (!filter) {
         return errorResponse("Subscription not found", 404);
       }
-      if (resolved.kind === "saved") {
-        listParams.type = "saved";
-      } else {
-        listParams.subscriptionId = resolved.subscriptionId;
-      }
+      Object.assign(listParams, filter);
       break;
     }
     case "state": {
@@ -146,13 +147,10 @@ export async function GET(request: Request): Promise<Response> {
 
   const itemRefs = result.items.map((entry) => {
     const int64Id = uuidToInt64(entry.id);
-    // Saved articles have no subscription; address them by their saved-feed id
-    // (issue #730) so the ref points at the synthetic "Saved Articles" feed.
-    const directStreamId = entry.subscriptionId
-      ? feedStreamId(entry.subscriptionId)
-      : entry.type === "saved"
-        ? feedStreamId(entry.feedId)
-        : null;
+    // Saved articles have no subscription; `entryFeedStreamId` addresses them by
+    // their saved-feed id (issue #730) so the ref points at the synthetic
+    // "Saved Articles" feed, matching the item's origin.
+    const directStreamId = entryFeedStreamId(entry);
     return {
       id: int64Id.toString(),
       directStreamIds: directStreamId ? [directStreamId] : [],

--- a/src/app/api/greader.php/reader/api/0/subscription/list/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/list/route.ts
@@ -3,15 +3,14 @@
  *
  * GET /api/greader.php/reader/api/0/subscription/list
  *
- * Returns all subscriptions for the authenticated user.
- * Supports `output=json` parameter (default is JSON anyway).
+ * Returns all subscriptions for the authenticated user, including the synthetic
+ * "Saved Articles" feed (issue #730). Supports `output=json` (default is JSON).
  */
 
 import { requireAuth } from "@/server/google-reader/auth";
 import { jsonResponse } from "@/server/google-reader/parse";
-import { formatSubscription, formatSavedSubscription } from "@/server/google-reader/format";
-import * as subscriptionsService from "@/server/services/subscriptions";
-import { getSavedFeedId } from "@/server/feed/saved-feed";
+import { formatSubscription } from "@/server/google-reader/format";
+import { listGreaderSubscriptions } from "@/server/google-reader/subscriptions";
 import { db } from "@/server/db";
 
 export const dynamic = "force-dynamic";
@@ -20,21 +19,12 @@ export async function GET(request: Request): Promise<Response> {
   const session = await requireAuth(request);
   if (session instanceof Response) return session;
 
-  // Google Reader clients expect the whole subscription list at once. Fetch it in
-  // a single query (not a cursor loop) concurrently with the saved-feed lookup.
-  const [allSubscriptions, savedFeedId] = await Promise.all([
-    subscriptionsService.listAllSubscriptions(db, session.user.id),
-    getSavedFeedId(db, session.user.id),
-  ]);
-
-  const subscriptions = allSubscriptions.map(formatSubscription);
-
-  // Expose saved articles as a synthetic "Saved Articles" subscription (issue
-  // #730). Only when the saved feed exists — a user who has never saved anything
-  // gets no empty feed.
-  if (savedFeedId) {
-    subscriptions.push(formatSavedSubscription(savedFeedId));
-  }
+  // `formatSubscription` ignores unread counts, but listGreaderSubscriptions
+  // still computes them (they're baked into the subscription query). Skipping
+  // that discarded aggregate is tracked as an optimization in issue #1074.
+  const subscriptions = (
+    await listGreaderSubscriptions(db, session.user.id, { showSpam: session.user.showSpam })
+  ).map(formatSubscription);
 
   return jsonResponse({ subscriptions });
 }

--- a/src/app/api/greader.php/reader/api/0/unread-count/route.ts
+++ b/src/app/api/greader.php/reader/api/0/unread-count/route.ts
@@ -3,15 +3,14 @@
  *
  * GET /api/greader.php/reader/api/0/unread-count
  *
- * Returns per-subscription unread counts.
+ * Returns per-subscription unread counts, including the synthetic "Saved
+ * Articles" feed (issue #730) folded into the reading-list total.
  */
 
 import { requireAuth } from "@/server/google-reader/auth";
 import { jsonResponse } from "@/server/google-reader/parse";
 import { formatUnreadCounts } from "@/server/google-reader/format";
-import * as subscriptionsService from "@/server/services/subscriptions";
-import { countEntries } from "@/server/services/entries";
-import { getSavedFeedId } from "@/server/feed/saved-feed";
+import { listGreaderSubscriptions } from "@/server/google-reader/subscriptions";
 import { db } from "@/server/db";
 
 export const dynamic = "force-dynamic";
@@ -20,25 +19,9 @@ export async function GET(request: Request): Promise<Response> {
   const session = await requireAuth(request);
   if (session instanceof Response) return session;
 
-  // Fetch the full subscription list (with per-subscription unread counts) in a
-  // single query, concurrently with the saved-feed lookup.
-  const [allSubscriptions, savedFeedId] = await Promise.all([
-    subscriptionsService.listAllSubscriptions(db, session.user.id),
-    getSavedFeedId(db, session.user.id),
-  ]);
+  const subscriptions = await listGreaderSubscriptions(db, session.user.id, {
+    showSpam: session.user.showSpam,
+  });
 
-  // Include the synthetic "Saved Articles" feed (issue #730) so its unread items
-  // are counted alongside subscriptions and folded into the reading-list total.
-  // countEntries runs only when a saved feed exists (users who never saved
-  // anything skip the extra aggregate).
-  let savedFeed: { feedId: string; unreadCount: number } | undefined;
-  if (savedFeedId) {
-    const { unread } = await countEntries(db, session.user.id, {
-      type: "saved",
-      showSpam: session.user.showSpam,
-    });
-    savedFeed = { feedId: savedFeedId, unreadCount: unread };
-  }
-
-  return jsonResponse(formatUnreadCounts(allSubscriptions, savedFeed));
+  return jsonResponse(formatUnreadCounts(subscriptions));
 }

--- a/src/server/google-reader/format.ts
+++ b/src/server/google-reader/format.ts
@@ -7,7 +7,6 @@
 
 import { uuidToInt64, int64ToLongFormId, subscriptionToStreamId, feedStreamId } from "./id";
 import { stateStreamId, labelStreamId } from "./streams";
-import { SAVED_FEED_TITLE } from "@/server/feed/saved-feed";
 import type { EntryFull } from "@/server/services/entries";
 import type { Subscription } from "@/server/services/subscriptions";
 import type { ListTagsResult } from "@/server/services/tags";
@@ -77,7 +76,7 @@ export function formatEntryAsItem(entry: EntryFull): GoogleReaderItem {
       // Saved articles have no subscription; address them by their saved-feed id
       // (exposed as the synthetic "Saved Articles" subscription — issue #730) so
       // clients attach them to a known feed instead of dropping an empty origin.
-      streamId: originStreamId(entry),
+      streamId: entryFeedStreamId(entry) ?? "",
       title: entry.feedTitle ?? "",
       htmlUrl: entry.feedUrl ?? entry.url ?? "",
     },
@@ -86,18 +85,24 @@ export function formatEntryAsItem(entry: EntryFull): GoogleReaderItem {
 }
 
 /**
- * The `origin.streamId` for an item. Regular entries use their subscription's
- * stream id; saved articles (no subscription) use their saved-feed id, matching
- * the synthetic subscription emitted by `formatSavedSubscription`.
+ * The `feed/{int64}` stream an entry belongs to, or null if it has none. Regular
+ * entries use their subscription's stream id; saved articles (no subscription)
+ * use their saved-feed id (the synthetic "Saved Articles" subscription — issue
+ * #730). Shared by item formatting and the stream/items/ids item refs so both
+ * address saved articles the same way.
  */
-function originStreamId(entry: EntryFull): string {
+export function entryFeedStreamId(entry: {
+  subscriptionId: string | null;
+  feedId: string;
+  type: "web" | "email" | "saved";
+}): string | null {
   if (entry.subscriptionId) {
     return subscriptionToStreamId(entry.subscriptionId);
   }
   if (entry.type === "saved") {
     return feedStreamId(entry.feedId);
   }
-  return "";
+  return null;
 }
 
 // ============================================================================
@@ -132,28 +137,6 @@ export function formatSubscription(sub: Subscription): GoogleReaderSubscription 
     firstitemmsec: sub.subscribedAt.getTime().toString(),
     url: sub.url ?? "",
     htmlUrl: sub.siteUrl ?? sub.url ?? "",
-    iconUrl: "",
-  };
-}
-
-/**
- * Formats the per-user saved-articles feed as a synthetic Google Reader
- * subscription (issue #730). Saved articles have no real subscription row, so
- * they are exposed as an uncategorized "Saved Articles" feed keyed by the saved
- * feed's own id. No categories (uncategorized) avoids the folder-name-uniqueness
- * edge cases a synthetic folder would introduce.
- */
-export function formatSavedSubscription(savedFeedId: string): GoogleReaderSubscription {
-  const int64Id = uuidToInt64(savedFeedId);
-
-  return {
-    id: feedStreamId(savedFeedId),
-    title: SAVED_FEED_TITLE,
-    categories: [],
-    sortid: int64Id.toString(16).padStart(16, "0"),
-    firstitemmsec: "0",
-    url: "",
-    htmlUrl: "",
     iconUrl: "",
   };
 }
@@ -208,16 +191,13 @@ interface GoogleReaderUnreadCount {
 }
 
 /**
- * Formats unread counts per subscription for the Google Reader unread-count endpoint.
- *
- * `savedFeed`, when present, adds the synthetic "Saved Articles" feed (issue
- * #730) as its own line and folds its unread into the reading-list total —
- * keeping the total consistent with saved articles appearing in the reading-list
- * stream.
+ * Formats unread counts per subscription for the Google Reader unread-count
+ * endpoint. The saved-articles feed arrives as a synthetic subscription in
+ * `subscriptions` (issue #730), so it is counted and folded into the
+ * reading-list total exactly like a real feed — no special case here.
  */
 export function formatUnreadCounts(
-  subscriptions: Array<{ id: string; unreadCount: number; subscribedAt: Date }>,
-  savedFeed?: { feedId: string; unreadCount: number }
+  subscriptions: Array<{ id: string; unreadCount: number; subscribedAt: Date }>
 ): {
   max: number;
   unreadcounts: GoogleReaderUnreadCount[];
@@ -234,15 +214,6 @@ export function formatUnreadCounts(
       });
       totalUnread += sub.unreadCount;
     }
-  }
-
-  if (savedFeed && savedFeed.unreadCount > 0) {
-    unreadcounts.push({
-      id: feedStreamId(savedFeed.feedId),
-      count: savedFeed.unreadCount,
-      newestItemTimestampUsec: Date.now().toString() + "000",
-    });
-    totalUnread += savedFeed.unreadCount;
   }
 
   // Add total unread count for reading-list

--- a/src/server/google-reader/subscriptions.ts
+++ b/src/server/google-reader/subscriptions.ts
@@ -1,0 +1,102 @@
+/**
+ * Google Reader subscription enumeration & feed-stream resolution.
+ *
+ * The per-user saved-articles feed is exposed to Google Reader clients as a
+ * synthetic, uncategorized "Saved Articles" subscription (issue #730). It has no
+ * real subscription row, so every endpoint that lists subscriptions or resolves a
+ * `feed/{int64}` stream has to account for it. Rather than re-deriving that
+ * special case in each route handler — which is how mark-all-as-read once ended
+ * up silently no-op'ing on the saved feed (issue #1069) — the handlers go through
+ * the helpers here, so the saved feed is materialized in exactly one place.
+ */
+
+import type { db as dbType } from "@/server/db";
+import * as subscriptionsService from "@/server/services/subscriptions";
+import { countEntries } from "@/server/services/entries";
+import { getSavedFeedId, SAVED_FEED_TITLE } from "@/server/feed/saved-feed";
+import { resolveFeedStream } from "./id";
+
+/**
+ * An entries-service feed filter fragment. Both `listEntries` and
+ * `markAllEntriesRead` accept `type`/`subscriptionId`, so a resolved feed stream
+ * spreads straight into either param object.
+ */
+export type GreaderFeedFilter = { type: "saved" } | { subscriptionId: string };
+
+/**
+ * Resolves a `feed/{int64}` stream to the entries-service filter that selects its
+ * entries: a real subscription id, or the `type: "saved"` filter for the
+ * saved-articles feed (which has no subscription row — issue #730). Returns null
+ * when the int64 matches nothing the user owns.
+ *
+ * This is the single place a Google Reader feed stream becomes a service filter,
+ * so stream/contents, stream/items/ids, and mark-all-as-read all treat the
+ * synthetic saved feed identically.
+ */
+export async function resolveFeedStreamFilter(
+  db: typeof dbType,
+  userId: string,
+  streamInt64: bigint
+): Promise<GreaderFeedFilter | null> {
+  const resolved = await resolveFeedStream(db, userId, streamInt64);
+  if (!resolved) return null;
+  return resolved.kind === "saved"
+    ? { type: "saved" }
+    : { subscriptionId: resolved.subscriptionId };
+}
+
+/**
+ * Enumerates every subscription a Google Reader client should see, with the
+ * per-user saved-articles feed appended as a synthetic subscription (issue #730).
+ * Google Reader has no pagination on the wire, so the real subscriptions are
+ * fetched in a single unbounded query (`listAllSubscriptions`) rather than a
+ * cursor loop, concurrently with the saved-feed lookup.
+ *
+ * Centralizing the saved-feed append here means subscription/list and
+ * unread-count inherit it for free instead of each re-deriving it (issue #1069).
+ */
+export async function listGreaderSubscriptions(
+  db: typeof dbType,
+  userId: string,
+  opts: { showSpam: boolean }
+): Promise<subscriptionsService.Subscription[]> {
+  const [all, saved] = await Promise.all([
+    subscriptionsService.listAllSubscriptions(db, userId),
+    getSavedSubscription(db, userId, opts),
+  ]);
+
+  return saved ? [...all, saved] : all;
+}
+
+/**
+ * The saved-articles feed as a synthetic `Subscription`, or null if the user has
+ * no saved feed yet (a user who has never saved anything gets no empty feed). It
+ * carries its unread count and enough metadata to be formatted and counted
+ * exactly like a real subscription (uncategorized, titled "Saved Articles"), so
+ * downstream formatting needs no saved special case. `subscribedAt` is the epoch
+ * — the saved feed has no meaningful subscription time.
+ */
+export async function getSavedSubscription(
+  db: typeof dbType,
+  userId: string,
+  opts: { showSpam: boolean }
+): Promise<subscriptionsService.Subscription | null> {
+  const feedId = await getSavedFeedId(db, userId);
+  if (!feedId) return null;
+
+  const { unread } = await countEntries(db, userId, { type: "saved", showSpam: opts.showSpam });
+
+  return {
+    id: feedId,
+    type: "saved",
+    url: null,
+    title: SAVED_FEED_TITLE,
+    originalTitle: SAVED_FEED_TITLE,
+    description: null,
+    siteUrl: null,
+    subscribedAt: new Date(0),
+    unreadCount: unread,
+    tags: [],
+    fetchFullContent: false,
+  };
+}


### PR DESCRIPTION
Fixes #1069.

## Problem

PR #1068 exposed saved (read-it-later) articles through the Google Reader API as a synthetic, uncategorized "Saved Articles" subscription (`feed/{int64(savedFeedId)}`), but the concept was a **route-layer bolt-on** re-derived in each handler:

- `subscription/list` appended `formatSavedSubscription(savedFeedId)`
- `unread-count` added a saved line + a separate `countEntries({ type: 'saved' })`
- `stream/contents` / `stream/items/ids` each ran the same `resolved.kind === 'saved'` switch
- `mark-all-as-read` had to be patched separately (it was the bug that motivated the issue)

Because "the saved feed is a subscription" was materialized only at the HTTP layer, every endpoint had to re-orchestrate it by hand, and a new one could silently omit it.

## Change

Hoist the concept into one shared helper module, `src/server/google-reader/subscriptions.ts` (kept compat-API-only, as #1068 intended — nothing leaks into core services/views/UI):

- **`listGreaderSubscriptions`** — drains the subscription cursor and appends the saved feed as a first-class synthetic `Subscription`. `subscription/list` and `unread-count` now enumerate through this and inherit saved for free.
- **`resolveFeedStreamFilter`** — maps a `feed/{int64}` stream to the entries-service filter (`{ type: "saved" }` or `{ subscriptionId }`), used identically by `stream/contents`, `stream/items/ids`, and `mark-all-as-read`. This is the single translation point that once diverged.
- **`getSavedSubscription`** — the saved feed as a synthetic `Subscription` (with unread count); the one place its metadata is materialized.

Because the saved feed is now a first-class synthetic `Subscription`:
- `formatSavedSubscription` is deleted (a synthetic sub through `formatSubscription` produces byte-identical output).
- `formatUnreadCounts`' `savedFeed` param is gone — saved is counted and folded into the reading-list total like any real feed.
- The saved-vs-subscription origin stream id (duplicated between item formatting and item refs) is unified into an exported `entryFeedStreamId` helper.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (2062 passed)
- `pnpm test:e2e:local greader-api` — all 18 pass, including the saved-articles synthetic subscription and mark-all-as-read-on-saved regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)