### PR TITLE
Stop YouTube's intermittent errors from starving feeds for a week

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -629,7 +629,7 @@ Lion Reader has an extensible plugin system (`src/server/plugins/`) that consoli
 
 The registry indexes plugins by hostname for O(1) lookup, then calls the plugin's `matchUrl(url)`; `findWithCapability(url, capability)` returns the first plugin that matches AND declares the capability:
 
-- **`feed`** capability: transform page URLs to feed URLs, clean entry content, transform feed titles (e.g., LessWrong GraphQL API)
+- **`feed`** capability: transform page URLs to feed URLs, clean entry content, transform feed titles (e.g., LessWrong GraphQL API), raise the source's minimum polling interval (e.g., YouTube rate-limit avoidance)
 - **`savedArticle`** capability: fetch full article content for read-it-later, optionally skipping Readability when the source returns clean HTML
 
 `matchUrl` must be selective, not "any URL on my hosts" — a plugin should only match URLs it can actually handle (e.g. LessWrong `/tag/...` pages must return `false` so the caller falls back to normal fetching).

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -280,9 +280,9 @@ The `.well-known/*` OAuth metadata routes and the `/api/mcp` tool surface are **
    - 200 OK: parse feed, process entries
    - 301 Permanent Redirect: track, update URL after 7-day wait period (HTTP-to-HTTPS applied immediately)
    - 302/307 Temporary Redirect: follow without updating URL
-   - 429 Too Many Requests / 5xx: treated as a failure with exponential backoff; when a `Retry-After` header is present it is honored as a floor on the backoff (`max(retryAfterSeconds, backoff)`, capped at the 7-day max), so we never poll earlier than the server asked
-   - 4xx/5xx: increment failures, backoff
-5. Calculate `next_fetch_at` based on Cache-Control (10min with cache hint, 60min default min, 7day max)
+   - 429 Too Many Requests / 5xx: treated as a failure with exponential backoff; when a `Retry-After` header is present it is honored as a floor on the backoff (`max(retryAfterSeconds, backoff)`, capped at the 7-day max), so we never poll earlier than the server asked. 429 backoff is additionally capped at 6 hours (`RATE_LIMIT_MAX_BACKOFF_SECONDS`) — rate limiting means "slow down right now", not "this feed is broken", and the per-IP blocks behind it last hours, not days, so a chronically rate-limited feed must not be starved at the 7-day max (a larger `Retry-After` still wins over the cap)
+   - 4xx/5xx: increment failures, backoff. This includes a 404/410 with no tracked redirect: a single 404 is **not** proof the feed is gone (YouTube returns 404 for all of its feeds for a few hours most days — issue #1114), so instead of jumping straight to a 7-day next fetch, the ordinary backoff ladder applies — it converges to the same 7-day cadence if the 404 persists, and one success resets it. A 404/410 with a tracked redirect URL still applies the redirect immediately
+5. Calculate `next_fetch_at` based on Cache-Control (10min with cache hint, 60min default min, 7day max). A URL plugin can raise the minimum for its source (`FeedCapability.minFetchIntervalSeconds`): YouTube serves `max-age=900` but rate-limits RSS fetches per IP, so its plugin floors polling at 1 hour
 
 ### Feed Types
 
@@ -636,12 +636,13 @@ The registry indexes plugins by hostname for O(1) lookup, then calls the plugin'
 
 ### Available Plugins
 
-| Plugin          | Capabilities           | Description                                        |
-| --------------- | ---------------------- | -------------------------------------------------- |
-| **LessWrong**   | `feed`, `savedArticle` | GraphQL API for posts/comments, user profile feeds |
-| **Google Docs** | `savedArticle`         | Fetch Google Docs content via API                  |
-| **ArXiv**       | `savedArticle`         | Fetch ArXiv paper content                          |
-| **GitHub**      | `savedArticle`         | Fetch GitHub content                               |
+| Plugin          | Capabilities           | Description                                                |
+| --------------- | ---------------------- | ---------------------------------------------------------- |
+| **LessWrong**   | `feed`, `savedArticle` | GraphQL API for posts/comments, user profile feeds         |
+| **Google Docs** | `savedArticle`         | Fetch Google Docs content via API                          |
+| **ArXiv**       | `savedArticle`         | Fetch ArXiv paper content                                  |
+| **GitHub**      | `savedArticle`         | Fetch GitHub content                                       |
+| **YouTube**     | `feed`                 | Polling floor (1h) to avoid YouTube's per-IP rate limiting |
 
 ---
 

--- a/src/server/feed/scheduling.ts
+++ b/src/server/feed/scheduling.ts
@@ -61,6 +61,18 @@ const MAX_CONSECUTIVE_FAILURES = 10;
 const FAILURE_BASE_BACKOFF_SECONDS = 30 * 60; // 1800
 
 /**
+ * Maximum backoff for rate-limited (429) failures: 6 hours.
+ *
+ * A 429 means "you're polling too fast right now", not "this feed is broken",
+ * and the blocks behind it are transient (YouTube's per-IP blocks last hours,
+ * not days — see issue #1114). Letting the ordinary failure ladder escalate a
+ * chronically rate-limited feed to the 7-day max starves it long after the
+ * block has lifted, so rate-limited failures cap out here instead. A larger
+ * server-sent Retry-After still wins over this cap.
+ */
+export const RATE_LIMIT_MAX_BACKOFF_SECONDS = 6 * 60 * 60; // 21600
+
+/**
  * Seconds per syndication period.
  */
 const PERIOD_SECONDS: Record<NonNullable<SyndicationHints["updatePeriod"]>, number> = {
@@ -127,6 +139,22 @@ export interface CalculateNextFetchOptions {
    * Ignored on success (there's no failure to back off from).
    */
   retryAfterSeconds?: number;
+  /**
+   * Whether the current failure is a rate limit (429). Caps the failure
+   * backoff at RATE_LIMIT_MAX_BACKOFF_SECONDS instead of letting it escalate
+   * to the 7-day max — rate limiting is transient, not feed brokenness.
+   * Only meaningful alongside consecutiveFailures > 0.
+   */
+  rateLimited?: boolean;
+  /**
+   * Source-specific minimum interval in seconds (from a URL plugin), raising
+   * the floor on the success-path interval. E.g. YouTube serves
+   * `Cache-Control: max-age=900`, but polling every channel every 15 minutes
+   * is a fast way to get an IP rate-limited, so its plugin floors the
+   * interval at an hour. Never lowers the context minimum, and doesn't
+   * affect failure backoff.
+   */
+  minIntervalSeconds?: number;
   /**
    * Whether WebSub is active for this feed.
    * When true, uses a longer backup polling interval since WebSub
@@ -241,6 +269,8 @@ export function calculateNextFetch(options: CalculateNextFetchOptions = {}): Nex
     feedHints,
     consecutiveFailures = 0,
     retryAfterSeconds,
+    rateLimited = false,
+    minIntervalSeconds,
     websubActive = false,
     now = new Date(),
     randomSource = Math.random,
@@ -253,7 +283,9 @@ export function calculateNextFetch(options: CalculateNextFetchOptions = {}): Nex
   // Retry-After, honor it as a floor so we never poll earlier than asked
   // (capped at the max interval so we always check eventually).
   if (consecutiveFailures > 0) {
-    const backoff = calculateFailureBackoff(consecutiveFailures);
+    const backoff = rateLimited
+      ? Math.min(calculateFailureBackoff(consecutiveFailures), RATE_LIMIT_MAX_BACKOFF_SECONDS)
+      : calculateFailureBackoff(consecutiveFailures);
     if (retryAfterSeconds !== undefined && retryAfterSeconds > backoff) {
       intervalSeconds = Math.min(retryAfterSeconds, MAX_FETCH_INTERVAL_SECONDS);
     } else {
@@ -300,11 +332,13 @@ export function calculateNextFetch(options: CalculateNextFetchOptions = {}): Nex
     // - WebSub active: min 24h (backup polling since we get real-time push)
     // - Cache hint present: min 10min (trust server-provided hints)
     // - Otherwise: min 60min (configurable default)
-    const minInterval = websubActive
+    // A plugin-provided source minimum can raise (never lower) the floor.
+    const contextMinInterval = websubActive
       ? WEBSUB_BACKUP_POLL_INTERVAL_SECONDS
       : effectiveMaxAge !== undefined
         ? MIN_FETCH_INTERVAL_WITH_CACHE_HINT_SECONDS
         : getMinFetchIntervalSeconds();
+    const minInterval = Math.max(contextMinInterval, minIntervalSeconds ?? 0);
 
     if (baseInterval < minInterval) {
       intervalSeconds = minInterval;

--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -371,11 +371,13 @@ async function processSuccessfulFetch(
   // This allows parsedFeed.items (the large part) to be GC'd after processEntries
   let feedTitle = parsedFeed.title;
 
+  const feedPlugin = feed.url ? getFeedPlugin(feed.url) : null;
+
   // Let a matching plugin transform the feed title. For LessWrong user feeds this
   // appends the author name (e.g. "LessWrong - Brendan Long" instead of just
   // "LessWrong"), and automatically updates if the user changes their display name.
   if (feed.url && feedTitle) {
-    const transformTitle = getFeedPlugin(feed.url)?.capabilities.feed.transformFeedTitle;
+    const transformTitle = feedPlugin?.capabilities.feed.transformFeedTitle;
     if (transformTitle) {
       // Isolate plugin failures: a throwing hook must not fail the whole fetch.
       // Fall back to the untransformed title.
@@ -447,6 +449,8 @@ async function processSuccessfulFetch(
       syndication: feedMetadata.syndication,
     },
     consecutiveFailures: 0, // Reset failures on success
+    // Source-specific polling floor (e.g. YouTube's rate-limit-avoiding 1h)
+    minIntervalSeconds: feedPlugin?.capabilities.feed.minFetchIntervalSeconds,
     websubActive: feed.websubActive ?? false,
     now,
   });
@@ -616,6 +620,7 @@ async function processFetchResult(feed: Feed, result: FetchFeedResult): Promise<
         const nextFetch = calculateNextFetch({
           cacheControl: result.cacheHeaders.cacheControl,
           consecutiveFailures: 0,
+          minIntervalSeconds: getFeedPlugin(feed.url)?.capabilities.feed.minFetchIntervalSeconds,
           websubActive: feed.websubActive ?? false,
           now,
         });
@@ -680,6 +685,7 @@ async function processFetchResult(feed: Feed, result: FetchFeedResult): Promise<
       const nextFetch = calculateNextFetch({
         cacheControl: result.cacheHeaders.cacheControl,
         consecutiveFailures: 0,
+        minIntervalSeconds: getFeedPlugin(feed.url)?.capabilities.feed.minFetchIntervalSeconds,
         websubActive: feed.websubActive ?? false,
         now,
       });
@@ -712,55 +718,35 @@ async function processFetchResult(feed: Feed, result: FetchFeedResult): Promise<
     // fetch result — applying a redirect immediately here would contradict that wait.
 
     case "client_error": {
-      if (result.permanent) {
-        // Permanent error (404, 410) - the original URL is broken
-        // If we have a tracked redirect URL, apply it immediately since the original is gone
-        if (feed.redirectUrl) {
-          logger.info("Original URL broken, applying tracked redirect", {
-            feedId: feed.id,
-            originalUrl: feed.url,
-            redirectUrl: feed.redirectUrl,
-            error: result.message,
-          });
-
-          const redirectResult = await applyRedirectMigration(feed, feed.redirectUrl, now);
-          return {
-            success: true,
-            nextRunAt: redirectResult.nextRunAt ?? now,
-            metadata: {
-              ...redirectResult.metadata,
-              originalUrlBroken: true,
-              originalError: result.message,
-            },
-          };
-        }
-
-        // No tracked redirect - schedule far in future but don't stop entirely
-        // The job will remain enabled in case the feed comes back
-        const nextFetch = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000); // 7 days
-
-        await db
-          .update(feeds)
-          .set({
-            lastFetchedAt: now,
-            nextFetchAt: nextFetch,
-            consecutiveFailures: (feed.consecutiveFailures ?? 0) + 1,
-            lastError: result.message,
-            updatedAt: now,
-          })
-          .where(eq(feeds.id, feed.id));
-
-        return {
-          success: false,
-          nextRunAt: nextFetch,
+      if (result.permanent && feed.redirectUrl) {
+        // Permanent error (404, 410) with a tracked redirect URL - the original
+        // URL is broken, so apply the redirect immediately
+        logger.info("Original URL broken, applying tracked redirect", {
+          feedId: feed.id,
+          originalUrl: feed.url,
+          redirectUrl: feed.redirectUrl,
           error: result.message,
+        });
+
+        const redirectResult = await applyRedirectMigration(feed, feed.redirectUrl, now);
+        return {
+          success: true,
+          nextRunAt: redirectResult.nextRunAt ?? now,
           metadata: {
-            permanent: true,
+            ...redirectResult.metadata,
+            originalUrlBroken: true,
+            originalError: result.message,
           },
         };
       }
 
-      // Temporary client error - backoff
+      // All other client errors - exponential backoff. This deliberately
+      // includes "permanent" 404/410 with no tracked redirect: a single 404 is
+      // not proof the feed is gone (YouTube returns 404 for all of its feeds
+      // for a few hours most days — issue #1114), and jumping straight to a
+      // 7-day next fetch turns one poll landing in such a window into a week
+      // of staleness. The backoff ladder reaches the same 7-day cadence
+      // anyway once a feed 404s persistently, and one success resets it.
       return handleTemporaryError(feed, result.message, now);
     }
 
@@ -797,7 +783,10 @@ async function processFetchResult(feed: Feed, result: FetchFeedResult): Promise<
           ? result.retryAfter
           : undefined;
 
-      return handleTemporaryError(feed, errorMessage, now, retryAfterSeconds);
+      return handleTemporaryError(feed, errorMessage, now, {
+        retryAfterSeconds,
+        rateLimited: result.status === "rate_limited",
+      });
     }
 
     default: {
@@ -810,20 +799,23 @@ async function processFetchResult(feed: Feed, result: FetchFeedResult): Promise<
 /**
  * Handles temporary errors by calculating backoff and updating the feed.
  *
- * @param retryAfterSeconds - Server-requested retry delay (Retry-After header),
- *   honored as a floor on the exponential backoff when present.
+ * @param options.retryAfterSeconds - Server-requested retry delay (Retry-After
+ *   header), honored as a floor on the exponential backoff when present.
+ * @param options.rateLimited - Whether the failure was a 429; caps the backoff
+ *   at RATE_LIMIT_MAX_BACKOFF_SECONDS instead of the 7-day max.
  */
 async function handleTemporaryError(
   feed: Feed,
   errorMessage: string,
   now: Date,
-  retryAfterSeconds?: number
+  options: { retryAfterSeconds?: number; rateLimited?: boolean } = {}
 ): Promise<JobHandlerResult> {
   const newFailureCount = (feed.consecutiveFailures ?? 0) + 1;
 
   const nextFetch = calculateNextFetch({
     consecutiveFailures: newFailureCount,
-    retryAfterSeconds,
+    retryAfterSeconds: options.retryAfterSeconds,
+    rateLimited: options.rateLimited,
     websubActive: feed.websubActive ?? false,
     now,
   });

--- a/src/server/plugins/index.ts
+++ b/src/server/plugins/index.ts
@@ -10,6 +10,7 @@ import { lessWrongPlugin } from "./lesswrong";
 import { googleDocsPlugin } from "./google-docs";
 import { arxivPlugin } from "./arxiv";
 import { githubPlugin } from "./github";
+import { youtubePlugin } from "./youtube";
 import { logger } from "@/lib/logger";
 
 // Register all available plugins at module load time
@@ -17,9 +18,16 @@ pluginRegistry.register(lessWrongPlugin);
 pluginRegistry.register(googleDocsPlugin);
 pluginRegistry.register(arxivPlugin);
 pluginRegistry.register(githubPlugin);
+pluginRegistry.register(youtubePlugin);
 
 logger.info("Plugins registered", {
-  plugins: [lessWrongPlugin.name, googleDocsPlugin.name, arxivPlugin.name, githubPlugin.name],
+  plugins: [
+    lessWrongPlugin.name,
+    googleDocsPlugin.name,
+    arxivPlugin.name,
+    githubPlugin.name,
+    youtubePlugin.name,
+  ],
 });
 
 /**

--- a/src/server/plugins/types.ts
+++ b/src/server/plugins/types.ts
@@ -65,6 +65,15 @@ export interface FeedCapability {
    * Falls back to feed's own site name if not provided.
    */
   siteName?: string;
+
+  /**
+   * Minimum polling interval in seconds for feeds from this source, raising
+   * the floor on the scheduler's success-path interval (it never lowers the
+   * context minimum, and failure backoff is unaffected).
+   * E.g. YouTube serves `Cache-Control: max-age=900`, but polling every
+   * channel every 15 minutes is a fast way to get an IP rate-limited.
+   */
+  minFetchIntervalSeconds?: number;
 }
 
 export interface FeedTitleContext {

--- a/src/server/plugins/youtube.ts
+++ b/src/server/plugins/youtube.ts
@@ -1,0 +1,50 @@
+import type { UrlPlugin } from "./types";
+
+/**
+ * Minimum polling interval for YouTube feeds: 1 hour.
+ *
+ * YouTube serves `Cache-Control: max-age=900` on its feeds, which would have
+ * the scheduler poll every subscribed channel every 15 minutes. YouTube also
+ * rate-limits RSS fetches per IP (403/429 blocks lasting hours, worse from
+ * datacenter IPs) and, since late 2025, returns 404 for all feeds for a few
+ * hours most days (see issue #1114 and miniflux/v2#4261). Fetching 4x more
+ * often than hourly buys little — the feed only exposes the latest 15
+ * videos — while multiplying the per-IP request volume that triggers blocks.
+ */
+export const YOUTUBE_MIN_FETCH_INTERVAL_SECONDS = 60 * 60;
+
+/**
+ * YouTube plugin.
+ *
+ * Provides feed capability for YouTube's RSS feeds
+ * (`/feeds/videos.xml?channel_id=...`, `?playlist_id=...`, `?user=...`):
+ * currently just a polling floor so we don't hammer YouTube's aggressively
+ * rate-limited feed endpoint (see YOUTUBE_MIN_FETCH_INTERVAL_SECONDS).
+ *
+ * Note: YouTube supports WebSub push for channel feeds via Google's hub
+ * (https://developers.google.com/youtube/v3/guides/push_notifications), but
+ * the feeds don't advertise it (no rel="hub" link), the pushed payload is a
+ * stub (generic feed title, entries without metadata), and the hub has a
+ * documented history of silently dropping deliveries — so we deliberately
+ * stay on polling instead of hard-coding the hub here.
+ */
+export const youtubePlugin: UrlPlugin = {
+  name: "youtube",
+  hosts: ["www.youtube.com", "youtube.com", "m.youtube.com"],
+
+  matchUrl(url: URL): boolean {
+    // Only feed URLs; watch/channel/etc. pages are handled generically.
+    return (
+      url.pathname === "/feeds/videos.xml" &&
+      (url.searchParams.has("channel_id") ||
+        url.searchParams.has("playlist_id") ||
+        url.searchParams.has("user"))
+    );
+  },
+
+  capabilities: {
+    feed: {
+      minFetchIntervalSeconds: YOUTUBE_MIN_FETCH_INTERVAL_SECONDS,
+    },
+  },
+};

--- a/tests/unit/scheduling.test.ts
+++ b/tests/unit/scheduling.test.ts
@@ -12,6 +12,7 @@ import {
   getMinFetchIntervalSeconds,
   MIN_FETCH_INTERVAL_WITH_CACHE_HINT_SECONDS,
   MAX_FETCH_INTERVAL_SECONDS,
+  RATE_LIMIT_MAX_BACKOFF_SECONDS,
   DEFAULT_FETCH_INTERVAL_SECONDS,
   DEFAULT_JITTER_FRACTION,
   MAX_JITTER_SECONDS,
@@ -514,6 +515,111 @@ describe("calculateNextFetch", () => {
 
       expect(result.intervalSeconds).toBe(7200);
       expect(result.reason).toBe("cache_control");
+    });
+  });
+
+  describe("with rate-limited failures", () => {
+    it("caps rate-limited backoff at 6 hours instead of escalating to 7 days", () => {
+      // 10 ordinary failures would hit the 7-day max; a chronically
+      // rate-limited feed must keep retrying every few hours instead.
+      const result = calculateNextFetch({
+        consecutiveFailures: 10,
+        rateLimited: true,
+        now: fixedNow,
+        randomSource: noJitter,
+      });
+
+      expect(result.intervalSeconds).toBe(RATE_LIMIT_MAX_BACKOFF_SECONDS);
+      expect(result.reason).toBe("failure_backoff");
+    });
+
+    it("uses the ordinary ladder below the cap", () => {
+      const result = calculateNextFetch({
+        consecutiveFailures: 3,
+        rateLimited: true,
+        now: fixedNow,
+        randomSource: noJitter,
+      });
+
+      expect(result.intervalSeconds).toBe(2 * 60 * 60); // 2 hours, same as non-rate-limited
+      expect(result.reason).toBe("failure_backoff");
+    });
+
+    it("honors a Retry-After larger than the rate-limit cap", () => {
+      const result = calculateNextFetch({
+        consecutiveFailures: 10,
+        rateLimited: true,
+        retryAfterSeconds: 12 * 60 * 60,
+        now: fixedNow,
+        randomSource: noJitter,
+      });
+
+      expect(result.intervalSeconds).toBe(12 * 60 * 60);
+      expect(result.reason).toBe("failure_backoff");
+    });
+
+    it("does not cap non-rate-limited failures", () => {
+      const result = calculateNextFetch({
+        consecutiveFailures: 10,
+        rateLimited: false,
+        now: fixedNow,
+        randomSource: noJitter,
+      });
+
+      expect(result.intervalSeconds).toBe(MAX_FETCH_INTERVAL_SECONDS);
+    });
+  });
+
+  describe("with a plugin minimum interval", () => {
+    it("raises the floor above a shorter cache hint", () => {
+      // YouTube's max-age=900 would normally poll every 15 minutes; the
+      // plugin floor holds it at an hour.
+      const result = calculateNextFetch({
+        cacheControl: createCacheControl({ maxAge: 900 }),
+        minIntervalSeconds: 60 * 60,
+        now: fixedNow,
+        randomSource: noJitter,
+      });
+
+      expect(result.intervalSeconds).toBe(60 * 60);
+      expect(result.reason).toBe("cache_control_clamped_min");
+    });
+
+    it("does not lower a longer interval", () => {
+      const result = calculateNextFetch({
+        cacheControl: createCacheControl({ maxAge: 4 * 60 * 60 }),
+        minIntervalSeconds: 60 * 60,
+        now: fixedNow,
+        randomSource: noJitter,
+      });
+
+      expect(result.intervalSeconds).toBe(4 * 60 * 60);
+      expect(result.reason).toBe("cache_control");
+    });
+
+    it("does not shorten the WebSub backup interval", () => {
+      const result = calculateNextFetch({
+        cacheControl: createCacheControl({ maxAge: 900 }),
+        minIntervalSeconds: 60 * 60,
+        websubActive: true,
+        now: fixedNow,
+        randomSource: noJitter,
+      });
+
+      expect(result.intervalSeconds).toBe(24 * 60 * 60);
+      expect(result.reason).toBe("websub_backup");
+    });
+
+    it("does not affect failure backoff", () => {
+      const result = calculateNextFetch({
+        consecutiveFailures: 1,
+        minIntervalSeconds: 60 * 60,
+        now: fixedNow,
+        randomSource: noJitter,
+      });
+
+      expect(result.intervalSeconds).toBe(30 * 60);
+      expect(result.reason).toBe("failure_backoff");
     });
   });
 

--- a/tests/unit/youtube-plugin.test.ts
+++ b/tests/unit/youtube-plugin.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for the YouTube plugin's `feed` capability and the `getFeedPlugin`
+ * resolver. The plugin exists to floor YouTube's aggressive `max-age=900` cache
+ * hint at an hour so we don't trip YouTube's per-IP rate limiting (issue #1114).
+ */
+
+import { describe, it, expect } from "vitest";
+import { youtubePlugin, YOUTUBE_MIN_FETCH_INTERVAL_SECONDS } from "@/server/plugins/youtube";
+import { getFeedPlugin } from "@/server/plugins";
+
+describe("youtubePlugin.matchUrl", () => {
+  it("matches channel, playlist, and legacy user feed URLs", () => {
+    expect(
+      youtubePlugin.matchUrl(
+        new URL("https://www.youtube.com/feeds/videos.xml?channel_id=UCXuqSBlHAE6Xw-yeJA0Tunw")
+      )
+    ).toBe(true);
+    expect(
+      youtubePlugin.matchUrl(
+        new URL("https://www.youtube.com/feeds/videos.xml?playlist_id=PL1234567890")
+      )
+    ).toBe(true);
+    expect(
+      youtubePlugin.matchUrl(new URL("https://www.youtube.com/feeds/videos.xml?user=somename"))
+    ).toBe(true);
+  });
+
+  it("does not match non-feed YouTube URLs", () => {
+    expect(youtubePlugin.matchUrl(new URL("https://www.youtube.com/watch?v=abc123"))).toBe(false);
+    expect(youtubePlugin.matchUrl(new URL("https://www.youtube.com/@somechannel"))).toBe(false);
+    expect(youtubePlugin.matchUrl(new URL("https://www.youtube.com/feeds/videos.xml"))).toBe(false);
+  });
+});
+
+describe("getFeedPlugin resolution for YouTube", () => {
+  it("resolves YouTube feed URLs to the plugin with the polling floor", () => {
+    const plugin = getFeedPlugin(
+      "https://www.youtube.com/feeds/videos.xml?channel_id=UCXuqSBlHAE6Xw-yeJA0Tunw"
+    );
+    expect(plugin?.name).toBe("youtube");
+    expect(plugin?.capabilities.feed.minFetchIntervalSeconds).toBe(
+      YOUTUBE_MIN_FETCH_INTERVAL_SECONDS
+    );
+  });
+
+  it("resolves the bare and mobile hostnames too", () => {
+    expect(getFeedPlugin("https://youtube.com/feeds/videos.xml?channel_id=UCabc")?.name).toBe(
+      "youtube"
+    );
+    expect(getFeedPlugin("https://m.youtube.com/feeds/videos.xml?channel_id=UCabc")?.name).toBe(
+      "youtube"
+    );
+  });
+
+  it("does not resolve non-feed YouTube URLs", () => {
+    expect(getFeedPlugin("https://www.youtube.com/watch?v=abc123")).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #1114.

## Research: what's actually wrong with YouTube RSS

(Full write-up with citations in the session wiki; key sources: [miniflux/v2#4261](https://github.com/miniflux/v2/issues/4261), [FreshRSS#8808](https://github.com/FreshRSS/FreshRSS/issues/8808), [OpenRSS: "YouTube, your feeds are broken"](https://openrss.org/blog/youtube-your-feeds-are-broken).)

- **Since ~Dec 2025, YouTube's `videos.xml` endpoints return 404 for *all* feeds for a few hours most days** (roughly a time-of-day window, hitting residential ISPs too — not just datacenter IPs). This is the dominant failure mode across Miniflux, FreshRSS, and TT-RSS, and in every reader the real damage is done by the reader's own consecutive-failure logic (Miniflux's maintainer's prescribed fix is "never auto-disable").
- Separately, YouTube applies **per-IP 403/429 blocks lasting hours** (worse from datacenter ranges). Its error responses carry **no Retry-After**, its feeds **don't support conditional GET** (no ETag/Last-Modified; If-None-Match returns a full 200), and they serve `Cache-Control: max-age=900` from a shared cache.
- **It is not WebSub**: YouTube feeds advertise no `rel="hub"` link at all (verified live), so WebSub was never active for them — they are pure-polling feeds. Google's hub *can* be hard-coded per the [push notifications docs](https://developers.google.com/youtube/v3/guides/push_notifications), but the pushed payload is a stub (generic feed title, bare entries), pushes race the 15-minute feed cache, and silent non-delivery is repeatedly reported — so this PR deliberately stays on polling; a hard-coded hub could be a follow-up if polling proves insufficient.

## What this maps to in Lion Reader

A 404 was classified as a **permanent** error and immediately scheduled the next fetch **7 days out**. One poll landing in YouTube's daily 404 window ⇒ the feed goes dark for a week. Do that a few times and you get exactly the reported "extremely flaky" behavior. 429s additionally escalated the ordinary failure ladder to the same 7-day max.

## Changes

1. **404/410 without a tracked redirect now uses the ordinary exponential backoff ladder** (30m → 1h → 2h → …) instead of jumping straight to 7 days. The ladder still converges to the 7-day cadence if the 404 persists (a genuinely dead feed ends up polled weekly, same as before), and a single success resets it. The 404-with-tracked-redirect migration path is unchanged.
2. **Rate-limited (429) backoff caps at 6 hours** (`RATE_LIMIT_MAX_BACKOFF_SECONDS`) instead of escalating to 7 days — rate limiting is "slow down", not "broken". A larger server-sent `Retry-After` still wins over the cap.
3. **New YouTube URL plugin + `FeedCapability.minFetchIntervalSeconds`**: YouTube's `max-age=900` had us polling every subscribed channel every 15 minutes — the fastest way to trip its per-IP blocks, for little gain (15-entry window, no conditional GET). The plugin floors YouTube feed polling at 1 hour. The floor only raises the success-path minimum; failure backoff and the WebSub backup interval are unaffected.

## Testing

- `pnpm test:unit` — 2163 passed (new cases: rate-limit cap incl. Retry-After interplay, plugin min-interval floor semantics, YouTube plugin matching/resolution)
- `pnpm test:integration:local` — 576 passed
- `pnpm typecheck`, eslint, prettier clean
- Verified live: YouTube feed headers (`max-age=900`, no ETag/Last-Modified) and absence of any hub link

🤖 Generated with [Claude Code](https://claude.com/claude-code)