### PR TITLE
Pause background resanitize sweep

### DIFF
--- a/src/server/jobs/queue.ts
+++ b/src/server/jobs/queue.ts
@@ -503,7 +503,11 @@ export const SINGLETON_JOB_TYPES: JobType[] = [
   "renew_websub",
   "monitor_feed_health",
   "cleanup",
-  "resanitize_entries",
+  // Temporarily paused: keeping "resanitize_entries" out of this list stops the
+  // worker from claiming (or self-creating) the singleton, so the background
+  // re-sanitization sweep does not run. The read-path self-heal still fixes any
+  // entry that is actually opened. Re-enable by restoring the entry below.
+  // "resanitize_entries",
 ];
 
 /**


### PR DESCRIPTION
## What

Temporarily pauses the background `resanitize_entries` sweep by removing it from `SINGLETON_JOB_TYPES`.

## Why

Requested: pause the background resanitize worker for now.

## How it works

The sweep is a stateless singleton the worker claims (and self-creates if missing) on every poll cycle by iterating `SINGLETON_JOB_TYPES`. Dropping `resanitize_entries` from that list means the worker never claims or re-creates it, so the sweep stops running. Any existing DB row for the job is simply never picked up (it's not a feed-job type, so the feed-claim query ignores it too).

This is fully reversible — restore the one line to re-enable. Correctness is unaffected in the meantime: the read-path self-heal (`resolveSanitizedContent`) still re-sanitizes any entry a user actually opens. Only the long-tail background convergence is paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)