### PR TITLE
Clean up dead fetch_feed jobs in retention sweep (#1085)

### DIFF
--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -1374,8 +1374,9 @@ const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
  * Deletes rows that expire but were never deleted anywhere (issue #953):
  * expired sessions, expired OAuth authorization codes / access tokens /
  * refresh tokens, long-revoked credentials, orphaned Dynamic Client
- * Registration clients (issue #975), and parked one-time process_opml_import
- * jobs. See src/server/services/retention.ts.
+ * Registration clients (issue #975), parked one-time process_opml_import
+ * jobs, and subscriber-less fetch_feed jobs (issue #1085). See
+ * src/server/services/retention.ts.
  */
 export async function handleCleanup(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/server/services/retention.ts
+++ b/src/server/services/retention.ts
@@ -3,8 +3,10 @@
  *
  * Run by the `cleanup` singleton job once a day. Every row deleted here is
  * already dead to the application — expired/revoked credentials all fail
- * validation on their read paths, and parked one-time jobs never run again —
- * so deletion only reclaims space and index bloat, never changes behavior.
+ * validation on their read paths, parked one-time jobs never run again, and
+ * subscriber-less `fetch_feed` jobs are permanently ineligible for claiming
+ * (issue #1085) — so deletion only reclaims space and index bloat (and, for
+ * dead feed jobs, un-drags the claim scan), never changes behavior.
  */
 
 import { and, eq, gt, isNull, lt, notExists, or, sql } from "drizzle-orm";
@@ -42,6 +44,18 @@ const REVOKED_RETENTION_MS = 30 * DAY_MS;
 const PARKED_JOB_THRESHOLD_MS = 180 * DAY_MS;
 
 /**
+ * Grace period before a subscriber-less `fetch_feed` job is deleted (issue #1085).
+ *
+ * `createSubscription` calls `ensureFeedJob` (committing the job row) *before*
+ * committing the subscription row, so for the very first subscriber to a feed
+ * there is a brief window where the job exists but no active subscription is yet
+ * visible. Requiring the job to be at least this old avoids racing that window;
+ * a genuinely dead job (feed unsubscribed / user deleted) has an old `created_at`
+ * — `ensureFeedJob`'s upsert never touches `created_at` — so it is unaffected.
+ */
+const DEAD_FEED_JOB_GRACE_MS = 60 * 60 * 1000;
+
+/**
  * How long an orphaned Dynamic Client Registration (RFC 7591) client is retained
  * before deletion. `/oauth/register` is open (no auth) and MCP clients such as
  * claude.ai re-register on every connect, so most rows never complete an
@@ -62,6 +76,7 @@ export interface RetentionCleanupResult {
   oauthRefreshTokens: number;
   oauthClients: number;
   parkedJobs: number;
+  deadFeedJobs: number;
 }
 
 /**
@@ -74,6 +89,7 @@ export async function runRetentionCleanup(db: Database): Promise<RetentionCleanu
   const expiryCutoff = new Date(now - EXPIRY_GRACE_MS);
   const revokedCutoff = new Date(now - REVOKED_RETENTION_MS);
   const parkedCutoff = new Date(now + PARKED_JOB_THRESHOLD_MS);
+  const deadFeedJobCutoff = new Date(now - DEAD_FEED_JOB_GRACE_MS);
   const orphanedClientCutoff = new Date(now - ORPHANED_CLIENT_RETENTION_MS);
 
   const expiredSessions = await db
@@ -116,6 +132,29 @@ export async function runRetentionCleanup(db: Database): Promise<RetentionCleanu
         gt(jobs.nextRunAt, parkedCutoff)
       )
     );
+
+  // Dead feed jobs (issue #1085): a `fetch_feed` job survives when its feed
+  // loses its last active subscriber (unsubscribe soft-delete) or the feed is
+  // hard-deleted (deleteUser orphan cleanup — jobs have no FK to feeds). Such a
+  // job is permanently ineligible for `claimFeedJob` (its active-subscriber
+  // EXISTS check fails) yet its `next_run_at` stays frozen in the past, so it
+  // sorts *first* and is walked on every claim attempt — including every idle
+  // poll — dragging the claim scan forever. Deleting it is safe: a new
+  // subscriber recreates the job via `ensureFeedJob`'s idempotent upsert. Guard
+  // with `running_since IS NULL` (never touch an in-flight job) and a grace on
+  // `created_at` (see DEAD_FEED_JOB_GRACE_MS) so we don't race the first-ever
+  // subscribe, where the job is committed just before its subscription.
+  const deadFeedJobs = await db.execute(sql`
+    DELETE FROM ${jobs} j
+    WHERE j.type = 'fetch_feed'
+      AND j.running_since IS NULL
+      AND j.created_at < ${deadFeedJobCutoff}
+      AND NOT EXISTS (
+        SELECT 1 FROM subscriptions s
+        WHERE s.feed_id = (j.payload->>'feedId')::uuid
+          AND s.unsubscribed_at IS NULL
+      )
+  `);
 
   // Orphaned Dynamic Client Registration clients (issue #975): every row in
   // oauth_clients comes from open /oauth/register (CIMD URL clients are resolved
@@ -173,5 +212,6 @@ export async function runRetentionCleanup(db: Database): Promise<RetentionCleanu
     oauthRefreshTokens: expiredRefreshTokens.rowCount ?? 0,
     oauthClients: orphanedClients.rowCount ?? 0,
     parkedJobs: parkedJobs.rowCount ?? 0,
+    deadFeedJobs: deadFeedJobs.rowCount ?? 0,
   };
 }

--- a/src/server/services/retention.ts
+++ b/src/server/services/retention.ts
@@ -144,6 +144,12 @@ export async function runRetentionCleanup(db: Database): Promise<RetentionCleanu
   // with `running_since IS NULL` (never touch an in-flight job) and a grace on
   // `created_at` (see DEAD_FEED_JOB_GRACE_MS) so we don't race the first-ever
   // subscribe, where the job is committed just before its subscription.
+  //
+  // The `running_since IS NULL` guard is deliberately stricter than
+  // `claimFeedJob`'s staleness check (`running_since IS NULL OR ... < staleThreshold`):
+  // we'd rather leave a rare crashed-mid-fetch job (stale `running_since`) in
+  // place than risk deleting a genuinely in-flight one. Such a job is reclaimed
+  // by `claimFeedJob`'s stale path and becomes deletable on a later sweep.
   const deadFeedJobs = await db.execute(sql`
     DELETE FROM ${jobs} j
     WHERE j.type = 'fetch_feed'

--- a/tests/integration/retention.test.ts
+++ b/tests/integration/retention.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { db } from "../../src/server/db";
 import {
+  feeds,
   jobs,
   oauthAccessTokens,
   oauthAuthorizationCodes,
@@ -16,6 +17,7 @@ import {
   oauthConsentGrants,
   oauthRefreshTokens,
   sessions,
+  subscriptions,
   users,
 } from "../../src/server/db/schema";
 import { runRetentionCleanup } from "../../src/server/services/retention";
@@ -142,6 +144,49 @@ async function createAuthCode(userId: string, expiresAt: Date): Promise<string> 
   return id;
 }
 
+async function createFeed(): Promise<string> {
+  const id = generateUuidv7();
+  await db.insert(feeds).values({
+    id,
+    type: "web",
+    url: `https://retention-${id}.example.com/feed.xml`,
+  });
+  return id;
+}
+
+async function createSubscription(
+  userId: string,
+  feedId: string,
+  options: { unsubscribedAt?: Date } = {}
+): Promise<string> {
+  const id = generateUuidv7();
+  await db.insert(subscriptions).values({
+    id,
+    userId,
+    feedId,
+    unsubscribedAt: options.unsubscribedAt ?? null,
+  });
+  return id;
+}
+
+async function createFeedJob(
+  feedId: string,
+  options: { createdAt?: Date; runningSince?: Date } = {}
+): Promise<string> {
+  const id = generateUuidv7();
+  const createdAt = options.createdAt ?? new Date(Date.now() - DAY_MS);
+  await db.insert(jobs).values({
+    id,
+    type: "fetch_feed",
+    payload: { feedId },
+    nextRunAt: new Date(Date.now() - DAY_MS),
+    runningSince: options.runningSince ?? null,
+    createdAt,
+    updatedAt: createdAt,
+  });
+  return id;
+}
+
 async function cleanupTables(): Promise<void> {
   await db.delete(oauthRefreshTokens);
   await db.delete(oauthAccessTokens);
@@ -150,6 +195,8 @@ async function cleanupTables(): Promise<void> {
   await db.delete(oauthClients);
   await db.delete(sessions);
   await db.delete(jobs);
+  await db.delete(subscriptions);
+  await db.delete(feeds);
   await db.delete(users);
 }
 
@@ -290,6 +337,41 @@ describe("runRetentionCleanup", () => {
     expect(remaining).not.toContain(parkedId);
   });
 
+  it("deletes subscriber-less fetch_feed jobs but keeps subscribed, running, or fresh ones", async () => {
+    const userId = await createTestUser();
+
+    // Active subscriber: kept.
+    const subscribedFeed = await createFeed();
+    await createSubscription(userId, subscribedFeed);
+    const subscribedJobId = await createFeedJob(subscribedFeed);
+
+    // Only an unsubscribed (soft-deleted) subscription: dead, deleted.
+    const unsubscribedFeed = await createFeed();
+    await createSubscription(userId, unsubscribedFeed, { unsubscribedAt: new Date() });
+    const unsubscribedJobId = await createFeedJob(unsubscribedFeed);
+
+    // No subscription at all (e.g. deleteUser orphan cleanup): dead, deleted.
+    const orphanFeed = await createFeed();
+    const orphanJobId = await createFeedJob(orphanFeed);
+
+    // No subscribers but currently running: kept (never touch an in-flight job).
+    const runningFeed = await createFeed();
+    const runningJobId = await createFeedJob(runningFeed, { runningSince: new Date() });
+
+    // No subscribers but freshly created — races the first-ever subscribe, whose
+    // job commits just before its subscription: kept by the created_at grace.
+    const freshFeed = await createFeed();
+    const freshJobId = await createFeedJob(freshFeed, { createdAt: new Date() });
+
+    const result = await runRetentionCleanup(db);
+
+    expect(result.deadFeedJobs).toBe(2);
+    const remaining = (await db.select({ id: jobs.id }).from(jobs)).map((r) => r.id);
+    expect(remaining.sort()).toEqual([subscribedJobId, runningJobId, freshJobId].sort());
+    expect(remaining).not.toContain(unsubscribedJobId);
+    expect(remaining).not.toContain(orphanJobId);
+  });
+
   it("deletes orphaned old DCR clients but keeps recent or actively-used ones", async () => {
     const userId = await createTestUser();
     const old = new Date(Date.now() - 40 * DAY_MS);
@@ -351,6 +433,7 @@ describe("runRetentionCleanup", () => {
       oauthRefreshTokens: 0,
       oauthClients: 0,
       parkedJobs: 0,
+      deadFeedJobs: 0,
     });
   });
 });

--- a/tests/integration/retention.test.ts
+++ b/tests/integration/retention.test.ts
@@ -358,6 +358,14 @@ describe("runRetentionCleanup", () => {
     const runningFeed = await createFeed();
     const runningJobId = await createFeedJob(runningFeed, { runningSince: new Date() });
 
+    // No subscribers, running_since set but stale (crashed mid-fetch): still
+    // kept — the guard is intentionally stricter than claimFeedJob's staleness
+    // check, deferring to a later sweep after the stale job is reclaimed.
+    const staleRunningFeed = await createFeed();
+    const staleRunningJobId = await createFeedJob(staleRunningFeed, {
+      runningSince: new Date(Date.now() - 7 * DAY_MS),
+    });
+
     // No subscribers but freshly created — races the first-ever subscribe, whose
     // job commits just before its subscription: kept by the created_at grace.
     const freshFeed = await createFeed();
@@ -367,7 +375,9 @@ describe("runRetentionCleanup", () => {
 
     expect(result.deadFeedJobs).toBe(2);
     const remaining = (await db.select({ id: jobs.id }).from(jobs)).map((r) => r.id);
-    expect(remaining.sort()).toEqual([subscribedJobId, runningJobId, freshJobId].sort());
+    expect(remaining.sort()).toEqual(
+      [subscribedJobId, runningJobId, staleRunningJobId, freshJobId].sort()
+    );
     expect(remaining).not.toContain(unsubscribedJobId);
     expect(remaining).not.toContain(orphanJobId);
   });


### PR DESCRIPTION
## Problem

Fixes #1085.

When a feed loses its last active subscriber (unsubscribe soft-delete) or is hard-deleted (`deleteUser` orphan cleanup — jobs have no FK to feeds), its `fetch_feed` job row survives with `next_run_at` frozen in the past. `claimFeedJob` never claims it (the `EXISTS (subscriptions … unsubscribed_at IS NULL)` check fails), and only claiming reschedules `next_run_at`. Since the claim query is `… WHERE next_run_at <= now AND EXISTS(…) ORDER BY next_run_at ASC LIMIT 1`, these permanently-due, permanently-ineligible rows sort **first** and must be walked on **every** claim attempt — including every idle 5s poll. Cost grows monotonically with unsubscribe churn, forever.

## Fix

Add a retention rule to the daily `cleanup` sweep (`runRetentionCleanup`) that deletes subscriber-less `fetch_feed` jobs. This covers both the last-unsubscribe case and the `deleteUser` orphan case in one centralized place.

Safety:
- **Deletion is safe** — a new subscriber recreates the job via `ensureFeedJob`'s idempotent `INSERT … ON CONFLICT` upsert.
- **`running_since IS NULL`** guard never touches an in-flight job.
- **`created_at` grace period** (1h) avoids racing the first-ever subscribe, where `createSubscription` commits the job row (`ensureFeedJob`) just before the subscription row. A genuinely dead job has an old `created_at` (`ensureFeedJob`'s upsert never touches `created_at`), so it's unaffected.

## Testing

New integration test in `tests/integration/retention.test.ts` covers: subscribed feed job kept, unsubscribed-only job deleted, orphan (no subscription) job deleted, running job kept, freshly-created job kept (race guard). Full integration suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)