### PR TITLE
sync.events: fix tie data-loss, fail-open visibility, duplicate events (#1080)

### DIFF
--- a/src/components/layout/RealtimeProvider.tsx
+++ b/src/components/layout/RealtimeProvider.tsx
@@ -48,7 +48,7 @@ interface RealtimeProviderProps {
  * export default function AppLayout({ children }) {
  *   // Initial cursors - null values for fresh sync
  *   const initialCursors: SyncCursors = {
- *     entries: null, subscriptions: null, tags: null
+ *     entries: null, entriesAfterId: null, subscriptions: null, tags: null
  *   };
  *   return (
  *     <RealtimeProvider initialCursors={initialCursors}>

--- a/src/lib/events/cursors.ts
+++ b/src/lib/events/cursors.ts
@@ -4,9 +4,25 @@
  * Pure helpers for tracking per-entity-type sync cursors as SSE/sync events
  * arrive. Cursors are ISO8601 timestamps based on max(updated_at) per entity
  * type, and are sent to the sync.events endpoint to catch up on missed changes.
+ *
+ * The entries cursor is a keyset: a `(timestamp, entryId)` pair rather than a
+ * bare timestamp. `markAllEntriesRead` (and the subscribe-time insert) stamp one
+ * identical timestamp onto every affected `user_entries` row, so a catch-up over
+ * a large mark-all-read produces hundreds of rows sharing that exact timestamp.
+ * A timestamp-only cursor advanced past that group with a strict `>` would drop
+ * every remaining tied row permanently; carrying the entry id lets the sync page
+ * *within* a tied-timestamp group (keyset pagination, same as `listEntries`).
  */
 
 import type { SyncEvent } from "./schemas";
+
+/**
+ * Largest possible UUID. Used as the entries id tiebreaker for `mark_all_read`,
+ * which carries no single entry id: advancing past `(T, MAX_UUID)` skips every
+ * entry tied at timestamp T (they were all just marked read), so a catch-up
+ * doesn't re-deliver them one by one.
+ */
+const MAX_UUID = "ffffffff-ffff-ffff-ffff-ffffffffffff";
 
 /**
  * Sync cursors for each entity type.
@@ -14,6 +30,13 @@ import type { SyncEvent } from "./schemas";
  */
 export interface SyncCursors {
   entries: string | null;
+  /**
+   * Id tiebreaker for the entries cursor: the entry id of the newest processed
+   * entry change at the `entries` timestamp. Together `(entries, entriesAfterId)`
+   * form a keyset so the sync can page within a group of entries sharing one
+   * timestamp (e.g. a large mark-all-read). Null until the first entry change.
+   */
+  entriesAfterId: string | null;
   subscriptions: string | null;
   tags: string | null;
 }
@@ -46,6 +69,47 @@ export function cursorTypeForEvent(event: SyncEvent): keyof SyncCursors | null {
 }
 
 /**
+ * The entries-cursor id tiebreaker an event advances to. Per-entry events carry
+ * their own id; mark_all_read has none and advances past the whole tied group.
+ */
+function entryEventAfterId(event: SyncEvent): string {
+  switch (event.type) {
+    case "new_entry":
+    case "entry_updated":
+    case "entry_state_changed":
+      return event.entryId;
+    default:
+      // mark_all_read (the only other event mapped to the entries cursor).
+      return MAX_UUID;
+  }
+}
+
+/**
+ * Advances the entries keyset cursor `(entries, entriesAfterId)` for an entry
+ * event. Moves forward on a newer timestamp, and within the same timestamp moves
+ * the id tiebreaker forward — so paging through a tied-timestamp group never
+ * loses or re-delivers rows. Returns the same object reference when unchanged.
+ */
+function advanceEntriesCursor(cursors: SyncCursors, event: SyncEvent): SyncCursors {
+  const updatedAt = event.updatedAt;
+  const afterId = entryEventAfterId(event);
+  const current = cursors.entries;
+
+  if (!current || new Date(updatedAt) > new Date(current)) {
+    // Newer timestamp: reset the keyset to this event.
+    return { ...cursors, entries: updatedAt, entriesAfterId: afterId };
+  }
+  if (updatedAt === current) {
+    // Same timestamp group: advance the id tiebreaker forward only.
+    // UUIDs are lowercase, so string ordering matches Postgres uuid ordering.
+    if (!cursors.entriesAfterId || afterId > cursors.entriesAfterId) {
+      return { ...cursors, entriesAfterId: afterId };
+    }
+  }
+  return cursors;
+}
+
+/**
  * Advances the appropriate cursor for an event. Only moves a cursor forward:
  * events older than the current cursor leave it unchanged. Returns the same
  * object reference when nothing changed.
@@ -54,6 +118,10 @@ export function advanceCursors(cursors: SyncCursors, event: SyncEvent): SyncCurs
   const cursorType = cursorTypeForEvent(event);
   if (!cursorType) {
     return cursors;
+  }
+
+  if (cursorType === "entries") {
+    return advanceEntriesCursor(cursors, event);
   }
 
   const currentCursor = cursors[cursorType];

--- a/src/lib/events/cursors.ts
+++ b/src/lib/events/cursors.ts
@@ -21,6 +21,14 @@ import type { SyncEvent } from "./schemas";
  * which carries no single entry id: advancing past `(T, MAX_UUID)` skips every
  * entry tied at timestamp T (they were all just marked read), so a catch-up
  * doesn't re-deliver them one by one.
+ *
+ * Known limitation (pre-existing, not introduced by the keyset): if an unrelated
+ * new entry is inserted at the *exact* same microsecond timestamp T as the
+ * mark-all-read and its live `new_entry` is missed, this sentinel makes a
+ * later catch-up skip it (`GREATEST = T AND id > MAX_UUID` is false). The old
+ * timestamp-only strict-`>` cursor had the identical blind spot. Collisions at
+ * µs precision are vanishingly rare, and `mark_all_read` already invalidates the
+ * entry lists, so the entry reappears on the next list refresh regardless.
  */
 const MAX_UUID = "ffffffff-ffff-ffff-ffff-ffffffffffff";
 

--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -102,7 +102,7 @@ const SSE_EVENT_NAMES = [
  * ```tsx
  * function AppLayout({ children }) {
  *   // Get initial cursors from server or use null for initial sync
- *   const initialCursors: SyncCursors = { entries: null, subscriptions: null, tags: null };
+ *   const initialCursors: SyncCursors = { entries: null, entriesAfterId: null, subscriptions: null, tags: null };
  *   const { status, isConnected, isPolling } = useRealtimeUpdates(initialCursors);
  *
  *   return (
@@ -186,6 +186,7 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
       const result = await utils.client.sync.events.query({
         cursors: {
           entries: currentCursors.entries ?? undefined,
+          entriesAfterId: currentCursors.entriesAfterId ?? undefined,
           subscriptions: currentCursors.subscriptions ?? undefined,
           tags: currentCursors.tags ?? undefined,
         },

--- a/src/server/trpc/routers/sync.ts
+++ b/src/server/trpc/routers/sync.ts
@@ -6,7 +6,7 @@
  */
 
 import { z } from "zod";
-import { eq, and, inArray, sql } from "drizzle-orm";
+import { eq, and, inArray, sql, type SQL, type SQLWrapper } from "drizzle-orm";
 
 import { createTRPCRouter, confirmedProtectedProcedure as protectedProcedure } from "../trpc";
 import {
@@ -91,6 +91,14 @@ const syncEventsOutputSchema = z.object({
 const syncCursorsSchema = z.object({
   /** Cursor for entries - max of GREATEST(entries.updated_at, user_entries.updated_at) */
   entries: z.string().datetime().nullable(),
+  /**
+   * Id tiebreaker for the entries cursor. Together `(entries, entriesAfterId)`
+   * form a keyset so a catch-up can page within a group of entries sharing one
+   * timestamp (e.g. a large mark-all-read) instead of losing the tied rows to a
+   * strict `>` comparison. It is the id of the entry achieving the max entries
+   * timestamp; null when there are no entries.
+   */
+  entriesAfterId: z.string().uuid().nullable(),
   /** Cursor for subscriptions - max(subscriptions.updated_at), covers both active and removed */
   subscriptions: z.string().datetime().nullable(),
   /** Cursor for tags - max(tags.updated_at), covers creates, updates, and soft deletes */
@@ -119,17 +127,26 @@ export const syncRouter = createTRPCRouter({
     // Avoids JavaScript Date truncation which loses microseconds and causes
     // cursor comparison bugs (see #680).
     const [entriesResult, subscriptionsResult, tagsResult] = await Promise.all([
-      // Entries: max of GREATEST(entries.updated_at, user_entries.updated_at)
-      // This catches both entry metadata changes AND read/starred state changes
+      // Entries: newest GREATEST(entries.updated_at, user_entries.updated_at)
+      // plus the id of the entry achieving it, forming the `(entries,
+      // entriesAfterId)` keyset. This catches both entry metadata changes AND
+      // read/starred state changes; the id lets a catch-up page within a tied
+      // timestamp group. Ordered by (key DESC, id DESC) so LIMIT 1 is the argmax.
       ctx.db
         .select({
           max: sql<
             string | null
-          >`to_char(MAX(GREATEST(${entries.updatedAt}, ${userEntries.updatedAt})) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+          >`to_char(GREATEST(${entries.updatedAt}, ${userEntries.updatedAt}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+          maxId: entries.id,
         })
         .from(userEntries)
         .innerJoin(entries, eq(entries.id, userEntries.entryId))
-        .where(eq(userEntries.userId, userId)),
+        .where(eq(userEntries.userId, userId))
+        .orderBy(
+          sql`GREATEST(${entries.updatedAt}, ${userEntries.updatedAt}) DESC`,
+          sql`${entries.id} DESC`
+        )
+        .limit(1),
 
       // Subscriptions: max(updated_at) from ALL subscriptions (active and removed)
       // updated_at is set when unsubscribing, so this covers both cases
@@ -155,6 +172,7 @@ export const syncRouter = createTRPCRouter({
 
     return {
       entries: entriesResult[0]?.max ?? null,
+      entriesAfterId: entriesResult[0]?.maxId ?? null,
       subscriptions: subscriptionsResult[0]?.max ?? null,
       tags: tagsResult[0]?.max ?? null,
     };
@@ -179,6 +197,12 @@ export const syncRouter = createTRPCRouter({
         cursors: z
           .object({
             entries: z.string().datetime().optional(),
+            /**
+             * Id tiebreaker for the entries cursor (keyset pagination within a
+             * tied-timestamp group). Optional for backward compatibility: when
+             * absent the server falls back to a strict timestamp comparison.
+             */
+            entriesAfterId: z.string().uuid().optional(),
             subscriptions: z.string().datetime().optional(),
             tags: z.string().datetime().optional(),
           })
@@ -216,9 +240,32 @@ export const syncRouter = createTRPCRouter({
       // Uses GREATEST(entries.updated_at, user_entries.updated_at) > cursor
       // to catch all changes with a single cursor, avoiding missed updates
       // when one timestamp advances past the other (see #738).
+      //
+      // Keyset pagination on (GREATEST(...), entry_id): markAllEntriesRead (and
+      // the subscribe-time insert) stamp one identical timestamp onto hundreds
+      // of rows, so a strict timestamp `>` cursor would drop every tied row past
+      // the MAX_ENTRIES boundary permanently. Carrying the entry id as a
+      // tiebreaker (same pattern as listEntries) lets the client page within a
+      // tied-timestamp group. See #1080.
+      //
+      // The metadata/state/new booleans are computed in SQL against the same
+      // (ts, id) keyset the selection uses — not with JavaScript Date math —
+      // because new Date() truncates Postgres µs to ms, which could select a row
+      // by µs precision yet then emit no event (leaving the cursor stuck). #1080
       // ========================================================================
       if (entriesCursor) {
-        const entriesCursorDate = new Date(entriesCursor);
+        const entriesAfterId = input.cursors?.entriesAfterId ?? null;
+
+        // `col` is "after" the keyset cursor when it is past the timestamp, or at
+        // the timestamp with a larger entry id. Without an id tiebreaker (legacy
+        // clients / first sync) fall back to a strict timestamp comparison.
+        const afterCursor = (col: SQLWrapper): SQL =>
+          entriesAfterId
+            ? sql`(${col} > ${entriesCursor}::timestamptz OR (${col} = ${entriesCursor}::timestamptz AND ${entries.id} > ${entriesAfterId}::uuid))`
+            : sql`${col} > ${entriesCursor}::timestamptz`;
+
+        const greatest = sql`GREATEST(${entries.updatedAt}, ${userEntries.updatedAt})`;
+
         const changedEntryResults = await ctx.db
           .select({
             id: entries.id,
@@ -230,17 +277,19 @@ export const syncRouter = createTRPCRouter({
             fetchedAt: entries.fetchedAt,
             siteName: entries.siteName,
             isSpam: entries.isSpam,
-            createdAt: entries.createdAt,
-            entryUpdatedAt: entries.updatedAt,
             read: userEntries.read,
             starred: userEntries.starred,
-            userEntryUpdatedAt: userEntries.updatedAt,
             subscriptionId: subscriptions.id,
             feedId: entries.feedId,
             feedType: feeds.type,
             feedTitle: feeds.title,
+            // Categorization booleans, computed in SQL at µs precision against
+            // the keyset cursor so selection and categorization never disagree.
+            metadataChanged: sql<boolean>`${afterCursor(entries.updatedAt)}`,
+            stateChanged: sql<boolean>`${afterCursor(userEntries.updatedAt)}`,
+            isNew: sql<boolean>`${afterCursor(entries.createdAt)}`,
             // Raw ISO string with µs precision for cursor/timestamp output
-            maxUpdatedAtRaw: sql<string>`to_char(GREATEST(${entries.updatedAt}, ${userEntries.updatedAt}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+            maxUpdatedAtRaw: sql<string>`to_char(${greatest} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
           })
           .from(userEntries)
           .innerJoin(entries, eq(entries.id, userEntries.entryId))
@@ -256,14 +305,20 @@ export const syncRouter = createTRPCRouter({
           .where(
             and(
               eq(userEntries.userId, userId),
-              sql`GREATEST(${entries.updatedAt}, ${userEntries.updatedAt}) > ${entriesCursor}::timestamptz`,
-              // Visibility: match visible_entries view logic
-              // LEFT JOIN produces NULL unsubscribedAt for saved articles (no subscription),
-              // and NULL IS NULL = TRUE, so saved articles pass this check
-              sql`(${subscriptions.unsubscribedAt} IS NULL OR ${userEntries.starred} = true)`
+              afterCursor(greatest),
+              // Fail-closed visibility, matching the visible_entries view
+              // (migration 0073): an entry is visible only via an ACTIVE
+              // subscription, being starred, or being a saved article. The old
+              // `subscriptions.unsubscribed_at IS NULL` was fail-OPEN — for an
+              // orphaned user_entries row the LEFT JOIN yields NULL and
+              // `NULL IS NULL` = TRUE, leaking entries the web app hides. #1080
+              sql`((${subscriptions.id} IS NOT NULL AND ${subscriptions.unsubscribedAt} IS NULL) OR ${userEntries.starred} = true OR ${entries.type} = 'saved')`
             )
           )
-          .orderBy(sql`GREATEST(${entries.updatedAt}, ${userEntries.updatedAt})`)
+          // uq_subscriptions_user_feed guarantees at most one subscription per
+          // (user, feed), so the LEFT JOINs above can't fan out an entry into
+          // duplicate rows/events.
+          .orderBy(greatest, entries.id)
           .limit(MAX_ENTRIES + 1);
 
         if (changedEntryResults.length > MAX_ENTRIES) {
@@ -276,18 +331,14 @@ export const syncRouter = createTRPCRouter({
         // events for each — the frontend handles them with different cache updates.
 
         // Collect entries with state changes for batch count computation
-        const stateChangedEntries = changedEntryResults.filter(
-          (row) => row.userEntryUpdatedAt > entriesCursorDate
-        );
+        const stateChangedEntries = changedEntryResults.filter((row) => row.stateChanged);
 
         // Entries created after the cursor emit new_entry events. Compute one
         // absolute-count snapshot covering all of them so each new_entry event
         // carries server-authoritative counts (the client sets them directly
         // rather than applying a +1 delta, making the events idempotent across
         // the live-SSE / catch-up-sync overlap).
-        const newEntries = changedEntryResults.filter(
-          (row) => row.entryUpdatedAt > entriesCursorDate && row.createdAt > entriesCursorDate
-        );
+        const newEntries = changedEntryResults.filter((row) => row.metadataChanged && row.isNew);
         const newEntryCounts =
           newEntries.length > 0
             ? await getBulkEntryRelatedCounts(
@@ -316,11 +367,11 @@ export const syncRouter = createTRPCRouter({
             : undefined;
 
         for (const row of changedEntryResults) {
-          const entryMetadataChanged = row.entryUpdatedAt > entriesCursorDate;
-          const entryStateChanged = row.userEntryUpdatedAt > entriesCursorDate;
+          const entryMetadataChanged = row.metadataChanged;
+          const entryStateChanged = row.stateChanged;
 
           if (entryMetadataChanged) {
-            if (row.createdAt > entriesCursorDate) {
+            if (row.isNew) {
               // New entry created after cursor - emit new_entry for count and
               // list updates. The entry payload mirrors the live SSE path so a
               // catch-up sync inserts missed entries into cached lists too.

--- a/tests/integration/sync-events.test.ts
+++ b/tests/integration/sync-events.test.ts
@@ -20,6 +20,8 @@ import {
 } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
+import { advanceCursors, type SyncCursors } from "../../src/lib/events/cursors";
+import type { SyncEvent } from "../../src/lib/events/schemas";
 import type { Context } from "../../src/server/trpc/context";
 
 // ============================================================================
@@ -193,6 +195,34 @@ async function linkTagToSubscription(tagId: string, subscriptionId: string): Pro
     subscriptionId,
     createdAt: new Date(),
   });
+}
+
+const ENTRY_EVENT_TYPES = new Set(["new_entry", "entry_updated", "entry_state_changed"]);
+
+/**
+ * Drives sync.events like the real client does: repeatedly polls, advancing the
+ * keyset cursors through the actual `advanceCursors` bookkeeping, until the
+ * server reports no more pages. Returns every event collected across pages.
+ */
+async function drainEntrySync(userId: string, start: SyncCursors): Promise<SyncEvent[]> {
+  let cursors = start;
+  const collected: SyncEvent[] = [];
+  for (let guard = 0; guard < 50; guard++) {
+    const result = await createCaller(createAuthContext(userId)).sync.events({
+      cursors: {
+        entries: cursors.entries ?? undefined,
+        entriesAfterId: cursors.entriesAfterId ?? undefined,
+        subscriptions: cursors.subscriptions ?? undefined,
+        tags: cursors.tags ?? undefined,
+      },
+    });
+    for (const event of result.events as SyncEvent[]) {
+      cursors = advanceCursors(cursors, event);
+      collected.push(event);
+    }
+    if (!result.hasMore) return collected;
+  }
+  throw new Error("drainEntrySync did not terminate");
 }
 
 // ============================================================================
@@ -766,5 +796,172 @@ describe("sync.events", () => {
       );
       expect(entryEvents).toHaveLength(1000);
     }, 30000); // 30s timeout for bulk insert
+  });
+
+  // ==========================================================================
+  // Keyset pagination within tied-timestamp groups + fail-closed visibility
+  // Regression tests for #1080.
+  // ==========================================================================
+
+  describe("keyset pagination (#1080)", () => {
+    it("pages within a tied-timestamp group using entriesAfterId without losing rows", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/tied.xml");
+      await createTestSubscription(userId, feedId);
+
+      // Three entries sharing one exact timestamp (like markAllEntriesRead
+      // stamps). Sort them by id so we can reason about the keyset order.
+      const tiedTime = new Date("2025-01-01T00:00:00.000Z");
+      const ids: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const id = await createTestEntry(feedId, { createdAt: tiedTime, updatedAt: tiedTime });
+        await createUserEntry(userId, id, { updatedAt: tiedTime });
+        ids.push(id);
+      }
+      ids.sort();
+      const [first, second, third] = ids;
+
+      // Simulate a page boundary landing exactly on the first tied row: the
+      // client's keyset cursor is (tiedTime, first). The OLD strict `> tiedTime`
+      // comparison would exclude every remaining tied row (data loss); the
+      // keyset must instead return the two rows past `first`.
+      const cursorTs = tiedTime.toISOString();
+      const afterFirst = await createCaller(createAuthContext(userId)).sync.events({
+        cursors: { entries: cursorTs, entriesAfterId: first },
+      });
+      const afterFirstNewIds = afterFirst.events
+        .filter((e) => e.type === "new_entry")
+        .map((e) => (e.type === "new_entry" ? e.entryId : ""));
+      expect(afterFirstNewIds.sort()).toEqual([second, third]);
+
+      // Cursor past the last tied row → nothing left in the group.
+      const afterLast = await createCaller(createAuthContext(userId)).sync.events({
+        cursors: { entries: cursorTs, entriesAfterId: third },
+      });
+      expect(afterLast.events.filter((e) => ENTRY_EVENT_TYPES.has(e.type))).toHaveLength(0);
+    });
+
+    it("delivers every row of an oversized tied group across a full drain", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/tied-large.xml");
+      await createTestSubscription(userId, feedId);
+
+      // More than MAX_ENTRIES (500) rows sharing ONE timestamp — the exact
+      // markAllEntriesRead-over-a-large-backlog shape that used to lose every
+      // row past the first page.
+      const tiedTime = new Date("2025-02-02T00:00:00.000Z");
+      const total = 550;
+      const entryValues = [];
+      const userEntryValues = [];
+      const allIds = new Set<string>();
+      for (let i = 0; i < total; i++) {
+        const entryId = generateUuidv7();
+        allIds.add(entryId);
+        entryValues.push({
+          id: entryId,
+          feedId,
+          type: "web" as const,
+          guid: `guid-tied-${i}`,
+          title: `Tied ${i}`,
+          contentHash: `hash-tied-${i}`,
+          fetchedAt: tiedTime,
+          publishedAt: tiedTime,
+          lastSeenAt: tiedTime,
+          createdAt: tiedTime,
+          updatedAt: tiedTime,
+        });
+        userEntryValues.push({ userId, entryId, read: false, starred: false, updatedAt: tiedTime });
+      }
+      const batchSize = 100;
+      for (let i = 0; i < entryValues.length; i += batchSize) {
+        await db.insert(entries).values(entryValues.slice(i, i + batchSize));
+        await db.insert(userEntries).values(userEntryValues.slice(i, i + batchSize));
+      }
+
+      // Start just before the tied timestamp and drain to completion, exactly
+      // as the client would (multiple pages, keyset-advanced between them).
+      const start: SyncCursors = {
+        entries: new Date("2025-02-01T00:00:00.000Z").toISOString(),
+        entriesAfterId: null,
+        subscriptions: null,
+        tags: null,
+      };
+      const events = await drainEntrySync(userId, start);
+
+      const deliveredIds = events
+        .filter((e) => e.type === "new_entry")
+        .map((e) => (e.type === "new_entry" ? e.entryId : ""));
+      // Every tied row delivered exactly once — no loss, no duplication.
+      expect(new Set(deliveredIds).size).toBe(total);
+      expect(deliveredIds.length).toBe(total);
+      expect([...deliveredIds].every((id) => allIds.has(id))).toBe(true);
+    }, 30000);
+  });
+
+  // ==========================================================================
+  // Fail-closed visibility (#1080)
+  // ==========================================================================
+
+  describe("visibility (#1080)", () => {
+    it("hides an orphaned user_entries row (no active subscription, not starred)", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/orphan.xml");
+      // No subscription / subscription_feeds row → orphaned. Old fail-open
+      // predicate leaked this via `NULL IS NULL`; fail-closed must hide it.
+      const entryId = await createTestEntry(feedId, {
+        createdAt: new Date("2025-03-02T00:00:00.000Z"),
+        updatedAt: new Date("2025-03-02T00:00:00.000Z"),
+      });
+      await createUserEntry(userId, entryId, { updatedAt: new Date("2025-03-02T00:00:00.000Z") });
+
+      const result = await createCaller(createAuthContext(userId)).sync.events({
+        cursors: { entries: new Date("2025-03-01T00:00:00.000Z").toISOString() },
+      });
+
+      expect(result.events.filter((e) => ENTRY_EVENT_TYPES.has(e.type))).toHaveLength(0);
+    });
+
+    it("shows an orphaned entry when it is starred (starred exception)", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/orphan-starred.xml");
+      const entryId = await createTestEntry(feedId, {
+        createdAt: new Date("2025-03-02T00:00:00.000Z"),
+        updatedAt: new Date("2025-03-02T00:00:00.000Z"),
+      });
+      await createUserEntry(userId, entryId, {
+        starred: true,
+        updatedAt: new Date("2025-03-02T00:00:00.000Z"),
+      });
+
+      const result = await createCaller(createAuthContext(userId)).sync.events({
+        cursors: { entries: new Date("2025-03-01T00:00:00.000Z").toISOString() },
+      });
+
+      const entryEvents = result.events.filter((e) => ENTRY_EVENT_TYPES.has(e.type));
+      expect(entryEvents.length).toBeGreaterThan(0);
+    });
+
+    it("hides entries from an unsubscribed subscription (not starred)", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/unsubscribed.xml");
+      // Subscription exists but is soft-deleted (unsubscribed).
+      await createTestSubscription(userId, feedId);
+      await db
+        .update(subscriptions)
+        .set({ unsubscribedAt: new Date("2025-03-01T12:00:00.000Z") })
+        .where(eq(subscriptions.userId, userId));
+
+      const entryId = await createTestEntry(feedId, {
+        createdAt: new Date("2025-03-02T00:00:00.000Z"),
+        updatedAt: new Date("2025-03-02T00:00:00.000Z"),
+      });
+      await createUserEntry(userId, entryId, { updatedAt: new Date("2025-03-02T00:00:00.000Z") });
+
+      const result = await createCaller(createAuthContext(userId)).sync.events({
+        cursors: { entries: new Date("2025-03-01T00:00:00.000Z").toISOString() },
+      });
+
+      expect(result.events.filter((e) => ENTRY_EVENT_TYPES.has(e.type))).toHaveLength(0);
+    });
   });
 });

--- a/tests/unit/frontend/events/cursors.test.ts
+++ b/tests/unit/frontend/events/cursors.test.ts
@@ -6,12 +6,17 @@ import { describe, it, expect } from "vitest";
 import { advanceCursors, cursorTypeForEvent, type SyncCursors } from "@/lib/events/cursors";
 import type { SyncEvent } from "@/lib/events/schemas";
 
-const EMPTY_CURSORS: SyncCursors = { entries: null, subscriptions: null, tags: null };
+const EMPTY_CURSORS: SyncCursors = {
+  entries: null,
+  entriesAfterId: null,
+  subscriptions: null,
+  tags: null,
+};
 
-function entryEvent(updatedAt: string): SyncEvent {
+function entryEvent(updatedAt: string, entryId = "entry-1"): SyncEvent {
   return {
     type: "entry_state_changed",
-    entryId: "entry-1",
+    entryId,
     read: true,
     starred: false,
     counts: { all: { unread: 0 }, starred: { unread: 0 }, subscriptions: [], tags: [] },
@@ -86,6 +91,7 @@ describe("advanceCursors", () => {
     const next = advanceCursors(EMPTY_CURSORS, entryEvent("2026-01-01T00:00:00.000Z"));
     expect(next).toEqual({
       entries: "2026-01-01T00:00:00.000Z",
+      entriesAfterId: "entry-1",
       subscriptions: null,
       tags: null,
     });
@@ -94,6 +100,7 @@ describe("advanceCursors", () => {
   it("only advances the cursor for the event's entity type", () => {
     const cursors: SyncCursors = {
       entries: "2026-01-01T00:00:00.000Z",
+      entriesAfterId: "entry-0",
       subscriptions: "2026-01-01T00:00:00.000Z",
       tags: "2026-01-01T00:00:00.000Z",
     };
@@ -120,5 +127,38 @@ describe("advanceCursors", () => {
 
   it("returns the same object for events that don't affect cursors", () => {
     expect(advanceCursors(EMPTY_CURSORS, importEvent())).toBe(EMPTY_CURSORS);
+  });
+
+  describe("entries keyset (ts, entriesAfterId)", () => {
+    const T = "2026-01-01T00:00:00.000000Z";
+
+    it("resets the id tiebreaker when the timestamp advances", () => {
+      const cursors = advanceCursors(EMPTY_CURSORS, entryEvent(T, "b"));
+      const later = advanceCursors(cursors, entryEvent("2026-01-02T00:00:00.000000Z", "a"));
+      expect(later.entries).toBe("2026-01-02T00:00:00.000000Z");
+      expect(later.entriesAfterId).toBe("a");
+    });
+
+    it("advances the id tiebreaker forward within a tied-timestamp group", () => {
+      // Same timestamp, larger id → tiebreaker moves forward, timestamp stays.
+      const cursors = advanceCursors(EMPTY_CURSORS, entryEvent(T, "a"));
+      const next = advanceCursors(cursors, entryEvent(T, "c"));
+      expect(next.entries).toBe(T);
+      expect(next.entriesAfterId).toBe("c");
+    });
+
+    it("does not move the id tiebreaker backward within a tied-timestamp group", () => {
+      const cursors = advanceCursors(EMPTY_CURSORS, entryEvent(T, "c"));
+      // Same timestamp, smaller id → no change (already processed).
+      expect(advanceCursors(cursors, entryEvent(T, "a"))).toBe(cursors);
+    });
+
+    it("advances past the whole tied group for mark_all_read (max id sentinel)", () => {
+      const cursors = advanceCursors(EMPTY_CURSORS, entryEvent(T, "b"));
+      const next = advanceCursors(cursors, markAllReadEvent(T));
+      expect(next.entries).toBe(T);
+      // ffff… is larger than any real uuid, so the next sync skips every tied row.
+      expect(next.entriesAfterId).toBe("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    });
   });
 });


### PR DESCRIPTION
Fixes #1080.

The offline/polling delta endpoint `sync.events` hand-rolled a query that diverged from `visible_entries`/`listEntries` in three ways. This PR fixes all three.

## 1. Data loss on timestamp ties (high)

`markAllEntriesRead` (and the subscribe-time insert) stamp **one identical timestamp** onto every affected `user_entries` row. A catch-up over >500 such rows returned a full page all sharing that timestamp with `hasMore: true`; the client advanced its cursor to that timestamp and the strict `>` then **excluded every remaining tied row permanently**.

Fix: keyset-paginate on `(GREATEST(entries.updated_at, user_entries.updated_at), entry_id)`, the same pattern `listEntries` uses:
- The entries cursor now carries an `entriesAfterId` id tiebreaker — added to both `sync.cursors` (returns the argmax id) and `sync.events` input.
- The client tracks `entriesAfterId` in `advanceCursors`, advancing it forward within a tied-timestamp group and past the whole group for `mark_all_read` (which has no single id → max-uuid sentinel).
- The server uses a row comparison `(col > ts) OR (col = ts AND id > afterId)` for both selection and — this closes the sub-bug — **categorization**. The metadata/state/new booleans are now computed in SQL at µs precision instead of via ms-truncated JS `Date` math, so a change within the same millisecond as the cursor can no longer be selected yet emit no event (leaving the cursor stuck).

Backward compatible: `entriesAfterId` is an additive optional field. When absent (legacy client / first sync), the server falls back to a strict timestamp comparison — the prior behavior.

## 2. Fail-open visibility predicate (medium)

`(subscriptions.unsubscribed_at IS NULL OR starred)` over LEFT JOINs let an orphaned `user_entries` row through (`NULL IS NULL = TRUE`) — the exact case migration `0073` made the view fail-closed to hide. Replaced with the view's exact predicate: **active subscription OR starred OR saved article**.

## 3. Duplicate events (low)

Documented that `uq_subscriptions_user_feed` guarantees at most one subscription per `(user, feed)`, so the LEFT JOINs can't fan out an entry into duplicate events.

## Tests

- Integration: keyset paging within a tied group without loss/duplication, a full drain of **550 rows sharing one timestamp** (crossing the 500-row page boundary — the definitive regression for the data-loss bug), and fail-closed visibility (orphaned hidden, starred-orphan shown, unsubscribed hidden).
- Unit: entries keyset advance in `advanceCursors` (reset on newer ts, forward within a tied group, no backward move, mark_all_read sentinel).

`pnpm typecheck`, `pnpm test:unit` (2071), and `pnpm test:integration` (sync-events: 22) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)