### PR TITLE
Embed YouTube videos in entry content (#1115)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -629,20 +629,20 @@ Lion Reader has an extensible plugin system (`src/server/plugins/`) that consoli
 
 The registry indexes plugins by hostname for O(1) lookup, then calls the plugin's `matchUrl(url)`; `findWithCapability(url, capability)` returns the first plugin that matches AND declares the capability:
 
-- **`feed`** capability: transform page URLs to feed URLs, clean entry content, transform feed titles (e.g., LessWrong GraphQL API), raise the source's minimum polling interval (e.g., YouTube rate-limit avoidance)
+- **`feed`** capability: transform page URLs to feed URLs, clean entry content, synthesize entry content from parsed-entry metadata (e.g., YouTube's embedded player + description), transform feed titles (e.g., LessWrong GraphQL API), raise the source's minimum polling interval (e.g., YouTube rate-limit avoidance)
 - **`savedArticle`** capability: fetch full article content for read-it-later, optionally skipping Readability when the source returns clean HTML
 
 `matchUrl` must be selective, not "any URL on my hosts" — a plugin should only match URLs it can actually handle (e.g. LessWrong `/tag/...` pages must return `false` so the caller falls back to normal fetching).
 
 ### Available Plugins
 
-| Plugin          | Capabilities           | Description                                                |
-| --------------- | ---------------------- | ---------------------------------------------------------- |
-| **LessWrong**   | `feed`, `savedArticle` | GraphQL API for posts/comments, user profile feeds         |
-| **Google Docs** | `savedArticle`         | Fetch Google Docs content via API                          |
-| **ArXiv**       | `savedArticle`         | Fetch ArXiv paper content                                  |
-| **GitHub**      | `savedArticle`         | Fetch GitHub content                                       |
-| **YouTube**     | `feed`                 | Polling floor (1h) to avoid YouTube's per-IP rate limiting |
+| Plugin          | Capabilities           | Description                                                                                                                         |
+| --------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **LessWrong**   | `feed`, `savedArticle` | GraphQL API for posts/comments, user profile feeds                                                                                  |
+| **Google Docs** | `savedArticle`         | Fetch Google Docs content via API                                                                                                   |
+| **ArXiv**       | `savedArticle`         | Fetch ArXiv paper content                                                                                                           |
+| **GitHub**      | `savedArticle`         | Fetch GitHub content                                                                                                                |
+| **YouTube**     | `feed`                 | Polling floor (1h) to avoid per-IP rate limiting; synthesizes entry content (embedded player + description) from Media RSS metadata |
 
 ---
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -304,6 +304,23 @@ body {
 }
 
 /* =================================
+   Reader Prose Video Embeds
+
+   The only iframes that survive sanitization are YouTube embeds (see
+   sanitize.ts). Feed-supplied width/height attributes are arbitrary, so make
+   the player fill the column at the standard 16:9 aspect instead.
+   ================================= */
+
+.reader-prose iframe {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+  border: 0;
+  border-radius: 0.5rem;
+}
+
+/* =================================
    Prose Link Hover
    Element-level hover so only the hovered link changes color,
    not all links in the entry.

--- a/src/server/feed/content-utils.ts
+++ b/src/server/feed/content-utils.ts
@@ -52,10 +52,35 @@ export function cleanEntryContent(
   options: CleanEntryContentOptions = {}
 ): EntryContentResult {
   const { entryUrl, feedUrl } = options;
+  const feedCapability = getFeedPlugin(feedUrl)?.capabilities.feed;
   const originalContent = parsedEntry.content ?? parsedEntry.summary ?? null;
 
-  // If no content, return early
-  if (!originalContent) {
+  // Absolutize relative URLs in original content if we have a base URL
+  const absolutizedOriginal =
+    originalContent && entryUrl ? absolutizeUrls(originalContent, entryUrl) : originalContent;
+
+  let contentCleaned: string | null = null;
+
+  // Content synthesis via the matching plugin (if any): builds the entry body
+  // from parsed-entry metadata for sources whose feeds carry no usable HTML
+  // (e.g. YouTube's video embed + media:description). Takes precedence over
+  // cleaning — the synthesized body replaces the feed content for display.
+  const builder = feedCapability?.buildEntryContent;
+  if (builder) {
+    // Isolate plugin failures: a throwing hook must not fail the entry (or,
+    // since this runs per-entry, every entry of the feed).
+    try {
+      contentCleaned = builder(parsedEntry, entryUrl);
+    } catch (error) {
+      logger.warn("Plugin buildEntryContent hook threw; using feed content", {
+        feedUrl,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  // If no synthesized and no feed-provided content, return early
+  if (!contentCleaned && !absolutizedOriginal) {
     return {
       contentOriginal: null,
       contentCleaned: null,
@@ -63,19 +88,12 @@ export function cleanEntryContent(
     };
   }
 
-  // Absolutize relative URLs in original content if we have a base URL
-  const absolutizedOriginal = entryUrl
-    ? absolutizeUrls(originalContent, entryUrl)
-    : originalContent;
-
-  // Apply feed-specific content cleaning via the matching plugin (if any)
-  let contentCleaned: string | null = null;
-
-  const cleaner = getFeedPlugin(feedUrl)?.capabilities.feed.cleanEntryContent;
-  if (cleaner) {
-    // Isolate plugin failures: a throwing cleaner must not fail the entry (or,
-    // since this runs per-entry, every entry of the feed). Fall back to the
-    // uncleaned-but-absolutized content.
+  // Apply feed-specific content cleaning via the matching plugin (if any),
+  // unless synthesis already produced the cleaned content.
+  const cleaner = feedCapability?.cleanEntryContent;
+  if (!contentCleaned && absolutizedOriginal && cleaner) {
+    // Isolate plugin failures: fall back to the uncleaned-but-absolutized
+    // content.
     try {
       const cleaned = cleaner(absolutizedOriginal);
       // Only set contentCleaned if cleaning actually changed something
@@ -95,7 +113,8 @@ export function cleanEntryContent(
   // AND they are different, meaning the summary is actually intended as an excerpt.
   // When content === summary (like RSS feeds without content:encoded), the parser
   // sets both to the same value, so we should use cleaned content for summary.
-  const contentForSummary = contentCleaned ?? absolutizedOriginal;
+  // Non-null: the early return above fires when both are null.
+  const contentForSummary = contentCleaned ?? absolutizedOriginal ?? "";
   const { content: entryContent, summary: entrySummary } = parsedEntry;
   const hasSeparateSummary = entryContent && entrySummary && entryContent !== entrySummary;
   const summary = hasSeparateSummary

--- a/src/server/feed/entry-processor.ts
+++ b/src/server/feed/entry-processor.ts
@@ -103,7 +103,10 @@ export function generateContentHash(entry: ParsedEntry): string {
   // Use deriveEntryUrl so the hash tracks the URL we actually store (link, or a
   // URL-shaped guid), matching updateEntryContent's write.
   const title = entry.title ?? "";
-  const content = entry.content ?? entry.summary ?? "";
+  // mediaDescription is the content fallback for feeds that provide neither
+  // content nor summary (YouTube), so hash it in that case — otherwise a
+  // description edit would never propagate to the stored entry.
+  const content = entry.content ?? entry.summary ?? entry.mediaDescription ?? "";
   const author = entry.author ?? "";
   const url = deriveEntryUrl(entry) ?? "";
 

--- a/src/server/feed/streaming/atom-parser.ts
+++ b/src/server/feed/streaming/atom-parser.ts
@@ -22,6 +22,7 @@ type AtomParserState =
   | "in_entry_title"
   | "in_entry_summary"
   | "in_entry_content"
+  | "in_entry_media_description"
   | "in_entry_published"
   | "in_entry_updated"
   | "in_entry_author"
@@ -112,9 +113,16 @@ export function parseAtom(content: string): FeedParseResult {
           else if (tagName === "title") state = "in_entry_title";
           else if (tagName === "summary") state = "in_entry_summary";
           else if (tagName === "content") state = "in_entry_content";
+          // Media RSS: YouTube nests these in <media:group>, which doesn't
+          // change state, so they're seen here whether grouped or direct.
+          else if (tagName === "media:description") state = "in_entry_media_description";
           else if (tagName === "published") state = "in_entry_published";
           else if (tagName === "updated") state = "in_entry_updated";
           else if (tagName === "author") state = "in_entry_author";
+
+          if (tagName === "media:thumbnail" && attribs.url && !currentEntry.mediaThumbnailUrl) {
+            currentEntry.mediaThumbnailUrl = attribs.url;
+          }
 
           if (tagName === "link") {
             const rel = attribs.rel;
@@ -193,6 +201,9 @@ export function parseAtom(content: string): FeedParseResult {
           } else if (state === "in_entry_content") {
             currentEntryContent = decodedText;
             currentEntry.content = decodedText;
+            state = "in_entry";
+          } else if (state === "in_entry_media_description") {
+            currentEntry.mediaDescription = decodedText;
             state = "in_entry";
           } else if (state === "in_entry_published") {
             if (decodedText) {

--- a/src/server/feed/types.ts
+++ b/src/server/feed/types.ts
@@ -70,6 +70,14 @@ export interface ParsedEntry {
   summary?: string;
   /** Publication date of the entry */
   pubDate?: Date;
+  /**
+   * Media RSS `media:description` (plain text, NOT HTML). YouTube feeds carry
+   * the video description here and provide no `content`/`summary` at all;
+   * the YouTube plugin builds entry content from it (see `buildEntryContent`).
+   */
+  mediaDescription?: string;
+  /** Media RSS `media:thumbnail` URL (first one found). */
+  mediaThumbnailUrl?: string;
 }
 
 /**

--- a/src/server/html/sanitize.ts
+++ b/src/server/html/sanitize.ts
@@ -18,6 +18,11 @@ import sanitizeHtml from "sanitize-html";
 
 import { logger } from "@/lib/logger";
 import { convertMathJaxChtmlToMathml } from "./mathjax-chtml";
+import {
+  normalizeYouTubeEmbedUrl,
+  YOUTUBE_IFRAME_ALLOW,
+  YOUTUBE_IFRAME_SANDBOX,
+} from "./youtube-embed";
 
 /**
  * Version of the sanitization config. Bump this whenever `SANITIZE_OPTIONS`
@@ -32,7 +37,7 @@ import { convertMathJaxChtmlToMathml } from "./mathjax-chtml";
  * stale and transparently re-sanitizes it on next read instead of serving stale
  * output.
  */
-export const SANITIZER_VERSION = 5;
+export const SANITIZER_VERSION = 6;
 
 // Tags allowed in entry content. Superset of sanitize-html's defaults covering
 // the formatting, table, and media elements real articles use. `script` and
@@ -119,11 +124,14 @@ const ALLOWED_TAGS = [
   "audio",
   "video",
   "track",
-  // `iframe` is deliberately excluded: an allowed cross-origin iframe lets a feed
-  // embed an arbitrary page full-bleed inside the reader's trusted UI (phishing /
-  // tracking surface), and it isn't in DOMPurify's default tag list either. If we
-  // reintroduce embeds (YouTube/Vimeo), gate them with `allowedIframeHostnames`
-  // and a forced `sandbox` attribute, and bump SANITIZER_VERSION.
+  // `iframe` is allowed ONLY for YouTube embeds (issue #1115). An unrestricted
+  // cross-origin iframe would let a feed embed an arbitrary page full-bleed
+  // inside the reader's trusted UI (phishing / tracking surface), so the
+  // `transformTags.iframe` hook validates the src as a YouTube embed URL and
+  // normalizes it to youtube-nocookie.com with a forced `sandbox`; anything
+  // else loses its src and is dropped by `exclusiveFilter`.
+  // `allowedIframeHostnames` backstops the same rule.
+  "iframe",
 ];
 
 // Presentation MathML, allowed so equations render natively (modern browsers
@@ -241,6 +249,18 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     col: [...GLOBAL_ATTRS, "span"],
     colgroup: [...GLOBAL_ATTRS, "span"],
     time: [...GLOBAL_ATTRS, "datetime"],
+    // The transformTags.iframe hook forces sandbox/allow/loading and rewrites
+    // src; width/height/title pass through from the source embed.
+    iframe: [
+      ...GLOBAL_ATTRS,
+      "src",
+      "width",
+      "height",
+      "allowfullscreen",
+      "sandbox",
+      "allow",
+      "loading",
+    ],
   },
   // Only safe URL schemes. `on*` event-handler attributes are never in the
   // allow-list, so they're dropped regardless.
@@ -251,6 +271,12 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     source: ["http", "https", "data"],
   },
   allowProtocolRelative: true,
+  // Defense in depth for iframes: even if the transform below were bypassed,
+  // sanitize-html strips the src of any iframe not pointing at this hostname
+  // (every surviving src is normalized to it), and src-less iframes are then
+  // removed entirely by `exclusiveFilter`.
+  allowedIframeHostnames: ["www.youtube-nocookie.com"],
+  exclusiveFilter: (frame) => frame.tag === "iframe" && !frame.attribs.src,
   transformTags: {
     // External links open in a new tab with a safe rel (was the old
     // afterSanitizeAttributes hook). Relative/in-page links are left alone.
@@ -272,6 +298,30 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     },
     // Lazy-load all images.
     img: (tagName, attribs) => ({ tagName, attribs: { ...attribs, loading: "lazy" } }),
+    // Iframes: only YouTube embeds survive. The src is validated and rewritten
+    // to the privacy-enhanced youtube-nocookie.com host with a filtered query
+    // string, and sandbox/allow/loading are forced regardless of what the feed
+    // supplied. A non-YouTube iframe has all attributes dropped here, then the
+    // src-less shell is removed by `exclusiveFilter`.
+    iframe: (tagName, attribs) => {
+      const src = normalizeYouTubeEmbedUrl(attribs.src);
+      if (!src) return { tagName, attribs: {} };
+      const kept: Record<string, string> = {};
+      for (const attr of ["width", "height", "title"]) {
+        if (attribs[attr] !== undefined) kept[attr] = attribs[attr];
+      }
+      return {
+        tagName,
+        attribs: {
+          ...kept,
+          src,
+          sandbox: YOUTUBE_IFRAME_SANDBOX,
+          allow: YOUTUBE_IFRAME_ALLOW,
+          allowfullscreen: "",
+          loading: "lazy",
+        },
+      };
+    },
   },
 };
 

--- a/src/server/html/youtube-embed.ts
+++ b/src/server/html/youtube-embed.ts
@@ -1,0 +1,124 @@
+/**
+ * YouTube embed URL handling, shared by the sanitizer (which validates and
+ * normalizes iframes found in feed content) and the YouTube plugin (which
+ * synthesizes embed iframes for YouTube's own feeds).
+ *
+ * Iframes are the sanitizer's only cross-origin escape hatch, so everything
+ * here is allow-list based: only known YouTube embed hosts and the /embed/
+ * path shape are accepted, every src is rewritten to the privacy-enhanced
+ * youtube-nocookie.com host, and only a small set of playback-related query
+ * params survives (autoplay/mute/JS-API flags are dropped).
+ */
+
+// Hosts that serve the YouTube embed player.
+const YOUTUBE_EMBED_HOSTS = new Set([
+  "youtube.com",
+  "www.youtube.com",
+  "m.youtube.com",
+  "youtube-nocookie.com",
+  "www.youtube-nocookie.com",
+]);
+
+// A single path segment after /embed/: an 11-char video id in practice, or
+// the literal "videoseries" for playlist embeds. Bounded so a pathological
+// path can't smuggle arbitrary content into the normalized URL.
+const EMBED_PATH_RE = /^\/embed\/([A-Za-z0-9_-]{1,64})$/;
+
+// Query params preserved on embed URLs: playback position, playlists, and
+// captions/localization. Everything else (autoplay, mute, enablejsapi,
+// origin, widget_referrer, ...) is dropped.
+const ALLOWED_EMBED_PARAMS = new Set([
+  "start",
+  "end",
+  "list",
+  "listType",
+  "loop",
+  "playlist",
+  "rel",
+  "cc_load_policy",
+  "cc_lang_pref",
+  "hl",
+]);
+
+/**
+ * Sandbox for YouTube embed iframes. The player needs scripts and its own
+ * origin's storage; popups (with sandbox escape) let "Watch on YouTube" open
+ * a normal tab. `allow-same-origin` is safe here because the framed content
+ * is always cross-origin (youtube-nocookie.com), never our own origin.
+ */
+export const YOUTUBE_IFRAME_SANDBOX =
+  "allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-presentation";
+
+/** Permissions-policy grants for the embed (no autoplay). */
+export const YOUTUBE_IFRAME_ALLOW = "fullscreen; encrypted-media; picture-in-picture";
+
+/**
+ * Validates an iframe src as a YouTube embed and returns the normalized
+ * https://www.youtube-nocookie.com/embed/... URL, or null if the src is not a
+ * YouTube embed.
+ */
+export function normalizeYouTubeEmbedUrl(src: string | null | undefined): string | null {
+  if (!src) return null;
+  const trimmed = src.trim();
+  // Feeds commonly use protocol-relative embed srcs.
+  const absolute = trimmed.startsWith("//") ? `https:${trimmed}` : trimmed;
+
+  let url: URL;
+  try {
+    url = new URL(absolute);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+  if (!YOUTUBE_EMBED_HOSTS.has(url.hostname.toLowerCase())) return null;
+
+  const match = EMBED_PATH_RE.exec(url.pathname);
+  if (!match) return null;
+
+  const normalized = new URL(`https://www.youtube-nocookie.com/embed/${match[1]}`);
+  for (const [key, value] of url.searchParams) {
+    if (ALLOWED_EMBED_PARAMS.has(key)) {
+      normalized.searchParams.set(key, value);
+    }
+  }
+  return normalized.toString();
+}
+
+/**
+ * Extracts a YouTube video id from a video page URL (watch, youtu.be, shorts,
+ * live, or embed form). Returns null for anything else.
+ */
+export function extractYouTubeVideoId(urlString: string | null | undefined): string | null {
+  if (!urlString) return null;
+
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    return null;
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  const isVideoId = (id: string | null | undefined): id is string =>
+    !!id && /^[A-Za-z0-9_-]{5,20}$/.test(id);
+
+  if (hostname === "youtu.be") {
+    const id = url.pathname.slice(1);
+    return isVideoId(id) ? id : null;
+  }
+
+  if (!YOUTUBE_EMBED_HOSTS.has(hostname)) return null;
+
+  if (url.pathname === "/watch") {
+    const id = url.searchParams.get("v");
+    return isVideoId(id) ? id : null;
+  }
+
+  const pathMatch = /^\/(?:shorts|live|embed)\/([^/]+)$/.exec(url.pathname);
+  if (pathMatch && isVideoId(pathMatch[1])) {
+    return pathMatch[1];
+  }
+
+  return null;
+}

--- a/src/server/plugins/types.ts
+++ b/src/server/plugins/types.ts
@@ -3,6 +3,8 @@
  * Consolidates custom parsing logic for feeds, entries, and saved articles.
  */
 
+import type { ParsedEntry } from "@/server/feed/types";
+
 /**
  * Core plugin interface with hostname-based registry support.
  */
@@ -51,6 +53,17 @@ export interface FeedCapability {
    * Runs synchronously during feed processing.
    */
   cleanEntryContent?(html: string): string;
+
+  /**
+   * Synthesize entry content HTML from the parsed entry, for sources whose
+   * feed entries carry no usable HTML body. E.g., YouTube feeds provide only
+   * Media RSS metadata, from which the plugin builds a video embed plus the
+   * description. The result is stored as the entry's cleaned content (the
+   * feed-provided content, if any, remains the original).
+   * Runs synchronously during feed processing; return null to fall back to
+   * normal content handling.
+   */
+  buildEntryContent?(entry: ParsedEntry, entryUrl: string | undefined): string | null;
 
   /**
    * Transform feed title after parsing.

--- a/src/server/plugins/youtube.ts
+++ b/src/server/plugins/youtube.ts
@@ -1,4 +1,11 @@
 import type { UrlPlugin } from "./types";
+import type { ParsedEntry } from "@/server/feed/types";
+import { escapeHtml } from "@/server/http/html";
+import {
+  extractYouTubeVideoId,
+  YOUTUBE_IFRAME_ALLOW,
+  YOUTUBE_IFRAME_SANDBOX,
+} from "@/server/html/youtube-embed";
 
 /**
  * Minimum polling interval for YouTube feeds: 1 hour.
@@ -14,12 +21,46 @@ import type { UrlPlugin } from "./types";
 export const YOUTUBE_MIN_FETCH_INTERVAL_SECONDS = 60 * 60;
 
 /**
+ * Converts a plain-text YouTube video description to HTML: escapes it, turns
+ * blank-line-separated blocks into paragraphs (single newlines into <br>), and
+ * links bare http(s) URLs (YouTube descriptions are full of them).
+ */
+export function youtubeDescriptionToHtml(description: string): string {
+  const paragraphs = description
+    .split(/\n{2,}/)
+    .map((block) => linkifyEscapedText(escapeHtml(block.trim())).replace(/\n/g, "<br>"))
+    .filter((block) => block.length > 0);
+  return paragraphs.map((p) => `<p>${p}</p>`).join("");
+}
+
+/**
+ * Wraps bare http(s) URLs in already-HTML-escaped text with <a> tags. Escaped
+ * text contains no raw `<`/`"`, so a match is safe to place in an href
+ * attribute as-is (entities like `&amp;` decode back to the original URL).
+ */
+function linkifyEscapedText(escapedText: string): string {
+  return escapedText.replace(/https?:\/\/[^\s]+/g, (match) => {
+    // Trailing sentence punctuation is almost never part of the URL; a
+    // trailing `)` only is when the URL itself contains `(`.
+    let url = match.replace(/[.,!?]+$/, "");
+    if (url.endsWith(")") && !url.includes("(")) {
+      url = url.slice(0, -1);
+    }
+    const trailer = match.slice(url.length);
+    return `<a href="${url}">${url}</a>${trailer}`;
+  });
+}
+
+/**
  * YouTube plugin.
  *
  * Provides feed capability for YouTube's RSS feeds
  * (`/feeds/videos.xml?channel_id=...`, `?playlist_id=...`, `?user=...`):
- * currently just a polling floor so we don't hammer YouTube's aggressively
- * rate-limited feed endpoint (see YOUTUBE_MIN_FETCH_INTERVAL_SECONDS).
+ * a polling floor so we don't hammer YouTube's aggressively rate-limited feed
+ * endpoint (see YOUTUBE_MIN_FETCH_INTERVAL_SECONDS), and entry-content
+ * synthesis — the feed entries carry no HTML body, only Media RSS metadata,
+ * so `buildEntryContent` builds one from the embedded player plus the
+ * `media:description` (issue #1115).
  *
  * Note: YouTube supports WebSub push for channel feeds via Google's hub
  * (https://developers.google.com/youtube/v3/guides/push_notifications), but
@@ -45,6 +86,34 @@ export const youtubePlugin: UrlPlugin = {
   capabilities: {
     feed: {
       minFetchIntervalSeconds: YOUTUBE_MIN_FETCH_INTERVAL_SECONDS,
+
+      buildEntryContent(entry: ParsedEntry, entryUrl: string | undefined): string | null {
+        // Video id from the entry link (watch?v=...), falling back to the
+        // Atom guid (`yt:video:VIDEOID`).
+        const videoId =
+          extractYouTubeVideoId(entryUrl) ??
+          (entry.guid?.startsWith("yt:video:")
+            ? extractYouTubeVideoId(
+                `https://www.youtube.com/watch?v=${entry.guid.slice("yt:video:".length)}`
+              )
+            : null);
+        if (!videoId) return null;
+
+        // The sanitizer re-validates the src and re-forces sandbox/allow on
+        // the read path (see transformTags.iframe in sanitize.ts); setting
+        // them here just keeps the stored raw content self-contained.
+        const title = entry.title ? ` title="${escapeHtml(entry.title)}"` : "";
+        const iframe =
+          `<iframe src="https://www.youtube-nocookie.com/embed/${videoId}"` +
+          ` width="560" height="315"${title}` +
+          ` sandbox="${YOUTUBE_IFRAME_SANDBOX}" allow="${YOUTUBE_IFRAME_ALLOW}"` +
+          ` allowfullscreen loading="lazy"></iframe>`;
+
+        const description = entry.mediaDescription
+          ? youtubeDescriptionToHtml(entry.mediaDescription)
+          : "";
+        return iframe + description;
+      },
     },
   },
 };

--- a/src/server/trpc/routers/feeds.ts
+++ b/src/server/trpc/routers/feeds.ts
@@ -112,8 +112,10 @@ function truncateText(text: string | undefined, maxLength: number): string | nul
  * @returns A sample entry object
  */
 function toSampleEntry(entry: ParsedEntry, feedUrl: string): z.infer<typeof sampleEntrySchema> {
-  // Get the content to use for summary
-  let content = entry.summary ?? entry.content;
+  // Get the content to use for summary. mediaDescription is the fallback for
+  // feeds that provide neither (YouTube); it's plain text, which truncateText
+  // handles the same way.
+  let content = entry.summary ?? entry.content ?? entry.mediaDescription;
 
   // Apply feed-specific cleaning via the matching plugin (if any)
   if (content) {

--- a/tests/unit/clean-entry-content.test.ts
+++ b/tests/unit/clean-entry-content.test.ts
@@ -111,3 +111,62 @@ describe("cleanEntryContent", () => {
     });
   });
 });
+
+describe("YouTube feeds (synthesized content via buildEntryContent)", () => {
+  const youtubeFeedUrl = "https://www.youtube.com/feeds/videos.xml?channel_id=UCabc123";
+
+  it("synthesizes embed + description content for entries with no feed content", () => {
+    const parsedEntry: ParsedEntry = {
+      guid: "yt:video:dQw4w9WgXcQ",
+      link: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      title: "Video Title",
+      mediaDescription: "A description of the video.\n\nMore details here.",
+    };
+
+    const result = cleanEntryContent(parsedEntry, {
+      entryUrl: parsedEntry.link,
+      feedUrl: youtubeFeedUrl,
+    });
+
+    // No feed-provided content, so original stays null; the synthesized body
+    // is the cleaned content.
+    expect(result.contentOriginal).toBeNull();
+    expect(result.contentCleaned).toContain(
+      'src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"'
+    );
+    expect(result.contentCleaned).toContain("A description of the video.");
+
+    // Summary comes from the synthesized content (iframe strips to nothing).
+    expect(result.summary).toContain("A description of the video.");
+    expect(result.summary).not.toContain("<iframe");
+  });
+
+  it("still returns empty results when no video id can be derived", () => {
+    const parsedEntry: ParsedEntry = {
+      guid: "not-a-video",
+      title: "Weird entry",
+    };
+
+    const result = cleanEntryContent(parsedEntry, { feedUrl: youtubeFeedUrl });
+
+    expect(result.contentOriginal).toBeNull();
+    expect(result.contentCleaned).toBeNull();
+    expect(result.summary).toBe("");
+  });
+
+  it("does not synthesize content for non-YouTube feeds", () => {
+    const parsedEntry: ParsedEntry = {
+      guid: "yt:video:dQw4w9WgXcQ",
+      link: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      mediaDescription: "description",
+    };
+
+    const result = cleanEntryContent(parsedEntry, {
+      entryUrl: parsedEntry.link,
+      feedUrl: "https://example.com/feed.xml",
+    });
+
+    expect(result.contentCleaned).toBeNull();
+    expect(result.contentOriginal).toBeNull();
+  });
+});

--- a/tests/unit/feed-parser.test.ts
+++ b/tests/unit/feed-parser.test.ts
@@ -443,3 +443,50 @@ describe("UnknownFeedFormatError", () => {
     expect(error).toBeInstanceOf(UnknownFeedFormatError);
   });
 });
+
+describe("Media RSS extraction (YouTube-style Atom feeds)", () => {
+  const youtubeAtom = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/" xmlns="http://www.w3.org/2005/Atom">
+  <title>Channel Title</title>
+  <entry>
+    <id>yt:video:dQw4w9WgXcQ</id>
+    <yt:videoId>dQw4w9WgXcQ</yt:videoId>
+    <title>Video Title</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"/>
+    <author><name>Channel Author</name></author>
+    <published>2026-07-01T12:00:00+00:00</published>
+    <media:group>
+      <media:title>Video Title</media:title>
+      <media:content url="https://www.youtube.com/v/dQw4w9WgXcQ?version=3" type="application/x-shockwave-flash" width="640" height="390"/>
+      <media:thumbnail url="https://i2.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg" width="480" height="360"/>
+      <media:description>First line of description.
+
+Links: https://example.com/sponsor &amp; more</media:description>
+    </media:group>
+  </entry>
+</feed>`;
+
+  it("extracts media:description and media:thumbnail from media:group", () => {
+    const feed = parseFeed(youtubeAtom);
+    const entry = feed.items[0];
+
+    expect(entry.mediaDescription).toBe(
+      "First line of description.\n\nLinks: https://example.com/sponsor & more"
+    );
+    expect(entry.mediaThumbnailUrl).toBe("https://i2.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg");
+  });
+
+  it("does not let media:group children clobber the entry's own fields", () => {
+    const feed = parseFeed(youtubeAtom);
+    const entry = feed.items[0];
+
+    expect(entry.title).toBe("Video Title");
+    expect(entry.guid).toBe("yt:video:dQw4w9WgXcQ");
+    expect(entry.link).toBe("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+    expect(entry.author).toBe("Channel Author");
+    // YouTube provides no <content>/<summary>; media:description must not
+    // masquerade as either (it's plain text, not HTML).
+    expect(entry.content).toBeUndefined();
+    expect(entry.summary).toBeUndefined();
+  });
+});

--- a/tests/unit/sanitize-entry-html.test.ts
+++ b/tests/unit/sanitize-entry-html.test.ts
@@ -146,7 +146,7 @@ describe("sanitizeEntryHtml", () => {
       expect(out).toContain('colspan="2"');
     });
 
-    it("strips iframes (phishing/tracking surface; not on DOMPurify's default list)", () => {
+    it("strips non-YouTube iframes (phishing/tracking surface)", () => {
       const out =
         sanitizeEntryHtml(
           '<iframe src="https://evil.example/fake-login" allowfullscreen></iframe>'
@@ -163,6 +163,71 @@ describe("sanitizeEntryHtml", () => {
     it("preserves the narration data-para-id attribute", () => {
       const out = sanitizeEntryHtml('<p data-para-id="3">x</p>') ?? "";
       expect(out).toContain('data-para-id="3"');
+    });
+  });
+
+  describe("YouTube embed iframes (issue #1115)", () => {
+    it("keeps a YouTube embed, rewritten to youtube-nocookie with forced sandbox", () => {
+      const out =
+        sanitizeEntryHtml(
+          '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="560" height="315"></iframe>'
+        ) ?? "";
+      expect(out).toContain('src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"');
+      expect(out).toContain('sandbox="allow-scripts allow-same-origin');
+      expect(out).toContain('loading="lazy"');
+      expect(out).toContain('width="560"');
+      expect(out).toContain('height="315"');
+    });
+
+    it("normalizes protocol-relative embed srcs", () => {
+      const out =
+        sanitizeEntryHtml('<iframe src="//www.youtube.com/embed/abc123def45"></iframe>') ?? "";
+      expect(out).toContain('src="https://www.youtube-nocookie.com/embed/abc123def45"');
+    });
+
+    it("keeps playback params but drops autoplay and JS-API params", () => {
+      const out =
+        sanitizeEntryHtml(
+          '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ?start=30&autoplay=1&enablejsapi=1"></iframe>'
+        ) ?? "";
+      expect(out).toContain("start=30");
+      expect(out).not.toContain("autoplay");
+      expect(out).not.toContain("enablejsapi");
+    });
+
+    it("keeps playlist embeds", () => {
+      const out =
+        sanitizeEntryHtml(
+          '<iframe src="https://www.youtube.com/embed/videoseries?list=PL0123abc"></iframe>'
+        ) ?? "";
+      expect(out).toContain(
+        'src="https://www.youtube-nocookie.com/embed/videoseries?list=PL0123abc"'
+      );
+    });
+
+    it("overrides a feed-supplied sandbox/allow with the forced values", () => {
+      const out =
+        sanitizeEntryHtml(
+          '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" sandbox="allow-top-navigation" allow="autoplay"></iframe>'
+        ) ?? "";
+      expect(out).not.toContain("allow-top-navigation");
+      expect(out).not.toContain('allow="autoplay"');
+    });
+
+    it("removes YouTube iframes that are not embed URLs", () => {
+      const out =
+        sanitizeEntryHtml(
+          '<iframe src="https://www.youtube.com/watch?v=dQw4w9WgXcQ"></iframe><p>x</p>'
+        ) ?? "";
+      expect(out).toBe("<p>x</p>");
+    });
+
+    it("removes iframes with dangerous or missing srcs entirely", () => {
+      expect(sanitizeEntryHtml('<iframe src="javascript:alert(1)"></iframe>')).toBe("");
+      expect(sanitizeEntryHtml("<iframe></iframe>")).toBe("");
+      expect(
+        sanitizeEntryHtml('<iframe src="https://www.youtube.com.evil.com/embed/x"></iframe>')
+      ).toBe("");
     });
   });
 });

--- a/tests/unit/youtube-plugin.test.ts
+++ b/tests/unit/youtube-plugin.test.ts
@@ -1,12 +1,21 @@
 /**
  * Unit tests for the YouTube plugin's `feed` capability and the `getFeedPlugin`
- * resolver. The plugin exists to floor YouTube's aggressive `max-age=900` cache
- * hint at an hour so we don't trip YouTube's per-IP rate limiting (issue #1114).
+ * resolver. The plugin floors YouTube's aggressive `max-age=900` cache hint at
+ * an hour so we don't trip YouTube's per-IP rate limiting (issue #1114), and
+ * synthesizes entry content (embedded player + description) from the feed's
+ * Media RSS metadata (issue #1115). Also covers the shared YouTube embed URL
+ * helpers used by the sanitizer.
  */
 
 import { describe, it, expect } from "vitest";
-import { youtubePlugin, YOUTUBE_MIN_FETCH_INTERVAL_SECONDS } from "@/server/plugins/youtube";
+import {
+  youtubePlugin,
+  youtubeDescriptionToHtml,
+  YOUTUBE_MIN_FETCH_INTERVAL_SECONDS,
+} from "@/server/plugins/youtube";
 import { getFeedPlugin } from "@/server/plugins";
+import { extractYouTubeVideoId, normalizeYouTubeEmbedUrl } from "@/server/html/youtube-embed";
+import type { ParsedEntry } from "@/server/feed/types";
 
 describe("youtubePlugin.matchUrl", () => {
   it("matches channel, playlist, and legacy user feed URLs", () => {
@@ -54,5 +63,136 @@ describe("getFeedPlugin resolution for YouTube", () => {
 
   it("does not resolve non-feed YouTube URLs", () => {
     expect(getFeedPlugin("https://www.youtube.com/watch?v=abc123")).toBeNull();
+  });
+});
+
+describe("normalizeYouTubeEmbedUrl", () => {
+  it("rewrites youtube.com embeds to www.youtube-nocookie.com", () => {
+    expect(normalizeYouTubeEmbedUrl("https://www.youtube.com/embed/dQw4w9WgXcQ")).toBe(
+      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"
+    );
+    expect(normalizeYouTubeEmbedUrl("https://youtube.com/embed/dQw4w9WgXcQ")).toBe(
+      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"
+    );
+  });
+
+  it("accepts protocol-relative srcs", () => {
+    expect(normalizeYouTubeEmbedUrl("//www.youtube-nocookie.com/embed/dQw4w9WgXcQ")).toBe(
+      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"
+    );
+  });
+
+  it("keeps only allow-listed query params", () => {
+    expect(
+      normalizeYouTubeEmbedUrl(
+        "https://www.youtube.com/embed/dQw4w9WgXcQ?start=30&autoplay=1&enablejsapi=1&origin=https%3A%2F%2Fevil.com"
+      )
+    ).toBe("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?start=30");
+  });
+
+  it("rejects non-embed and non-YouTube URLs", () => {
+    expect(normalizeYouTubeEmbedUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ")).toBeNull();
+    expect(normalizeYouTubeEmbedUrl("https://evil.com/embed/dQw4w9WgXcQ")).toBeNull();
+    expect(normalizeYouTubeEmbedUrl("https://www.youtube.com.evil.com/embed/x")).toBeNull();
+    expect(normalizeYouTubeEmbedUrl("https://www.youtube.com/embed/a/b")).toBeNull();
+    expect(normalizeYouTubeEmbedUrl("javascript:alert(1)")).toBeNull();
+    expect(normalizeYouTubeEmbedUrl(null)).toBeNull();
+    expect(normalizeYouTubeEmbedUrl("")).toBeNull();
+  });
+});
+
+describe("extractYouTubeVideoId", () => {
+  it("extracts from the URL forms YouTube uses", () => {
+    expect(extractYouTubeVideoId("https://www.youtube.com/watch?v=dQw4w9WgXcQ")).toBe(
+      "dQw4w9WgXcQ"
+    );
+    expect(extractYouTubeVideoId("https://youtu.be/dQw4w9WgXcQ")).toBe("dQw4w9WgXcQ");
+    expect(extractYouTubeVideoId("https://www.youtube.com/shorts/dQw4w9WgXcQ")).toBe("dQw4w9WgXcQ");
+    expect(extractYouTubeVideoId("https://www.youtube.com/live/dQw4w9WgXcQ")).toBe("dQw4w9WgXcQ");
+    expect(extractYouTubeVideoId("https://m.youtube.com/watch?v=dQw4w9WgXcQ")).toBe("dQw4w9WgXcQ");
+  });
+
+  it("returns null for non-video URLs", () => {
+    expect(extractYouTubeVideoId("https://www.youtube.com/@somechannel")).toBeNull();
+    expect(extractYouTubeVideoId("https://example.com/watch?v=dQw4w9WgXcQ")).toBeNull();
+    expect(extractYouTubeVideoId("not a url")).toBeNull();
+    expect(extractYouTubeVideoId(undefined)).toBeNull();
+  });
+});
+
+describe("youtubeDescriptionToHtml", () => {
+  it("escapes HTML in the description", () => {
+    expect(youtubeDescriptionToHtml("a <script>alert(1)</script> & b")).toBe(
+      "<p>a &lt;script&gt;alert(1)&lt;/script&gt; &amp; b</p>"
+    );
+  });
+
+  it("splits paragraphs on blank lines and lines on single newlines", () => {
+    expect(youtubeDescriptionToHtml("para one\nline two\n\npara two")).toBe(
+      "<p>para one<br>line two</p><p>para two</p>"
+    );
+  });
+
+  it("links bare URLs, trimming trailing punctuation", () => {
+    expect(youtubeDescriptionToHtml("See https://example.com/page. Done")).toBe(
+      '<p>See <a href="https://example.com/page">https://example.com/page</a>. Done</p>'
+    );
+    expect(youtubeDescriptionToHtml("(see https://example.com/page)")).toBe(
+      '<p>(see <a href="https://example.com/page">https://example.com/page</a>)</p>'
+    );
+  });
+
+  it("keeps escaped query separators in linked URLs", () => {
+    expect(youtubeDescriptionToHtml("https://example.com/x?a=1&b=2")).toBe(
+      '<p><a href="https://example.com/x?a=1&amp;b=2">https://example.com/x?a=1&amp;b=2</a></p>'
+    );
+  });
+});
+
+describe("youtubePlugin buildEntryContent", () => {
+  const buildEntryContent = youtubePlugin.capabilities.feed!.buildEntryContent!;
+
+  const entry = (overrides: Partial<ParsedEntry> = {}): ParsedEntry => ({
+    guid: "yt:video:dQw4w9WgXcQ",
+    link: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    title: "Video Title",
+    mediaDescription: "First line.\n\nSecond paragraph with https://example.com/link",
+    ...overrides,
+  });
+
+  it("builds an embed iframe plus the description", () => {
+    const html = buildEntryContent(entry(), "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+
+    expect(html).toContain('src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"');
+    expect(html).toContain("sandbox=");
+    expect(html).toContain('title="Video Title"');
+    expect(html).toContain("<p>First line.</p>");
+    expect(html).toContain('<a href="https://example.com/link">');
+  });
+
+  it("falls back to the yt:video guid when there is no usable URL", () => {
+    const html = buildEntryContent(entry(), undefined);
+    expect(html).toContain('src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"');
+  });
+
+  it("returns null when no video id can be derived", () => {
+    expect(buildEntryContent(entry({ guid: "something-else" }), undefined)).toBeNull();
+  });
+
+  it("builds the embed alone when there is no description", () => {
+    const html = buildEntryContent(
+      entry({ mediaDescription: undefined }),
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    );
+    expect(html).toContain("<iframe");
+    expect(html).not.toContain("<p>");
+  });
+
+  it("escapes HTML in the title attribute", () => {
+    const html = buildEntryContent(
+      entry({ title: '"><script>alert(1)</script>' }),
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    );
+    expect(html).not.toContain("<script>");
   });
 });


### PR DESCRIPTION
Fixes #1115.

## What this does

**1. YouTube's own feeds now render the embedded player + description.** YouTube's Atom feeds carry no `<content>`/`<summary>` — only Media RSS metadata inside `<media:group>` that the parser ignored — so YouTube entries had an empty body. The Atom parser now extracts `media:description`/`media:thumbnail` into `ParsedEntry`, and a new `FeedCapability.buildEntryContent` plugin hook lets a source synthesize entry content when the feed provides none. The YouTube plugin builds a sandboxed `youtube-nocookie.com` embed iframe plus the description (escaped, paragraphs preserved, bare URLs linked), stored as the entry's cleaned content.

**2. YouTube embeds in any normal feed now survive sanitization.** The sanitizer previously stripped all iframes. It now allows iframes gated to YouTube embeds only:

- src must parse as an `/embed/` URL on a known YouTube host; everything else is removed entirely (not just neutered)
- surviving srcs are rewritten to the privacy-enhanced `www.youtube-nocookie.com` host with only playback-related query params kept (`autoplay`/`enablejsapi`/`origin` etc. dropped)
- `sandbox`, `allow`, and `loading=lazy` are forced regardless of what the feed supplied (`allow-same-origin` is safe because the framed content is always cross-origin)
- `allowedIframeHostnames` + an `exclusiveFilter` backstop the transform

`SANITIZER_VERSION` is bumped to 6, so stored entries converge via the read-path heal and the `resanitize_entries` sweep — no migration needed. I considered a SQL fast-forward stamp for rows without `<iframe` in their raw content (per the CLAUDE.md guidance) but left it out to keep the release simple, matching every previous bump; happy to add it if the sweep cost is a concern.

Embeds render responsively at 16:9 via `.reader-prose iframe` CSS (safe since only YouTube embeds can survive sanitization).

## Rollout notes

- Existing YouTube entries get their synthesized body on each feed's next fetch with activity (the content hash now covers `media:description`, so the first post-deploy fetch rewrites them); embeds stripped from stored *sanitized* HTML of normal feeds reappear via the version-bump heal/sweep since raw content is retained.
- The worker bundle embeds the sanitizer rules, and deploy rebuilds it (`build:all`); the pool's version probe guards against a stale bundle regardless.

## Testing

- New unit tests: sanitizer iframe gating, Atom `media:group` extraction, embed URL normalization/video-id helpers, description→HTML conversion, plugin `buildEntryContent`, and the content-pipeline integration (`cleanEntryContent`).
- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (2190 passed), and `pnpm test:integration:local` (576 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)