### PR TITLE
Consolidate duplicated frontend styles into shared components (#1016)

### DIFF
--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -15,8 +15,11 @@ Reusable UI primitives are in `src/components/ui/`. **Always check for existing 
 | **Alert**             | Status messages (error, success, warning, info)           |
 | **Dialog**            | Modal dialogs with backdrop, focus trap, escape handling  |
 | **Card**              | Container with border, background, and consistent padding |
+| **CardSection**       | Subsection within a Card, separated by a top border       |
 | **StatusCard**        | Colored card for info/success/warning/error states        |
 | **ClientLink**        | Internal navigation links (use instead of Next.js Link)   |
+| **TextLink**          | Accent-colored inline text link (`external` for new tab)  |
+| **InlineCode**        | Small monospace chip for inline code, URLs, file names    |
 | **NavLink**           | Sidebar navigation links with active state and counts     |
 | **IconButton**        | Small icon-only action buttons (edit, close, etc.)        |
 | **NotFoundCard**      | Card for 404/missing content states                       |
@@ -49,6 +52,10 @@ Icons are in `@/components/ui/icon-button`. Use these instead of duplicating SVG
 - `ui-text-lg` - Large text (headings)
 
 The `ui-text-*` classes are defined in `src/app/globals.css` and provide responsive scaling.
+
+### Settings Sections
+
+Settings pages are built from `SettingsSection` (`@/components/settings/SettingsSection`), which renders the standard heading + `Card` shell and handles loading/error/success states. Don't hand-roll the `<section><h2>…</h2><div className="rounded-lg border …">` pattern — use `SettingsSection`, or `SettingsSectionHeading` + `Card` when the content doesn't fit the wrapper.
 
 ### Guidelines
 

--- a/src/components/narration/NarrationSettings.tsx
+++ b/src/components/narration/NarrationSettings.tsx
@@ -11,7 +11,9 @@
 import { useState, useEffect, useCallback, useSyncExternalStore } from "react";
 import dynamic from "next/dynamic";
 import { Button } from "@/components/ui/button";
+import { CardSection } from "@/components/ui/card";
 import { AlertIcon, InfoCircleIcon } from "@/components/ui/icon-button";
+import { SettingsSection } from "@/components/settings/SettingsSection";
 import { useNarrationSettings } from "@/lib/narration/settings";
 import { getNarrationSupportInfo, isFirefox } from "@/lib/narration/feature-detection";
 import { waitForVoices, rankVoices, findVoiceByUri } from "@/lib/narration/voices";
@@ -161,245 +163,262 @@ export function NarrationSettings() {
   // Show loading skeleton while checking support (avoids hydration mismatch)
   if (supportInfo === null) {
     return (
-      <section>
-        <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">Narration</h2>
-        <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-          <div className="flex items-center justify-between">
-            <div>
-              <div className="h-5 w-32 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-              <div className="mt-2 h-4 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-            </div>
-            <div className="h-6 w-11 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-700" />
+      <SettingsSection title="Narration">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="h-5 w-32 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+            <div className="mt-2 h-4 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
           </div>
+          <div className="h-6 w-11 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-700" />
         </div>
-      </section>
+      </SettingsSection>
     );
   }
 
   // Show unsupported message if narration is not available
   if (!supportInfo.supported) {
     return (
-      <section>
-        <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">Narration</h2>
-        <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-          <div className="flex items-start gap-3">
-            <AlertIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-zinc-400 dark:text-zinc-500" />
-            <div>
-              <p className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                Narration Unavailable
-              </p>
-              <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
-                {supportInfo.reason}
-              </p>
-              <p className="ui-text-xs mt-2 text-zinc-400 dark:text-zinc-500">
-                Try using Chrome, Safari, or Edge for the best narration experience.
-              </p>
-            </div>
+      <SettingsSection title="Narration">
+        <div className="flex items-start gap-3">
+          <AlertIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-zinc-400 dark:text-zinc-500" />
+          <div>
+            <p className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
+              Narration Unavailable
+            </p>
+            <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">{supportInfo.reason}</p>
+            <p className="ui-text-xs mt-2 text-zinc-400 dark:text-zinc-500">
+              Try using Chrome, Safari, or Edge for the best narration experience.
+            </p>
           </div>
         </div>
-      </section>
+      </SettingsSection>
     );
   }
 
   return (
-    <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">Narration</h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        {/* Enable/Disable Toggle */}
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
-              Enable narration
-            </h3>
-            <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
-              Listen to articles using text-to-speech.
-            </p>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={settings.enabled}
-            onClick={() => setSettings((prev) => ({ ...prev, enabled: !prev.enabled }))}
-            className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
-              settings.enabled ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
-            }`}
-          >
-            <span
-              aria-hidden="true"
-              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
-                settings.enabled ? "translate-x-5" : "translate-x-0"
-              }`}
-            />
-          </button>
+    <SettingsSection title="Narration">
+      {/* Enable/Disable Toggle */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
+            Enable narration
+          </h3>
+          <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+            Listen to articles using text-to-speech.
+          </p>
         </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={settings.enabled}
+          onClick={() => setSettings((prev) => ({ ...prev, enabled: !prev.enabled }))}
+          className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
+            settings.enabled ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
+          }`}
+        >
+          <span
+            aria-hidden="true"
+            className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
+              settings.enabled ? "translate-x-5" : "translate-x-0"
+            }`}
+          />
+        </button>
+      </div>
 
-        {/* Voice Settings (only shown when enabled) */}
-        {settings.enabled && (
-          <div className="mt-6 space-y-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
-            {/* Voice Provider Selection */}
-            <div>
-              <h3 className="ui-text-sm mb-3 font-medium text-zinc-900 dark:text-zinc-50">
-                Voice Provider
-              </h3>
-              <div className="space-y-3">
-                {/* Browser Voices Option */}
-                <label
-                  className={`relative flex cursor-pointer rounded-lg border p-4 transition-colors ${
-                    settings.provider === "browser"
-                      ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
-                      : "border-zinc-200 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50"
-                  }`}
-                >
-                  <input
-                    type="radio"
-                    name="voice-provider"
-                    value="browser"
-                    checked={settings.provider === "browser"}
-                    onChange={() => handleProviderChange("browser")}
-                    className="sr-only"
-                  />
-                  <div className="flex items-start gap-3">
-                    <div
-                      className={`mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border ${
-                        settings.provider === "browser"
-                          ? "border-zinc-900 dark:border-zinc-400"
-                          : "border-zinc-400 dark:border-zinc-500"
-                      }`}
-                    >
-                      {settings.provider === "browser" && (
-                        <div className="h-2 w-2 rounded-full bg-zinc-900 dark:bg-zinc-400" />
-                      )}
-                    </div>
-                    <div>
-                      <span className="ui-text-sm block font-medium text-zinc-900 dark:text-zinc-100">
-                        Browser Voices
-                      </span>
-                      <span className="ui-text-xs mt-0.5 block text-zinc-500 dark:text-zinc-400">
-                        Uses your browser&apos;s built-in text-to-speech
-                      </span>
-                    </div>
-                  </div>
-                </label>
-
-                {/* Enhanced Voices Option */}
-                <label
-                  className={`relative flex cursor-pointer rounded-lg border p-4 transition-colors ${
-                    settings.provider === "piper"
-                      ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
-                      : "border-zinc-200 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50"
-                  }`}
-                >
-                  <input
-                    type="radio"
-                    name="voice-provider"
-                    value="piper"
-                    checked={settings.provider === "piper"}
-                    onChange={() => handleProviderChange("piper")}
-                    className="sr-only"
-                  />
-                  <div className="flex items-start gap-3">
-                    <div
-                      className={`mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border ${
-                        settings.provider === "piper"
-                          ? "border-zinc-900 dark:border-zinc-400"
-                          : "border-zinc-400 dark:border-zinc-500"
-                      }`}
-                    >
-                      {settings.provider === "piper" && (
-                        <div className="h-2 w-2 rounded-full bg-zinc-900 dark:bg-zinc-400" />
-                      )}
-                    </div>
-                    <div>
-                      <span className="ui-text-sm block font-medium text-zinc-900 dark:text-zinc-100">
-                        Enhanced Voices
-                      </span>
-                      <span className="ui-text-xs mt-0.5 block text-zinc-500 dark:text-zinc-400">
-                        Higher quality voices (requires download)
-                      </span>
-                    </div>
-                  </div>
-                </label>
-              </div>
-            </div>
-
-            {/* Browser Voice Selector (only shown when browser provider selected) */}
-            {settings.provider === "browser" && (
-              <div>
-                <label
-                  htmlFor="narration-voice"
-                  className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
-                >
-                  Voice
-                </label>
-                <div className="flex gap-3">
-                  <select
-                    id="narration-voice"
-                    value={settings.voiceId || ""}
-                    onChange={handleVoiceChange}
-                    disabled={isLoadingVoices}
-                    className="ui-text-sm block flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+      {/* Voice Settings (only shown when enabled) */}
+      {settings.enabled && (
+        <CardSection className="space-y-6">
+          {/* Voice Provider Selection */}
+          <div>
+            <h3 className="ui-text-sm mb-3 font-medium text-zinc-900 dark:text-zinc-50">
+              Voice Provider
+            </h3>
+            <div className="space-y-3">
+              {/* Browser Voices Option */}
+              <label
+                className={`relative flex cursor-pointer rounded-lg border p-4 transition-colors ${
+                  settings.provider === "browser"
+                    ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
+                    : "border-zinc-200 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50"
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="voice-provider"
+                  value="browser"
+                  checked={settings.provider === "browser"}
+                  onChange={() => handleProviderChange("browser")}
+                  className="sr-only"
+                />
+                <div className="flex items-start gap-3">
+                  <div
+                    className={`mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border ${
+                      settings.provider === "browser"
+                        ? "border-zinc-900 dark:border-zinc-400"
+                        : "border-zinc-400 dark:border-zinc-500"
+                    }`}
                   >
-                    {isLoadingVoices ? (
-                      <option value="">Loading voices...</option>
-                    ) : voices.length === 0 ? (
-                      <option value="">No voices available</option>
-                    ) : (
-                      <>
-                        <option value="">Default voice</option>
-                        {voices.map((voice) => (
-                          <option key={voice.voiceURI} value={voice.voiceURI}>
-                            {voice.name}
-                            {voice.localService ? "" : " (online)"}
-                          </option>
-                        ))}
-                      </>
+                    {settings.provider === "browser" && (
+                      <div className="h-2 w-2 rounded-full bg-zinc-900 dark:bg-zinc-400" />
                     )}
-                  </select>
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    onClick={isPreviewing ? handleStopPreview : handlePreview}
-                    disabled={isLoadingVoices || voices.length === 0}
+                  </div>
+                  <div>
+                    <span className="ui-text-sm block font-medium text-zinc-900 dark:text-zinc-100">
+                      Browser Voices
+                    </span>
+                    <span className="ui-text-xs mt-0.5 block text-zinc-500 dark:text-zinc-400">
+                      Uses your browser&apos;s built-in text-to-speech
+                    </span>
+                  </div>
+                </div>
+              </label>
+
+              {/* Enhanced Voices Option */}
+              <label
+                className={`relative flex cursor-pointer rounded-lg border p-4 transition-colors ${
+                  settings.provider === "piper"
+                    ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
+                    : "border-zinc-200 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50"
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="voice-provider"
+                  value="piper"
+                  checked={settings.provider === "piper"}
+                  onChange={() => handleProviderChange("piper")}
+                  className="sr-only"
+                />
+                <div className="flex items-start gap-3">
+                  <div
+                    className={`mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border ${
+                      settings.provider === "piper"
+                        ? "border-zinc-900 dark:border-zinc-400"
+                        : "border-zinc-400 dark:border-zinc-500"
+                    }`}
                   >
-                    {isPreviewing ? "Stop" : "Preview"}
-                  </Button>
+                    {settings.provider === "piper" && (
+                      <div className="h-2 w-2 rounded-full bg-zinc-900 dark:bg-zinc-400" />
+                    )}
+                  </div>
+                  <div>
+                    <span className="ui-text-sm block font-medium text-zinc-900 dark:text-zinc-100">
+                      Enhanced Voices
+                    </span>
+                    <span className="ui-text-xs mt-0.5 block text-zinc-500 dark:text-zinc-400">
+                      Higher quality voices (requires download)
+                    </span>
+                  </div>
                 </div>
-                <p className="ui-text-xs mt-1.5 text-zinc-500 dark:text-zinc-400">
-                  Voices are provided by your browser. Chrome and Safari typically offer higher
-                  quality voices.
-                </p>
-              </div>
-            )}
+              </label>
+            </div>
+          </div>
 
-            {/* Enhanced Voices List (only shown when piper provider selected) */}
-            {settings.provider === "piper" && (
-              <div className="space-y-4">
-                <div>
-                  <label className="ui-text-sm mb-3 block font-medium text-zinc-700 dark:text-zinc-300">
-                    Select Voice
-                  </label>
-                  <EnhancedVoiceList settings={settings} setSettings={setSettings} />
-                </div>
-                <EnhancedVoicesHelp />
-              </div>
-            )}
-
-            {/* Speed Slider */}
+          {/* Browser Voice Selector (only shown when browser provider selected) */}
+          {settings.provider === "browser" && (
             <div>
               <label
-                htmlFor="narration-rate"
+                htmlFor="narration-voice"
                 className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
               >
-                Speed: {settings.rate.toFixed(1)}x
+                Voice
+              </label>
+              <div className="flex gap-3">
+                <select
+                  id="narration-voice"
+                  value={settings.voiceId || ""}
+                  onChange={handleVoiceChange}
+                  disabled={isLoadingVoices}
+                  className="ui-text-sm block flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+                >
+                  {isLoadingVoices ? (
+                    <option value="">Loading voices...</option>
+                  ) : voices.length === 0 ? (
+                    <option value="">No voices available</option>
+                  ) : (
+                    <>
+                      <option value="">Default voice</option>
+                      {voices.map((voice) => (
+                        <option key={voice.voiceURI} value={voice.voiceURI}>
+                          {voice.name}
+                          {voice.localService ? "" : " (online)"}
+                        </option>
+                      ))}
+                    </>
+                  )}
+                </select>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={isPreviewing ? handleStopPreview : handlePreview}
+                  disabled={isLoadingVoices || voices.length === 0}
+                >
+                  {isPreviewing ? "Stop" : "Preview"}
+                </Button>
+              </div>
+              <p className="ui-text-xs mt-1.5 text-zinc-500 dark:text-zinc-400">
+                Voices are provided by your browser. Chrome and Safari typically offer higher
+                quality voices.
+              </p>
+            </div>
+          )}
+
+          {/* Enhanced Voices List (only shown when piper provider selected) */}
+          {settings.provider === "piper" && (
+            <div className="space-y-4">
+              <div>
+                <label className="ui-text-sm mb-3 block font-medium text-zinc-700 dark:text-zinc-300">
+                  Select Voice
+                </label>
+                <EnhancedVoiceList settings={settings} setSettings={setSettings} />
+              </div>
+              <EnhancedVoicesHelp />
+            </div>
+          )}
+
+          {/* Speed Slider */}
+          <div>
+            <label
+              htmlFor="narration-rate"
+              className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
+            >
+              Speed: {settings.rate.toFixed(1)}x
+            </label>
+            <input
+              id="narration-rate"
+              type="range"
+              min="0.5"
+              max="2"
+              step="0.1"
+              value={settings.rate}
+              onChange={handleRateChange}
+              className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-zinc-200 accent-zinc-900 dark:bg-zinc-700 dark:accent-zinc-400"
+            />
+            <div className="ui-text-xs mt-1 flex justify-between text-zinc-400 dark:text-zinc-500">
+              <span>0.5x</span>
+              <span>1.0x</span>
+              <span>1.5x</span>
+              <span>2.0x</span>
+            </div>
+          </div>
+
+          {/* Pitch Slider (browser voices only - Piper doesn't support pitch control) */}
+          {settings.provider === "browser" && (
+            <div>
+              <label
+                htmlFor="narration-pitch"
+                className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
+              >
+                Pitch: {settings.pitch.toFixed(1)}x
               </label>
               <input
-                id="narration-rate"
+                id="narration-pitch"
                 type="range"
                 min="0.5"
                 max="2"
                 step="0.1"
-                value={settings.rate}
-                onChange={handleRateChange}
+                value={settings.pitch}
+                onChange={handlePitchChange}
                 className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-zinc-200 accent-zinc-900 dark:bg-zinc-700 dark:accent-zinc-400"
               />
               <div className="ui-text-xs mt-1 flex justify-between text-zinc-400 dark:text-zinc-500">
@@ -409,172 +428,140 @@ export function NarrationSettings() {
                 <span>2.0x</span>
               </div>
             </div>
+          )}
 
-            {/* Pitch Slider (browser voices only - Piper doesn't support pitch control) */}
-            {settings.provider === "browser" && (
-              <div>
-                <label
-                  htmlFor="narration-pitch"
-                  className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
-                >
-                  Pitch: {settings.pitch.toFixed(1)}x
-                </label>
-                <input
-                  id="narration-pitch"
-                  type="range"
-                  min="0.5"
-                  max="2"
-                  step="0.1"
-                  value={settings.pitch}
-                  onChange={handlePitchChange}
-                  className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-zinc-200 accent-zinc-900 dark:bg-zinc-700 dark:accent-zinc-400"
-                />
-                <div className="ui-text-xs mt-1 flex justify-between text-zinc-400 dark:text-zinc-500">
-                  <span>0.5x</span>
-                  <span>1.0x</span>
-                  <span>1.5x</span>
-                  <span>2.0x</span>
-                </div>
-              </div>
-            )}
-
-            {/* Processing Settings - only shown if AI text processing is available */}
-            {isAiTextProcessingAvailable && (
-              <div className="space-y-4">
-                <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
-                  Processing
-                </h3>
-
-                {/* LLM Normalization Toggle */}
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="ui-text-sm text-zinc-700 dark:text-zinc-300">
-                      Use AI text processing
-                    </p>
-                    <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
-                      Improves narration quality by expanding abbreviations and formatting content
-                    </p>
-                  </div>
-                  <button
-                    type="button"
-                    role="switch"
-                    aria-checked={settings.useLlmNormalization}
-                    onClick={() =>
-                      setSettings((prev) => ({
-                        ...prev,
-                        useLlmNormalization: !prev.useLlmNormalization,
-                      }))
-                    }
-                    className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
-                      settings.useLlmNormalization
-                        ? "bg-primary-solid"
-                        : "bg-zinc-200 dark:bg-zinc-700"
-                    }`}
-                  >
-                    <span
-                      aria-hidden="true"
-                      className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
-                        settings.useLlmNormalization ? "translate-x-5" : "translate-x-0"
-                      }`}
-                    />
-                  </button>
-                </div>
-              </div>
-            )}
-
-            {/* Highlighting Settings */}
+          {/* Processing Settings - only shown if AI text processing is available */}
+          {isAiTextProcessingAvailable && (
             <div className="space-y-4">
-              <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
-                Highlighting
-              </h3>
+              <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">Processing</h3>
 
-              {/* Highlight Current Paragraph Toggle */}
+              {/* LLM Normalization Toggle */}
               <div className="flex items-center justify-between">
                 <div>
                   <p className="ui-text-sm text-zinc-700 dark:text-zinc-300">
-                    Highlight current paragraph
+                    Use AI text processing
                   </p>
                   <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
-                    Visually highlight the paragraph being read
+                    Improves narration quality by expanding abbreviations and formatting content
                   </p>
                 </div>
                 <button
                   type="button"
                   role="switch"
-                  aria-checked={settings.highlightEnabled}
+                  aria-checked={settings.useLlmNormalization}
                   onClick={() =>
-                    setSettings((prev) => ({ ...prev, highlightEnabled: !prev.highlightEnabled }))
+                    setSettings((prev) => ({
+                      ...prev,
+                      useLlmNormalization: !prev.useLlmNormalization,
+                    }))
                   }
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
-                    settings.highlightEnabled ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
+                    settings.useLlmNormalization
+                      ? "bg-primary-solid"
+                      : "bg-zinc-200 dark:bg-zinc-700"
                   }`}
                 >
                   <span
                     aria-hidden="true"
                     className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
-                      settings.highlightEnabled ? "translate-x-5" : "translate-x-0"
-                    }`}
-                  />
-                </button>
-              </div>
-
-              {/* Auto-scroll to Current Paragraph Toggle */}
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="ui-text-sm text-zinc-700 dark:text-zinc-300">
-                    Auto-scroll to current paragraph
-                  </p>
-                  <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
-                    Automatically scroll the page to keep the current paragraph visible
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={settings.autoScrollEnabled}
-                  onClick={() =>
-                    setSettings((prev) => ({ ...prev, autoScrollEnabled: !prev.autoScrollEnabled }))
-                  }
-                  className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
-                    settings.autoScrollEnabled ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
-                  }`}
-                >
-                  <span
-                    aria-hidden="true"
-                    className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
-                      settings.autoScrollEnabled ? "translate-x-5" : "translate-x-0"
+                      settings.useLlmNormalization ? "translate-x-5" : "translate-x-0"
                     }`}
                   />
                 </button>
               </div>
             </div>
+          )}
 
-            {/* Firefox Warning */}
-            {isFirefoxBrowser && (
-              <div className="ui-text-xs flex items-start gap-2 rounded-md bg-amber-50 p-3 text-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
-                <AlertIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
-                <span>
-                  Firefox has limited support for pausing narration. When you pause and resume,
-                  playback will restart from the beginning of the current paragraph.
-                </span>
+          {/* Highlighting Settings */}
+          <div className="space-y-4">
+            <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">Highlighting</h3>
+
+            {/* Highlight Current Paragraph Toggle */}
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="ui-text-sm text-zinc-700 dark:text-zinc-300">
+                  Highlight current paragraph
+                </p>
+                <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+                  Visually highlight the paragraph being read
+                </p>
               </div>
-            )}
-          </div>
-        )}
+              <button
+                type="button"
+                role="switch"
+                aria-checked={settings.highlightEnabled}
+                onClick={() =>
+                  setSettings((prev) => ({ ...prev, highlightEnabled: !prev.highlightEnabled }))
+                }
+                className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
+                  settings.highlightEnabled ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
+                }`}
+              >
+                <span
+                  aria-hidden="true"
+                  className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
+                    settings.highlightEnabled ? "translate-x-5" : "translate-x-0"
+                  }`}
+                />
+              </button>
+            </div>
 
-        {/* Media Session Info */}
-        {settings.enabled && supportInfo.mediaSession && (
-          <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
-            <div className="ui-text-xs flex items-start gap-2 text-zinc-500 dark:text-zinc-400">
-              <InfoCircleIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            {/* Auto-scroll to Current Paragraph Toggle */}
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="ui-text-sm text-zinc-700 dark:text-zinc-300">
+                  Auto-scroll to current paragraph
+                </p>
+                <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+                  Automatically scroll the page to keep the current paragraph visible
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={settings.autoScrollEnabled}
+                onClick={() =>
+                  setSettings((prev) => ({ ...prev, autoScrollEnabled: !prev.autoScrollEnabled }))
+                }
+                className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
+                  settings.autoScrollEnabled ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
+                }`}
+              >
+                <span
+                  aria-hidden="true"
+                  className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
+                    settings.autoScrollEnabled ? "translate-x-5" : "translate-x-0"
+                  }`}
+                />
+              </button>
+            </div>
+          </div>
+
+          {/* Firefox Warning */}
+          {isFirefoxBrowser && (
+            <div className="ui-text-xs flex items-start gap-2 rounded-md bg-amber-50 p-3 text-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+              <AlertIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
               <span>
-                Your browser supports media controls. You can control playback using your keyboard
-                media keys or lock screen controls.
+                Firefox has limited support for pausing narration. When you pause and resume,
+                playback will restart from the beginning of the current paragraph.
               </span>
             </div>
+          )}
+        </CardSection>
+      )}
+
+      {/* Media Session Info */}
+      {settings.enabled && supportInfo.mediaSession && (
+        <CardSection>
+          <div className="ui-text-xs flex items-start gap-2 text-zinc-500 dark:text-zinc-400">
+            <InfoCircleIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <span>
+              Your browser supports media controls. You can control playback using your keyboard
+              media keys or lock screen controls.
+            </span>
           </div>
-        )}
-      </div>
-    </section>
+        </CardSection>
+      )}
+    </SettingsSection>
   );
 }

--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -4,45 +4,44 @@
  * Displays attribution and links in a card format.
  */
 
+import { SettingsSection } from "@/components/settings/SettingsSection";
+
 export function AboutSection() {
   return (
-    <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">About</h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-          Lion Reader was created by{" "}
-          <a
-            href="https://www.brendanlong.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-zinc-900 hover:underline dark:text-zinc-50"
-          >
-            Brendan Long
-          </a>{" "}
-          and{" "}
-          <a
-            href="https://www.brendanlong.com/claude-wrote-me-a-400-commit-rss-reader-app.html"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-zinc-900 hover:underline dark:text-zinc-50"
-          >
-            Claude
-          </a>
-          .
-        </p>
-        <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">
-          View the source code on{" "}
-          <a
-            href="https://github.com/brendanlong/lion-reader"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-zinc-900 hover:underline dark:text-zinc-50"
-          >
-            GitHub
-          </a>
-          .
-        </p>
-      </div>
-    </section>
+    <SettingsSection title="About">
+      <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+        Lion Reader was created by{" "}
+        <a
+          href="https://www.brendanlong.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-zinc-900 hover:underline dark:text-zinc-50"
+        >
+          Brendan Long
+        </a>{" "}
+        and{" "}
+        <a
+          href="https://www.brendanlong.com/claude-wrote-me-a-400-commit-rss-reader-app.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-zinc-900 hover:underline dark:text-zinc-50"
+        >
+          Claude
+        </a>
+        .
+      </p>
+      <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">
+        View the source code on{" "}
+        <a
+          href="https://github.com/brendanlong/lion-reader"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-zinc-900 hover:underline dark:text-zinc-50"
+        >
+          GitHub
+        </a>
+        .
+      </p>
+    </SettingsSection>
   );
 }

--- a/src/components/settings/ApiKeySettings.tsx
+++ b/src/components/settings/ApiKeySettings.tsx
@@ -13,10 +13,12 @@ import { trpc } from "@/lib/trpc/client";
 import { CheckIcon } from "@/components/ui/icon-button";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { TextLink } from "@/components/ui/text-link";
 import {
   DEFAULT_SUMMARIZATION_MODEL,
   DEFAULT_SUMMARIZATION_MAX_WORDS,
 } from "@/lib/summarization/constants";
+import { SettingsSection } from "./SettingsSection";
 
 /**
  * Groq API key settings, displayed near the narration settings.
@@ -68,87 +70,77 @@ export function GroqApiKeySettings() {
   }, [updatePreferences]);
 
   return (
-    <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">
-        AI Text Processing
-      </h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
-          Add a{" "}
-          <a
-            href="https://console.groq.com/keys"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent hover:text-accent-hover font-medium"
-          >
-            Groq API key
-          </a>{" "}
-          to enable AI-powered text processing for narration. This improves narration quality by
-          expanding abbreviations and formatting content for text-to-speech.
-        </p>
+    <SettingsSection title="AI Text Processing">
+      <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
+        Add a{" "}
+        <TextLink href="https://console.groq.com/keys" external>
+          Groq API key
+        </TextLink>{" "}
+        to enable AI-powered text processing for narration. This improves narration quality by
+        expanding abbreviations and formatting content for text-to-speech.
+      </p>
 
-        {preferencesQuery.isLoading ? (
-          <div className="h-10 w-full animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
-        ) : isEditing ? (
-          <div className="space-y-3">
-            <Input
-              id="groq-api-key"
-              type="password"
-              placeholder="gsk_..."
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
+      {preferencesQuery.isLoading ? (
+        <div className="h-10 w-full animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+      ) : isEditing ? (
+        <div className="space-y-3">
+          <Input
+            id="groq-api-key"
+            type="password"
+            placeholder="gsk_..."
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            disabled={updatePreferences.isPending}
+            autoComplete="off"
+          />
+          <div className="flex gap-2">
+            <Button
+              onClick={handleSave}
+              loading={updatePreferences.isPending}
+              disabled={!apiKey.trim()}
+            >
+              Save
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setIsEditing(false);
+                setApiKey("");
+              }}
               disabled={updatePreferences.isPending}
-              autoComplete="off"
-            />
-            <div className="flex gap-2">
-              <Button
-                onClick={handleSave}
-                loading={updatePreferences.isPending}
-                disabled={!apiKey.trim()}
-              >
-                Save
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-3">
+          {hasKey ? (
+            <>
+              <span className="ui-text-sm inline-flex items-center text-green-600 dark:text-green-400">
+                <CheckIcon className="mr-1 h-4 w-4" />
+                API key configured
+              </span>
+              <Button variant="secondary" size="sm" onClick={() => setIsEditing(true)}>
+                Change
               </Button>
               <Button
                 variant="secondary"
-                onClick={() => {
-                  setIsEditing(false);
-                  setApiKey("");
-                }}
-                disabled={updatePreferences.isPending}
+                size="sm"
+                onClick={handleRemove}
+                loading={updatePreferences.isPending}
               >
-                Cancel
+                Remove
               </Button>
-            </div>
-          </div>
-        ) : (
-          <div className="flex items-center gap-3">
-            {hasKey ? (
-              <>
-                <span className="ui-text-sm inline-flex items-center text-green-600 dark:text-green-400">
-                  <CheckIcon className="mr-1 h-4 w-4" />
-                  API key configured
-                </span>
-                <Button variant="secondary" size="sm" onClick={() => setIsEditing(true)}>
-                  Change
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={handleRemove}
-                  loading={updatePreferences.isPending}
-                >
-                  Remove
-                </Button>
-              </>
-            ) : (
-              <Button variant="secondary" onClick={() => setIsEditing(true)}>
-                Add API key
-              </Button>
-            )}
-          </div>
-        )}
-      </div>
-    </section>
+            </>
+          ) : (
+            <Button variant="secondary" onClick={() => setIsEditing(true)}>
+              Add API key
+            </Button>
+          )}
+        </div>
+      )}
+    </SettingsSection>
   );
 }
 
@@ -305,51 +297,153 @@ export function SummarizationApiKeySettings() {
   }, [updatePreferences]);
 
   return (
-    <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">Summaries</h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
-          Add an{" "}
-          <a
-            href="https://console.anthropic.com/settings/keys"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent hover:text-accent-hover font-medium"
-          >
-            Anthropic API key
-          </a>{" "}
-          to enable AI-powered article summaries.
-        </p>
+    <SettingsSection title="Summaries">
+      <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
+        Add an{" "}
+        <TextLink href="https://console.anthropic.com/settings/keys" external>
+          Anthropic API key
+        </TextLink>{" "}
+        to enable AI-powered article summaries.
+      </p>
 
-        {preferencesQuery.isLoading ? (
-          <div className="h-10 w-full animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
-        ) : (
-          <div className="space-y-4">
-            {/* API Key */}
-            {isEditing ? (
+      {preferencesQuery.isLoading ? (
+        <div className="h-10 w-full animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+      ) : (
+        <div className="space-y-4">
+          {/* API Key */}
+          {isEditing ? (
+            <div className="space-y-3">
+              <Input
+                id="anthropic-api-key"
+                type="password"
+                placeholder="sk-ant-..."
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                disabled={updatePreferences.isPending}
+                autoComplete="off"
+              />
+              <div className="flex gap-2">
+                <Button
+                  onClick={handleSave}
+                  loading={updatePreferences.isPending}
+                  disabled={!apiKey.trim()}
+                >
+                  Save
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => {
+                    setIsEditing(false);
+                    setApiKey("");
+                  }}
+                  disabled={updatePreferences.isPending}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center gap-3">
+              {hasKey ? (
+                <>
+                  <span className="ui-text-sm inline-flex items-center text-green-600 dark:text-green-400">
+                    <CheckIcon className="mr-1 h-4 w-4" />
+                    API key configured
+                  </span>
+                  <Button variant="secondary" size="sm" onClick={() => setIsEditing(true)}>
+                    Change
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleRemove}
+                    loading={updatePreferences.isPending}
+                  >
+                    Remove
+                  </Button>
+                </>
+              ) : (
+                <Button variant="secondary" onClick={() => setIsEditing(true)}>
+                  Add API key
+                </Button>
+              )}
+            </div>
+          )}
+
+          {/* Model Selection */}
+          <div>
+            <label
+              htmlFor="summarization-model"
+              className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
+            >
+              Model
+            </label>
+            <select
+              id="summarization-model"
+              value={currentModel ?? defaultModelId}
+              onChange={handleModelChange}
+              disabled={updatePreferences.isPending || modelsQuery.isLoading}
+              className="ui-text-sm block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+            >
+              {modelsQuery.isLoading ? (
+                <option value={currentModel ?? defaultModelId}>Loading models...</option>
+              ) : models.length > 0 ? (
+                models.map((model) => (
+                  <option key={model.id} value={model.id}>
+                    {model.displayName}
+                    {model.id === defaultModelId ? " (default)" : ""}
+                  </option>
+                ))
+              ) : (
+                <option value={defaultModelId}>{defaultModelId}</option>
+              )}
+              {/* Show custom value if it's not in the models list */}
+              {currentModel &&
+                !modelsQuery.isLoading &&
+                models.length > 0 &&
+                !models.some((m) => m.id === currentModel) && (
+                  <option value={currentModel}>{currentModel}</option>
+                )}
+            </select>
+            <p className="ui-text-xs mt-1.5 text-zinc-500 dark:text-zinc-400">
+              Choose the Anthropic model used for generating article summaries. Sonnet models offer
+              the best balance of quality and cost.
+            </p>
+          </div>
+
+          {/* Max Words */}
+          <div>
+            <label
+              htmlFor="summarization-max-words"
+              className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
+            >
+              Max words
+            </label>
+            {isEditingMaxWords ? (
               <div className="space-y-3">
                 <Input
-                  id="anthropic-api-key"
-                  type="password"
-                  placeholder="sk-ant-..."
-                  value={apiKey}
-                  onChange={(e) => setApiKey(e.target.value)}
+                  id="summarization-max-words"
+                  type="number"
+                  min={1}
+                  max={10000}
+                  placeholder={String(DEFAULT_SUMMARIZATION_MAX_WORDS)}
+                  value={maxWordsInput}
+                  onChange={(e) => setMaxWordsInput(e.target.value)}
                   disabled={updatePreferences.isPending}
-                  autoComplete="off"
                 />
                 <div className="flex gap-2">
                   <Button
-                    onClick={handleSave}
+                    onClick={handleMaxWordsSave}
                     loading={updatePreferences.isPending}
-                    disabled={!apiKey.trim()}
+                    disabled={!maxWordsInput.trim()}
                   >
                     Save
                   </Button>
                   <Button
                     variant="secondary"
                     onClick={() => {
-                      setIsEditing(false);
-                      setApiKey("");
+                      setIsEditingMaxWords(false);
+                      setMaxWordsInput(currentMaxWords?.toString() ?? "");
                     }}
                     disabled={updatePreferences.isPending}
                   >
@@ -359,233 +453,120 @@ export function SummarizationApiKeySettings() {
               </div>
             ) : (
               <div className="flex items-center gap-3">
-                {hasKey ? (
-                  <>
-                    <span className="ui-text-sm inline-flex items-center text-green-600 dark:text-green-400">
-                      <CheckIcon className="mr-1 h-4 w-4" />
-                      API key configured
-                    </span>
-                    <Button variant="secondary" size="sm" onClick={() => setIsEditing(true)}>
-                      Change
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={handleRemove}
-                      loading={updatePreferences.isPending}
-                    >
-                      Remove
-                    </Button>
-                  </>
-                ) : (
-                  <Button variant="secondary" onClick={() => setIsEditing(true)}>
-                    Add API key
+                <span className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+                  {currentMaxWords ?? `${DEFAULT_SUMMARIZATION_MAX_WORDS} (default)`}
+                </span>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    setMaxWordsInput(currentMaxWords?.toString() ?? "");
+                    setIsEditingMaxWords(true);
+                  }}
+                >
+                  Change
+                </Button>
+                {currentMaxWords !== null && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleMaxWordsReset}
+                    loading={updatePreferences.isPending}
+                  >
+                    Reset
                   </Button>
                 )}
               </div>
             )}
-
-            {/* Model Selection */}
-            <div>
-              <label
-                htmlFor="summarization-model"
-                className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
-              >
-                Model
-              </label>
-              <select
-                id="summarization-model"
-                value={currentModel ?? defaultModelId}
-                onChange={handleModelChange}
-                disabled={updatePreferences.isPending || modelsQuery.isLoading}
-                className="ui-text-sm block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
-              >
-                {modelsQuery.isLoading ? (
-                  <option value={currentModel ?? defaultModelId}>Loading models...</option>
-                ) : models.length > 0 ? (
-                  models.map((model) => (
-                    <option key={model.id} value={model.id}>
-                      {model.displayName}
-                      {model.id === defaultModelId ? " (default)" : ""}
-                    </option>
-                  ))
-                ) : (
-                  <option value={defaultModelId}>{defaultModelId}</option>
-                )}
-                {/* Show custom value if it's not in the models list */}
-                {currentModel &&
-                  !modelsQuery.isLoading &&
-                  models.length > 0 &&
-                  !models.some((m) => m.id === currentModel) && (
-                    <option value={currentModel}>{currentModel}</option>
-                  )}
-              </select>
-              <p className="ui-text-xs mt-1.5 text-zinc-500 dark:text-zinc-400">
-                Choose the Anthropic model used for generating article summaries. Sonnet models
-                offer the best balance of quality and cost.
-              </p>
-            </div>
-
-            {/* Max Words */}
-            <div>
-              <label
-                htmlFor="summarization-max-words"
-                className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
-              >
-                Max words
-              </label>
-              {isEditingMaxWords ? (
-                <div className="space-y-3">
-                  <Input
-                    id="summarization-max-words"
-                    type="number"
-                    min={1}
-                    max={10000}
-                    placeholder={String(DEFAULT_SUMMARIZATION_MAX_WORDS)}
-                    value={maxWordsInput}
-                    onChange={(e) => setMaxWordsInput(e.target.value)}
-                    disabled={updatePreferences.isPending}
-                  />
-                  <div className="flex gap-2">
-                    <Button
-                      onClick={handleMaxWordsSave}
-                      loading={updatePreferences.isPending}
-                      disabled={!maxWordsInput.trim()}
-                    >
-                      Save
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      onClick={() => {
-                        setIsEditingMaxWords(false);
-                        setMaxWordsInput(currentMaxWords?.toString() ?? "");
-                      }}
-                      disabled={updatePreferences.isPending}
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
-              ) : (
-                <div className="flex items-center gap-3">
-                  <span className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-                    {currentMaxWords ?? `${DEFAULT_SUMMARIZATION_MAX_WORDS} (default)`}
-                  </span>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => {
-                      setMaxWordsInput(currentMaxWords?.toString() ?? "");
-                      setIsEditingMaxWords(true);
-                    }}
-                  >
-                    Change
-                  </Button>
-                  {currentMaxWords !== null && (
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={handleMaxWordsReset}
-                      loading={updatePreferences.isPending}
-                    >
-                      Reset
-                    </Button>
-                  )}
-                </div>
-              )}
-              <p className="ui-text-xs mt-1.5 text-zinc-500 dark:text-zinc-400">
-                Maximum number of words for generated summaries.
-              </p>
-            </div>
-
-            {/* Custom Prompt */}
-            <div>
-              <label
-                htmlFor="summarization-prompt"
-                className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
-              >
-                Custom prompt
-              </label>
-              {isEditingPrompt ? (
-                <div className="space-y-3">
-                  <textarea
-                    id="summarization-prompt"
-                    rows={10}
-                    placeholder={defaultPrompt}
-                    value={promptInput}
-                    onChange={(e) => setPromptInput(e.target.value)}
-                    disabled={updatePreferences.isPending}
-                    className="ui-text-sm block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
-                  />
-                  <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
-                    Available template variables:{" "}
-                    <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">
-                      {"{{content}}"}
-                    </code>
-                    ,{" "}
-                    <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">{"{{title}}"}</code>
-                    ,{" "}
-                    <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">
-                      {"{{maxWords}}"}
-                    </code>
-                    . The response should be wrapped in{" "}
-                    <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">{"<summary>"}</code>{" "}
-                    tags.
-                  </p>
-                  <div className="flex gap-2">
-                    <Button
-                      onClick={handlePromptSave}
-                      loading={updatePreferences.isPending}
-                      disabled={!promptInput.trim()}
-                    >
-                      Save
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      onClick={() => {
-                        setIsEditingPrompt(false);
-                        setPromptInput(currentPrompt ?? "");
-                      }}
-                      disabled={updatePreferences.isPending}
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
-              ) : (
-                <div className="flex items-center gap-3">
-                  <span className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-                    {currentPrompt ? "Custom prompt configured" : "Using default prompt"}
-                  </span>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => {
-                      setPromptInput(currentPrompt ?? "");
-                      setIsEditingPrompt(true);
-                    }}
-                  >
-                    {currentPrompt ? "Edit" : "Customize"}
-                  </Button>
-                  {currentPrompt && (
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={handlePromptReset}
-                      loading={updatePreferences.isPending}
-                    >
-                      Reset
-                    </Button>
-                  )}
-                </div>
-              )}
-              <p className="ui-text-xs mt-1.5 text-zinc-500 dark:text-zinc-400">
-                Override the default prompt sent to the AI model when generating summaries.
-              </p>
-            </div>
+            <p className="ui-text-xs mt-1.5 text-zinc-500 dark:text-zinc-400">
+              Maximum number of words for generated summaries.
+            </p>
           </div>
-        )}
-      </div>
-    </section>
+
+          {/* Custom Prompt */}
+          <div>
+            <label
+              htmlFor="summarization-prompt"
+              className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
+            >
+              Custom prompt
+            </label>
+            {isEditingPrompt ? (
+              <div className="space-y-3">
+                <textarea
+                  id="summarization-prompt"
+                  rows={10}
+                  placeholder={defaultPrompt}
+                  value={promptInput}
+                  onChange={(e) => setPromptInput(e.target.value)}
+                  disabled={updatePreferences.isPending}
+                  className="ui-text-sm block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+                />
+                <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+                  Available template variables:{" "}
+                  <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">{"{{content}}"}</code>
+                  , <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">{"{{title}}"}</code>
+                  ,{" "}
+                  <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">
+                    {"{{maxWords}}"}
+                  </code>
+                  . The response should be wrapped in{" "}
+                  <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">{"<summary>"}</code>{" "}
+                  tags.
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    onClick={handlePromptSave}
+                    loading={updatePreferences.isPending}
+                    disabled={!promptInput.trim()}
+                  >
+                    Save
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      setIsEditingPrompt(false);
+                      setPromptInput(currentPrompt ?? "");
+                    }}
+                    disabled={updatePreferences.isPending}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-center gap-3">
+                <span className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+                  {currentPrompt ? "Custom prompt configured" : "Using default prompt"}
+                </span>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    setPromptInput(currentPrompt ?? "");
+                    setIsEditingPrompt(true);
+                  }}
+                >
+                  {currentPrompt ? "Edit" : "Customize"}
+                </Button>
+                {currentPrompt && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handlePromptReset}
+                    loading={updatePreferences.isPending}
+                  >
+                    Reset
+                  </Button>
+                )}
+              </div>
+            )}
+            <p className="ui-text-xs mt-1.5 text-zinc-500 dark:text-zinc-400">
+              Override the default prompt sent to the AI model when generating summaries.
+            </p>
+          </div>
+        </div>
+      )}
+    </SettingsSection>
   );
 }

--- a/src/components/settings/AppearanceSettings.tsx
+++ b/src/components/settings/AppearanceSettings.tsx
@@ -11,6 +11,7 @@
 "use client";
 
 import { useTheme } from "next-themes";
+import { SettingsSection } from "@/components/settings/SettingsSection";
 import { useAppearance, useEntryTextStyles } from "@/lib/appearance/AppearanceProvider";
 import type { TextSize, TextJustification, FontFamily } from "@/lib/appearance/settings";
 
@@ -131,61 +132,53 @@ export function AppearanceSettings() {
   return (
     <div className="space-y-8">
       {/* Theme Section */}
-      <section>
-        <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">Theme</h2>
-        <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-          <OptionGroup
-            label="Color Mode"
-            description={
-              theme === "system" && resolvedTheme
-                ? `Following system preference (currently ${resolvedTheme})`
-                : theme === "system"
-                  ? "Following system preference"
-                  : undefined
-            }
-            value={theme || "system"}
-            options={THEME_OPTIONS}
-            onChange={setTheme}
-          />
-        </div>
-      </section>
+      <SettingsSection title="Theme">
+        <OptionGroup
+          label="Color Mode"
+          description={
+            theme === "system" && resolvedTheme
+              ? `Following system preference (currently ${resolvedTheme})`
+              : theme === "system"
+                ? "Following system preference"
+                : undefined
+          }
+          value={theme || "system"}
+          options={THEME_OPTIONS}
+          onChange={setTheme}
+        />
+      </SettingsSection>
 
       {/* Article Text Section */}
-      <section>
-        <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">
-          Article Text
-        </h2>
-        <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-          <p className="ui-text-sm mb-6 text-zinc-600 dark:text-zinc-400">
-            These settings affect how article content is displayed in the entry view.
-          </p>
+      <SettingsSection title="Article Text">
+        <p className="ui-text-sm mb-6 text-zinc-600 dark:text-zinc-400">
+          These settings affect how article content is displayed in the entry view.
+        </p>
 
-          <div className="space-y-6">
-            <OptionGroup
-              label="Text Size"
-              value={settings.textSize}
-              options={TEXT_SIZE_OPTIONS}
-              onChange={(textSize) => updateSettings({ textSize })}
-            />
+        <div className="space-y-6">
+          <OptionGroup
+            label="Text Size"
+            value={settings.textSize}
+            options={TEXT_SIZE_OPTIONS}
+            onChange={(textSize) => updateSettings({ textSize })}
+          />
 
-            <OptionGroup
-              label="Font"
-              value={settings.fontFamily}
-              options={FONT_OPTIONS}
-              onChange={(fontFamily) => updateSettings({ fontFamily })}
-            />
+          <OptionGroup
+            label="Font"
+            value={settings.fontFamily}
+            options={FONT_OPTIONS}
+            onChange={(fontFamily) => updateSettings({ fontFamily })}
+          />
 
-            <OptionGroup
-              label="Text Alignment"
-              value={settings.textJustification}
-              options={JUSTIFICATION_OPTIONS}
-              onChange={(textJustification) => updateSettings({ textJustification })}
-            />
+          <OptionGroup
+            label="Text Alignment"
+            value={settings.textJustification}
+            options={JUSTIFICATION_OPTIONS}
+            onChange={(textJustification) => updateSettings({ textJustification })}
+          />
 
-            <TextPreview />
-          </div>
+          <TextPreview />
         </div>
-      </section>
+      </SettingsSection>
     </div>
   );
 }

--- a/src/components/settings/BookmarkletSettings.tsx
+++ b/src/components/settings/BookmarkletSettings.tsx
@@ -8,6 +8,8 @@
 "use client";
 
 import { useState, useMemo, useEffect, useRef } from "react";
+import { SettingsSection } from "@/components/settings/SettingsSection";
+import { CardSection } from "@/components/ui/card";
 import {
   BookmarkIcon,
   ChevronRightIcon,
@@ -43,138 +45,133 @@ export function BookmarkletSettings() {
   }, [bookmarkletHref]);
 
   return (
-    <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">
-        Save to Lion Reader
-      </h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        {/* Description */}
-        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-          Save any webpage to Lion Reader with one click. The article will be added to your Saved
-          section where you can read it later.
+    <SettingsSection title="Save to Lion Reader">
+      {/* Description */}
+      <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+        Save any webpage to Lion Reader with one click. The article will be added to your Saved
+        section where you can read it later.
+      </p>
+
+      {/* Browser Extensions */}
+      <div className="mt-6">
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
+          Browser Extensions
+        </h3>
+        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+          The easiest way to save articles from your browser.
         </p>
-
-        {/* Browser Extensions */}
-        <div className="mt-6">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-            Browser Extensions
-          </h3>
-          <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-            The easiest way to save articles from your browser.
-          </p>
-          <div className="mt-3 flex flex-wrap gap-3">
-            <a
-              href="https://chromewebstore.google.com/detail/lion-reader/mpjddkjjkckmclaifjfokjppfoenmlpl"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-blue-300 bg-blue-50 px-4 py-2.5 font-medium text-blue-800 shadow-sm transition-all hover:border-blue-400 hover:bg-blue-100 hover:shadow dark:border-blue-700 dark:bg-blue-950 dark:text-blue-200 dark:hover:border-blue-600 dark:hover:bg-blue-900"
-            >
-              <ChromeIcon className="h-4 w-4" />
-              Install Chrome Extension
-            </a>
-            <a
-              href="https://addons.mozilla.org/en-US/firefox/addon/lion-reader/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-orange-300 bg-orange-50 px-4 py-2.5 font-medium text-orange-800 shadow-sm transition-all hover:border-orange-400 hover:bg-orange-100 hover:shadow dark:border-orange-700 dark:bg-orange-950 dark:text-orange-200 dark:hover:border-orange-600 dark:hover:bg-orange-900"
-            >
-              <FirefoxIcon className="h-4 w-4" />
-              Install Firefox Extension
-            </a>
-          </div>
-        </div>
-
-        {/* Bookmarklet Section */}
-        <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-            Bookmarklet (Other Browsers)
-          </h3>
-          <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-            For Safari and other browsers, use the bookmarklet.
-          </p>
-        </div>
-
-        {/* Draggable Bookmarklet Link */}
-        <div className="mt-4">
-          <p className="ui-text-sm mb-3 text-zinc-700 dark:text-zinc-300">
-            Drag this button to your bookmarks bar:
-          </p>
+        <div className="mt-3 flex flex-wrap gap-3">
           <a
-            ref={bookmarkletRef}
-            href="#"
-            onClick={(e) => e.preventDefault()}
-            draggable
-            className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-amber-300 bg-amber-50 px-4 py-2.5 font-medium text-amber-800 shadow-sm transition-all hover:border-amber-400 hover:bg-amber-100 hover:shadow active:scale-95 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200 dark:hover:border-amber-600 dark:hover:bg-amber-900"
+            href="https://chromewebstore.google.com/detail/lion-reader/mpjddkjjkckmclaifjfokjppfoenmlpl"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-blue-300 bg-blue-50 px-4 py-2.5 font-medium text-blue-800 shadow-sm transition-all hover:border-blue-400 hover:bg-blue-100 hover:shadow dark:border-blue-700 dark:bg-blue-950 dark:text-blue-200 dark:hover:border-blue-600 dark:hover:bg-blue-900"
           >
-            <BookmarkIcon className="h-4 w-4" />
-            Save to Lion Reader
+            <ChromeIcon className="h-4 w-4" />
+            Install Chrome Extension
+          </a>
+          <a
+            href="https://addons.mozilla.org/en-US/firefox/addon/lion-reader/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-orange-300 bg-orange-50 px-4 py-2.5 font-medium text-orange-800 shadow-sm transition-all hover:border-orange-400 hover:bg-orange-100 hover:shadow dark:border-orange-700 dark:bg-orange-950 dark:text-orange-200 dark:hover:border-orange-600 dark:hover:bg-orange-900"
+          >
+            <FirefoxIcon className="h-4 w-4" />
+            Install Firefox Extension
           </a>
         </div>
-
-        {/* Installation Instructions */}
-        <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-            Installation Instructions
-          </h3>
-          <ol className="ui-text-sm mt-2 list-inside list-decimal space-y-2 text-zinc-600 dark:text-zinc-400">
-            <li>Make sure your browser&apos;s bookmarks bar is visible</li>
-            <li>
-              Drag the{" "}
-              <strong className="text-zinc-900 dark:text-zinc-200">
-                &quot;Save to Lion Reader&quot;
-              </strong>{" "}
-              button above to your bookmarks bar
-            </li>
-            <li>
-              When you find an article you want to save, click the bookmarklet in your bookmarks bar
-            </li>
-            <li>A popup will appear confirming the article has been saved</li>
-          </ol>
-        </div>
-
-        {/* Show/Hide Code Section */}
-        <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
-          <button
-            type="button"
-            onClick={() => setShowCode(!showCode)}
-            className="ui-text-sm inline-flex items-center gap-2 font-medium text-zinc-700 transition-colors hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-50"
-          >
-            <ChevronRightIcon
-              className={`h-4 w-4 transition-transform ${showCode ? "rotate-90" : ""}`}
-            />
-            {showCode ? "Hide bookmarklet code" : "Show bookmarklet code"}
-          </button>
-
-          {showCode && (
-            <div className="mt-4">
-              <p className="ui-text-sm mb-2 text-zinc-500 dark:text-zinc-400">
-                If you prefer, you can manually create a bookmark with this JavaScript code:
-              </p>
-              <div className="relative">
-                <pre className="ui-text-xs overflow-x-auto rounded-md border border-zinc-200 bg-zinc-100 p-3 font-mono text-zinc-800 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
-                  <code className="break-all whitespace-pre-wrap">{bookmarkletHref}</code>
-                </pre>
-                <button
-                  type="button"
-                  onClick={() => {
-                    navigator.clipboard.writeText(bookmarkletHref);
-                  }}
-                  className="ui-text-xs absolute top-2 right-2 rounded border border-zinc-300 bg-white px-2 py-1 font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600 dark:hover:text-zinc-100"
-                >
-                  Copy
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* Note about app URL */}
-        {appUrl && (
-          <p className="ui-text-xs mt-4 text-zinc-400 dark:text-zinc-500">
-            Bookmarklet configured for: {appUrl}
-          </p>
-        )}
       </div>
-    </section>
+
+      {/* Bookmarklet Section */}
+      <CardSection>
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
+          Bookmarklet (Other Browsers)
+        </h3>
+        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+          For Safari and other browsers, use the bookmarklet.
+        </p>
+      </CardSection>
+
+      {/* Draggable Bookmarklet Link */}
+      <div className="mt-4">
+        <p className="ui-text-sm mb-3 text-zinc-700 dark:text-zinc-300">
+          Drag this button to your bookmarks bar:
+        </p>
+        <a
+          ref={bookmarkletRef}
+          href="#"
+          onClick={(e) => e.preventDefault()}
+          draggable
+          className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-amber-300 bg-amber-50 px-4 py-2.5 font-medium text-amber-800 shadow-sm transition-all hover:border-amber-400 hover:bg-amber-100 hover:shadow active:scale-95 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200 dark:hover:border-amber-600 dark:hover:bg-amber-900"
+        >
+          <BookmarkIcon className="h-4 w-4" />
+          Save to Lion Reader
+        </a>
+      </div>
+
+      {/* Installation Instructions */}
+      <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
+          Installation Instructions
+        </h3>
+        <ol className="ui-text-sm mt-2 list-inside list-decimal space-y-2 text-zinc-600 dark:text-zinc-400">
+          <li>Make sure your browser&apos;s bookmarks bar is visible</li>
+          <li>
+            Drag the{" "}
+            <strong className="text-zinc-900 dark:text-zinc-200">
+              &quot;Save to Lion Reader&quot;
+            </strong>{" "}
+            button above to your bookmarks bar
+          </li>
+          <li>
+            When you find an article you want to save, click the bookmarklet in your bookmarks bar
+          </li>
+          <li>A popup will appear confirming the article has been saved</li>
+        </ol>
+      </div>
+
+      {/* Show/Hide Code Section */}
+      <CardSection>
+        <button
+          type="button"
+          onClick={() => setShowCode(!showCode)}
+          className="ui-text-sm inline-flex items-center gap-2 font-medium text-zinc-700 transition-colors hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-50"
+        >
+          <ChevronRightIcon
+            className={`h-4 w-4 transition-transform ${showCode ? "rotate-90" : ""}`}
+          />
+          {showCode ? "Hide bookmarklet code" : "Show bookmarklet code"}
+        </button>
+
+        {showCode && (
+          <div className="mt-4">
+            <p className="ui-text-sm mb-2 text-zinc-500 dark:text-zinc-400">
+              If you prefer, you can manually create a bookmark with this JavaScript code:
+            </p>
+            <div className="relative">
+              <pre className="ui-text-xs overflow-x-auto rounded-md border border-zinc-200 bg-zinc-100 p-3 font-mono text-zinc-800 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
+                <code className="break-all whitespace-pre-wrap">{bookmarkletHref}</code>
+              </pre>
+              <button
+                type="button"
+                onClick={() => {
+                  navigator.clipboard.writeText(bookmarkletHref);
+                }}
+                className="ui-text-xs absolute top-2 right-2 rounded border border-zinc-300 bg-white px-2 py-1 font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600 dark:hover:text-zinc-100"
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+        )}
+      </CardSection>
+
+      {/* Note about app URL */}
+      {appUrl && (
+        <p className="ui-text-xs mt-4 text-zinc-400 dark:text-zinc-500">
+          Bookmarklet configured for: {appUrl}
+        </p>
+      )}
+    </SettingsSection>
   );
 }

--- a/src/components/settings/DiscordBotSettings.tsx
+++ b/src/components/settings/DiscordBotSettings.tsx
@@ -9,6 +9,9 @@
 
 import { useState } from "react";
 import { trpc } from "@/lib/trpc/client";
+import { SettingsSection } from "@/components/settings/SettingsSection";
+import { CardSection } from "@/components/ui/card";
+import { InlineCode } from "@/components/ui/inline-code";
 import { DiscordIcon, ExternalLinkIcon } from "@/components/ui/icon-button";
 
 /**
@@ -57,132 +60,119 @@ export function DiscordBotSettings() {
   const errorEmoji = botConfig.errorEmoji ? formatEmoji(botConfig.errorEmoji) : null;
 
   return (
-    <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">Discord Bot</h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        {/* Description */}
-        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-          Save articles to Lion Reader by reacting to Discord messages. When you react to a message
-          containing a URL, the article will be saved to your account.
+    <SettingsSection title="Discord Bot">
+      {/* Description */}
+      <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+        Save articles to Lion Reader by reacting to Discord messages. When you react to a message
+        containing a URL, the article will be saved to your account.
+      </p>
+
+      {/* Invite Button */}
+      <div className="mt-6">
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
+          Add Bot to Server
+        </h3>
+        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+          Invite the Lion Reader bot to your Discord server to enable saving articles.
         </p>
-
-        {/* Invite Button */}
-        <div className="mt-6">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-            Add Bot to Server
-          </h3>
-          <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-            Invite the Lion Reader bot to your Discord server to enable saving articles.
-          </p>
-          <div className="mt-3 flex flex-wrap gap-3">
-            <a
-              href={botConfig.inviteUrl ?? "#"}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-indigo-300 bg-indigo-50 px-4 py-2.5 font-medium text-indigo-800 shadow-sm transition-all hover:border-indigo-400 hover:bg-indigo-100 hover:shadow dark:border-indigo-700 dark:bg-indigo-950 dark:text-indigo-200 dark:hover:border-indigo-600 dark:hover:bg-indigo-900"
-            >
-              <DiscordIcon className="h-4 w-4" />
-              Invite Bot
-              <ExternalLinkIcon className="h-3.5 w-3.5" />
-            </a>
-            <button
-              type="button"
-              onClick={copyInviteUrl}
-              className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 font-medium text-zinc-700 shadow-sm transition-all hover:border-zinc-400 hover:bg-zinc-50 hover:shadow dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:bg-zinc-700"
-            >
-              {copied ? "Copied!" : "Copy Link"}
-            </button>
-          </div>
-        </div>
-
-        {/* Usage Instructions */}
-        <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">How to Use</h3>
-          <ol className="ui-text-sm mt-2 list-inside list-decimal space-y-2 text-zinc-600 dark:text-zinc-400">
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Link your account</strong> - Sign
-              in to Lion Reader with Discord, or use{" "}
-              <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
-                /link
-              </code>{" "}
-              with an API token
-            </li>
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">React to messages</strong> -{" "}
-              {emoji ? (
-                <>
-                  React with{" "}
-                  {emoji.isCustom ? (
-                    <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
-                      {emoji.text}
-                    </code>
-                  ) : (
-                    <span className="text-base">{emoji.text}</span>
-                  )}{" "}
-                  to any message containing a URL
-                </>
-              ) : (
-                "Add the configured emoji reaction to any message containing a URL"
-              )}
-            </li>
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Look for the reaction</strong> -{" "}
-              {successEmoji ? (
-                <>
-                  The bot will react with{" "}
-                  {successEmoji.isCustom ? (
-                    <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
-                      {successEmoji.text}
-                    </code>
-                  ) : (
-                    <span className="text-base">{successEmoji.text}</span>
-                  )}{" "}
-                  on success
-                  {errorEmoji && (
-                    <>
-                      {" "}
-                      or{" "}
-                      {errorEmoji.isCustom ? (
-                        <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
-                          {errorEmoji.text}
-                        </code>
-                      ) : (
-                        <span className="text-base">{errorEmoji.text}</span>
-                      )}{" "}
-                      on failure
-                    </>
-                  )}
-                </>
-              ) : (
-                "The bot will react to confirm the save succeeded or failed"
-              )}
-            </li>
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Check your Saved</strong> - The
-              article will appear in your Saved section
-            </li>
-          </ol>
-        </div>
-
-        {/* Bot Commands */}
-        <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Bot Commands</h3>
-          <dl className="ui-text-sm mt-2 space-y-2 text-zinc-600 dark:text-zinc-400">
-            <div>
-              <dt className="inline font-mono text-zinc-800 dark:text-zinc-200">/status</dt>
-              <dd className="ml-2 inline">- Check if your Discord account is linked</dd>
-            </div>
-            <div>
-              <dt className="inline font-mono text-zinc-800 dark:text-zinc-200">/link [token]</dt>
-              <dd className="ml-2 inline">- Link your account using an API token</dd>
-            </div>
-            <div>
-              <dt className="inline font-mono text-zinc-800 dark:text-zinc-200">/unlink</dt>
-              <dd className="ml-2 inline">- Remove your linked API token</dd>
-            </div>
-          </dl>
+        <div className="mt-3 flex flex-wrap gap-3">
+          <a
+            href={botConfig.inviteUrl ?? "#"}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-indigo-300 bg-indigo-50 px-4 py-2.5 font-medium text-indigo-800 shadow-sm transition-all hover:border-indigo-400 hover:bg-indigo-100 hover:shadow dark:border-indigo-700 dark:bg-indigo-950 dark:text-indigo-200 dark:hover:border-indigo-600 dark:hover:bg-indigo-900"
+          >
+            <DiscordIcon className="h-4 w-4" />
+            Invite Bot
+            <ExternalLinkIcon className="h-3.5 w-3.5" />
+          </a>
+          <button
+            type="button"
+            onClick={copyInviteUrl}
+            className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 font-medium text-zinc-700 shadow-sm transition-all hover:border-zinc-400 hover:bg-zinc-50 hover:shadow dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:bg-zinc-700"
+          >
+            {copied ? "Copied!" : "Copy Link"}
+          </button>
         </div>
       </div>
-    </section>
+
+      {/* Usage Instructions */}
+      <CardSection>
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">How to Use</h3>
+        <ol className="ui-text-sm mt-2 list-inside list-decimal space-y-2 text-zinc-600 dark:text-zinc-400">
+          <li>
+            <strong className="text-zinc-900 dark:text-zinc-200">Link your account</strong> - Sign
+            in to Lion Reader with Discord, or use <InlineCode>/link</InlineCode> with an API token
+          </li>
+          <li>
+            <strong className="text-zinc-900 dark:text-zinc-200">React to messages</strong> -{" "}
+            {emoji ? (
+              <>
+                React with{" "}
+                {emoji.isCustom ? (
+                  <InlineCode>{emoji.text}</InlineCode>
+                ) : (
+                  <span className="text-base">{emoji.text}</span>
+                )}{" "}
+                to any message containing a URL
+              </>
+            ) : (
+              "Add the configured emoji reaction to any message containing a URL"
+            )}
+          </li>
+          <li>
+            <strong className="text-zinc-900 dark:text-zinc-200">Look for the reaction</strong> -{" "}
+            {successEmoji ? (
+              <>
+                The bot will react with{" "}
+                {successEmoji.isCustom ? (
+                  <InlineCode>{successEmoji.text}</InlineCode>
+                ) : (
+                  <span className="text-base">{successEmoji.text}</span>
+                )}{" "}
+                on success
+                {errorEmoji && (
+                  <>
+                    {" "}
+                    or{" "}
+                    {errorEmoji.isCustom ? (
+                      <InlineCode>{errorEmoji.text}</InlineCode>
+                    ) : (
+                      <span className="text-base">{errorEmoji.text}</span>
+                    )}{" "}
+                    on failure
+                  </>
+                )}
+              </>
+            ) : (
+              "The bot will react to confirm the save succeeded or failed"
+            )}
+          </li>
+          <li>
+            <strong className="text-zinc-900 dark:text-zinc-200">Check your Saved</strong> - The
+            article will appear in your Saved section
+          </li>
+        </ol>
+      </CardSection>
+
+      {/* Bot Commands */}
+      <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Bot Commands</h3>
+        <dl className="ui-text-sm mt-2 space-y-2 text-zinc-600 dark:text-zinc-400">
+          <div>
+            <dt className="inline font-mono text-zinc-800 dark:text-zinc-200">/status</dt>
+            <dd className="ml-2 inline">- Check if your Discord account is linked</dd>
+          </div>
+          <div>
+            <dt className="inline font-mono text-zinc-800 dark:text-zinc-200">/link [token]</dt>
+            <dd className="ml-2 inline">- Link your account using an API token</dd>
+          </div>
+          <div>
+            <dt className="inline font-mono text-zinc-800 dark:text-zinc-200">/unlink</dt>
+            <dd className="ml-2 inline">- Remove your linked API token</dd>
+          </div>
+        </dl>
+      </div>
+    </SettingsSection>
   );
 }

--- a/src/components/settings/GoogleReaderApiSettings.tsx
+++ b/src/components/settings/GoogleReaderApiSettings.tsx
@@ -8,7 +8,11 @@
 "use client";
 
 import { useMemo } from "react";
+import { SettingsSection } from "@/components/settings/SettingsSection";
+import { CardSection } from "@/components/ui/card";
 import { CopyButton } from "@/components/ui/copy-button";
+import { InlineCode } from "@/components/ui/inline-code";
+import { TextLink } from "@/components/ui/text-link";
 
 export function GoogleReaderApiSettings() {
   const baseUrl = useMemo(() => {
@@ -21,137 +25,99 @@ export function GoogleReaderApiSettings() {
   const apiBase = `${baseUrl}/api/greader.php/reader/api/0`;
 
   return (
-    <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">
-        Google Reader API
-      </h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        {/* Description */}
-        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-          Lion Reader exposes a{" "}
-          <a
-            href="https://feedhq.readthedocs.io/en/latest/api/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent hover:text-accent-hover font-medium"
-          >
-            Google Reader-compatible API
-          </a>{" "}
-          so you can use third-party RSS reader apps to sync with your Lion Reader account.
+    <SettingsSection title="Google Reader API">
+      {/* Description */}
+      <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+        Lion Reader exposes a{" "}
+        <TextLink href="https://feedhq.readthedocs.io/en/latest/api/" external>
+          Google Reader-compatible API
+        </TextLink>{" "}
+        so you can use third-party RSS reader apps to sync with your Lion Reader account.
+      </p>
+
+      {/* Supported Clients */}
+      <div className="mt-6">
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Compatible Apps</h3>
+        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+          Any app that supports the Google Reader API should work, including:
         </p>
-
-        {/* Supported Clients */}
-        <div className="mt-6">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-            Compatible Apps
-          </h3>
-          <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-            Any app that supports the Google Reader API should work, including:
-          </p>
-          <ul className="ui-text-sm mt-2 list-inside list-disc space-y-1 text-zinc-600 dark:text-zinc-400">
-            <li>
-              <a
-                href="https://reederapp.com/classic/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-accent hover:text-accent-hover font-medium"
-              >
-                Reeder Classic
-              </a>{" "}
-              (iOS / macOS)
-            </li>
-            <li>
-              <a
-                href="https://netnewswire.com/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-accent hover:text-accent-hover font-medium"
-              >
-                NetNewsWire
-              </a>{" "}
-              (iOS / macOS)
-            </li>
-            <li>
-              <a
-                href="https://play.google.com/store/apps/details?id=allen.town.focus.reader"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-accent hover:text-accent-hover font-medium"
-              >
-                FocusReader
-              </a>{" "}
-              (Android)
-            </li>
-            <li>
-              <a
-                href="https://f-droid.org/packages/me.ash.reader"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-accent hover:text-accent-hover font-medium"
-              >
-                Read You
-              </a>{" "}
-              (Android)
-            </li>
-            <li>
-              <a
-                href="https://flathub.org/apps/io.gitlab.news_flash.NewsFlash"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-accent hover:text-accent-hover font-medium"
-              >
-                NewsFlash
-              </a>{" "}
-              (Linux)
-            </li>
-          </ul>
-        </div>
-
-        {/* Setup Instructions */}
-        <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Setup</h3>
-          <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-            In your app&apos;s account settings, choose &ldquo;FreshRSS&rdquo; as the service type,
-            then enter:
-          </p>
-          <ul className="ui-text-sm mt-3 space-y-2 text-zinc-600 dark:text-zinc-400">
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Server URL:</strong>{" "}
-              <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
-                {baseUrl}/api/greader.php
-              </code>
-              <CopyButton
-                value={`${baseUrl}/api/greader.php`}
-                className="ml-2 px-1.5 py-0.5"
-                title="Copy server URL"
-              />
-            </li>
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Email:</strong> Your Lion Reader
-              email address
-            </li>
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Password:</strong> Your Lion
-              Reader password
-            </li>
-          </ul>
-        </div>
-
-        {/* Note */}
-        <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
-          <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-            The API uses your regular Lion Reader credentials for authentication. All your
-            subscriptions, tags, read state, and starred articles sync automatically.
-          </p>
-        </div>
-
-        {/* API base URL note */}
-        {baseUrl && (
-          <p className="ui-text-xs mt-4 text-zinc-400 dark:text-zinc-500">
-            API endpoint: {apiBase}
-          </p>
-        )}
+        <ul className="ui-text-sm mt-2 list-inside list-disc space-y-1 text-zinc-600 dark:text-zinc-400">
+          <li>
+            <TextLink href="https://reederapp.com/classic/" external>
+              Reeder Classic
+            </TextLink>{" "}
+            (iOS / macOS)
+          </li>
+          <li>
+            <TextLink href="https://netnewswire.com/" external>
+              NetNewsWire
+            </TextLink>{" "}
+            (iOS / macOS)
+          </li>
+          <li>
+            <TextLink
+              href="https://play.google.com/store/apps/details?id=allen.town.focus.reader"
+              external
+            >
+              FocusReader
+            </TextLink>{" "}
+            (Android)
+          </li>
+          <li>
+            <TextLink href="https://f-droid.org/packages/me.ash.reader" external>
+              Read You
+            </TextLink>{" "}
+            (Android)
+          </li>
+          <li>
+            <TextLink href="https://flathub.org/apps/io.gitlab.news_flash.NewsFlash" external>
+              NewsFlash
+            </TextLink>{" "}
+            (Linux)
+          </li>
+        </ul>
       </div>
-    </section>
+
+      {/* Setup Instructions */}
+      <CardSection>
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Setup</h3>
+        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+          In your app&apos;s account settings, choose &ldquo;FreshRSS&rdquo; as the service type,
+          then enter:
+        </p>
+        <ul className="ui-text-sm mt-3 space-y-2 text-zinc-600 dark:text-zinc-400">
+          <li>
+            <strong className="text-zinc-900 dark:text-zinc-200">Server URL:</strong>{" "}
+            <InlineCode>{baseUrl}/api/greader.php</InlineCode>
+            <CopyButton
+              value={`${baseUrl}/api/greader.php`}
+              className="ml-2 px-1.5 py-0.5"
+              title="Copy server URL"
+            />
+          </li>
+          <li>
+            <strong className="text-zinc-900 dark:text-zinc-200">Email:</strong> Your Lion Reader
+            email address
+          </li>
+          <li>
+            <strong className="text-zinc-900 dark:text-zinc-200">Password:</strong> Your Lion Reader
+            password
+          </li>
+        </ul>
+      </CardSection>
+
+      {/* Note */}
+      <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+          The API uses your regular Lion Reader credentials for authentication. All your
+          subscriptions, tags, read state, and starred articles sync automatically.
+        </p>
+      </div>
+
+      {/* API base URL note */}
+      {baseUrl && (
+        <p className="ui-text-xs mt-4 text-zinc-400 dark:text-zinc-500">API endpoint: {apiBase}</p>
+      )}
+    </SettingsSection>
   );
 }

--- a/src/components/settings/IntegrationsSettings.tsx
+++ b/src/components/settings/IntegrationsSettings.tsx
@@ -8,8 +8,12 @@
 "use client";
 
 import { useMemo } from "react";
+import { SettingsSection } from "@/components/settings/SettingsSection";
 import { Alert } from "@/components/ui/alert";
+import { CardSection } from "@/components/ui/card";
 import { CodeBlock, CopyButton } from "@/components/ui/copy-button";
+import { InlineCode } from "@/components/ui/inline-code";
+import { TextLink } from "@/components/ui/text-link";
 
 export function IntegrationsSettings() {
   // Check env var first (available on both server and client), then fall back to window.location.origin
@@ -40,101 +44,75 @@ export function IntegrationsSettings() {
   const claudeCodeCommand = `claude mcp add --transport http lionreader ${mcpUrl}`;
 
   return (
-    <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">
-        AI Integrations
-      </h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        {/* Description */}
-        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-          Connect Lion Reader to AI assistants via{" "}
-          <a
-            href="https://modelcontextprotocol.io/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent hover:text-accent-hover font-medium"
-          >
-            MCP (Model Context Protocol)
-          </a>
-          . This lets Claude read, search, and manage your feeds directly.
+    <SettingsSection title="AI Integrations">
+      {/* Description */}
+      <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+        Connect Lion Reader to AI assistants via{" "}
+        <TextLink href="https://modelcontextprotocol.io/" external>
+          MCP (Model Context Protocol)
+        </TextLink>
+        . This lets Claude read, search, and manage your feeds directly.
+      </p>
+
+      {/* Claude Code */}
+      <div className="mt-6">
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Claude Code</h3>
+        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+          Run this command in your terminal:
         </p>
-
-        {/* Claude Code */}
-        <div className="mt-6">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Claude Code</h3>
-          <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-            Run this command in your terminal:
-          </p>
-          <CodeBlock code={claudeCodeCommand} className="mt-3" />
-        </div>
-
-        {/* Claude.ai */}
-        <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Claude.ai</h3>
-          <div className="mt-2">
-            <Alert variant="warning">
-              The claude.ai <strong>web</strong> connector is currently broken due to a bug on
-              claude.ai&rsquo;s side. See{" "}
-              <a
-                href="https://github.com/brendanlong/lion-reader/issues/986"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-medium underline"
-              >
-                this issue
-              </a>
-              . The MCP server should work with other tools, including Claude Code.
-            </Alert>
-          </div>
-          <ol className="ui-text-sm mt-2 list-inside list-decimal space-y-2 text-zinc-600 dark:text-zinc-400">
-            <li>Click your name in the bottom-left corner</li>
-            <li>
-              Go to <strong className="text-zinc-900 dark:text-zinc-200">Settings</strong> &rarr;{" "}
-              <strong className="text-zinc-900 dark:text-zinc-200">Connectors</strong>
-            </li>
-            <li>
-              Click{" "}
-              <strong className="text-zinc-900 dark:text-zinc-200">Add Custom Connector</strong>
-            </li>
-            <li>
-              Enter Name: <strong className="text-zinc-900 dark:text-zinc-200">Lion Reader</strong>
-            </li>
-            <li>
-              Enter Remote MCP server URL:{" "}
-              <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
-                {mcpUrl}
-              </code>
-              <CopyButton
-                value={mcpUrl}
-                className="ml-2 px-1.5 py-0.5"
-                title="Copy MCP server URL"
-              />
-            </li>
-          </ol>
-        </div>
-
-        {/* Claude Desktop */}
-        <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-            Claude Desktop
-          </h3>
-          <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-            Add this to your{" "}
-            <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
-              claude_desktop_config.json
-            </code>
-            :
-          </p>
-          <CodeBlock code={claudeDesktopConfig} className="mt-3" />
-        </div>
-
-        {/* Note about MCP URL */}
-        {baseUrl && (
-          <p className="ui-text-xs mt-4 text-zinc-400 dark:text-zinc-500">
-            MCP server URL: {mcpUrl}
-          </p>
-        )}
+        <CodeBlock code={claudeCodeCommand} className="mt-3" />
       </div>
-    </section>
+
+      {/* Claude.ai */}
+      <CardSection>
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Claude.ai</h3>
+        <div className="mt-2">
+          <Alert variant="warning">
+            The claude.ai <strong>web</strong> connector is currently broken due to a bug on
+            claude.ai&rsquo;s side. See{" "}
+            <a
+              href="https://github.com/brendanlong/lion-reader/issues/986"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium underline"
+            >
+              this issue
+            </a>
+            . The MCP server should work with other tools, including Claude Code.
+          </Alert>
+        </div>
+        <ol className="ui-text-sm mt-2 list-inside list-decimal space-y-2 text-zinc-600 dark:text-zinc-400">
+          <li>Click your name in the bottom-left corner</li>
+          <li>
+            Go to <strong className="text-zinc-900 dark:text-zinc-200">Settings</strong> &rarr;{" "}
+            <strong className="text-zinc-900 dark:text-zinc-200">Connectors</strong>
+          </li>
+          <li>
+            Click <strong className="text-zinc-900 dark:text-zinc-200">Add Custom Connector</strong>
+          </li>
+          <li>
+            Enter Name: <strong className="text-zinc-900 dark:text-zinc-200">Lion Reader</strong>
+          </li>
+          <li>
+            Enter Remote MCP server URL: <InlineCode>{mcpUrl}</InlineCode>
+            <CopyButton value={mcpUrl} className="ml-2 px-1.5 py-0.5" title="Copy MCP server URL" />
+          </li>
+        </ol>
+      </CardSection>
+
+      {/* Claude Desktop */}
+      <CardSection>
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Claude Desktop</h3>
+        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+          Add this to your <InlineCode>claude_desktop_config.json</InlineCode>:
+        </p>
+        <CodeBlock code={claudeDesktopConfig} className="mt-3" />
+      </CardSection>
+
+      {/* Note about MCP URL */}
+      {baseUrl && (
+        <p className="ui-text-xs mt-4 text-zinc-400 dark:text-zinc-500">MCP server URL: {mcpUrl}</p>
+      )}
+    </SettingsSection>
   );
 }

--- a/src/components/settings/KeyboardShortcutsSettings.tsx
+++ b/src/components/settings/KeyboardShortcutsSettings.tsx
@@ -8,61 +8,58 @@
 "use client";
 
 import { useKeyboardShortcutsContext } from "@/components/keyboard/KeyboardShortcutsProvider";
+import { SettingsSection } from "@/components/settings/SettingsSection";
+import { CardSection } from "@/components/ui/card";
 import { InfoCircleIcon } from "@/components/ui/icon-button";
 
 export function KeyboardShortcutsSettings() {
   const { enabled, setEnabled, openShortcutsModal } = useKeyboardShortcutsContext();
 
   return (
-    <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">
-        Keyboard Shortcuts
-      </h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        {/* Enable/Disable Toggle */}
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
-              Enable keyboard shortcuts
-            </h3>
-            <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
-              Use keyboard shortcuts to navigate entries and perform actions quickly.
-            </p>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={enabled}
-            onClick={() => setEnabled(!enabled)}
-            className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
-              enabled ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
+    <SettingsSection title="Keyboard Shortcuts">
+      {/* Enable/Disable Toggle */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
+            Enable keyboard shortcuts
+          </h3>
+          <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+            Use keyboard shortcuts to navigate entries and perform actions quickly.
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          onClick={() => setEnabled(!enabled)}
+          className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
+            enabled ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
+          }`}
+        >
+          <span
+            aria-hidden="true"
+            className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
+              enabled ? "translate-x-5" : "translate-x-0"
             }`}
-          >
-            <span
-              aria-hidden="true"
-              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
-                enabled ? "translate-x-5" : "translate-x-0"
-              }`}
-            />
-          </button>
-        </div>
-
-        {/* View Shortcuts Button */}
-        <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
-          <button
-            onClick={openShortcutsModal}
-            className="ui-text-sm inline-flex items-center gap-2 font-medium text-zinc-700 transition-colors hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-50"
-          >
-            <InfoCircleIcon className="h-4 w-4" />
-            View all keyboard shortcuts
-            {enabled && (
-              <kbd className="ui-text-xs ml-1 rounded border border-zinc-300 bg-zinc-100 px-1.5 py-0.5 font-mono font-medium text-zinc-600 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
-                ?
-              </kbd>
-            )}
-          </button>
-        </div>
+          />
+        </button>
       </div>
-    </section>
+
+      {/* View Shortcuts Button */}
+      <CardSection>
+        <button
+          onClick={openShortcutsModal}
+          className="ui-text-sm inline-flex items-center gap-2 font-medium text-zinc-700 transition-colors hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-50"
+        >
+          <InfoCircleIcon className="h-4 w-4" />
+          View all keyboard shortcuts
+          {enabled && (
+            <kbd className="ui-text-xs ml-1 rounded border border-zinc-300 bg-zinc-100 px-1.5 py-0.5 font-mono font-medium text-zinc-600 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+              ?
+            </kbd>
+          )}
+        </button>
+      </CardSection>
+    </SettingsSection>
   );
 }

--- a/src/components/settings/OpmlImportExport.tsx
+++ b/src/components/settings/OpmlImportExport.tsx
@@ -14,8 +14,10 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
+import { SettingsSectionHeading } from "@/components/settings/SettingsSection";
 import { Button } from "@/components/ui/button";
 import { Alert } from "@/components/ui/alert";
+import { Card } from "@/components/ui/card";
 import { UploadIcon, DownloadIcon, SpinnerIcon } from "@/components/ui/icon-button";
 import { parseOpml, type OpmlFeed } from "@/server/feed/opml";
 
@@ -51,9 +53,7 @@ type ImportState =
 export function OpmlImportExport() {
   return (
     <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">
-        Import / Export
-      </h2>
+      <SettingsSectionHeading>Import / Export</SettingsSectionHeading>
       <div className="space-y-6">
         <ImportSection />
         <ExportSection />
@@ -253,7 +253,7 @@ function ImportSection() {
   }, []);
 
   return (
-    <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+    <Card>
       <h3 className="ui-text-sm mb-2 font-medium text-zinc-900 dark:text-zinc-50">
         Import from OPML
       </h3>
@@ -355,7 +355,7 @@ function ImportSection() {
           onReset={handleReset}
         />
       )}
-    </div>
+    </Card>
   );
 }
 
@@ -557,7 +557,7 @@ function ExportSection() {
   }, [utils.subscriptions.export]);
 
   return (
-    <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+    <Card>
       <h3 className="ui-text-sm mb-2 font-medium text-zinc-900 dark:text-zinc-50">
         Export to OPML
       </h3>
@@ -581,6 +581,6 @@ function ExportSection() {
         <DownloadIcon className="mr-2 h-4 w-4" />
         Export subscriptions
       </Button>
-    </div>
+    </Card>
   );
 }

--- a/src/components/settings/SettingsSection.tsx
+++ b/src/components/settings/SettingsSection.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Alert } from "@/components/ui/alert";
+import { Card } from "@/components/ui/card";
 import type { ReactNode } from "react";
 
 // ============================================================================
@@ -26,7 +27,7 @@ interface SettingsSectionProps {
   /**
    * Optional description shown below the title inside the card.
    */
-  description?: string;
+  description?: ReactNode;
 
   /**
    * Whether the section is loading. Shows skeleton UI when true.
@@ -65,22 +66,22 @@ export function SettingsSection({
   if (isLoading) {
     return (
       <section>
-        <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">{title}</h2>
-        <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+        <SettingsSectionHeading>{title}</SettingsSectionHeading>
+        <Card>
           <div className="space-y-4">
             {Array.from({ length: skeletonRows }).map((_, i) => (
               <div key={i} className="h-10 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
             ))}
           </div>
-        </div>
+        </Card>
       </section>
     );
   }
 
   return (
     <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">{title}</h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+      <SettingsSectionHeading>{title}</SettingsSectionHeading>
+      <Card>
         {description && (
           <p className="ui-text-sm mb-4 text-zinc-500 dark:text-zinc-400">{description}</p>
         )}
@@ -98,7 +99,17 @@ export function SettingsSection({
         )}
 
         {children}
-      </div>
+      </Card>
     </section>
+  );
+}
+
+/**
+ * The standard settings section heading. Exported for sections whose card
+ * content doesn't fit the SettingsSection wrapper.
+ */
+export function SettingsSectionHeading({ children }: { children: ReactNode }) {
+  return (
+    <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">{children}</h2>
   );
 }

--- a/src/components/settings/TagManagement.tsx
+++ b/src/components/settings/TagManagement.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ChevronDownIcon, EditIcon, TrashIcon } from "@/components/ui/icon-button";
 import { ColorPicker, ColorDot } from "@/components/ui/color-picker";
+import { CardSection } from "@/components/ui/card";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { SettingsSection } from "./SettingsSection";
 
@@ -57,7 +58,7 @@ function TagManagementContent() {
       <CreateTagForm onSuccess={showSuccess} onError={showError} />
 
       {/* Tag list */}
-      <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
+      <CardSection>
         {tags.length === 0 ? (
           <p className="ui-text-sm text-zinc-500 dark:text-zinc-400">
             No tags created yet. Create your first tag above.
@@ -69,7 +70,7 @@ function TagManagementContent() {
             ))}
           </div>
         )}
-      </div>
+      </CardSection>
     </SettingsSection>
   );
 }

--- a/src/components/settings/WallabagApiSettings.tsx
+++ b/src/components/settings/WallabagApiSettings.tsx
@@ -11,8 +11,12 @@
 import { useMemo } from "react";
 import { QRCodeSVG } from "qrcode.react";
 import { trpc } from "@/lib/trpc/client";
-import { MobileIcon } from "@/components/ui/icon-button";
+import { SettingsSection } from "@/components/settings/SettingsSection";
+import { CardSection } from "@/components/ui/card";
 import { CopyButton } from "@/components/ui/copy-button";
+import { MobileIcon } from "@/components/ui/icon-button";
+import { InlineCode } from "@/components/ui/inline-code";
+import { TextLink } from "@/components/ui/text-link";
 
 export function WallabagApiSettings() {
   const userQuery = trpc.auth.me.useQuery();
@@ -42,175 +46,142 @@ export function WallabagApiSettings() {
   }, [email, baseUrl, serverUrl]);
 
   return (
-    <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">
-        Wallabag API (Save Articles)
-      </h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        {/* Description */}
-        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-          Lion Reader exposes a{" "}
-          <a
-            href="https://doc.wallabag.org/developer/api/methods/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent hover:text-accent-hover font-medium"
-          >
-            Wallabag-compatible API
-          </a>{" "}
-          so you can use the Wallabag app on your phone or tablet to save articles directly to Lion
-          Reader.
-        </p>
+    <SettingsSection title="Wallabag API (Save Articles)">
+      {/* Description */}
+      <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+        Lion Reader exposes a{" "}
+        <TextLink href="https://doc.wallabag.org/developer/api/methods/" external>
+          Wallabag-compatible API
+        </TextLink>{" "}
+        so you can use the Wallabag app on your phone or tablet to save articles directly to Lion
+        Reader.
+      </p>
 
-        {/* Supported Clients */}
-        <div className="mt-6">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-            Compatible Apps
-          </h3>
-          <ul className="ui-text-sm mt-2 list-inside list-disc space-y-1 text-zinc-600 dark:text-zinc-400">
-            <li>
+      {/* Supported Clients */}
+      <div className="mt-6">
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Compatible Apps</h3>
+        <ul className="ui-text-sm mt-2 list-inside list-disc space-y-1 text-zinc-600 dark:text-zinc-400">
+          <li>
+            <TextLink
+              href="https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche"
+              external
+            >
+              wallabag
+            </TextLink>{" "}
+            (Android)
+          </li>
+          <li>
+            <TextLink href="https://apps.apple.com/app/wallabag-2-official/id1170800946" external>
+              wallabag 2
+            </TextLink>{" "}
+            (iOS)
+          </li>
+        </ul>
+      </div>
+
+      {/* Quick Setup: QR Code + Deep Link */}
+      {wallabagDeepLink && (
+        <CardSection>
+          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Quick Setup</h3>
+          <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+            Scan this QR code with your phone or tap the button below to auto-configure the Wallabag
+            Android app. You&apos;ll need to enter your password, and fix the username if the{" "}
+            <code className="ui-text-xs rounded bg-zinc-100 px-1 font-mono dark:bg-zinc-800">
+              @
+            </code>{" "}
+            shows as{" "}
+            <code className="ui-text-xs rounded bg-zinc-100 px-1 font-mono dark:bg-zinc-800">
+              %40
+            </code>
+            .
+          </p>
+
+          <div className="mt-4 flex flex-col items-center gap-4 sm:flex-row sm:items-start">
+            {/* QR Code */}
+            <div className="rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-white">
+              <QRCodeSVG value={wallabagDeepLink} size={160} level="M" />
+            </div>
+
+            {/* Deep Link Button + Info */}
+            <div className="flex flex-col gap-3">
               <a
-                href="https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-accent hover:text-accent-hover font-medium"
+                href={wallabagDeepLink}
+                className="bg-accent hover:bg-accent-hover inline-flex items-center gap-2 rounded-md px-4 py-2 font-medium text-white transition-colors"
               >
-                wallabag
-              </a>{" "}
-              (Android)
-            </li>
-            <li>
-              <a
-                href="https://apps.apple.com/app/wallabag-2-official/id1170800946"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-accent hover:text-accent-hover font-medium"
-              >
-                wallabag 2
-              </a>{" "}
-              (iOS)
-            </li>
-          </ul>
-        </div>
-
-        {/* Quick Setup: QR Code + Deep Link */}
-        {wallabagDeepLink && (
-          <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
-            <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Quick Setup</h3>
-            <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-              Scan this QR code with your phone or tap the button below to auto-configure the
-              Wallabag Android app. You&apos;ll need to enter your password, and fix the username if
-              the{" "}
-              <code className="ui-text-xs rounded bg-zinc-100 px-1 font-mono dark:bg-zinc-800">
-                @
-              </code>{" "}
-              shows as{" "}
-              <code className="ui-text-xs rounded bg-zinc-100 px-1 font-mono dark:bg-zinc-800">
-                %40
-              </code>
-              .
-            </p>
-
-            <div className="mt-4 flex flex-col items-center gap-4 sm:flex-row sm:items-start">
-              {/* QR Code */}
-              <div className="rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-white">
-                <QRCodeSVG value={wallabagDeepLink} size={160} level="M" />
-              </div>
-
-              {/* Deep Link Button + Info */}
-              <div className="flex flex-col gap-3">
-                <a
-                  href={wallabagDeepLink}
-                  className="bg-accent hover:bg-accent-hover inline-flex items-center gap-2 rounded-md px-4 py-2 font-medium text-white transition-colors"
-                >
-                  <MobileIcon className="h-4 w-4" />
-                  Open in Wallabag App
-                </a>
-                <p className="ui-text-xs max-w-xs text-zinc-400 dark:text-zinc-500">
-                  The QR code and button pre-fill the server URL and your email address. Client ID
-                  and secret are both{" "}
-                  <code className="rounded bg-zinc-100 px-1 font-mono dark:bg-zinc-800">
-                    wallabag
-                  </code>
-                  .
-                </p>
-              </div>
+                <MobileIcon className="h-4 w-4" />
+                Open in Wallabag App
+              </a>
+              <p className="ui-text-xs max-w-xs text-zinc-400 dark:text-zinc-500">
+                The QR code and button pre-fill the server URL and your email address. Client ID and
+                secret are both{" "}
+                <code className="rounded bg-zinc-100 px-1 font-mono dark:bg-zinc-800">
+                  wallabag
+                </code>
+                .
+              </p>
             </div>
           </div>
-        )}
+        </CardSection>
+      )}
 
-        {/* Manual Setup Instructions */}
-        <div className="mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700">
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Manual Setup</h3>
-          <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-            In the Wallabag app, go to Settings and enter the following:
-          </p>
-          <ul className="ui-text-sm mt-3 space-y-2 text-zinc-600 dark:text-zinc-400">
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Server URL:</strong>{" "}
-              <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
-                {serverUrl}
-              </code>
-              <CopyButton
-                value={serverUrl}
-                className="ml-2 px-1.5 py-0.5"
-                title="Copy server URL"
-              />
-            </li>
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Client ID:</strong>{" "}
-              <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
-                wallabag
-              </code>
-              <CopyButton value="wallabag" className="ml-2 px-1.5 py-0.5" title="Copy client ID" />
-            </li>
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Client Secret:</strong>{" "}
-              <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
-                wallabag
-              </code>
-              <CopyButton
-                value="wallabag"
-                className="ml-2 px-1.5 py-0.5"
-                title="Copy client secret"
-              />
-            </li>
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Username:</strong>{" "}
-              {email ? (
-                <>
-                  <code className="ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
-                    {email}
-                  </code>
-                  <CopyButton value={email} className="ml-2 px-1.5 py-0.5" title="Copy username" />
-                </>
-              ) : (
-                "Your Lion Reader email address"
-              )}
-            </li>
-            <li>
-              <strong className="text-zinc-900 dark:text-zinc-200">Password:</strong> Your Lion
-              Reader password
-            </li>
-          </ul>
-        </div>
+      {/* Manual Setup Instructions */}
+      <CardSection>
+        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Manual Setup</h3>
+        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+          In the Wallabag app, go to Settings and enter the following:
+        </p>
+        <ul className="ui-text-sm mt-3 space-y-2 text-zinc-600 dark:text-zinc-400">
+          <li>
+            <strong className="text-zinc-900 dark:text-zinc-200">Server URL:</strong>{" "}
+            <InlineCode>{serverUrl}</InlineCode>
+            <CopyButton value={serverUrl} className="ml-2 px-1.5 py-0.5" title="Copy server URL" />
+          </li>
+          <li>
+            <strong className="text-zinc-900 dark:text-zinc-200">Client ID:</strong>{" "}
+            <InlineCode>wallabag</InlineCode>
+            <CopyButton value="wallabag" className="ml-2 px-1.5 py-0.5" title="Copy client ID" />
+          </li>
+          <li>
+            <strong className="text-zinc-900 dark:text-zinc-200">Client Secret:</strong>{" "}
+            <InlineCode>wallabag</InlineCode>
+            <CopyButton
+              value="wallabag"
+              className="ml-2 px-1.5 py-0.5"
+              title="Copy client secret"
+            />
+          </li>
+          <li>
+            <strong className="text-zinc-900 dark:text-zinc-200">Username:</strong>{" "}
+            {email ? (
+              <>
+                <InlineCode>{email}</InlineCode>
+                <CopyButton value={email} className="ml-2 px-1.5 py-0.5" title="Copy username" />
+              </>
+            ) : (
+              "Your Lion Reader email address"
+            )}
+          </li>
+          <li>
+            <strong className="text-zinc-900 dark:text-zinc-200">Password:</strong> Your Lion Reader
+            password
+          </li>
+        </ul>
+      </CardSection>
 
-        {/* How it works */}
-        <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
-          <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-            When you share a URL to the Wallabag app, it will save it to your Lion Reader account as
-            a saved article. You can also view, archive, star, and delete saved articles from the
-            app.
-          </p>
-        </div>
-
-        {/* API base URL note */}
-        {baseUrl && (
-          <p className="ui-text-xs mt-4 text-zinc-400 dark:text-zinc-500">
-            API endpoint: {serverUrl}
-          </p>
-        )}
+      {/* How it works */}
+      <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+          When you share a URL to the Wallabag app, it will save it to your Lion Reader account as a
+          saved article. You can also view, archive, star, and delete saved articles from the app.
+        </p>
       </div>
-    </section>
+
+      {/* API base URL note */}
+      {baseUrl && (
+        <p className="ui-text-xs mt-4 text-zinc-400 dark:text-zinc-500">
+          API endpoint: {serverUrl}
+        </p>
+      )}
+    </SettingsSection>
   );
 }

--- a/src/components/settings/pages/AccountSettingsContent.tsx
+++ b/src/components/settings/pages/AccountSettingsContent.tsx
@@ -22,6 +22,8 @@ import { CheckIcon } from "@/components/ui/icon-button";
 import { LinkedAccounts } from "@/components/settings/LinkedAccounts";
 import { KeyboardShortcutsSettings } from "@/components/settings/KeyboardShortcutsSettings";
 import { AboutSection } from "@/components/settings/AboutSection";
+import { SettingsSection } from "@/components/settings/SettingsSection";
+import { TextLink } from "@/components/ui/text-link";
 
 /**
  * Handles OAuth link success/error messages from query params.
@@ -85,61 +87,56 @@ function AccountInfoSection() {
   const userQuery = trpc.auth.me.useQuery();
 
   return (
-    <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">
-        Account Information
-      </h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        {userQuery.isLoading ? (
-          <div className="space-y-4">
-            <div className="h-5 w-48 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
-            <div className="h-5 w-32 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+    <SettingsSection title="Account Information">
+      {userQuery.isLoading ? (
+        <div className="space-y-4">
+          <div className="h-5 w-48 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+          <div className="h-5 w-32 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+        </div>
+      ) : userQuery.error ? (
+        <p className="ui-text-sm text-red-600 dark:text-red-400">
+          Failed to load account information
+        </p>
+      ) : (
+        <dl className="space-y-4">
+          <div>
+            <dt className="ui-text-sm font-medium text-zinc-500 dark:text-zinc-400">Email</dt>
+            <dd className="ui-text-sm mt-1 text-zinc-900 dark:text-zinc-50">
+              {userQuery.data?.user.email}
+            </dd>
           </div>
-        ) : userQuery.error ? (
-          <p className="ui-text-sm text-red-600 dark:text-red-400">
-            Failed to load account information
-          </p>
-        ) : (
-          <dl className="space-y-4">
-            <div>
-              <dt className="ui-text-sm font-medium text-zinc-500 dark:text-zinc-400">Email</dt>
-              <dd className="ui-text-sm mt-1 text-zinc-900 dark:text-zinc-50">
-                {userQuery.data?.user.email}
-              </dd>
-            </div>
-            <div>
-              <dt className="ui-text-sm font-medium text-zinc-500 dark:text-zinc-400">
-                Member since
-              </dt>
-              <dd className="ui-text-sm mt-1 text-zinc-900 dark:text-zinc-50">
-                {userQuery.data?.user.createdAt
-                  ? new Date(userQuery.data.user.createdAt).toLocaleDateString("en-US", {
-                      year: "numeric",
-                      month: "long",
-                      day: "numeric",
-                    })
-                  : "Unknown"}
-              </dd>
-            </div>
-            <div>
-              <dt className="ui-text-sm font-medium text-zinc-500 dark:text-zinc-400">
-                Email verified
-              </dt>
-              <dd className="ui-text-sm mt-1 text-zinc-900 dark:text-zinc-50">
-                {userQuery.data?.user.emailVerifiedAt ? (
-                  <span className="inline-flex items-center text-green-600 dark:text-green-400">
-                    <CheckIcon className="mr-1 h-4 w-4" />
-                    Verified
-                  </span>
-                ) : (
-                  <span className="text-zinc-500 dark:text-zinc-400">Not verified</span>
-                )}
-              </dd>
-            </div>
-          </dl>
-        )}
-      </div>
-    </section>
+          <div>
+            <dt className="ui-text-sm font-medium text-zinc-500 dark:text-zinc-400">
+              Member since
+            </dt>
+            <dd className="ui-text-sm mt-1 text-zinc-900 dark:text-zinc-50">
+              {userQuery.data?.user.createdAt
+                ? new Date(userQuery.data.user.createdAt).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })
+                : "Unknown"}
+            </dd>
+          </div>
+          <div>
+            <dt className="ui-text-sm font-medium text-zinc-500 dark:text-zinc-400">
+              Email verified
+            </dt>
+            <dd className="ui-text-sm mt-1 text-zinc-900 dark:text-zinc-50">
+              {userQuery.data?.user.emailVerifiedAt ? (
+                <span className="inline-flex items-center text-green-600 dark:text-green-400">
+                  <CheckIcon className="mr-1 h-4 w-4" />
+                  Verified
+                </span>
+              ) : (
+                <span className="text-zinc-500 dark:text-zinc-400">Not verified</span>
+              )}
+            </dd>
+          </div>
+        </dl>
+      )}
+    </SettingsSection>
   );
 }
 
@@ -149,12 +146,9 @@ function PasswordSection() {
 
   if (linkedAccountsQuery.isLoading) {
     return (
-      <section>
-        <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">Password</h2>
-        <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-          <div className="h-32 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
-        </div>
-      </section>
+      <SettingsSection title="Password">
+        <div className="h-32 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+      </SettingsSection>
     );
   }
 
@@ -255,77 +249,72 @@ function PasswordForm({ mode, onSuccess }: { mode: "set" | "change"; onSuccess: 
   };
 
   return (
-    <section>
-      <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">
-        {isSetMode ? "Set Password" : "Change Password"}
-      </h2>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        {isSetMode && (
-          <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
-            Your account was created with OAuth. Set a password to also log in with your email and
-            password.
-          </p>
-        )}
+    <SettingsSection title={isSetMode ? "Set Password" : "Change Password"}>
+      {isSetMode && (
+        <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
+          Your account was created with OAuth. Set a password to also log in with your email and
+          password.
+        </p>
+      )}
 
-        {successMessage && (
-          <Alert variant="success" className="mb-4">
-            {successMessage}
-          </Alert>
-        )}
+      {successMessage && (
+        <Alert variant="success" className="mb-4">
+          {successMessage}
+        </Alert>
+      )}
 
-        {errors.form && (
-          <Alert variant="error" className="mb-4">
-            {errors.form}
-          </Alert>
-        )}
+      {errors.form && (
+        <Alert variant="error" className="mb-4">
+          {errors.form}
+        </Alert>
+      )}
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {!isSetMode && (
-            <Input
-              id="current-password"
-              type="password"
-              label="Current password"
-              placeholder="Enter your current password"
-              value={currentPassword}
-              onChange={(e) => setCurrentPassword(e.target.value)}
-              error={errors.currentPassword}
-              autoComplete="current-password"
-              disabled={mutation.isPending}
-            />
-          )}
-
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {!isSetMode && (
           <Input
-            id="new-password"
+            id="current-password"
             type="password"
-            label={isSetMode ? "Password" : "New password"}
-            placeholder={isSetMode ? "Enter a password" : "Enter your new password"}
-            value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
-            error={errors.newPassword}
-            autoComplete="new-password"
+            label="Current password"
+            placeholder="Enter your current password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            error={errors.currentPassword}
+            autoComplete="current-password"
             disabled={mutation.isPending}
           />
+        )}
 
-          <Input
-            id="confirm-password"
-            type="password"
-            label={isSetMode ? "Confirm password" : "Confirm new password"}
-            placeholder={isSetMode ? "Confirm your password" : "Confirm your new password"}
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            error={errors.confirmPassword}
-            autoComplete="new-password"
-            disabled={mutation.isPending}
-          />
+        <Input
+          id="new-password"
+          type="password"
+          label={isSetMode ? "Password" : "New password"}
+          placeholder={isSetMode ? "Enter a password" : "Enter your new password"}
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          error={errors.newPassword}
+          autoComplete="new-password"
+          disabled={mutation.isPending}
+        />
 
-          <div className="pt-2">
-            <Button type="submit" loading={mutation.isPending}>
-              {isSetMode ? "Set password" : "Change password"}
-            </Button>
-          </div>
-        </form>
-      </div>
-    </section>
+        <Input
+          id="confirm-password"
+          type="password"
+          label={isSetMode ? "Confirm password" : "Confirm new password"}
+          placeholder={isSetMode ? "Confirm your password" : "Confirm your new password"}
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          error={errors.confirmPassword}
+          autoComplete="new-password"
+          disabled={mutation.isPending}
+        />
+
+        <div className="pt-2">
+          <Button type="submit" loading={mutation.isPending}>
+            {isSetMode ? "Set password" : "Change password"}
+          </Button>
+        </div>
+      </form>
+    </SettingsSection>
   );
 }
 
@@ -350,27 +339,19 @@ export default function AccountSettingsContent() {
       <KeyboardShortcutsSettings />
 
       {/* Privacy & Legal Section - fully static */}
-      <section>
-        <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">
-          Privacy & Legal
-        </h2>
-        <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-          <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-            Learn more about how we collect, use, and protect your data.
-          </p>
-          <div className="mt-4 flex gap-4">
-            <a
-              href="/privacy"
-              className="ui-text-sm text-accent hover:text-accent-hover font-medium"
-            >
-              View Privacy Policy &rarr;
-            </a>
-            <a href="/terms" className="ui-text-sm text-accent hover:text-accent-hover font-medium">
-              View Terms of Service &rarr;
-            </a>
-          </div>
+      <SettingsSection title="Privacy & Legal">
+        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+          Learn more about how we collect, use, and protect your data.
+        </p>
+        <div className="mt-4 flex gap-4">
+          <TextLink href="/privacy" className="ui-text-sm">
+            View Privacy Policy &rarr;
+          </TextLink>
+          <TextLink href="/terms" className="ui-text-sm">
+            View Terms of Service &rarr;
+          </TextLink>
         </div>
-      </section>
+      </SettingsSection>
 
       {/* About Section - fully static */}
       <AboutSection />

--- a/src/components/settings/pages/ApiTokensSettingsContent.tsx
+++ b/src/components/settings/pages/ApiTokensSettingsContent.tsx
@@ -13,6 +13,7 @@ import { trpc } from "@/lib/trpc/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
+import { Card } from "@/components/ui/card";
 import { SettingsListContainer } from "@/components/settings/SettingsListContainer";
 import { CloseIcon, KeyIcon } from "@/components/ui/icon-button";
 import { formatRelativeTime } from "@/lib/format";
@@ -169,7 +170,7 @@ export default function ApiTokensSettingsContent() {
 
       {/* Create Token Form */}
       {showCreateForm && (
-        <div className="mb-6 rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+        <Card className="mb-6">
           <h3 className="mb-4 font-medium text-zinc-900 dark:text-zinc-50">Create New Token</h3>
 
           <div className="space-y-4">
@@ -256,7 +257,7 @@ export default function ApiTokensSettingsContent() {
               </Button>
             </div>
           </div>
-        </div>
+        </Card>
       )}
 
       {/* Active Tokens List */}
@@ -338,7 +339,7 @@ interface ActiveTokenCardProps {
 
 function ActiveTokenCard({ token, onRevoke, isRevoking }: ActiveTokenCardProps) {
   return (
-    <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+    <Card padding="md">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex-1">
           <div className="flex items-center gap-2">
@@ -402,6 +403,6 @@ function ActiveTokenCard({ token, onRevoke, isRevoking }: ActiveTokenCardProps) 
           Revoke
         </Button>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -14,6 +14,7 @@ import { trpc } from "@/lib/trpc/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
+import { Card } from "@/components/ui/card";
 import {
   Dialog,
   DialogHeader,
@@ -421,7 +422,7 @@ function SpamPreferenceSection() {
   return (
     <section>
       <h3 className="ui-text-sm mb-4 font-medium text-zinc-900 dark:text-zinc-50">Preferences</h3>
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+      <Card>
         <div className="flex items-center justify-between">
           <div>
             <h4 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
@@ -449,7 +450,7 @@ function SpamPreferenceSection() {
             />
           </button>
         </div>
-      </div>
+      </Card>
     </section>
   );
 }

--- a/src/components/subscribe/SubscribeContent.tsx
+++ b/src/components/subscribe/SubscribeContent.tsx
@@ -17,6 +17,7 @@ import { clientPush } from "@/lib/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
+import { Card } from "@/components/ui/card";
 import {
   CheckCircleIcon,
   SpinnerIcon,
@@ -219,7 +220,7 @@ export function SubscribeContent() {
       </h1>
 
       {step === "input" && (
-        <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+        <Card>
           <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
             Enter the URL of an RSS or Atom feed, or a website that has a feed. We&apos;ll
             automatically discover the feed if possible.
@@ -273,13 +274,13 @@ export function SubscribeContent() {
               Preview Feed
             </Button>
           </form>
-        </div>
+        </Card>
       )}
 
       {step === "discovery" && (
         <div className="space-y-4">
           {/* Discovery Results Card */}
-          <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+          <Card>
             <div className="mb-4 flex items-center gap-2">
               <CheckCircleIcon className="h-5 w-5 text-green-600 dark:text-green-400" />
               <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
@@ -352,7 +353,7 @@ export function SubscribeContent() {
                 </a>
               </p>
             )}
-          </div>
+          </Card>
 
           {/* Back button */}
           <div className="flex">
@@ -366,7 +367,7 @@ export function SubscribeContent() {
       {step === "preview" && (
         <div className="space-y-4">
           {/* Feed Preview Card */}
-          <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+          <Card>
             <div className="mb-4 flex items-start justify-between">
               <div>
                 <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
@@ -394,7 +395,7 @@ export function SubscribeContent() {
             <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
               Feed URL: <span className="font-mono">{previewQuery.data?.feed.url}</span>
             </p>
-          </div>
+          </Card>
 
           {/* Sample Entries */}
           {previewQuery.data?.feed.sampleEntries &&

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -110,6 +110,23 @@ export function CardFooter({ children, className = "" }: CardFooterProps) {
 }
 
 /**
+ * A subsection within a Card, separated from the content above it by a
+ * top border. Use for the repeated divided-section pattern inside cards.
+ */
+export interface CardSectionProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function CardSection({ children, className = "" }: CardSectionProps) {
+  return (
+    <div className={`mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700 ${className}`}>
+      {children}
+    </div>
+  );
+}
+
+/**
  * Colored status card for alerts, summaries, etc.
  */
 export interface StatusCardProps {

--- a/src/components/ui/inline-code.tsx
+++ b/src/components/ui/inline-code.tsx
@@ -1,0 +1,23 @@
+/**
+ * InlineCode Component
+ *
+ * Small monospace chip for inline code, URLs, file names, and custom emoji
+ * text. Use instead of copying the mono-chip classes onto raw <code> tags.
+ */
+
+import type { HTMLAttributes } from "react";
+
+export interface InlineCodeProps extends HTMLAttributes<HTMLElement> {
+  className?: string;
+}
+
+export function InlineCode({ className = "", children, ...props }: InlineCodeProps) {
+  return (
+    <code
+      className={`ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800 ${className}`}
+      {...props}
+    >
+      {children}
+    </code>
+  );
+}

--- a/src/components/ui/text-link.tsx
+++ b/src/components/ui/text-link.tsx
@@ -1,0 +1,26 @@
+/**
+ * TextLink Component
+ *
+ * Inline text link with the standard accent color styling. Use for links
+ * inside prose (descriptions, help text, legal pages) instead of copying
+ * the accent classes onto raw anchors.
+ */
+
+import type { AnchorHTMLAttributes } from "react";
+
+export interface TextLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** Open in a new tab with rel="noopener noreferrer" */
+  external?: boolean;
+}
+
+export function TextLink({ external = false, className = "", children, ...props }: TextLinkProps) {
+  return (
+    <a
+      {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+      className={`text-accent hover:text-accent-hover font-medium ${className}`}
+      {...props}
+    >
+      {children}
+    </a>
+  );
+}


### PR DESCRIPTION
Fixes #1016.

The settings pages hand-rolled the same handful of style patterns dozens of times — the section shell (`<section><h2>…</h2><div className="rounded-lg border …">`), accent text links, inline monospace chips, and the border-t card divider. This PR moves each standard style into one place and references it everywhere, without changing the rendered DOM (class order aside).

## New shared components

- **`TextLink`** (`ui/text-link.tsx`) — accent-colored inline text link; `external` prop adds `target="_blank" rel="noopener noreferrer"`. Replaces 15 raw anchors that copied `text-accent hover:text-accent-hover font-medium`.
- **`InlineCode`** (`ui/inline-code.tsx`) — small monospace chip for inline code/URLs/file names. Replaces 11 raw `<code>` tags.
- **`CardSection`** (`ui/card.tsx`) — divided subsection within a `Card` (the repeated `mt-6 border-t … pt-6` wrapper). Replaces 11 raw divs.

## SettingsSection

- Now renders its card through the existing `Card` component, so the card shell classes live only in `card.tsx`.
- Exports `SettingsSectionHeading` for sections whose content doesn't fit the wrapper (e.g. OPML import/export, which renders two cards under one heading).
- `description` accepts `ReactNode`.

## Migrations

16 components that hand-rolled these patterns now use `SettingsSection`/`Card`/`CardSection`/`TextLink`/`InlineCode`: all of the settings sections (About, Appearance, Bookmarklet, Keyboard Shortcuts, Discord Bot, Google Reader API, Wallabag API, AI Integrations, OPML, API keys, Narration, Tag Management), the Account/API Tokens/Email settings pages, and the subscribe flow's card shells.

Deliberately left alone: styles that only *look* similar but deviate (zinc-50 note boxes, pill-button anchors, `px-1` code chips, the QR-code wrapper), the legal pages' prose classes, and the privacy page's `<Link>` (different navigation semantics). After this change, each of the five consolidated class strings greps to exactly one definition site under `src/`.

`src/components/CLAUDE.md` documents the new components and the settings-section pattern.

## Testing

- `pnpm typecheck`, `pnpm lint`, `prettier --check src/` all pass
- `pnpm test:unit`: 2163 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)