### PR TITLE
Skip unread-count aggregation where Google Reader discards it (#1074)

### DIFF
--- a/src/app/api/greader.php/reader/api/0/subscription/list/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/list/route.ts
@@ -19,14 +19,15 @@ export async function GET(request: Request): Promise<Response> {
   const session = await requireAuth(request);
   if (session instanceof Response) return session;
 
-  // `formatSubscription` ignores unread counts, but listGreaderSubscriptions
-  // computes them anyway: the per-subscription counts are baked into the
-  // subscription query (skipping those is tracked as issue #1074), and the
-  // synthetic saved feed runs its own separate `countEntries` (out of scope for
-  // #1074) whose result is likewise discarded here. Both are wasted work only on
-  // this endpoint; unread-count needs the counts.
+  // `formatSubscription` ignores unread counts, so skip computing them — the
+  // per-subscription unread aggregate scales with the user's unread backlog and
+  // would dominate this query for nothing (issue #1074). unread-count is the
+  // endpoint that needs the counts and keeps the default.
   const subscriptions = (
-    await listGreaderSubscriptions(db, session.user.id, { showSpam: session.user.showSpam })
+    await listGreaderSubscriptions(db, session.user.id, {
+      showSpam: session.user.showSpam,
+      includeUnreadCounts: false,
+    })
   ).map(formatSubscription);
 
   return jsonResponse({ subscriptions });

--- a/src/app/api/greader.php/reader/api/0/subscription/quickadd/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/quickadd/route.ts
@@ -57,11 +57,13 @@ export async function POST(request: Request): Promise<Response> {
         .limit(1);
 
       if (existingSub.length > 0) {
-        // Already subscribed — return existing subscription
+        // Already subscribed — return existing subscription. Only the title is
+        // used in the response, so skip the unread-count aggregate (issue #1074).
         const sub = await subscriptionsService.getSubscription(
           db,
           session.user.id,
-          existingSub[0].id
+          existingSub[0].id,
+          { includeUnreadCounts: false }
         );
         return jsonResponse({
           query: feedUrl,

--- a/src/server/google-reader/subscriptions.ts
+++ b/src/server/google-reader/subscriptions.ts
@@ -62,14 +62,21 @@ export async function resolveFeedStreamFilter(
  *
  * Centralizing the saved-feed append here means subscription/list and
  * unread-count inherit it for free instead of each re-deriving it (issue #1069).
+ *
+ * `includeUnreadCounts: false` (issue #1074) skips both the per-subscription
+ * unread aggregate and the saved feed's `countEntries`, returning every
+ * `unreadCount` as 0 — for callers like subscription/list that never emit
+ * counts. unread-count keeps the default.
  */
 export async function listGreaderSubscriptions(
   db: typeof dbType,
   userId: string,
-  opts: { showSpam: boolean }
+  opts: { showSpam: boolean; includeUnreadCounts?: boolean }
 ): Promise<subscriptionsService.Subscription[]> {
   const [all, saved] = await Promise.all([
-    subscriptionsService.listAllSubscriptions(db, userId),
+    subscriptionsService.listAllSubscriptions(db, userId, {
+      includeUnreadCounts: opts.includeUnreadCounts,
+    }),
     getSavedSubscription(db, userId, opts),
   ]);
 
@@ -90,12 +97,15 @@ export async function listGreaderSubscriptions(
 async function getSavedSubscription(
   db: typeof dbType,
   userId: string,
-  opts: { showSpam: boolean }
+  opts: { showSpam: boolean; includeUnreadCounts?: boolean }
 ): Promise<subscriptionsService.Subscription | null> {
   const feedId = await getSavedFeedId(db, userId);
   if (!feedId) return null;
 
-  const { unread } = await countEntries(db, userId, { type: "saved", showSpam: opts.showSpam });
+  const unread =
+    (opts.includeUnreadCounts ?? true)
+      ? (await countEntries(db, userId, { type: "saved", showSpam: opts.showSpam })).unread
+      : 0;
 
   return {
     id: feedId,

--- a/src/server/services/subscriptions.ts
+++ b/src/server/services/subscriptions.ts
@@ -54,10 +54,30 @@ export interface Subscription {
 // ============================================================================
 
 /**
- * Builds the base query for fetching subscriptions using the user_feeds view.
- * Includes unread counts and tags.
+ * Options shared by the subscription read functions.
  */
-function buildSubscriptionBaseQuery(db: typeof dbType, userId: string) {
+export interface SubscriptionQueryOptions {
+  /**
+   * Compute per-subscription unread counts (default true). The count is a
+   * grouped aggregate over `visible_entries` that scales with the user's unread
+   * backlog — often the dominant cost of the query — so callers that discard
+   * `unreadCount` (Google Reader `subscription/list`/`quickadd`, issue #1074)
+   * pass false and get a literal 0 instead.
+   */
+  includeUnreadCounts?: boolean;
+}
+
+/**
+ * Builds the base query for fetching subscriptions using the user_feeds view.
+ * Includes unread counts (unless opted out) and tags.
+ */
+function buildSubscriptionBaseQuery(
+  db: typeof dbType,
+  userId: string,
+  opts: SubscriptionQueryOptions = {}
+) {
+  const includeUnreadCounts = opts.includeUnreadCounts ?? true;
+
   // Subquery to get unread counts per subscription.
   // Counts through visible_entries (grouped by subscription_id) rather than by
   // entries.feed_id: a subscription can own entries under multiple feed_ids via
@@ -76,7 +96,7 @@ function buildSubscriptionBaseQuery(db: typeof dbType, userId: string) {
     .groupBy(visibleEntries.subscriptionId)
     .as("unread_counts");
 
-  return db
+  const baseSelect = db
     .select({
       // From user_feeds view - subscription fields
       id: userFeeds.id,
@@ -90,8 +110,11 @@ function buildSubscriptionBaseQuery(db: typeof dbType, userId: string) {
       originalTitle: userFeeds.originalTitle,
       description: userFeeds.description,
       siteUrl: userFeeds.siteUrl,
-      // Unread count from subquery
-      unreadCount: sql<number>`COALESCE(${unreadCountsSubquery.unreadCount}, 0)`,
+      // Unread count from subquery (a literal 0 when skipped — the column stays
+      // declared so the row shape is identical either way)
+      unreadCount: includeUnreadCounts
+        ? sql<number>`COALESCE(${unreadCountsSubquery.unreadCount}, 0)`
+        : sql<number>`0`,
       // Tags aggregated as JSON array
       tags: sql<Array<{ id: string; name: string; color: string | null }>>`
         COALESCE(
@@ -103,7 +126,16 @@ function buildSubscriptionBaseQuery(db: typeof dbType, userId: string) {
       `,
     })
     .from(userFeeds)
-    .leftJoin(unreadCountsSubquery, eq(unreadCountsSubquery.subscriptionId, userFeeds.id))
+    .$dynamic();
+
+  return (
+    includeUnreadCounts
+      ? baseSelect.leftJoin(
+          unreadCountsSubquery,
+          eq(unreadCountsSubquery.subscriptionId, userFeeds.id)
+        )
+      : baseSelect
+  )
     .leftJoin(subscriptionTags, eq(subscriptionTags.subscriptionId, userFeeds.id))
     .leftJoin(tags, eq(tags.id, subscriptionTags.tagId))
     .groupBy(
@@ -117,7 +149,7 @@ function buildSubscriptionBaseQuery(db: typeof dbType, userId: string) {
       userFeeds.originalTitle,
       userFeeds.description,
       userFeeds.siteUrl,
-      unreadCountsSubquery.unreadCount
+      ...(includeUnreadCounts ? [unreadCountsSubquery.unreadCount] : [])
     );
 }
 
@@ -303,9 +335,10 @@ export async function listSubscriptions(
  */
 export async function listAllSubscriptions(
   db: typeof dbType,
-  userId: string
+  userId: string,
+  opts: SubscriptionQueryOptions = {}
 ): Promise<Subscription[]> {
-  const results = await buildSubscriptionBaseQuery(db, userId)
+  const results = await buildSubscriptionBaseQuery(db, userId, opts)
     .where(eq(userFeeds.userId, userId))
     .orderBy(sql`COALESCE(${userFeeds.title}, '') ASC`, userFeeds.id);
   return results.map(formatSubscriptionRow);
@@ -317,9 +350,10 @@ export async function listAllSubscriptions(
 export async function getSubscription(
   db: typeof dbType,
   userId: string,
-  subscriptionId: string
+  subscriptionId: string,
+  opts: SubscriptionQueryOptions = {}
 ): Promise<Subscription> {
-  const results = await buildSubscriptionBaseQuery(db, userId)
+  const results = await buildSubscriptionBaseQuery(db, userId, opts)
     .where(and(eq(userFeeds.id, subscriptionId), eq(userFeeds.userId, userId)))
     .limit(1);
 

--- a/tests/integration/subscriptions.test.ts
+++ b/tests/integration/subscriptions.test.ts
@@ -9,7 +9,14 @@
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { eq } from "drizzle-orm";
 import { db } from "../../src/server/db";
-import { users, feeds, entries, subscriptions, userEntries } from "../../src/server/db/schema";
+import {
+  users,
+  feeds,
+  entries,
+  subscriptions,
+  subscriptionFeeds,
+  userEntries,
+} from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
@@ -1099,5 +1106,54 @@ describe("listAllSubscriptions", () => {
     const userId = await createTestUser();
     const all = await subscriptionsService.listAllSubscriptions(db, userId);
     expect(all).toEqual([]);
+  });
+});
+
+describe("includeUnreadCounts: false (issue #1074)", () => {
+  /**
+   * A user with one subscription and one unread visible entry, so the default
+   * query provably counts it (unreadCount 1) and the opt-out is observable
+   * (unreadCount 0) rather than vacuously matching an empty backlog.
+   */
+  async function createUserWithUnreadEntry(): Promise<{ userId: string; subId: string }> {
+    const userId = await createTestUser();
+    const feedId = await createTestFeed({
+      url: `https://example.com/unread-${userId}.xml`,
+      title: "Counted Feed",
+    });
+    const subId = await createTestSubscription(userId, feedId);
+    // visible_entries maps entries to subscriptions via subscription_feeds
+    await db.insert(subscriptionFeeds).values({ subscriptionId: subId, feedId, userId });
+    const entryId = await createTestEntry(feedId);
+    await db.insert(userEntries).values({ userId, entryId });
+    return { userId, subId };
+  }
+
+  it("listAllSubscriptions returns the same rows with unreadCount pinned to 0", async () => {
+    const { userId } = await createUserWithUnreadEntry();
+
+    const withCounts = await subscriptionsService.listAllSubscriptions(db, userId);
+    const withoutCounts = await subscriptionsService.listAllSubscriptions(db, userId, {
+      includeUnreadCounts: false,
+    });
+
+    // Sanity: the default query actually counts the unread entry.
+    expect(withCounts).toHaveLength(1);
+    expect(withCounts[0].unreadCount).toBe(1);
+
+    // Identical rows apart from the skipped count.
+    expect(withoutCounts).toEqual([{ ...withCounts[0], unreadCount: 0 }]);
+  });
+
+  it("getSubscription returns the same row with unreadCount pinned to 0", async () => {
+    const { userId, subId } = await createUserWithUnreadEntry();
+
+    const withCounts = await subscriptionsService.getSubscription(db, userId, subId);
+    const withoutCounts = await subscriptionsService.getSubscription(db, userId, subId, {
+      includeUnreadCounts: false,
+    });
+
+    expect(withCounts.unreadCount).toBe(1);
+    expect(withoutCounts).toEqual({ ...withCounts, unreadCount: 0 });
   });
 });


### PR DESCRIPTION
Closes #1074. This is step 2 of the sequencing converged on in #1117 ("count-free subscription lookups for GReader/Wallabag — independent, immediate win").

## Problem

The Google Reader `subscription/list` and `subscription/quickadd` endpoints computed per-subscription unread counts and then discarded them — `formatSubscription` never reads `unreadCount`. The count is a grouped aggregate over `visible_entries` that scales with the user's **unread backlog** (potentially thousands of rows), while the subscription listing itself is a bounded scan — so for a user with a real backlog, the discarded aggregate is plausibly the dominant cost of the query. `subscription/list` also ran a separate `countEntries` for the synthetic Saved Articles feed and discarded that too.

## Change

- `buildSubscriptionBaseQuery` takes `includeUnreadCounts` (default **true**). When false, the unread-counts subquery join is omitted entirely and `unreadCount` is selected as a literal `0` — the row shape is identical either way, so no caller-facing type changes.
- `listAllSubscriptions` / `getSubscription` accept and pass through the option; `listSubscriptions` (tRPC/MCP pagination path) is untouched.
- `listGreaderSubscriptions` threads the flag through, also skipping the saved feed's `countEntries` when counts aren't wanted.
- `subscription/list` and `quickadd` pass `includeUnreadCounts: false`; `unread-count` keeps the default and is unchanged.

Every existing caller uses the default, so tRPC `subscriptions.list/get`, MCP, and the `unread-count` endpoint behave exactly as before.

## Testing

- New integration tests seed an unread visible entry and assert the default query counts it (`unreadCount: 1`) while the opt-out returns the identical row with `unreadCount: 0` — for both `listAllSubscriptions` and `getSubscription` (non-vacuous: the flag's effect is observable).
- `pnpm typecheck` clean; full integration suite passes (540 tests); all 18 Google Reader e2e tests pass, including the synthetic Saved Articles flow that exercises both the count-skipping and count-keeping endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)