### PR TITLE
Stop bumping entries.updated_at on last_seen_at refresh (#1084)

### DIFF
--- a/src/server/feed/entry-processor.ts
+++ b/src/server/feed/entry-processor.ts
@@ -525,6 +525,16 @@ async function processEntryWithCache(
  *
  * Only applies to rss/atom/json feeds - email/saved entries don't use lastSeenAt.
  *
+ * Deliberately does NOT touch `updated_at`: that column is the "content changed"
+ * signal (set only by createEntry/updateEntryContent) and drives every
+ * subscriber's delta sync via visible_entries.updated_at (sync.events + the
+ * Wallabag `since` query). Bumping it here — on every still-present entry of any
+ * feed that gained a single item — would re-ship `entry_updated` payloads for
+ * entries whose content never changed and rewrite every wide row on the largest
+ * table (MVCC/WAL/index churn). `last_seen_at` alone is what visibility needs.
+ * We also only write rows whose `last_seen_at` actually differs, so entries just
+ * created in this fetch (already stamped with `fetchedAt`) aren't rewritten. See #1084.
+ *
  * @param entryIds - Array of entry IDs seen in this fetch
  * @param lastSeenAt - Timestamp to set (should match feed.lastFetchedAt)
  */
@@ -539,8 +549,10 @@ async function updateEntriesLastSeenAt(entryIds: string[], lastSeenAt: Date): Pr
     const batch = entryIds.slice(i, i + BATCH_SIZE);
     await db
       .update(entries)
-      .set({ lastSeenAt, updatedAt: new Date() })
-      .where(inArray(entries.id, batch));
+      .set({ lastSeenAt })
+      .where(
+        and(inArray(entries.id, batch), sql`${entries.lastSeenAt} IS DISTINCT FROM ${lastSeenAt}`)
+      );
   }
 }
 

--- a/tests/integration/entry-processor.test.ts
+++ b/tests/integration/entry-processor.test.ts
@@ -536,6 +536,59 @@ describe("Entry Processor", () => {
       expect(result.unchangedCount).toBe(1);
     });
 
+    it("bumps last_seen_at without touching updated_at for unchanged entries (#1084)", async () => {
+      const feed = await createTestFeed();
+
+      // First fetch: 2 entries become current.
+      const firstFetchedAt = new Date("2024-06-15T10:00:00Z");
+      await processEntries(
+        feed.id,
+        feed.type,
+        {
+          title: "Test Feed",
+          items: [
+            { guid: "entry-a", title: "Entry A", content: "Content A" },
+            { guid: "entry-b", title: "Entry B", content: "Content B" },
+          ],
+        },
+        { fetchedAt: firstFetchedAt }
+      );
+
+      const beforeA = await findEntryByGuid(feed.id, "entry-a");
+      const beforeB = await findEntryByGuid(feed.id, "entry-b");
+      expect(beforeA?.lastSeenAt?.toISOString()).toBe(firstFetchedAt.toISOString());
+
+      // Second fetch: entry A is unchanged, a new entry C appears. This is a
+      // "hasChanges" fetch, so lastSeenAt is refreshed for all still-present
+      // entries — but updated_at must NOT move for the unchanged entry A, or
+      // every subscriber's delta sync would re-ship it as a content change.
+      const secondFetchedAt = new Date("2024-06-15T11:00:00Z");
+      await processEntries(
+        feed.id,
+        feed.type,
+        {
+          title: "Test Feed",
+          items: [
+            { guid: "entry-a", title: "Entry A", content: "Content A" }, // unchanged
+            { guid: "entry-c", title: "Entry C", content: "Content C" }, // new
+          ],
+        },
+        {
+          fetchedAt: secondFetchedAt,
+          previousLastEntriesUpdatedAt: firstFetchedAt,
+        }
+      );
+
+      const afterA = await findEntryByGuid(feed.id, "entry-a");
+      // last_seen_at advanced (A is still present in the feed)...
+      expect(afterA?.lastSeenAt?.toISOString()).toBe(secondFetchedAt.toISOString());
+      // ...but updated_at did not (A's content never changed).
+      expect(afterA?.updatedAt.toISOString()).toBe(beforeA?.updatedAt.toISOString());
+      // Entry B disappeared from the feed; its last_seen_at stays put.
+      const afterB = await findEntryByGuid(feed.id, "entry-b");
+      expect(afterB?.lastSeenAt?.toISOString()).toBe(beforeB?.lastSeenAt?.toISOString());
+    });
+
     it("uses provided fetchedAt timestamp", async () => {
       const feed = await createTestFeed();
       const customFetchedAt = new Date("2024-06-15T10:00:00Z");


### PR DESCRIPTION
## Summary

Fixes item 1 of #1084 (write amplification + unindexable-scan amplifier).

`updateEntriesLastSeenAt` set `updated_at = now()` on **every currently-listed entry** whenever a feed changed at all. Two problems:

1. **Write amplification** — a 100-entry feed gaining one item rewrote all 100 wide rows (MVCC/WAL/index churn, autovacuum load on the largest table).
2. **Overloaded `updated_at`** — that column is also the "content changed" signal driving `visible_entries.updated_at = GREATEST(e.updated_at, ue.updated_at)`, consumed by `sync.events` and the Wallabag `since` delta query. So every such fetch made all 100 entries look "changed" to every subscriber's delta query, re-shipping `entry_updated` payloads for entries whose content never changed.

## Change

- `updateEntriesLastSeenAt` no longer touches `updated_at`. Content changes still bump it via `createEntry`/`updateEntryContent` — the correct and only "content changed" write sites.
- Only rows whose `last_seen_at` actually differs are written (`IS DISTINCT FROM`), so entries just created in this fetch (already stamped with `fetchedAt`) aren't rewritten either.

This also shrinks the "changed" set that the unindexable cross-table `GREATEST` delta query (issue item 2) scans — the issue explicitly frames this as the minimum ship. The full index-driven rewrite of that query (item 2) is left as a follow-up given its risk against the sync query's keyset/µs-precision invariants.

## Tests

Added an integration test asserting that on a `hasChanges` fetch, an unchanged still-present entry gets its `last_seen_at` advanced but its `updated_at` left untouched. Full integration suite passes (526 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)