### PR TITLE
Stop reading/writing the vestigial entry-scoring columns (#1101, release 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Use the database views for frontend queries instead of manual joins:
 - **`user_feeds`**: Active subscriptions with feed data merged. Use for `subscriptions.list/get/export`. Already filters out unsubscribed entries and resolves title (custom or original).
 - **`visible_entries`**: Entries with visibility rules applied. Use for `entries.list/get/count`. Includes read/starred state and subscription_id. An entry is visible if a `user_entries` row exists for the `(user, entry)` pair AND (the entry is from an active subscription OR is starred OR is a saved article). Privacy gating happens when `user_entries` rows are inserted (subscribe-time / fetch-time), not in the view. See "Entry Visibility" in docs/DESIGN.md.
 
-These views were introduced in `migrations/0035_subscription_views.sql` (current `visible_entries` definition: `migrations/0073_drop_entry_scoring.sql`) and have Drizzle schemas in `src/server/db/schema.ts`.
+These views were introduced in `migrations/0035_subscription_views.sql` (current `visible_entries` definition: `migrations/0087_visible_entries_subscription_id.sql`) and have Drizzle schemas in `src/server/db/schema.ts`.
 
 ## API Conventions
 

--- a/src/components/entries/EntryArticle.tsx
+++ b/src/components/entries/EntryArticle.tsx
@@ -3,7 +3,7 @@
  *
  * Pure presentational component for rendering an article.
  * Extracted from EntryContentBody to be SSR-compatible (no "use client").
- * Interactive features (narration, summarization, voting, etc.) are passed
+ * Interactive features (narration, summarization, etc.) are passed
  * as slots from client components.
  */
 
@@ -46,8 +46,6 @@ export interface EntryArticleProps {
   // Slots for interactive client components
   /** Back button slot (has onClick) */
   backButton?: ReactNode;
-  /** Vote controls slot (score display on right side of title) */
-  voteControls?: ReactNode;
   /** Action buttons slot (star, read, narration, summarize buttons) */
   actionButtons?: ReactNode;
   /** Content inserted before the main article content (e.g., summary card, narration highlight styles) */
@@ -78,7 +76,6 @@ export function EntryArticle({
   isContentLoading,
   contentRef,
   backButton,
-  voteControls,
   actionButtons,
   beforeContent,
   afterContent,
@@ -101,58 +98,49 @@ export function EntryArticle({
 
       {/* Header */}
       <header className="mb-6 sm:mb-8">
-        {/* Title row: title+meta on left, vote controls on right */}
-        <div className="mb-4 flex gap-4 sm:mb-6">
-          {/* Left column: title and meta */}
-          <div className="min-w-0 flex-1">
-            {/* Title */}
-            <div className="mb-2">
-              {url ? (
-                <a
-                  href={url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="ui-text-xl sm:ui-text-2xl hover:text-accent block leading-tight font-bold text-zinc-900 underline-offset-2 transition-colors hover:underline md:text-3xl dark:text-zinc-100"
-                >
-                  {title}
-                </a>
-              ) : (
-                <h1 className="ui-text-xl sm:ui-text-2xl leading-tight font-bold text-zinc-900 md:text-3xl dark:text-zinc-100">
-                  {title}
-                </h1>
-              )}
-            </div>
-
-            {/* Meta row: Source, Author, Date */}
-            <div className="ui-text-xs sm:ui-text-sm flex flex-wrap items-center gap-x-3 gap-y-1 text-zinc-600 sm:gap-x-4 sm:gap-y-2 dark:text-zinc-400">
-              <span className="font-medium">{source}</span>
-              {author && author.toLowerCase().trim() !== source.toLowerCase().trim() && (
-                <>
-                  <span
-                    aria-hidden="true"
-                    className="hidden text-zinc-400 sm:inline dark:text-zinc-600"
-                  >
-                    |
-                  </span>
-                  <span className="hidden sm:inline">by {author}</span>
-                  <span className="sm:hidden">- {author}</span>
-                </>
-              )}
-              <span
-                aria-hidden="true"
-                className="hidden text-zinc-400 sm:inline dark:text-zinc-600"
+        {/* Title and meta */}
+        <div className="mb-4 sm:mb-6">
+          {/* Title */}
+          <div className="mb-2">
+            {url ? (
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ui-text-xl sm:ui-text-2xl hover:text-accent block leading-tight font-bold text-zinc-900 underline-offset-2 transition-colors hover:underline md:text-3xl dark:text-zinc-100"
               >
-                |
-              </span>
-              <time dateTime={date.toISOString()} className="basis-full sm:basis-auto">
-                {datePrefix ? `${datePrefix} ` : ""}
-                {formatDate(date)}
-              </time>
-            </div>
+                {title}
+              </a>
+            ) : (
+              <h1 className="ui-text-xl sm:ui-text-2xl leading-tight font-bold text-zinc-900 md:text-3xl dark:text-zinc-100">
+                {title}
+              </h1>
+            )}
           </div>
 
-          {/* Right column: vote controls slot */}
-          {voteControls}
+          {/* Meta row: Source, Author, Date */}
+          <div className="ui-text-xs sm:ui-text-sm flex flex-wrap items-center gap-x-3 gap-y-1 text-zinc-600 sm:gap-x-4 sm:gap-y-2 dark:text-zinc-400">
+            <span className="font-medium">{source}</span>
+            {author && author.toLowerCase().trim() !== source.toLowerCase().trim() && (
+              <>
+                <span
+                  aria-hidden="true"
+                  className="hidden text-zinc-400 sm:inline dark:text-zinc-600"
+                >
+                  |
+                </span>
+                <span className="hidden sm:inline">by {author}</span>
+                <span className="sm:hidden">- {author}</span>
+              </>
+            )}
+            <span aria-hidden="true" className="hidden text-zinc-400 sm:inline dark:text-zinc-600">
+              |
+            </span>
+            <time dateTime={date.toISOString()} className="basis-full sm:basis-auto">
+              {datePrefix ? `${datePrefix} ` : ""}
+              {formatDate(date)}
+            </time>
+          </div>
         </div>
 
         {/* Action buttons slot */}

--- a/src/components/entries/EntryContent.tsx
+++ b/src/components/entries/EntryContent.tsx
@@ -309,8 +309,6 @@ function EntryContentInner({
   };
 
   // Handle read toggle from entry view
-  // Marking unread sets implicit score signal (+1), marking read does NOT
-  // (only marking read from the entry list sets implicit -1)
   const handleReadToggle = () => {
     if (!entry) return;
     markRead([entryId], !entry.read);

--- a/src/components/entries/EntryListContainer.tsx
+++ b/src/components/entries/EntryListContainer.tsx
@@ -168,14 +168,7 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
   }, [previousEntryId, setOpenEntryId]);
 
   // Entry mutations
-  const { toggleRead: rawToggleRead, toggleStar } = useEntryMutations();
-
-  const handleToggleRead = useCallback(
-    (entryId: string, currentlyRead: boolean) => {
-      rawToggleRead(entryId, currentlyRead, true);
-    },
-    [rawToggleRead]
-  );
+  const { toggleRead, toggleStar } = useEntryMutations();
 
   // Entry click handler
   const handleEntryClick = useCallback(
@@ -201,7 +194,7 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
     isEntryOpen: !!openEntryId,
     openEntryId,
     enabled: keyboardShortcutsEnabled,
-    onToggleRead: handleToggleRead,
+    onToggleRead: toggleRead,
     onToggleStar: toggleStar,
     onRefresh: () => utils.entries.list.invalidate(),
     onToggleUnreadOnly: toggleShowUnreadOnly,
@@ -258,7 +251,7 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
       onEntryClick={handleEntryClick}
       onEntryMouseDown={handleEntryMouseDown}
       selectedEntryId={selectedEntryId}
-      onToggleRead={handleToggleRead}
+      onToggleRead={toggleRead}
       onToggleStar={toggleStar}
       externalEntries={entries}
       externalQueryState={externalQueryState}

--- a/src/components/settings/pages/DeleteAccountSettingsContent.tsx
+++ b/src/components/settings/pages/DeleteAccountSettingsContent.tsx
@@ -81,8 +81,8 @@ export default function DeleteAccountSettingsContent() {
           </p>
           <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">
             This will delete your subscriptions, reading history, starred items, tags, saved
-            articles, email ingest addresses, score models, AI summaries, sessions, API tokens, and
-            all other account data.
+            articles, email ingest addresses, AI summaries, sessions, API tokens, and all other
+            account data.
           </p>
           <div className="mt-4">
             <Button

--- a/src/lib/cache/entry-cache.ts
+++ b/src/lib/cache/entry-cache.ts
@@ -55,8 +55,6 @@ export function updateEntriesInListCache(
   updates: Partial<{
     read: boolean;
     starred: boolean;
-    score: number | null;
-    implicitScore: number;
   }>
 ): void {
   const entryIdSet = new Set(entryIds);

--- a/src/lib/hooks/useEntryMutations.ts
+++ b/src/lib/hooks/useEntryMutations.ts
@@ -53,15 +53,13 @@ export interface MarkAllReadOptions {
 export interface UseEntryMutationsResult {
   /**
    * Mark one or more entries as read or unread.
-   * @param fromList - If true, sets implicit score signal (mark-read-on-list)
    */
-  markRead: (ids: string[], read: boolean, fromList?: boolean) => void;
+  markRead: (ids: string[], read: boolean) => void;
 
   /**
    * Toggle the read status of an entry.
-   * @param fromList - If true, sets implicit score signal (mark-read-on-list)
    */
-  toggleRead: (entryId: string, currentlyRead: boolean, fromList?: boolean) => void;
+  toggleRead: (entryId: string, currentlyRead: boolean) => void;
 
   /**
    * Mark all entries as read with optional filters.
@@ -261,7 +259,6 @@ export function useEntryMutations(): UseEntryMutationsResult {
   };
 
   // markRead mutation - uses optimistic updates for instant UI feedback
-  // Also updates score cache since marking read/unread sets implicit signal flags
   const markReadMutation = trpc.entries.markRead.useMutation({
     // Optimistic update: immediately update the UI before server responds
     onMutate: async (variables) => {
@@ -359,7 +356,6 @@ export function useEntryMutations(): UseEntryMutationsResult {
   });
 
   // setStarred mutation - uses optimistic updates for instant UI feedback
-  // Also updates score cache since starring sets hasStarred implicit signal
   const setStarredMutation = trpc.entries.setStarred.useMutation({
     // Optimistic update: immediately show the entry with new starred status
     onMutate: async (variables) => {
@@ -419,23 +415,21 @@ export function useEntryMutations(): UseEntryMutationsResult {
 
   // Generate timestamp at action time for idempotent updates
   const markRead = useCallback(
-    (ids: string[], read: boolean, fromList?: boolean) => {
+    (ids: string[], read: boolean) => {
       const changedAt = new Date();
       markReadMutation.mutate({
         entries: ids.map((id) => ({ id, changedAt })),
         read,
-        fromList: fromList || undefined,
       });
     },
     [markReadMutation]
   );
 
   const toggleRead = useCallback(
-    (entryId: string, currentlyRead: boolean, fromList?: boolean) => {
+    (entryId: string, currentlyRead: boolean) => {
       markReadMutation.mutate({
         entries: [{ id: entryId, changedAt: new Date() }],
         read: !currentlyRead,
-        fromList: fromList || undefined,
       });
     },
     [markReadMutation]

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -673,15 +673,10 @@ export const userEntries = pgTable(
     read: boolean("read").notNull().default(false),
     starred: boolean("starred").notNull().default(false),
 
-    // Explicit score: user-voted score (-2 to +2), null means no vote
-    score: smallint("score"),
-    scoreChangedAt: timestamp("score_changed_at", { withTimezone: true }),
-
-    // Implicit signal flags - track user actions that imply interest/disinterest
-    // Priority for implicit score: starred (+2) > saved (+1) > read-on-list (-1) > default (0)
-    hasMarkedReadOnList: boolean("has_marked_read_on_list").notNull().default(false),
-    hasMarkedUnread: boolean("has_marked_unread").notNull().default(false),
-    hasStarred: boolean("has_starred").notNull().default(false),
+    // The vestigial entry-scoring columns (score, score_changed_at,
+    // has_marked_read_on_list, has_marked_unread, has_starred) still exist in
+    // the database but are no longer read or written (issue #1101); they are
+    // dropped in a follow-up release.
 
     // Timestamps for idempotent updates - tracks when each field was last set
     // Used for conditional updates: only apply if incoming timestamp is newer
@@ -770,7 +765,7 @@ export const userFeeds = pgView("user_feeds", {
  *    OR it is a saved article (saved feeds have no subscription rows)
  *
  * Note: This view is defined in migration 0035_subscription_views.sql
- * (most recently redefined in 0073_drop_entry_scoring.sql).
+ * (most recently redefined in 0087_visible_entries_subscription_id.sql).
  * The Drizzle definition here allows type-safe queries against the view.
  */
 export const visibleEntries = pgView("visible_entries", {
@@ -805,10 +800,9 @@ export const visibleEntries = pgView("visible_entries", {
   fullContentError: text("full_content_error"),
   read: boolean("read").notNull(),
   starred: boolean("starred").notNull(),
-  score: smallint("score"),
-  hasMarkedReadOnList: boolean("has_marked_read_on_list").notNull(),
-  hasMarkedUnread: boolean("has_marked_unread").notNull(),
-  hasStarred: boolean("has_starred").notNull(),
+  // The view also still selects the vestigial scoring columns (score, has_*);
+  // they are deliberately omitted here so nothing can reference them before
+  // they are removed from the view in a follow-up release (issue #1101).
   subscriptionId: uuid("subscription_id"), // nullable - null for orphaned starred entries
   unsubscribeUrl: text("unsubscribe_url"), // extracted from email HTML body
   readChangedAt: timestamp("read_changed_at", { withTimezone: true }),

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -313,8 +313,7 @@ const entryFullSelectFields = {
 
 /**
  * Superset selected by `selectFullEntry` for the tRPC full-entry view: adds
- * the full-content family, score-signal flags, and the subscription's
- * fetchFullContent setting.
+ * the full-content family and the subscription's fetchFullContent setting.
  */
 const fullEntrySelectFields = {
   ...entryFullSelectFields,
@@ -328,9 +327,6 @@ const fullEntrySelectFields = {
   fullContentFetchedAt: visibleEntries.fullContentFetchedAt,
   fullContentError: visibleEntries.fullContentError,
   contentHash: visibleEntries.contentHash,
-  hasMarkedReadOnList: visibleEntries.hasMarkedReadOnList,
-  hasMarkedUnread: visibleEntries.hasMarkedUnread,
-  hasStarred: visibleEntries.hasStarred,
   fetchFullContent: subscriptions.fetchFullContent,
 };
 
@@ -488,12 +484,6 @@ export async function toFullEntry(
   row: NonNullable<Awaited<ReturnType<typeof selectFullEntry>>>
 ) {
   const {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    hasStarred,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    hasMarkedUnread,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    hasMarkedReadOnList,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     contentHash,
     contentOriginalSanitized,
@@ -949,10 +939,6 @@ export async function getEntries(
  * read_changed_at timestamp. This prevents stale updates from overwriting newer
  * state. Supports per-entry timestamps for offline sync.
  *
- * Sets the implicit signal flags (vestiges of the removed entry-scoring feature):
- * - `has_marked_unread` whenever marking unread
- * - `has_marked_read_on_list` when marking read with `fromList`
- *
  * Returns the final state for all requested entries (with the context fields
  * callers need for cache updates) plus the absolute unread counts for every
  * affected list. Counts are computed once here and both returned and published,
@@ -982,8 +968,6 @@ export async function getEntries(
  * `changed`+`counts` itself after the commit, so a rolled-back mark can't emit
  * a phantom event.
  *
- * @param options.fromList - Whether the mark-read originated from the entry list
- *   (weak negative signal). Only meaningful when marking read.
  * @param options.publish - Whether to publish `entry_state_changed` events here
  *   (default true). Pass false when calling inside a transaction and publish the
  *   returned `changed`/`counts` after the commit.
@@ -993,7 +977,7 @@ export async function markEntriesRead(
   userId: string,
   entriesToMark: MarkReadEntry[],
   read: boolean,
-  options: { fromList?: boolean; publish?: boolean } = {}
+  options: { publish?: boolean } = {}
 ): Promise<{
   entries: MarkReadEntryState[];
   changed: MarkReadEntryState[];
@@ -1024,17 +1008,9 @@ export async function markEntriesRead(
     (entry) => sql`(${entry.id}::uuid, ${(entry.changedAt ?? now).toISOString()}::timestamptz)`
   );
 
-  // Implicit score-signal flag, identical for every entry in this call.
-  const signalAssignment =
-    read && options.fromList
-      ? sql`, has_marked_read_on_list = true` // marking read from the list → implicit -1
-      : !read
-        ? sql`, has_marked_unread = true` // marking unread → implicit 0 (overrides read-on-list)
-        : sql``;
-
   const updated = await db.execute<{ entry_id: string; old_read: boolean }>(sql`
     UPDATE user_entries AS ue
-    SET read = ${read}, updated_at = ${now}, read_changed_at = v.ts${signalAssignment}
+    SET read = ${read}, updated_at = ${now}, read_changed_at = v.ts
     FROM (VALUES ${sql.join(rows, sql`, `)}) AS v(entry_id, ts)
     JOIN user_entries AS prev
       ON prev.user_id = ${userId}::uuid
@@ -1258,9 +1234,6 @@ export async function markAllEntriesRead(
  * Uses idempotent updates: only applies if changedAt is newer than the stored
  * starred_changed_at timestamp. This prevents stale updates from overwriting newer state.
  *
- * Sets the `has_starred` implicit signal flag when starring (a vestige of the
- * removed entry-scoring feature).
- *
  * Returns the entry's final state plus the absolute unread counts for every
  * affected list. Counts are computed once here and both returned and published,
  * so callers don't re-query them.
@@ -1295,9 +1268,6 @@ export async function updateEntryStarred(
   starred: boolean,
   changedAt: Date = new Date()
 ): Promise<{ entry: EntryState; counts?: UnreadCounts }> {
-  // Implicit score-signal flag, set only when starring.
-  const signalAssignment = starred ? sql`, has_starred = true` : sql``;
-
   // Conditional update: only apply if incoming timestamp is newer or equal
   // (starred_changed_at is NOT NULL with a default, so no NULL guard needed).
   // Date params bind un-cast here because SET/WHERE column context supplies the
@@ -1309,7 +1279,7 @@ export async function updateEntryStarred(
   // pre-SELECT and its wider TOCTOU window.
   const updated = await db.execute<{ old_starred: boolean }>(sql`
     UPDATE user_entries AS ue
-    SET starred = ${starred}, starred_changed_at = ${changedAt}, updated_at = ${new Date()}${signalAssignment}
+    SET starred = ${starred}, starred_changed_at = ${changedAt}, updated_at = ${new Date()}
     FROM user_entries AS prev
     WHERE ue.user_id = ${userId}::uuid
       AND ue.entry_id = ${entryId}::uuid

--- a/src/server/trpc/routers/entries.ts
+++ b/src/server/trpc/routers/entries.ts
@@ -356,8 +356,6 @@ export const entriesRouter = createTRPCRouter({
           .min(1, "At least one entry is required")
           .max(1000, "Maximum 1000 entries per request"),
         read: z.boolean(),
-        // Implicit score signal: set when marking read from the entry list
-        fromList: z.boolean().optional(),
       })
     )
     .output(
@@ -391,8 +389,7 @@ export const entriesRouter = createTRPCRouter({
         ctx.db,
         userId,
         input.entries,
-        input.read,
-        { fromList: input.fromList }
+        input.read
       );
 
       return {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -180,7 +180,7 @@ export async function starEntry(db: TestDb, userId: string, entryId: string): Pr
   const now = new Date();
   await db
     .update(schema.userEntries)
-    .set({ starred: true, hasStarred: true, starredChangedAt: now, updatedAt: now })
+    .set({ starred: true, starredChangedAt: now, updatedAt: now })
     .where(and(eq(schema.userEntries.userId, userId), eq(schema.userEntries.entryId, entryId)));
 }
 

--- a/tests/integration/entries-perf.test.ts
+++ b/tests/integration/entries-perf.test.ts
@@ -461,7 +461,7 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
       // 2. visible_entries lookup for one entry
       const { timing: t2 } = await timeAsync("visible_entries single entry", () =>
         db.execute(sql`
-          SELECT ve.id, ve.read, ve.starred, ve.updated_at, ve.score, ve.subscription_id, ve.type
+          SELECT ve.id, ve.read, ve.starred, ve.updated_at, ve.subscription_id, ve.type
           FROM visible_entries ve
           WHERE ve.user_id = ${testUserId} AND ve.id = ${entryId}
         `)
@@ -472,7 +472,7 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
       const tenIds = testEntryIds.slice(0, 10);
       const { timing: t3 } = await timeAsync("visible_entries 10 entries", () =>
         db.execute(sql`
-          SELECT ve.id, ve.read, ve.starred, ve.updated_at, ve.score, ve.subscription_id, ve.type
+          SELECT ve.id, ve.read, ve.starred, ve.updated_at, ve.subscription_id, ve.type
           FROM visible_entries ve
           WHERE ve.user_id = ${testUserId} AND ve.id = ANY(${pgUuidArray(tenIds)}::uuid[])
         `)
@@ -595,7 +595,7 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
       const entryId = testEntryIds[0];
       const result = await db.execute(sql`
         EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
-        SELECT ve.id, ve.read, ve.starred, ve.updated_at, ve.score, ve.subscription_id, ve.type
+        SELECT ve.id, ve.read, ve.starred, ve.updated_at, ve.subscription_id, ve.type
         FROM visible_entries ve
         WHERE ve.user_id = ${testUserId} AND ve.id = ${entryId}
       `);
@@ -717,7 +717,6 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
           caller.entries.markRead({
             entries: [{ id: entryId }],
             read: true,
-            fromList: true,
           })
         );
         timings.push(timing);
@@ -743,7 +742,6 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
           caller.entries.markRead({
             entries: entryIds.map((id) => ({ id })),
             read: true,
-            fromList: true,
           })
         );
         timings.push(timing);
@@ -762,7 +760,6 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
         caller.entries.markRead({
           entries: entryIds.map((id) => ({ id })),
           read: true,
-          fromList: true,
         })
       );
 
@@ -784,7 +781,7 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
       const { timing: t1 } = await timeAsync("1. UPDATE user_entries", () =>
         db.execute(sql`
           UPDATE user_entries
-          SET starred = true, starred_changed_at = now(), updated_at = now(), has_starred = true
+          SET starred = true, starred_changed_at = now(), updated_at = now()
           WHERE user_id = ${testUserId} AND entry_id = ${entryId}
             AND starred_changed_at <= now()
         `)
@@ -794,8 +791,7 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
       // Step 2: SELECT from visible_entries (get final state)
       const { timing: t2 } = await timeAsync("2. SELECT visible_entries (1 entry)", () =>
         db.execute(sql`
-          SELECT id, read, starred, updated_at, score, has_marked_read_on_list,
-                 has_marked_unread, has_starred, type
+          SELECT id, read, starred, updated_at, type
           FROM visible_entries
           WHERE user_id = ${testUserId} AND id = ${entryId}
         `)
@@ -897,7 +893,7 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
       const { timing: t1 } = await timeAsync("1. UPDATE user_entries (10 entries)", () =>
         db.execute(sql`
           UPDATE user_entries
-          SET read = true, read_changed_at = now(), updated_at = now(), has_marked_read_on_list = true
+          SET read = true, read_changed_at = now(), updated_at = now()
           WHERE user_id = ${testUserId} AND entry_id = ANY(${pgUuidArray(entryIds)}::uuid[])
             AND read_changed_at <= now()
         `)
@@ -909,8 +905,7 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
         "2. SELECT visible_entries (10 entries)",
         () =>
           db.execute(sql`
-          SELECT id, subscription_id, read, starred, type, updated_at, score,
-                 has_marked_read_on_list, has_marked_unread, has_starred
+          SELECT id, subscription_id, read, starred, type, updated_at
           FROM visible_entries
           WHERE user_id = ${testUserId} AND id = ANY(${pgUuidArray(entryIds)}::uuid[])
         `)

--- a/tests/utils/cache-test-helpers.ts
+++ b/tests/utils/cache-test-helpers.ts
@@ -57,10 +57,7 @@ export interface SeededEntry {
   read: boolean;
   starred: boolean;
   feedTitle: string | null;
-  score: number | null;
-  implicitScore: number;
   siteName: string | null;
-  predictedScore: number | null;
 }
 
 // ============================================================================
@@ -164,10 +161,7 @@ export const DEFAULT_ENTRIES: SeededEntry[] = [
     read: false,
     starred: true,
     feedTitle: "Feed One",
-    score: null,
-    implicitScore: 0,
     siteName: null,
-    predictedScore: null,
   },
   {
     id: "entry-2",
@@ -184,10 +178,7 @@ export const DEFAULT_ENTRIES: SeededEntry[] = [
     read: false,
     starred: false,
     feedTitle: "Feed One",
-    score: null,
-    implicitScore: 0,
     siteName: null,
-    predictedScore: null,
   },
   {
     id: "entry-3",
@@ -204,10 +195,7 @@ export const DEFAULT_ENTRIES: SeededEntry[] = [
     read: true,
     starred: false,
     feedTitle: "Feed Two",
-    score: null,
-    implicitScore: 0,
     siteName: null,
-    predictedScore: null,
   },
   {
     id: "entry-saved",
@@ -224,10 +212,7 @@ export const DEFAULT_ENTRIES: SeededEntry[] = [
     read: false,
     starred: false,
     feedTitle: null,
-    score: null,
-    implicitScore: 0,
     siteName: null,
-    predictedScore: null,
   },
   {
     id: "entry-starred-orphan",
@@ -244,10 +229,7 @@ export const DEFAULT_ENTRIES: SeededEntry[] = [
     read: false,
     starred: true,
     feedTitle: "Old Feed",
-    score: null,
-    implicitScore: 0,
     siteName: null,
-    predictedScore: null,
   },
 ];
 


### PR DESCRIPTION
## Summary

Release 1 of the expand/contract cleanup for #1101: delete every remaining read and write of the vestigial ML entry-scoring columns on `user_entries` (`score`, `score_changed_at`, `has_marked_read_on_list`, `has_marked_unread`, `has_starred`), left behind when the feature was removed in #953 / migration `0073`.

- **`markEntriesRead`**: removed the `has_marked_read_on_list`/`has_marked_unread` SET clauses and the `fromList` option that existed only to feed them — removed end-to-end (tRPC `entries.markRead` input, `useEntryMutations` `markRead`/`toggleRead` params, and `EntryListContainer`'s wrapper that passed `fromList: true`). This also fixes the confusion noted in #1082 where a system-triggered unread flip set a dead signal flag.
- **`updateEntryStarred`**: removed the `has_starred` SET clause.
- **`selectFullEntry`/`toFullEntry`**: stopped selecting the `has_*` view columns just to destructure-and-discard them.
- **Drizzle schema**: removed the five columns from `userEntries` and the four vestigial columns from the `visibleEntries` view definition, with comments noting the DB columns/view columns remain until the follow-up migration.
- **Frontend**: removed the never-passed `score`/`implicitScore` fields from `updateEntriesInListCache` and stale "score cache"/"implicit signal" comments; dropped the "score models" mention from the delete-account copy (that table was dropped in #953). The `hasStarred` parameter in `shouldUpdateEntryListCache` is a real "is this entry starred" flag (naming collision) and is untouched, per the issue.
- **Tests**: removed the vestiges from the perf test's raw-SQL mirrors, the cache test fixtures (`score`/`implicitScore`/`predictedScore`), and the e2e `starEntry` helper.
- **Docs**: updated CLAUDE.md/schema comments that pointed at `0073` as the current `visible_entries` definition (it's `0087` now).

## Why no migration in this PR

The issue's plan put the `visible_entries` rebuild in release 1, but that would break the expand/contract rule: migrations run in `release_command` **before** the canary deploy, and the currently-deployed release still selects `has_marked_read_on_list`/`has_marked_unread`/`has_starred` from the view (in `fullEntrySelectFields`), so dropping those view columns now would 500 `entries.get` on old machines during rollout (and after a rollback). Once this release is deployed, a follow-up release ships one migration that rebuilds the view without `score`/`has_*` and `DROP COLUMN`s the five `user_entries` columns.

## Testing

- `pnpm typecheck`, `pnpm lint`
- `pnpm test:unit` (2163 passed)
- `pnpm test:integration:local` (576 passed)
- `pnpm test:e2e:local` (39 passed)

Closes nothing yet — #1101 stays open for the release-2 migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)