### PR TITLE
resanitize-bulk: seek idx_entries_resanitize instead of walking entries_pkey

### DIFF
--- a/scripts/resanitize-bulk.ts
+++ b/scripts/resanitize-bulk.ts
@@ -27,8 +27,8 @@
  * clock: the DB sits idle while the CPU chews, and the CPU sits idle while the DB
  * fetches. Instead this runs both at once:
  *
- *   - A single **producer** walks the stale rows by keyset (`id < cursor`) in
- *     chunks and pushes each row into a bounded queue.
+ *   - A single **producer** walks the stale rows by keyset over
+ *     `(stalenessKey, id)` in chunks and pushes each row into a bounded queue.
  *   - `concurrency` **consumers** each pull one row at a time and sanitize its
  *     stale families in the piscina worker pool, then persist under the CAS guard.
  *
@@ -43,15 +43,22 @@
  *
  * ## Row selection
  *
- * We page the stale set (`RESANITIZE_STALENESS_KEY < SANITIZER_VERSION`) by
- * primary key descending, keyset-style (`id < cursor`). Right after a version
- * bump essentially every row is stale, so a backward scan of `entries_pkey`
- * finds a full chunk almost immediately on every page — a clean single pass with
- * no offset cost and no cursor to persist across runs. As rows heal they leave
- * the stale range, but we never revisit them because the cursor only moves toward
- * smaller ids, so healed/skipped rows don't cost us a re-fetch. (This favors the
- * common post-bump case; if only a sparse scattering of rows is stale, the tail
- * pages scan more of the pkey to find matches — acceptable for a one-shot tool.)
+ * We page the stale set (`RESANITIZE_STALENESS_KEY < SANITIZER_VERSION`) via the
+ * shared `selectStaleEntriesForResanitize`, ordered by the staleness key
+ * descending (then `id` descending) and keyset-paginated on `(stalenessKey, id)`.
+ * That ordering is exactly what `idx_entries_resanitize` provides, so every chunk
+ * is an index range seek into the stale rows — never a full table scan. This
+ * matters most *between* version bumps, when only a sparse scattering of rows is
+ * stale (or none): the earlier `ORDER BY id` walked `entries_pkey` and evaluated
+ * the staleness expression as a filter on every row, so a near-caught-up corpus
+ * cost a near-full-table scan per page just to find a handful of matches. Seeking
+ * the index instead makes an empty stale set return immediately.
+ *
+ * The cursor only moves toward smaller `(key, id)`, and healed rows leave the
+ * stale range entirely (their key jumps to `SANITIZER_VERSION`), so we never
+ * re-fetch a row we already passed — nor one the background sweep or a normal
+ * write healed ahead of us. No cursor is persisted across runs; a fresh run just
+ * re-seeks the current stale range from the top.
  *
  * ## Usage
  *
@@ -69,15 +76,12 @@
  * producer's fetches (default pool is 20).
  */
 
-import { and, desc, lt, sql } from "drizzle-orm";
-
 import { db, pool } from "../src/server/db";
-import { entries } from "../src/server/db/schema";
 import { SANITIZER_VERSION } from "../src/server/html/sanitize";
 import {
   isSanitizedFamilyStale,
   persistResanitizedFamily,
-  RESANITIZE_STALENESS_KEY,
+  selectStaleEntriesForResanitize,
 } from "../src/server/services/resanitize";
 import {
   getWorkerSanitizerVersion,
@@ -172,37 +176,16 @@ class BoundedQueue<T> {
 // Row selection + per-row work
 // ---------------------------------------------------------------------------
 
-type StaleRow = {
-  id: string;
-  contentOriginal: string | null;
-  contentCleaned: string | null;
-  contentSanitizedVersion: number | null;
-  contentHash: string | null;
-  fullContentOriginal: string | null;
-  fullContentCleaned: string | null;
-  fullContentSanitizedVersion: number | null;
-  fullContentHash: string | null;
-};
+// Row shape and query are shared with the background sweep so the two can't
+// drift (and so both use idx_entries_resanitize).
+type StaleRow = Awaited<ReturnType<typeof selectStaleEntriesForResanitize>>[number];
 
-/** Fetch the next chunk of stale rows with id < cursor (or from the top). */
-function fetchChunk(cursor: string | null, limit: number): Promise<StaleRow[]> {
-  const staleFilter = sql`${RESANITIZE_STALENESS_KEY} < ${SANITIZER_VERSION}`;
-  return db
-    .select({
-      id: entries.id,
-      contentOriginal: entries.contentOriginal,
-      contentCleaned: entries.contentCleaned,
-      contentSanitizedVersion: entries.contentSanitizedVersion,
-      contentHash: entries.contentHash,
-      fullContentOriginal: entries.fullContentOriginal,
-      fullContentCleaned: entries.fullContentCleaned,
-      fullContentSanitizedVersion: entries.fullContentSanitizedVersion,
-      fullContentHash: entries.fullContentHash,
-    })
-    .from(entries)
-    .where(cursor ? and(staleFilter, lt(entries.id, cursor)) : staleFilter)
-    .orderBy(desc(entries.id))
-    .limit(limit);
+/** Keyset cursor over the index ordering `(stalenessKey DESC, id DESC)`. */
+type Cursor = { stalenessKey: number; id: string };
+
+/** Fetch the next chunk of stale rows after the keyset cursor (or from the top). */
+function fetchChunk(cursor: Cursor | null, limit: number): Promise<StaleRow[]> {
+  return selectStaleEntriesForResanitize(db, limit, cursor ?? undefined);
 }
 
 type RowOutcome = { content: boolean; fullContent: boolean; failed: boolean };
@@ -324,12 +307,13 @@ async function main(): Promise<void> {
   // Producer: walk the stale set by keyset and feed the queue. `push` provides
   // backpressure, so this stays at most PREFETCH_CHUNKS ahead of the consumers.
   const producer = (async () => {
-    let cursor: string | null = null;
+    let cursor: Cursor | null = null;
     while (fetched < LIMIT) {
       const remaining = LIMIT - fetched;
       const chunk = await fetchChunk(cursor, Math.min(CHUNK_SIZE, remaining));
       if (chunk.length === 0) break;
-      cursor = chunk[chunk.length - 1].id;
+      const last = chunk[chunk.length - 1];
+      cursor = { stalenessKey: last.stalenessKey, id: last.id };
       fetched += chunk.length;
       for (const row of chunk) {
         await queue.push(row);

--- a/src/server/services/resanitize.ts
+++ b/src/server/services/resanitize.ts
@@ -98,15 +98,39 @@ export const RESANITIZE_STALENESS_KEY = sql<number>`LEAST(
 )`;
 
 /**
- * Builds the "stalest rows first" query used by both the sweep and the EXPLAIN
- * test, so the test verifies the exact query the service runs. Selects each
- * family's content hash so the persist can guard against the raw changing under
- * us (see persistResanitizedFamily).
+ * Builds the "stalest rows first" query shared by the background sweep, the bulk
+ * re-sanitize script (`scripts/resanitize-bulk.ts`), and the EXPLAIN test, so all
+ * three run the exact query `idx_entries_resanitize` is designed for. Orders by
+ * the staleness key `DESC` (then `id DESC`) under the `key < SANITIZER_VERSION`
+ * bound, which the index serves as a single range seek — no full scan, no sort,
+ * even when only a sparse scattering of rows is stale (the steady state between
+ * version bumps).
+ *
+ * Selects each family's content hash so the persist can guard against the raw
+ * changing under us (see persistResanitizedFamily), plus the computed
+ * `stalenessKey` so a paginating caller can build the next keyset cursor from the
+ * last row. The optional `cursor` keyset-paginates *within* the stale range on
+ * `(stalenessKey, id)` descending — used by the bulk script to walk the whole set
+ * without re-fetching in-flight rows. The background sweep passes no cursor and
+ * instead relies on healed rows leaving the stale range to make forward progress.
  */
-export function selectStaleEntriesForResanitize(db: typeof dbType, limit: number) {
+export function selectStaleEntriesForResanitize(
+  db: typeof dbType,
+  limit: number,
+  cursor?: { stalenessKey: number; id: string }
+) {
+  const staleFilter = sql`${RESANITIZE_STALENESS_KEY} < ${SANITIZER_VERSION}`;
+  // Keyset over the index's own ordering `(key DESC, id DESC)`: rows strictly
+  // "after" the cursor are those with a smaller key, or the same key and a
+  // smaller id. Combined with staleFilter (a bound on the same leading indexed
+  // expression) the planner still serves it from `idx_entries_resanitize`.
+  const keysetFilter = cursor
+    ? sql`(${RESANITIZE_STALENESS_KEY} < ${cursor.stalenessKey} OR (${RESANITIZE_STALENESS_KEY} = ${cursor.stalenessKey} AND ${entries.id} < ${cursor.id}))`
+    : undefined;
   return db
     .select({
       id: entries.id,
+      stalenessKey: RESANITIZE_STALENESS_KEY,
       contentOriginal: entries.contentOriginal,
       contentCleaned: entries.contentCleaned,
       contentSanitizedVersion: entries.contentSanitizedVersion,
@@ -117,7 +141,7 @@ export function selectStaleEntriesForResanitize(db: typeof dbType, limit: number
       fullContentHash: entries.fullContentHash,
     })
     .from(entries)
-    .where(sql`${RESANITIZE_STALENESS_KEY} < ${SANITIZER_VERSION}`)
+    .where(keysetFilter ? and(staleFilter, keysetFilter) : staleFilter)
     .orderBy(sql`${RESANITIZE_STALENESS_KEY} DESC`, desc(entries.id))
     .limit(limit);
 }

--- a/tests/integration/resanitize-entries.test.ts
+++ b/tests/integration/resanitize-entries.test.ts
@@ -310,6 +310,29 @@ describe("resanitizeStaleEntries", () => {
     expect(plan).toContain("idx_entries_resanitize");
     expect(plan).not.toContain("Sort");
   });
+
+  it("uses idx_entries_resanitize with no sort when keyset-paginated (EXPLAIN)", async () => {
+    const feedId = await seedFeed();
+    for (let i = 0; i < 40; i++) await seedStaleEntry(feedId);
+    await db.execute(sql`ANALYZE entries`);
+
+    // The bulk script (scripts/resanitize-bulk.ts) pages the stale set with a
+    // keyset cursor; guard that the cursor variant still seeks the index rather
+    // than falling back to a pkey walk + filter (the pre-fix regression that
+    // scanned the whole table when little was stale).
+    const query = selectStaleEntriesForResanitize(db, RESANITIZE_BATCH_SIZE, {
+      stalenessKey: SANITIZER_VERSION - 1,
+      id: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    });
+    const plan = await db.transaction(async (tx) => {
+      await tx.execute(sql`SET LOCAL enable_seqscan = off`);
+      const explain = await tx.execute(sql`EXPLAIN ${query.getSQL()}`);
+      return explain.rows.map((r) => r["QUERY PLAN"] as string).join("\n");
+    });
+
+    expect(plan).toContain("idx_entries_resanitize");
+    expect(plan).not.toContain("Sort");
+  });
 });
 
 describe("handleResanitizeEntries", () => {


### PR DESCRIPTION
## Problem

While investigating recent DB CPU spikes (the shared database hit its CPU quota during a manual sanitize-version backfill), I traced the cause to `scripts/resanitize-bulk.ts`.

The bulk re-sanitize tool paged the stale set by primary key:

```ts
.where(cursor ? and(staleFilter, lt(entries.id, cursor)) : staleFilter)
.orderBy(desc(entries.id))
```

So it walked `entries_pkey` and evaluated `RESANITIZE_STALENESS_KEY < SANITIZER_VERSION` — the `LEAST(CASE… COALESCE…)` expression — as a **filter on every row**. That's only cheap right after a `SANITIZER_VERSION` bump, when almost every row is stale. Between bumps (the steady state — few or no rows stale, e.g. running it at the current v5 with the corpus already caught up) each page scanned huge stretches of the `entries` table to find a handful of matches, or none. That's the "surprisingly hard on the database just to query" load.

The **background sweep** (`resanitize_entries` job) was never affected — it orders by the staleness key and is served by `idx_entries_resanitize`, seeking straight to the (empty) stale range. This PR makes the bulk script do the same.

## Fix

- Page by the staleness key, ordered `(key DESC, id DESC)` under the `key < SANITIZER_VERSION` bound and keyset-paginated on `(stalenessKey, id)` — exactly what `idx_entries_resanitize` provides, so an empty/sparse stale set returns immediately via an index seek.
- Share the query with the background sweep: `selectStaleEntriesForResanitize` gains an optional keyset cursor and a computed `stalenessKey` column, so the two paths can't drift from the index.
- The cursor only advances toward smaller `(key, id)` and healed rows leave the stale range, so no row is re-fetched (nor one the background sweep / a normal write heals ahead of us).
- Adds an EXPLAIN test for the keyset-paginated variant mirroring the existing no-cursor one.

## Testing

- `pnpm typecheck` ✅
- `pnpm test:integration` (resanitize suite, incl. both EXPLAIN index-usage assertions) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)