### PR TITLE
Discord bot: crash-proof event handlers, log silent reaction drops, machine-identity logs

### DIFF
--- a/scripts/discord-bot.ts
+++ b/scripts/discord-bot.ts
@@ -36,6 +36,21 @@ let stopHeartbeat: (() => void) | undefined;
 logger.info("Starting Discord bot", {
   pid: process.pid,
   saveEmoji: process.env.DISCORD_SAVE_EMOJI || "🦁",
+  // Machine identity: makes it obvious in aggregated logs which Fly machine /
+  // process group a line came from, so a machine running the wrong binary
+  // (config drift) is visible at a glance.
+  flyProcessGroup: process.env.FLY_PROCESS_GROUP,
+  flyMachineId: process.env.FLY_MACHINE_ID,
+});
+
+// Surface Node process warnings (deprecations etc.) as structured logs instead
+// of unstructured stderr lines that scroll past in `fly logs`.
+process.on("warning", (warning) => {
+  logger.warn("Node process warning", {
+    name: warning.name,
+    message: warning.message,
+    stack: warning.stack,
+  });
 });
 
 // Start internal metrics server on port 9093 (separate from Next.js/worker)

--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -45,6 +45,10 @@ logger.info("Starting standalone worker", {
   pollIntervalMs,
   concurrency,
   pid: process.pid,
+  // Machine identity: a "Starting standalone worker" line carrying a discord/app
+  // process group is the smoking gun for a machine running the wrong binary.
+  flyProcessGroup: process.env.FLY_PROCESS_GROUP,
+  flyMachineId: process.env.FLY_MACHINE_ID,
 });
 
 // Start internal metrics server on port 9092 (separate from Next.js on 9091)

--- a/src/server/discord/bot.ts
+++ b/src/server/discord/bot.ts
@@ -175,7 +175,9 @@ export async function startDiscordBot(): Promise<void> {
       GatewayIntentBits.GuildMessageReactions,
       GatewayIntentBits.MessageContent,
     ],
-    partials: [Partials.Message, Partials.Reaction],
+    // User partial: guild reaction payloads carry the full member, but DM
+    // reactions from uncached users are silently dropped without it.
+    partials: [Partials.Message, Partials.Reaction, Partials.User],
   });
 
   // Gateway diagnostics. `client.login()` resolves as soon as the token
@@ -233,7 +235,24 @@ export async function startDiscordBot(): Promise<void> {
     if (user.bot) return;
 
     const emoji = reaction.emoji.name;
-    if (emoji !== DISCORD_SAVE_EMOJI) return;
+    if (emoji !== DISCORD_SAVE_EMOJI) {
+      // Users can't react with application emojis (they're only usable by the
+      // bot itself), so the save trigger must be a server emoji whose name
+      // matches DISCORD_SAVE_EMOJI exactly. Log mismatches so a wrong or
+      // renamed server emoji is diagnosable instead of silently ignored.
+      logger.info("Ignoring reaction with non-save emoji", {
+        emoji,
+        emojiId: reaction.emoji.id,
+        expected: DISCORD_SAVE_EMOJI,
+        userId: user.id,
+      });
+      return;
+    }
+
+    logger.info("Save reaction received", {
+      userId: user.id,
+      messageId: reaction.message.id,
+    });
 
     await handleSaveReaction(reaction.message, user);
   });
@@ -418,7 +437,7 @@ async function handleSaveReaction(
   // Look up Lion Reader user
   const resolved = await resolveUser(user.id);
   if (!resolved) {
-    // User hasn't linked their account - silently ignore
+    logger.info("Ignoring save reaction from unlinked Discord user", { discordId: user.id });
     return;
   }
 
@@ -437,7 +456,13 @@ async function handleSaveReaction(
 
   // Extract URLs
   const urls = extractUrls(message.content);
-  if (urls.length === 0) return;
+  if (urls.length === 0) {
+    logger.info("Save reaction message contained no URLs", {
+      messageId: message.id,
+      contentLength: message.content?.length ?? 0,
+    });
+    return;
+  }
 
   // Save each URL
   let hasSuccess = false;

--- a/src/server/discord/bot.ts
+++ b/src/server/discord/bot.ts
@@ -10,6 +10,7 @@
 import {
   Client,
   GatewayIntentBits,
+  MessageFlags,
   Partials,
   REST,
   Routes,
@@ -215,18 +216,25 @@ export async function startDiscordBot(): Promise<void> {
   // Register slash commands
   await registerCommands();
 
-  // Handle slash commands
+  // Handle slash commands.
+  // A rejection from an async event listener is an unhandled promise rejection,
+  // which kills the whole process (Sentry's global handler captures then exits)
+  // — so one failed reply or DB hiccup must not take the bot down.
   client.on("interactionCreate", async (interaction) => {
     if (!interaction.isChatInputCommand()) return;
 
     const { commandName, user } = interaction;
 
-    if (commandName === "link") {
-      await handleLinkCommand(interaction, user);
-    } else if (commandName === "unlink") {
-      await handleUnlinkCommand(interaction, user);
-    } else if (commandName === "status") {
-      await handleStatusCommand(interaction, user);
+    try {
+      if (commandName === "link") {
+        await handleLinkCommand(interaction, user);
+      } else if (commandName === "unlink") {
+        await handleUnlinkCommand(interaction, user);
+      } else if (commandName === "status") {
+        await handleStatusCommand(interaction, user);
+      }
+    } catch (error) {
+      logger.error("Discord command handler failed", { commandName, error });
     }
   });
 
@@ -254,7 +262,16 @@ export async function startDiscordBot(): Promise<void> {
       messageId: reaction.message.id,
     });
 
-    await handleSaveReaction(reaction.message, user);
+    try {
+      await handleSaveReaction(reaction.message, user);
+    } catch (error) {
+      // Same rationale as interactionCreate: a rejection here (e.g. the
+      // resolveUser DB lookup) would otherwise crash the whole bot process.
+      logger.error("Discord save-reaction handler failed", {
+        messageId: reaction.message.id,
+        error,
+      });
+    }
   });
 
   // Watchdog: `client.login()` below resolves on token handshake, not on a live
@@ -349,7 +366,7 @@ async function handleLinkCommand(
       content:
         "Invalid API token. Please check your token and try again.\n\n" +
         "To get a token: Lion Reader → Settings → API Tokens → Create with 'Save articles' scope.",
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -391,14 +408,14 @@ async function handleUnlinkCommand(
       content: hasOAuth
         ? "API token removed. You're still linked via Discord OAuth, so saving will continue to work."
         : "API token removed. You're no longer linked to Lion Reader.",
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
   } else {
     await interaction.reply({
       content: hasOAuth
         ? "You don't have an API token linked, but you're connected via Discord OAuth."
         : "You don't have an API token linked. Use `/link` to connect, or sign in with Discord on the Lion Reader website.",
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
   }
 }
@@ -413,7 +430,7 @@ async function handleStatusCommand(
     const methodText = resolved.method === "oauth" ? "Discord OAuth" : "API token";
     await interaction.reply({
       content: `Your account is linked via ${methodText}. React to messages with ${DISCORD_SAVE_EMOJI} to save articles.`,
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
   } else {
     await interaction.reply({
@@ -421,7 +438,7 @@ async function handleStatusCommand(
         `Your account is not linked. You can:\n` +
         `• Sign in with Discord at Lion Reader (recommended)\n` +
         `• Use \`/link\` with an API token from Settings > API Tokens`,
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
   }
 }

--- a/src/server/discord/bot.ts
+++ b/src/server/discord/bot.ts
@@ -7,6 +7,7 @@
  * 2. Using /link with an API token
  */
 
+import * as Sentry from "@sentry/nextjs";
 import {
   Client,
   GatewayIntentBits,
@@ -234,6 +235,10 @@ export async function startDiscordBot(): Promise<void> {
         await handleStatusCommand(interaction, user);
       }
     } catch (error) {
+      // logger.error only adds a Sentry breadcrumb; capture explicitly so the
+      // error still becomes a Sentry event now that it no longer crashes the
+      // process (where the global handler used to report it).
+      Sentry.captureException(error);
       logger.error("Discord command handler failed", { commandName, error });
     }
   });
@@ -267,6 +272,7 @@ export async function startDiscordBot(): Promise<void> {
     } catch (error) {
       // Same rationale as interactionCreate: a rejection here (e.g. the
       // resolveUser DB lookup) would otherwise crash the whole bot process.
+      Sentry.captureException(error);
       logger.error("Discord save-reaction handler failed", {
         messageId: reaction.message.id,
         error,
@@ -378,7 +384,7 @@ async function handleLinkCommand(
     content:
       `Your Lion Reader account is now linked via API token. ` +
       `React to any message containing a URL with ${DISCORD_SAVE_EMOJI} to save it.`,
-    ephemeral: true,
+    flags: MessageFlags.Ephemeral,
   });
 
   logger.info("Discord user linked via API token", {


### PR DESCRIPTION
## Context

Follow-up to #1119, continuing the broken-reactions investigation. Three findings from production debugging, one fix each:

1. **The bot process silently died and restarted after a reaction** (observed 2026-07-11 ~10:10). Async discord.js event listeners rejecting = unhandled promise rejection = Sentry's global handler captures and **exits the process**. The reaction path called `resolveUser` (DB + Redis) with no try/catch, so one failed query could kill the bot for ~60s until Fly's restart policy rebooted it — with zero logs, indistinguishable from "reaction ignored". Both `interactionCreate` and the save-reaction handler now catch and log instead of dying.

2. **Every non-saving reaction outcome was a silent `return`.** Now each path logs: emoji-name mismatch (with actual vs expected name — key because the configured save emoji is an *application* emoji users can't react with, so the trigger must be a same-named server emoji), unlinked user, and no-URLs-in-message. Also adds `Partials.User` so DM reactions from uncached users reach the handler at all (guild reactions already carried the full member).

3. **A machine claiming `process_group=discord` ran `fetch_feed` jobs for days** and no log line could say which binary was on which machine. Startup logs now stamp `FLY_PROCESS_GROUP` / `FLY_MACHINE_ID`, and Node process warnings (deprecations) are logged structured instead of scrolling by on stderr.

Also replaces the deprecated `ephemeral: true` reply option with `flags: MessageFlags.Ephemeral` (the source of the once-per-process deprecation warning seen in prod).

## Testing

- `pnpm typecheck` passes.
- Handler wiring is discord.js I/O glue verified by review (no internal mocks per project policy); the log-only changes carry no behavior risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)