### PR TITLE
Backend correctness/perf cleanup (markAllRead visibility, soft-deleted tags, cursors, counts) (#1089)

### DIFF
--- a/src/app/api/greader.php/reader/api/0/mark-all-as-read/route.ts
+++ b/src/app/api/greader.php/reader/api/0/mark-all-as-read/route.ts
@@ -24,6 +24,7 @@ export async function POST(request: Request): Promise<Response> {
   const session = await requireAuth(request);
   if (session instanceof Response) return session;
   const userId = session.user.id;
+  const showSpam = session.user.showSpam;
 
   const params = await parseFormData(request);
   const streamIdStr = params.get("s");
@@ -53,7 +54,7 @@ export async function POST(request: Request): Promise<Response> {
 
       // `filter` is the saved-feed type filter or a real subscription id (issue
       // #730), resolved identically to the stream/contents endpoints.
-      await markAllEntriesRead(db, { userId, ...filter, before: beforeDate });
+      await markAllEntriesRead(db, { userId, ...filter, before: beforeDate, showSpam });
       break;
     }
     case "state": {
@@ -62,6 +63,7 @@ export async function POST(request: Request): Promise<Response> {
           await markAllEntriesRead(db, {
             userId,
             before: beforeDate,
+            showSpam,
           });
           break;
         case "starred":
@@ -69,6 +71,7 @@ export async function POST(request: Request): Promise<Response> {
             userId,
             starredOnly: true,
             before: beforeDate,
+            showSpam,
           });
           break;
         default:
@@ -89,6 +92,7 @@ export async function POST(request: Request): Promise<Response> {
         userId,
         tagId: tag.id,
         before: beforeDate,
+        showSpam,
       });
       break;
     }

--- a/src/server/db/errors.ts
+++ b/src/server/db/errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Postgres error helpers.
+ */
+
+/**
+ * Postgres SQLSTATE for a unique-constraint violation.
+ */
+export const PG_UNIQUE_VIOLATION = "23505";
+
+/**
+ * Returns true if the error is a Postgres unique-constraint violation.
+ * The `pg` driver surfaces the SQLSTATE on the error's `code` property, but
+ * Drizzle wraps query errors and puts the original on `cause`, so we walk the
+ * cause chain.
+ */
+export function isUniqueViolation(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && typeof current === "object" && current !== null; depth++) {
+    if ((current as { code?: unknown }).code === PG_UNIQUE_VIOLATION) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}

--- a/src/server/jobs/queue.ts
+++ b/src/server/jobs/queue.ts
@@ -18,6 +18,7 @@
 import { and, eq, sql } from "drizzle-orm";
 import { db } from "../db";
 import { jobs, type Job } from "../db/schema";
+import { isUniqueViolation } from "../db/errors";
 import { generateUuidv7 } from "../../lib/uuidv7";
 
 /**
@@ -35,28 +36,6 @@ type RawJobRow = {
   created_at: string;
   updated_at: string;
 } & Record<string, unknown>;
-
-/**
- * Postgres SQLSTATE for a unique-constraint violation.
- */
-const PG_UNIQUE_VIOLATION = "23505";
-
-/**
- * Returns true if the error is a Postgres unique-constraint violation.
- * The `pg` driver surfaces the SQLSTATE on the error's `code` property, but
- * Drizzle wraps query errors and puts the original on `cause`, so we walk the
- * cause chain.
- */
-function isUniqueViolation(error: unknown): boolean {
-  let current: unknown = error;
-  for (let depth = 0; depth < 5 && typeof current === "object" && current !== null; depth++) {
-    if ((current as { code?: unknown }).code === PG_UNIQUE_VIOLATION) {
-      return true;
-    }
-    current = (current as { cause?: unknown }).cause;
-  }
-  return false;
-}
 
 /**
  * Converts a raw SQL row to a Job with proper Date objects.

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -24,9 +24,9 @@ import {
   subscriptionFeeds,
   userEntries,
   subscriptions,
-  subscriptionTags,
   visibleEntries,
 } from "@/server/db/schema";
+import { isValidUuid } from "@/lib/uuidv7";
 import { SANITIZER_VERSION } from "@/server/html/sanitize";
 import { sanitizeEntryHtmlInWorker } from "@/server/worker-thread/pool";
 import { logger } from "@/lib/logger";
@@ -44,6 +44,7 @@ import {
   buildEntryFeedFilter,
   buildEntryFilterConditions,
   buildTaggedFeedIdsSubquery,
+  buildUncategorizedFeedIdsSubquery,
 } from "./entry-filters";
 
 // ============================================================================
@@ -247,7 +248,12 @@ function decodeCursor(cursor: string): CursorData {
     // URL-encoding the standard form (e.g. "+" arriving as a space).
     const decoded = Buffer.from(cursor, "base64").toString("utf8");
     const parsed = JSON.parse(decoded) as CursorData;
-    if (!parsed.ts || !parsed.id) {
+    // Both callers interpolate `id` into a uuid comparison, so a non-UUID would
+    // reach Postgres as "invalid input syntax for type uuid" and 500 (Sentry
+    // noise) — reject it here, matching the subscriptions cursor hardening. `ts`
+    // is validated per-caller since its meaning differs (an ISO timestamp for
+    // the timeline, a float rank for search).
+    if (typeof parsed.ts !== "string" || typeof parsed.id !== "string" || !isValidUuid(parsed.id)) {
       throw new Error("Invalid cursor structure");
     }
     return parsed;
@@ -364,7 +370,7 @@ export async function selectFullEntry(db: typeof dbType, userId: string, entryId
  * (getEntry/getEntries) don't pay to fetch and re-sanitize full-content HTML
  * they never return.
  */
-async function resolveSanitizedFamily(
+export async function resolveSanitizedFamily(
   db: typeof dbType,
   entryId: string,
   family: "content" | "fullContent",
@@ -625,6 +631,11 @@ export async function listEntries(
   // causing entries to fall into gaps between cursor and actual timestamps.
   if (params.cursor) {
     const { ts, id } = decodeCursor(params.cursor);
+    // ts is cast to ::timestamptz below; reject a non-date string here so it
+    // surfaces as a validation error rather than a Postgres cast 500.
+    if (Number.isNaN(Date.parse(ts))) {
+      throw errors.validation("Invalid cursor format");
+    }
     if (sortOrder === "newest") {
       conditions.push(
         sql`(${sortColumn} < ${ts}::timestamptz OR (${sortColumn} = ${ts}::timestamptz AND ${visibleEntries.id} < ${id}))`
@@ -747,6 +758,11 @@ async function searchEntries(
   if (params.cursor) {
     const { ts: rankStr, id } = decodeCursor(params.cursor);
     const cursorRank = parseFloat(rankStr);
+    // The search cursor encodes a float rank in the ts field; reject a
+    // non-numeric value so NaN never reaches the rank comparison.
+    if (!Number.isFinite(cursorRank)) {
+      throw errors.validation("Invalid cursor format");
+    }
     conditions.push(
       sql`(${rankColumn} < ${cursorRank} OR (${rankColumn} = ${cursorRank} AND ${visibleEntries.id} < ${id}))`
     );
@@ -943,53 +959,35 @@ export async function markEntriesRead(
 
   const now = new Date();
 
-  // Build the SET clause, including implicit score signal flags
-  const setClause: Record<string, unknown> = {
-    read,
-    updatedAt: now,
-  };
-  if (read && options.fromList) {
-    // Marking read from the entry list → implicit -1
-    setClause.hasMarkedReadOnList = true;
-  } else if (!read) {
-    // Marking unread from anywhere → implicit 0 (overrides read-on-list penalty)
-    setClause.hasMarkedUnread = true;
-  }
+  // Apply every entry's per-entry changedAt in a single UPDATE ... FROM
+  // (VALUES ...). Offline sync can send a distinct timestamp per entry; the
+  // previous code grouped by timestamp and issued one UPDATE per distinct value
+  // — up to N sequential round-trips outside a transaction. One statement does
+  // it atomically. The per-row `read_changed_at <= v.ts` guard preserves the
+  // idempotent last-write-wins semantics, and RETURNING tells us which rows
+  // actually changed so idempotent replays don't publish.
+  const rows = entriesToMark.map(
+    (entry) => sql`(${entry.id}::uuid, ${(entry.changedAt ?? now).toISOString()}::timestamptz)`
+  );
 
-  // Group entries by timestamp for efficient batch updates. Most interactive
-  // cases share a single timestamp; per-entry timestamps come from offline sync.
-  const entriesByTimestamp = new Map<string, string[]>();
-  for (const entry of entriesToMark) {
-    const ts = (entry.changedAt ?? now).toISOString();
-    const existing = entriesByTimestamp.get(ts) ?? [];
-    existing.push(entry.id);
-    entriesByTimestamp.set(ts, existing);
-  }
+  // Implicit score-signal flag, identical for every entry in this call.
+  const signalAssignment =
+    read && options.fromList
+      ? sql`, has_marked_read_on_list = true` // marking read from the list → implicit -1
+      : !read
+        ? sql`, has_marked_unread = true` // marking unread → implicit 0 (overrides read-on-list)
+        : sql``;
 
-  // Conditional update per timestamp group: only apply if incoming timestamp is
-  // newer or equal than the stored read_changed_at (or it is NULL). `returning`
-  // tells us which entries actually changed so idempotent replays don't publish.
-  const changedIds = new Set<string>();
-  for (const [tsIso, entryIds] of entriesByTimestamp) {
-    const changedAt = new Date(tsIso);
-    const updated = await db
-      .update(userEntries)
-      .set({
-        ...setClause,
-        readChangedAt: changedAt,
-      })
-      .where(
-        and(
-          eq(userEntries.userId, userId),
-          inArray(userEntries.entryId, entryIds),
-          or(isNull(userEntries.readChangedAt), lte(userEntries.readChangedAt, changedAt))
-        )
-      )
-      .returning({ entryId: userEntries.entryId });
-    for (const row of updated) {
-      changedIds.add(row.entryId);
-    }
-  }
+  const updated = await db.execute<{ entry_id: string }>(sql`
+    UPDATE user_entries AS ue
+    SET read = ${read}, updated_at = ${now}, read_changed_at = v.ts${signalAssignment}
+    FROM (VALUES ${sql.join(rows, sql`, `)}) AS v(entry_id, ts)
+    WHERE ue.user_id = ${userId}::uuid
+      AND ue.entry_id = v.entry_id
+      AND (ue.read_changed_at IS NULL OR ue.read_changed_at <= v.ts)
+    RETURNING ue.entry_id AS entry_id
+  `);
+  const changedIds = new Set(updated.rows.map((row) => row.entry_id));
 
   // Always resolve final state for all requested entries, including the context
   // fields callers need for cache updates and count queries.
@@ -1047,6 +1045,14 @@ export async function markAllEntriesRead(
     type?: "web" | "email" | "saved";
     before?: Date;
     changedAt?: Date;
+    /**
+     * Whether to include spam entries, matching the user's preference. When
+     * false (the default), only entries visible via `visible_entries` with
+     * `is_spam = false` are marked — otherwise "mark all read" would also flip
+     * hidden spam and unsubscribed-orphan `user_entries` rows the user never
+     * saw, which would surface as already-read if they later enable showSpam.
+     */
+    showSpam: boolean;
   }
 ): Promise<string[]> {
   const changedAt = params.changedAt ?? new Date();
@@ -1056,6 +1062,23 @@ export async function markAllEntriesRead(
     eq(userEntries.read, false),
     or(isNull(userEntries.readChangedAt), lte(userEntries.readChangedAt, changedAt))!,
   ];
+
+  // Only mark entries the user can actually see, matching listEntries/countEntries
+  // (which go through visible_entries). This excludes hidden spam (unless
+  // showSpam) and unsubscribed-feed orphans that aren't starred/saved.
+  const visibleConditions = [eq(visibleEntries.userId, params.userId)];
+  if (!params.showSpam) {
+    visibleConditions.push(eq(visibleEntries.isSpam, false));
+  }
+  conditions.push(
+    inArray(
+      userEntries.entryId,
+      db
+        .select({ id: visibleEntries.id })
+        .from(visibleEntries)
+        .where(and(...visibleConditions))
+    )
+  );
 
   // Filter by explicit feed IDs (used by GReader route after stream resolution)
   if (params.feedIds) {
@@ -1105,20 +1128,10 @@ export async function markAllEntriesRead(
     conditions.push(inArray(userEntries.entryId, taggedEntryIdsSubquery));
   }
 
-  // Filter by uncategorized (no tags) - use LEFT JOIN anti-join to avoid scanning all subscription_tags
+  // Filter by uncategorized (no tags). Reuse the shared subquery builder so this
+  // stays in sync with buildEntryFeedFilter (listEntries/countEntries).
   if (params.uncategorized) {
-    const uncategorizedFeedIdsSubquery = db
-      .select({ feedId: subscriptionFeeds.feedId })
-      .from(subscriptions)
-      .innerJoin(subscriptionFeeds, eq(subscriptionFeeds.subscriptionId, subscriptions.id))
-      .leftJoin(subscriptionTags, eq(subscriptionTags.subscriptionId, subscriptions.id))
-      .where(
-        and(
-          eq(subscriptions.userId, params.userId),
-          isNull(subscriptions.unsubscribedAt),
-          isNull(subscriptionTags.subscriptionId)
-        )
-      );
+    const uncategorizedFeedIdsSubquery = buildUncategorizedFeedIdsSubquery(db, params.userId);
 
     const uncategorizedEntryIdsSubquery = db
       .select({ id: entries.id })
@@ -1319,6 +1332,12 @@ export async function countEntries(
   // Apply entry filter conditions (unreadOnly, starredOnly, type, excludeTypes, showSpam)
   conditions.push(...buildEntryFilterConditions(params));
 
+  // Callers only consume `unread`, so push read=false into the WHERE clause
+  // (rather than a FILTER over all visible entries) — this lets the partial
+  // idx_user_entries_unread index drive the scan instead of counting every
+  // visible entry, matching how counts.ts computes unread counts.
+  conditions.push(eq(visibleEntries.read, false));
+
   // count(DISTINCT id), not count(*): visible_entries emits one row per matching
   // subscription_feeds row, so an entry reachable through overlapping
   // subscriptions (redirect/merge history) would be counted multiple times.
@@ -1326,7 +1345,7 @@ export async function countEntries(
   // dedupes the same way.
   const result = await db
     .select({
-      unread: sql<number>`count(DISTINCT ${visibleEntries.id}) FILTER (WHERE ${visibleEntries.read} = false)::int`,
+      unread: sql<number>`count(DISTINCT ${visibleEntries.id})::int`,
     })
     .from(visibleEntries)
     .where(and(...conditions));

--- a/src/server/services/entry-filters.ts
+++ b/src/server/services/entry-filters.ts
@@ -91,8 +91,10 @@ export async function getSubscriptionFeedIds(
 
 /**
  * Builds a subquery for feed IDs associated with a tag.
- * The join with tags table ensures the tag belongs to the user, eliminating
- * the need for a separate tag ownership validation query.
+ * The join with tags table ensures the tag belongs to the user (and is not
+ * soft-deleted), eliminating the need for a separate tag ownership validation
+ * query. Excluding tombstoned tags means a client can't filter/mark-read
+ * entries through a tag that no longer appears in listTags.
  */
 export function buildTaggedFeedIdsSubquery(db: typeof dbType, tagId: string, userId: string) {
   return db
@@ -102,7 +104,10 @@ export function buildTaggedFeedIdsSubquery(db: typeof dbType, tagId: string, use
       subscriptionFeeds,
       eq(subscriptionTags.subscriptionId, subscriptionFeeds.subscriptionId)
     )
-    .innerJoin(tags, and(eq(subscriptionTags.tagId, tags.id), eq(tags.userId, userId)))
+    .innerJoin(
+      tags,
+      and(eq(subscriptionTags.tagId, tags.id), eq(tags.userId, userId), isNull(tags.deletedAt))
+    )
     .where(eq(subscriptionTags.tagId, tagId));
 }
 
@@ -110,8 +115,11 @@ export function buildTaggedFeedIdsSubquery(db: typeof dbType, tagId: string, use
  * Builds a subquery for feed IDs from uncategorized subscriptions.
  * Uses a LEFT JOIN anti-join pattern: subscriptions with no matching
  * subscription_tags row are "uncategorized".
+ *
+ * Exported so markAllEntriesRead reuses the exact same definition rather than
+ * reimplementing it against a different base table (they must stay in sync).
  */
-function buildUncategorizedFeedIdsSubquery(db: typeof dbType, userId: string) {
+export function buildUncategorizedFeedIdsSubquery(db: typeof dbType, userId: string) {
   return db
     .select({ feedId: subscriptionFeeds.feedId })
     .from(userFeeds)

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -17,7 +17,6 @@ import { fetchHtmlPage, HttpFetchError, ContentTooLargeError } from "@/server/ht
 import { processMarkdown } from "@/server/markdown";
 import { usageLimitsConfig } from "@/server/config/env";
 import { extractTextFromHtml } from "@/server/http/html";
-import { sanitizeEntryHtml } from "@/server/html/sanitize";
 import { absolutizeUrls } from "@/server/feed/content-cleaner";
 import { cleanContentInWorker, sanitizeEntryHtmlInWorker } from "@/server/worker-thread/pool";
 import { getOrCreateSavedFeed, getSavedFeedId, SAVED_FEED_TITLE } from "@/server/feed/saved-feed";
@@ -27,7 +26,7 @@ import { logger } from "@/lib/logger";
 import { publishNewEntry, publishEntryUpdatedFromEntry } from "@/server/redis/pubsub";
 import { toNewEntryListData } from "@/lib/events/schemas";
 import { errors } from "@/server/trpc/errors";
-import { markEntriesRead } from "@/server/services/entries";
+import { markEntriesRead, resolveSanitizedFamily } from "@/server/services/entries";
 import { publishMarkReadStateChanges } from "@/server/services/entry-events";
 import { pluginRegistry } from "@/server/plugins";
 import {
@@ -58,7 +57,9 @@ export interface SaveArticleParams {
   html?: string;
   /**
    * When true, re-fetch and update the article if the URL is already saved.
-   * Default: return the existing article without refetching.
+   * When omitted here, the existing article is returned without refetching —
+   * but note the tRPC/REST `saved.save` endpoint defaults this to `true`, so
+   * that surface refetches by default (MCP and other direct callers do not).
    */
   refetch?: boolean;
   /** With refetch, update even if the new content appears lower quality. */
@@ -753,6 +754,16 @@ export async function saveArticle(
   if (existing.length > 0) {
     if (!params.refetch) {
       const { entry, userState } = existing[0];
+      // Serve the stored sanitized body, healing it off the event loop if the
+      // stored SANITIZER_VERSION is behind (raw content must not leave the
+      // service layer). resolveSanitizedFamily version-checks, offloads large
+      // sanitizes to the worker pool, and self-heals — matching entries.get.
+      const { cleaned } = await resolveSanitizedFamily(db, entry.id, "content", {
+        originalSanitized: entry.contentOriginalSanitized,
+        cleanedSanitized: entry.contentCleanedSanitized,
+        version: entry.contentSanitizedVersion,
+        hasRaw: entry.contentOriginal !== null || entry.contentCleaned !== null,
+      });
       return {
         id: entry.id,
         url: entry.url!,
@@ -760,9 +771,7 @@ export async function saveArticle(
         siteName: entry.siteName,
         author: entry.author,
         imageUrl: entry.imageUrl,
-        // Serve the stored sanitized body (self-heal happens on entries.get);
-        // raw content must not leave the service layer.
-        contentCleaned: entry.contentCleanedSanitized ?? sanitizeEntryHtml(entry.contentCleaned),
+        contentCleaned: cleaned,
         excerpt: entry.summary,
         read: userState.read,
         starred: userState.starred,
@@ -1003,6 +1012,14 @@ export async function saveArticle(
       throw new Error(`Saved article vanished after conflict: ${normalizedUrl}`);
     }
     const { entry, userState } = row;
+    // See the no-refetch path above: version-check + worker-offload + self-heal
+    // rather than a synchronous re-sanitize of a possibly-stale body.
+    const { cleaned } = await resolveSanitizedFamily(db, entry.id, "content", {
+      originalSanitized: entry.contentOriginalSanitized,
+      cleanedSanitized: entry.contentCleanedSanitized,
+      version: entry.contentSanitizedVersion,
+      hasRaw: entry.contentOriginal !== null || entry.contentCleaned !== null,
+    });
     return {
       id: entry.id,
       url: entry.url!,
@@ -1010,7 +1027,7 @@ export async function saveArticle(
       siteName: entry.siteName,
       author: entry.author,
       imageUrl: entry.imageUrl,
-      contentCleaned: entry.contentCleanedSanitized ?? sanitizeEntryHtml(entry.contentCleaned),
+      contentCleaned: cleaned,
       excerpt: entry.summary,
       read: userState.read,
       starred: userState.starred,
@@ -1038,7 +1055,11 @@ export async function deleteSavedArticle(
   userId: string,
   articleId: string
 ): Promise<boolean> {
-  const savedFeedId = await getOrCreateSavedFeed(db, userId);
+  // Read-only lookup: deleting can never need to create the saved feed, so avoid
+  // the write side effect. No saved feed → nothing to delete (matches
+  // savedArticleExistsByUrl).
+  const savedFeedId = await getSavedFeedId(db, userId);
+  if (!savedFeedId) return false;
 
   // Verify the article exists and belongs to the user's saved feed
   const existing = await db

--- a/src/server/services/summarization.ts
+++ b/src/server/services/summarization.ts
@@ -93,7 +93,7 @@ Write your summary inside <summary> tags.`;
  * Uses the user's custom prompt if provided, otherwise falls back to the default.
  * Template variables: {{content}}, {{title}}, {{maxWords}}
  */
-function buildSummarizationPrompt(
+export function buildSummarizationPrompt(
   content: string,
   title: string,
   options?: { userMaxWords?: number | null; userPrompt?: string | null }
@@ -101,10 +101,20 @@ function buildSummarizationPrompt(
   const maxWords = getMaxWords(options?.userMaxWords);
   const template = options?.userPrompt || DEFAULT_SUMMARIZATION_PROMPT;
 
-  return template
-    .replaceAll("{{content}}", content)
-    .replaceAll("{{title}}", title)
-    .replaceAll("{{maxWords}}", String(maxWords));
+  // Single pass with a function replacement, NOT sequential string replaceAll:
+  // string replacements interpret `$&`, `` $` ``, `$'` etc. in the replacement,
+  // so article content containing `$` patterns would splice in template
+  // fragments. A single regex pass also prevents content substituted for one
+  // placeholder from injecting into a later placeholder's slot.
+  const substitutions: Record<string, string> = {
+    "{{content}}": content,
+    "{{title}}": title,
+    "{{maxWords}}": String(maxWords),
+  };
+  return template.replaceAll(
+    /\{\{(?:content|title|maxWords)\}\}/g,
+    (match) => substitutions[match]
+  );
 }
 
 /**

--- a/src/server/services/tags.ts
+++ b/src/server/services/tags.ts
@@ -14,6 +14,7 @@ import {
   userFeeds,
 } from "@/server/db/schema";
 import { errors } from "@/server/trpc/errors";
+import { isUniqueViolation } from "@/server/db/errors";
 import { generateUuidv7 } from "@/lib/uuidv7";
 import { publishTagCreated, publishTagUpdated, publishTagDeleted } from "@/server/redis/pubsub";
 
@@ -287,7 +288,17 @@ export async function updateTag(
     updateData.color = params.color;
   }
 
-  await db.update(tags).set(updateData).where(eq(tags.id, tagId));
+  // The duplicate check above is check-then-act; a concurrent rename to the same
+  // name can still slip in between and trip the partial unique index. Catch that
+  // as a validation error instead of surfacing a raw 500.
+  try {
+    await db.update(tags).set(updateData).where(eq(tags.id, tagId));
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      throw errors.validation("A tag with this name already exists");
+    }
+    throw err;
+  }
 
   // Get updated tag with feed count and unread count
   const tagUnreadCounts = tagUnreadCountsQuery(db, userId);
@@ -352,21 +363,29 @@ export async function updateTag(
 export async function deleteTag(db: typeof dbType, userId: string, tagId: string): Promise<void> {
   const now = new Date();
 
-  const deleted = await db
-    .update(tags)
-    .set({ deletedAt: now, updatedAt: now })
-    .where(and(eq(tags.id, tagId), eq(tags.userId, userId), isNull(tags.deletedAt)))
-    .returning({ id: tags.id, updatedAt: tags.updatedAt });
+  // Tombstone the tag and drop its subscription associations as one unit, so a
+  // crash between them can't leave a soft-deleted tag with live associations
+  // (which would silently drop subscriptions from "Uncategorized" while the tag
+  // is invisible in listTags).
+  const updatedAt = await db.transaction(async (tx) => {
+    const deleted = await tx
+      .update(tags)
+      .set({ deletedAt: now, updatedAt: now })
+      .where(and(eq(tags.id, tagId), eq(tags.userId, userId), isNull(tags.deletedAt)))
+      .returning({ id: tags.id, updatedAt: tags.updatedAt });
 
-  if (deleted.length === 0) {
-    throw errors.tagNotFound();
-  }
+    if (deleted.length === 0) {
+      throw errors.tagNotFound();
+    }
 
-  // Remove subscription_tags associations (these aren't synced, so hard delete is fine)
-  await db.delete(subscriptionTags).where(eq(subscriptionTags.tagId, tagId));
+    // Remove subscription_tags associations (these aren't synced, so hard delete is fine)
+    await tx.delete(subscriptionTags).where(eq(subscriptionTags.tagId, tagId));
+
+    return deleted[0].updatedAt;
+  });
 
   // Publish tag deleted event for multi-tab/device sync (fire and forget)
-  publishTagDeleted(userId, tagId, deleted[0].updatedAt).catch(() => {
+  publishTagDeleted(userId, tagId, updatedAt).catch(() => {
     // Ignore publish errors - SSE is best-effort
   });
 }

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -10,7 +10,7 @@
  */
 
 import { z } from "zod";
-import { eq, and } from "drizzle-orm";
+import { eq, and, isNull } from "drizzle-orm";
 
 import {
   createTRPCRouter,
@@ -432,12 +432,14 @@ export const entriesRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
-      // Validate tag belongs to user before passing to service
+      // Validate tag belongs to user (and isn't soft-deleted) before passing to
+      // the service — a tombstoned tag is invisible in listTags and must not be
+      // markable.
       if (input.tagId) {
         const tagExists = await ctx.db
           .select({ id: tags.id })
           .from(tags)
-          .where(and(eq(tags.id, input.tagId), eq(tags.userId, userId)))
+          .where(and(eq(tags.id, input.tagId), eq(tags.userId, userId), isNull(tags.deletedAt)))
           .limit(1);
 
         if (tagExists.length === 0) {
@@ -464,6 +466,7 @@ export const entriesRouter = createTRPCRouter({
         type: input.type,
         before: input.before,
         changedAt: input.changedAt,
+        showSpam: ctx.session.user.showSpam,
       });
 
       return { count: entryIds.length };

--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -402,16 +402,19 @@ export const subscriptionsRouter = createTRPCRouter({
           .innerJoin(tags, eq(tags.id, subscriptionTags.tagId))
           .where(eq(subscriptionTags.subscriptionId, subscription.id)),
 
-        // Unread count (use visibleEntries view to include entries from redirected feeds)
+        // Unread count (use visibleEntries view to include entries from redirected feeds).
+        // read=false lives in WHERE (not a FILTER over all entries) so the partial
+        // idx_user_entries_unread index can drive the scan, matching counts.ts.
         ctx.db
           .select({
-            count: sql<number>`COUNT(*) FILTER (WHERE ${visibleEntries.read} = false)::int`,
+            count: sql<number>`COUNT(*)::int`,
           })
           .from(visibleEntries)
           .where(
             and(
               eq(visibleEntries.userId, userId),
-              eq(visibleEntries.subscriptionId, subscription.id)
+              eq(visibleEntries.subscriptionId, subscription.id),
+              eq(visibleEntries.read, false)
             )
           ),
       ]);
@@ -895,11 +898,16 @@ export const subscriptionsRouter = createTRPCRouter({
         return {};
       }
 
-      // Verify all tag IDs belong to the current user and get tag details
+      // Verify all tag IDs belong to the current user, are not soft-deleted, and
+      // get tag details. Excluding tombstoned tags prevents assigning a tag that
+      // is invisible in listTags (which would silently drop the subscription
+      // from "Uncategorized").
       const userTags = await ctx.db
         .select({ id: tags.id, name: tags.name, color: tags.color })
         .from(tags)
-        .where(and(eq(tags.userId, userId), inArray(tags.id, input.tagIds)));
+        .where(
+          and(eq(tags.userId, userId), inArray(tags.id, input.tagIds), isNull(tags.deletedAt))
+        );
 
       const validTagIds = new Set(userTags.map((t) => t.id));
       const invalidTagIds = input.tagIds.filter((id) => !validTagIds.has(id));

--- a/tests/e2e/realtime.spec.ts
+++ b/tests/e2e/realtime.spec.ts
@@ -357,7 +357,7 @@ test("mark_all_read event empties the unread list and clears badges via a refetc
   // marks read in the DB AND publishes the mark_all_read signal — the exact code
   // path the tRPC mutation and the Google Reader mark-all-as-read route hit.
   const db = getDb();
-  await markAllEntriesRead(db, { userId: user.id });
+  await markAllEntriesRead(db, { userId: user.id, showSpam: false });
 
   // The unread-only /all view empties out and every sidebar unread badge clears
   // (CountBadge renders nothing at 0; the tag/sub/uncategorized rows hide).

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -144,23 +144,30 @@ async function createTestEntry(
     title?: string;
     contentCleaned?: string;
     publishedAt?: Date;
+    isSpam?: boolean;
+    type?: "web" | "email" | "saved";
   } = {}
 ): Promise<string> {
   const entryId = generateUuidv7();
   const now = new Date();
   const guid = options.guid ?? `guid-${entryId}`;
+  // is_spam is only permitted on email entries (entries_spam_only_email);
+  // last_seen_at is only permitted on fetched/web entries
+  // (entries_last_seen_only_fetched).
+  const type = options.type ?? (options.isSpam ? "email" : "web");
 
   await db.insert(entries).values({
     id: entryId,
     feedId,
-    type: "web",
+    type,
     guid,
     title: options.title ?? `Entry ${entryId}`,
     contentCleaned: options.contentCleaned ?? `Content for ${options.title ?? entryId}`,
     contentHash: `hash-${entryId}`,
     fetchedAt: options.publishedAt ?? now,
     publishedAt: options.publishedAt ?? now,
-    lastSeenAt: now,
+    lastSeenAt: type === "web" ? now : null,
+    isSpam: options.isSpam ?? false,
     createdAt: now,
     updatedAt: now,
   });
@@ -825,7 +832,7 @@ describe("Entries", () => {
       await createTestSubscription(attackerId, feedId);
       await createUserEntry(attackerId, entryId, { read: false });
 
-      const marked = await markAllEntriesRead(db, { userId: attackerId, tagId });
+      const marked = await markAllEntriesRead(db, { userId: attackerId, tagId, showSpam: false });
       expect(marked).toEqual([]);
 
       const attackerEntries = await db
@@ -835,8 +842,36 @@ describe("Entries", () => {
       expect(attackerEntries).toEqual([{ read: false }]);
 
       // The owner can still mark through their tag
-      const ownMarked = await markAllEntriesRead(db, { userId: victimId, tagId });
+      const ownMarked = await markAllEntriesRead(db, { userId: victimId, tagId, showSpam: false });
       expect(ownMarked).toEqual([entryId]);
+    });
+
+    it("excludes hidden spam entries unless showSpam is set", async () => {
+      // "Mark all read" must only touch entries the user can actually see, like
+      // listEntries/countEntries — otherwise hidden spam would be marked read and
+      // surface as already-read if the user later enables showSpam (issue #1089).
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://spam-feed.com/rss");
+      await createTestSubscription(userId, feedId);
+
+      const normalId = await createTestEntry(feedId, { title: "Normal" });
+      const spamId = await createTestEntry(feedId, { title: "Spam", isSpam: true });
+      await createUserEntry(userId, normalId, { read: false });
+      await createUserEntry(userId, spamId, { read: false });
+
+      // With spam hidden, only the non-spam entry is marked.
+      const marked = await markAllEntriesRead(db, { userId, showSpam: false });
+      expect(marked).toEqual([normalId]);
+
+      const spamState = await db
+        .select({ read: userEntries.read })
+        .from(userEntries)
+        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, spamId)));
+      expect(spamState).toEqual([{ read: false }]);
+
+      // With showSpam, the spam entry is marked too.
+      const markedWithSpam = await markAllEntriesRead(db, { userId, showSpam: true });
+      expect(markedWithSpam).toEqual([spamId]);
     });
   });
 

--- a/tests/unit/summarization-settings.test.ts
+++ b/tests/unit/summarization-settings.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import {
   getMaxWords,
   hashPrompt,
+  buildSummarizationPrompt,
   DEFAULT_SUMMARIZATION_PROMPT,
 } from "@/server/services/summarization";
 import { DEFAULT_SUMMARIZATION_MAX_WORDS } from "@/lib/summarization/constants";
@@ -57,5 +58,33 @@ describe("hashPrompt", () => {
 
   it("distinguishes a custom prompt from the default", () => {
     expect(hashPrompt("a custom prompt")).not.toBe(hashPrompt(null));
+  });
+});
+
+describe("buildSummarizationPrompt", () => {
+  it("substitutes placeholders", () => {
+    const result = buildSummarizationPrompt("BODY", "TITLE", {
+      userPrompt: "Title: {{title}} / Content: {{content}} / Max: {{maxWords}}",
+      userMaxWords: 50,
+    });
+    expect(result).toBe("Title: TITLE / Content: BODY / Max: 50");
+  });
+
+  it("does not interpret $ patterns in content as replacement specials", () => {
+    // A string replaceAll would turn `$&`/`$'`/`` $` `` in the content into
+    // spliced template fragments; the function replacement inserts them verbatim.
+    const content = "price is $5 and $& and $` and $' and $$";
+    const result = buildSummarizationPrompt(content, "T", {
+      userPrompt: "[{{content}}]",
+    });
+    expect(result).toBe(`[${content}]`);
+  });
+
+  it("does not let content inject into a later placeholder slot", () => {
+    // Content containing another placeholder must not be re-substituted.
+    const result = buildSummarizationPrompt("{{title}}", "REAL TITLE", {
+      userPrompt: "{{content}}|{{title}}",
+    });
+    expect(result).toBe("{{title}}|REAL TITLE");
   });
 });


### PR DESCRIPTION
Fixes #1089 — a batch of lower-severity backend correctness / maintainability items found in the repo-wide audit.

## Correctness
- **`markAllEntriesRead` marked invisible entries.** It filtered `user_entries` directly with no visibility/spam predicate, so "mark all read" also flipped hidden spam and unsubscribed-orphan rows the user never saw. It now restricts to `visible_entries` (excluding `is_spam` unless the user's `showSpam` is set), threading `showSpam` through the tRPC and Google Reader callers.
- **Soft-deleted tags were still reachable.** `buildTaggedFeedIdsSubquery` and the `setTags` / `markAllRead` ownership checks now add `isNull(tags.deletedAt)`, so a client can't filter/mark-read through a tombstoned tag that's invisible in `listTags`.
- **`deleteTag` is now transactional** (tombstone + association drop as one unit), and **`updateTag` catches the unique-violation** from a concurrent rename instead of surfacing a raw 500. The Postgres unique-violation helper is extracted to `src/server/db/errors.ts` and shared with the job queue.
- **`buildSummarizationPrompt`** uses a single-pass function replacement so article content containing `$&`/`` $` ``/`$'` can't splice in template fragments, and content can't inject into a later placeholder slot.
- **`decodeCursor`** validates the `id` (UUID) and each caller validates its `ts` (ISO date for the timeline, finite float rank for search) — a malformed cursor is now a validation error instead of a Postgres cast 500.

## Performance
- **`markEntriesRead`** applies every per-entry `changedAt` in one `UPDATE ... FROM (VALUES ...)` (preserving the `read_changed_at <= ts` guard) instead of one sequential UPDATE per distinct timestamp.
- **`countEntries`** and **`subscriptions.update`** push `read=false` into WHERE (dropping the FILTER over all visible entries) so the partial unread index can drive.
- **Saved-article "existing" paths** reuse `resolveSanitizedFamily` (version-check + worker-pool offload + self-heal) instead of a synchronous re-sanitize of a possibly-stale body.

## Maintainability
- `markAllEntriesRead` reuses the shared `buildUncategorizedFeedIdsSubquery` instead of a divergent reimplementation.
- `deleteSavedArticle` uses read-only `getSavedFeedId` (no feed-creation side effect).
- Fixed the `saved.save` `refetch`-default doc to match the effective tRPC behavior.

## Tests
- New integration test: `markAllEntriesRead` excludes hidden spam unless `showSpam`.
- New unit tests for `buildSummarizationPrompt` (`$` handling + no placeholder re-injection).
- Full unit + integration suites pass; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)