### PR TITLE
saved: fix refetch read-state bypass, awaited publishes, unbounded upload (#1082)

### DIFF
--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -79,3 +79,12 @@ export const db = drizzle(pool, {
 });
 
 export type Database = typeof db;
+
+/** A transaction handle, as passed to `db.transaction(async (tx) => ...)`. */
+export type Transaction = Parameters<Parameters<Database["transaction"]>[0]>[0];
+
+/**
+ * Either the root `db` or an open transaction. Use this for service functions
+ * that must be callable both standalone and inside a caller's transaction.
+ */
+export type DbOrTx = Database | Transaction;

--- a/src/server/services/counts.ts
+++ b/src/server/services/counts.ts
@@ -11,7 +11,7 @@
  */
 
 import { eq, and, sql, inArray } from "drizzle-orm";
-import type { db as dbType } from "@/server/db";
+import type { db as dbType, DbOrTx } from "@/server/db";
 import { visibleEntries, subscriptionTags, userFeeds } from "@/server/db/schema";
 
 // ============================================================================
@@ -120,7 +120,7 @@ export function toBulkUnreadCounts(counts: UnreadCounts): NewEntryUnreadCounts {
  * slower (per-row subplan), so the view scan is the right shape here.
  */
 async function getGlobalUnreadCounts(
-  db: typeof dbType,
+  db: DbOrTx,
   userId: string
 ): Promise<{ allUnread: number; starredUnread: number; savedUnread: number }> {
   const result = await db
@@ -344,7 +344,7 @@ export interface BulkUnreadCounts {
  * @returns Aggregated unread counts for all affected lists
  */
 export async function getBulkEntryRelatedCounts(
-  db: typeof dbType,
+  db: DbOrTx,
   userId: string,
   entries: Array<{ subscriptionId: string | null; type: "web" | "email" | "saved" }>
 ): Promise<BulkUnreadCounts> {

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -874,23 +874,31 @@ export async function getEntries(
  * `read_changed_at <= changedAt` guard) update no rows and therefore publish
  * nothing. Fire and forget.
  *
- * This publishes after the (autocommitted) UPDATEs complete. Today's callers
- * pass the global `db`, so that's always post-commit. If a future caller runs
- * this inside a transaction, move the publish to after the commit so a
- * rolled-back mark can't emit a phantom event.
+ * This publishes after the (autocommitted) UPDATEs complete. Callers that pass
+ * the global `db` get post-commit publishing for free. A caller running this
+ * inside a transaction must pass `publish: false` and publish the returned
+ * `changed`+`counts` itself after the commit, so a rolled-back mark can't emit
+ * a phantom event.
  *
  * @param options.fromList - Whether the mark-read originated from the entry list
  *   (weak negative signal). Only meaningful when marking read.
+ * @param options.publish - Whether to publish `entry_state_changed` events here
+ *   (default true). Pass false when calling inside a transaction and publish the
+ *   returned `changed`/`counts` after the commit.
  */
 export async function markEntriesRead(
   db: DbOrTx,
   userId: string,
   entriesToMark: MarkReadEntry[],
   read: boolean,
-  options: { fromList?: boolean } = {}
-): Promise<{ entries: MarkReadEntryState[]; counts: BulkUnreadCounts }> {
+  options: { fromList?: boolean; publish?: boolean } = {}
+): Promise<{
+  entries: MarkReadEntryState[];
+  changed: MarkReadEntryState[];
+  counts: BulkUnreadCounts;
+}> {
   if (entriesToMark.length === 0) {
-    return { entries: [], counts: await getBulkEntryRelatedCounts(db, userId, []) };
+    return { entries: [], changed: [], counts: await getBulkEntryRelatedCounts(db, userId, []) };
   }
 
   if (entriesToMark.length > 1000) {
@@ -968,12 +976,16 @@ export async function markEntriesRead(
   // Notify the user's other tabs/devices for the entries that actually changed,
   // carrying the absolute counts so they set them directly. See the function
   // doc for publish/transaction ordering. Fire and forget.
+  //
+  // Transactional callers pass `publish: false` and publish `changed`+`counts`
+  // themselves after the commit, so a rolled-back mark can't emit a phantom
+  // event (see the function doc).
   const changed = entries.filter((entry) => changedIds.has(entry.id));
-  if (changed.length > 0) {
+  if (options.publish !== false && changed.length > 0) {
     publishMarkReadStateChanges(userId, changed, counts);
   }
 
-  return { entries, counts };
+  return { entries, changed, counts };
 }
 
 /**

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -17,7 +17,7 @@ import {
   or,
   type SQL,
 } from "drizzle-orm";
-import type { db as dbType } from "@/server/db";
+import type { db as dbType, DbOrTx } from "@/server/db";
 import {
   entries,
   feeds,
@@ -883,7 +883,7 @@ export async function getEntries(
  *   (weak negative signal). Only meaningful when marking read.
  */
 export async function markEntriesRead(
-  db: typeof dbType,
+  db: DbOrTx,
   userId: string,
   entriesToMark: MarkReadEntry[],
   read: boolean,

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -28,6 +28,7 @@ import { publishNewEntry, publishEntryUpdatedFromEntry } from "@/server/redis/pu
 import { toNewEntryListData } from "@/lib/events/schemas";
 import { errors } from "@/server/trpc/errors";
 import { markEntriesRead } from "@/server/services/entries";
+import { publishMarkReadStateChanges } from "@/server/services/entry-events";
 import { pluginRegistry } from "@/server/plugins";
 import {
   isGoogleDocsUrl,
@@ -911,14 +912,20 @@ export async function saveArticle(
     // unread flip is routed through markEntriesRead (rather than a bare
     // `read=false` UPDATE) so it maintains read_changed_at (the changedAt
     // idempotency contract — otherwise a stale queued offline "mark read" older
-    // than this refetch would win later), bumps updated_at (so sync.events
-    // reports it to offline clients), and publishes entry_state_changed + counts
-    // (so other tabs' unread badges refresh). Both writes share one transaction
-    // so a crash can't leave new content with the old read state.
-    await db.transaction(async (tx) => {
+    // than this refetch would win later) and bumps updated_at (so sync.events
+    // reports it to offline clients). Both writes share one transaction so a
+    // crash can't leave new content with the old read state. Publishing is
+    // suppressed inside the tx and done after commit (below) so a rolled-back
+    // mark can't emit a phantom entry_state_changed event.
+    const { changed: readChanged, counts: readCounts } = await db.transaction(async (tx) => {
       await tx.update(entries).set(update).where(eq(entries.id, oldEntry.id));
-      await markEntriesRead(tx, userId, [{ id: oldEntry.id, changedAt: now }], false);
+      return markEntriesRead(tx, userId, [{ id: oldEntry.id, changedAt: now }], false, {
+        publish: false,
+      });
     });
+
+    // Post-commit: notify other tabs of the unread flip + refreshed counts.
+    publishMarkReadStateChanges(userId, readChanged, readCounts);
 
     logger.info("Refetched saved article", {
       entryId: oldEntry.id,

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -27,6 +27,7 @@ import { logger } from "@/lib/logger";
 import { publishNewEntry, publishEntryUpdatedFromEntry } from "@/server/redis/pubsub";
 import { toNewEntryListData } from "@/lib/events/schemas";
 import { errors } from "@/server/trpc/errors";
+import { markEntriesRead } from "@/server/services/entries";
 import { pluginRegistry } from "@/server/plugins";
 import {
   isGoogleDocsUrl,
@@ -325,13 +326,15 @@ async function insertSavedEntry(
     return null;
   }
 
-  await publishNewEntry(
+  // Fire-and-forget: SSE is best-effort and must never fail the save response
+  // (the entry transaction has already committed). See entry-events.ts.
+  void publishNewEntry(
     savedFeedId,
     entryId,
     now,
     "saved",
     toNewEntryListData(values, SAVED_FEED_TITLE)
-  );
+  ).catch(() => {});
 
   return {
     id: entryId,
@@ -904,13 +907,18 @@ export async function saveArticle(
       },
       presanitizedCleaned
     );
-    await db.update(entries).set(update).where(eq(entries.id, oldEntry.id));
-
-    // Mark as unread since content was updated
-    await db
-      .update(userEntries)
-      .set({ read: false })
-      .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, oldEntry.id)));
+    // Update the content and flip the entry back to unread atomically. The
+    // unread flip is routed through markEntriesRead (rather than a bare
+    // `read=false` UPDATE) so it maintains read_changed_at (the changedAt
+    // idempotency contract — otherwise a stale queued offline "mark read" older
+    // than this refetch would win later), bumps updated_at (so sync.events
+    // reports it to offline clients), and publishes entry_state_changed + counts
+    // (so other tabs' unread badges refresh). Both writes share one transaction
+    // so a crash can't leave new content with the old read state.
+    await db.transaction(async (tx) => {
+      await tx.update(entries).set(update).where(eq(entries.id, oldEntry.id));
+      await markEntriesRead(tx, userId, [{ id: oldEntry.id, changedAt: now }], false);
+    });
 
     logger.info("Refetched saved article", {
       entryId: oldEntry.id,
@@ -918,8 +926,10 @@ export async function saveArticle(
       forced: params.force ?? false,
     });
 
-    // Publish event to notify other browser windows/tabs of the update
-    await publishEntryUpdatedFromEntry(savedFeedId, {
+    // Publish event to notify other browser windows/tabs of the content update.
+    // Fire-and-forget: SSE is best-effort and must never fail the response (the
+    // transaction has already committed). See entry-events.ts.
+    void publishEntryUpdatedFromEntry(savedFeedId, {
       id: oldEntry.id,
       title: finalTitle,
       author: finalAuthor,
@@ -927,7 +937,7 @@ export async function saveArticle(
       url: normalizedUrl,
       publishedAt: oldEntry.publishedAt,
       updatedAt: now,
-    });
+    }).catch(() => {});
 
     return {
       id: oldEntry.id,

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -223,7 +223,17 @@ export const savedRouter = createTRPCRouter({
     })
     .input(
       z.object({
-        content: z.string().min(1, "File content is required"),
+        // Base64 inflates by ~4/3; cap the encoded string so an oversized upload
+        // is rejected by validation before we spend memory/CPU decoding it. The
+        // decoded byte length is enforced exactly below (base64 length is only an
+        // upper bound on decoded size). Slack covers padding/newlines.
+        content: z
+          .string()
+          .min(1, "File content is required")
+          .max(
+            Math.ceil((usageLimitsConfig.maxSavedArticleSizeBytes * 4) / 3) + 1024,
+            "File content exceeds the maximum saved article size"
+          ),
         filename: z.string().min(1, "Filename is required"),
         title: z.string().optional(),
       })
@@ -250,6 +260,12 @@ export const savedRouter = createTRPCRouter({
           code: "BAD_REQUEST",
           message: "Invalid file content encoding. Expected base64.",
         });
+      }
+
+      // Enforce the size limit on the decoded bytes before any conversion
+      // (mammoth/Readability/marked), so a large upload can't burn memory/CPU.
+      if (fileBuffer.length > usageLimitsConfig.maxSavedArticleSizeBytes) {
+        throw errors.contentTooLarge("Uploaded file", usageLimitsConfig.maxSavedArticleSizeBytes);
       }
 
       // Process the file

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -175,6 +175,7 @@ async function createTestSavedArticle(
     starred: options.starred ?? false,
     readChangedAt: pastTime,
     starredChangedAt: pastTime,
+    updatedAt: pastTime,
   });
 
   return articleId;

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -20,6 +20,7 @@ import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
 import { saveArticle, savedArticleExistsByUrl } from "../../src/server/services/saved";
+import { markEntriesRead } from "../../src/server/services/entries";
 
 // ============================================================================
 // Test Helpers
@@ -863,6 +864,72 @@ describe("Saved Articles API", () => {
       expect(result.article.starred).toBe(true);
     });
 
+    it("advances read_changed_at/updated_at on the unread flip so stale offline mark-read loses", async () => {
+      // Regression for #1082: the refetch unread flip must go through the
+      // read-state machinery (read_changed_at + updated_at), not a bare
+      // `read=false` UPDATE. Otherwise a stale queued offline "mark read" older
+      // than the refetch would still win when it later replays.
+      const userId = await createTestUser();
+      const testUrl = "https://example.com/refetch-read-changed-at";
+
+      const articleId = await createTestSavedArticle(userId, {
+        url: testUrl,
+        title: "Original Title",
+        read: true,
+      });
+
+      const [before] = await db
+        .select({ readChangedAt: userEntries.readChangedAt, updatedAt: userEntries.updatedAt })
+        .from(userEntries)
+        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, articleId)));
+
+      const ctx = createAuthContext(userId);
+      const caller = createCaller(ctx);
+
+      const newHtml = `
+        <!DOCTYPE html>
+        <html>
+          <head><title>New Title</title></head>
+          <body>
+            <article>
+              <p>Sufficient content for quality check to pass with new information.</p>
+              <p>The content has been refreshed and updated with new information.</p>
+            </article>
+          </body>
+        </html>
+      `;
+
+      await caller.saved.save({ url: testUrl, html: newHtml, refetch: true });
+
+      const [after] = await db
+        .select({
+          read: userEntries.read,
+          readChangedAt: userEntries.readChangedAt,
+          updatedAt: userEntries.updatedAt,
+        })
+        .from(userEntries)
+        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, articleId)));
+
+      expect(after.read).toBe(false);
+      // Both change timestamps must have advanced past the pre-refetch values.
+      expect(after.readChangedAt!.getTime()).toBeGreaterThan(before.readChangedAt!.getTime());
+      expect(after.updatedAt.getTime()).toBeGreaterThan(before.updatedAt.getTime());
+
+      // A stale offline "mark read" from before the refetch must not win.
+      await markEntriesRead(
+        db,
+        userId,
+        [{ id: articleId, changedAt: before.readChangedAt! }],
+        true
+      );
+
+      const [final] = await db
+        .select({ read: userEntries.read })
+        .from(userEntries)
+        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, articleId)));
+      expect(final.read).toBe(false);
+    });
+
     it("rejects refetch when new content is significantly shorter", async () => {
       const userId = await createTestUser();
       const testUrl = "https://example.com/refetch-reject-short";
@@ -1200,6 +1267,39 @@ describe("Saved Articles API", () => {
       const rows = await db.select({ id: entries.id }).from(entries).where(eq(entries.guid, url));
       expect(rows).toHaveLength(1);
       expect(rows[0].id).toBe(a.id);
+    });
+  });
+
+  describe("saved.uploadFile size limit (#1082)", () => {
+    it("rejects a decoded upload larger than the saved article size limit before processing", async () => {
+      const userId = await createTestUser();
+      const ctx = createAuthContext(userId);
+      const caller = createCaller(ctx);
+
+      const { usageLimitsConfig } = await import("../../src/server/config/env");
+      // A buffer just over the limit; its base64 stays under the schema cap
+      // (~4/3 inflation) so it reaches the runtime decoded-size guard.
+      const oversized = Buffer.alloc(usageLimitsConfig.maxSavedArticleSizeBytes + 1, 97).toString(
+        "base64"
+      );
+
+      await expect(
+        caller.saved.uploadFile({ content: oversized, filename: "big.md" })
+      ).rejects.toThrow(/exceeds the maximum size/i);
+
+      // Nothing persisted for this user.
+      const savedFeed = await db
+        .select({ id: feeds.id })
+        .from(feeds)
+        .where(and(eq(feeds.type, "saved"), eq(feeds.userId, userId)));
+      const savedEntries =
+        savedFeed.length > 0
+          ? await db
+              .select({ id: entries.id })
+              .from(entries)
+              .where(eq(entries.feedId, savedFeed[0].id))
+          : [];
+      expect(savedEntries).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
Fixes #1082. All three findings are in the saved-articles service/router.

## 1. Refetch flipped `read=false` outside the read-state machinery (correctness)
The refetch path did a bare `UPDATE user_entries SET read=false`, bypassing everything `markEntriesRead` maintains:
- no `read_changed_at` → broke the changedAt idempotency contract (a stale queued offline "mark read" older than the refetch could win when it replayed later)
- no `updated_at` bump → `sync.events` classified it metadata-only, so offline clients never learned it went unread
- no `entry_state_changed` / counts publish → other tabs' unread badges went stale

It was also a second statement outside the content-update transaction (a crash could leave new content with old read state).

**Fix:** route the unread flip through `markEntriesRead`, inside one transaction with the content update, so the writes are atomic and the read-state machinery (timestamps + SSE publish) is reused.

## 2. Saved mutations `await`ed Redis publishes (error handling)
With Redis configured but down, `client.publish` rejects, so `saveArticle` threw a 500 **after** the entry transaction already committed. Made both `publishNewEntry` / `publishEntryUpdatedFromEntry` sites fire-and-forget with `.catch()`, matching every other publish site.

## 3. `saved.uploadFile` had no input size cap (DoS)
`content` was unbounded base64, and the size check ran only after full decode + mammoth/Readability/marked. Capped the encoded string in the schema (~4/3 base64 inflation + slack) and enforce the decoded byte length before any processing.

## Supporting change
Widened `markEntriesRead` / `getBulkEntryRelatedCounts` / `getGlobalUnreadCounts` to accept a transaction via a new `DbOrTx` type, so the refetch can run them inside its transaction.

## Tests
- Refetch advances `read_changed_at`/`updated_at` and a stale offline mark-read loses.
- Oversized uploads are rejected before processing.

`pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (2067), and the saved-articles integration suite (510) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)