### PR TITLE
Normalize unintentional style drift onto shared components (#1016)

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -7,6 +7,7 @@
 
 import type { Metadata } from "next";
 import Link from "next/link";
+import { TextLink } from "@/components/ui/text-link";
 
 export const metadata: Metadata = {
   title: "Privacy Policy - Lion Reader",
@@ -206,14 +207,9 @@ export default function PrivacyPolicyPage() {
                   sent to external servers.
                 </p>
                 <p className="mt-2">
-                  <a
-                    href="https://groq.com/privacy-policy/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="ui-text-sm text-accent hover:text-accent-hover"
-                  >
+                  <TextLink href="https://groq.com/privacy-policy/" external className="ui-text-sm">
                     View Groq&apos;s Privacy Policy &rarr;
-                  </a>
+                  </TextLink>
                 </p>
               </div>
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -7,6 +7,7 @@
 
 import type { Metadata } from "next";
 import Link from "next/link";
+import { TextLink } from "@/components/ui/text-link";
 
 export const metadata: Metadata = {
   title: "Terms of Service - Lion Reader",
@@ -44,7 +45,7 @@ export default function TermsOfServicePage() {
             </p>
             <p className="mt-2 text-zinc-600 dark:text-zinc-400">
               Please also review our{" "}
-              <Link href="/privacy" className="text-accent hover:text-accent-hover underline">
+              <Link href="/privacy" className="text-accent hover:text-accent-hover font-medium">
                 Privacy Policy
               </Link>
               , which describes how we collect and use your data.
@@ -166,7 +167,7 @@ export default function TermsOfServicePage() {
             <p className="mt-2 text-zinc-600 dark:text-zinc-400">
               You may also delete your account at any time. Upon termination, your personal data
               will be handled according to our{" "}
-              <Link href="/privacy" className="text-accent hover:text-accent-hover underline">
+              <Link href="/privacy" className="text-accent hover:text-accent-hover font-medium">
                 Privacy Policy
               </Link>
               .
@@ -179,14 +180,9 @@ export default function TermsOfServicePage() {
             </h2>
             <p className="mt-2 text-zinc-600 dark:text-zinc-400">
               Lion Reader is open-source software. The source code is available on{" "}
-              <a
-                href="https://github.com/brendanlong/lion-reader"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-accent hover:text-accent-hover underline"
-              >
+              <TextLink href="https://github.com/brendanlong/lion-reader" external>
                 GitHub
-              </a>
+              </TextLink>
               . Content you subscribe to or save through the service remains the property of its
               respective owners. We do not claim ownership of any content fetched from external
               feeds.
@@ -226,14 +222,9 @@ export default function TermsOfServicePage() {
             <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">Contact</h2>
             <p className="mt-2 text-zinc-600 dark:text-zinc-400">
               If you have any questions about these Terms of Service, please open an issue on our{" "}
-              <a
-                href="https://github.com/brendanlong/lion-reader"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-accent hover:text-accent-hover underline"
-              >
+              <TextLink href="https://github.com/brendanlong/lion-reader" external>
                 GitHub repository
-              </a>
+              </TextLink>
               .
             </p>
           </section>

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -16,10 +16,12 @@ Reusable UI primitives are in `src/components/ui/`. **Always check for existing 
 | **Dialog**            | Modal dialogs with backdrop, focus trap, escape handling  |
 | **Card**              | Container with border, background, and consistent padding |
 | **CardSection**       | Subsection within a Card, separated by a top border       |
+| **NoteBox**           | Subtle zinc-tinted box for notes and secondary content    |
 | **StatusCard**        | Colored card for info/success/warning/error states        |
 | **ClientLink**        | Internal navigation links (use instead of Next.js Link)   |
 | **TextLink**          | Accent-colored inline text link (`external` for new tab)  |
 | **InlineCode**        | Small monospace chip for inline code, URLs, file names    |
+| **Kbd**               | Keyboard key chip for displaying shortcut keys            |
 | **NavLink**           | Sidebar navigation links with active state and counts     |
 | **IconButton**        | Small icon-only action buttons (edit, close, etc.)        |
 | **NotFoundCard**      | Card for 404/missing content states                       |

--- a/src/components/keyboard/KeyboardShortcutsModal.tsx
+++ b/src/components/keyboard/KeyboardShortcutsModal.tsx
@@ -12,6 +12,7 @@ import { useEffect, useRef } from "react";
 import { Dialog, DialogHeader, DialogBody, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { IconButton, CloseIcon } from "@/components/ui/icon-button";
+import { Kbd } from "@/components/ui/kbd";
 
 /**
  * Shortcut definition for display
@@ -126,9 +127,7 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsMod
                         {index > 0 && (
                           <span className="ui-text-xs text-zinc-400 dark:text-zinc-500">then</span>
                         )}
-                        <kbd className="ui-text-xs inline-flex min-w-[24px] items-center justify-center rounded border border-zinc-300 bg-zinc-100 px-1.5 py-0.5 font-mono font-medium text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
-                          {key}
-                        </kbd>
+                        <Kbd>{key}</Kbd>
                       </span>
                     ))}
                   </div>

--- a/src/components/narration/EnhancedVoiceList.tsx
+++ b/src/components/narration/EnhancedVoiceList.tsx
@@ -11,6 +11,7 @@
 
 import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
+import { NoteBox } from "@/components/ui/note-box";
 import {
   CheckIcon,
   AlertCircleIcon,
@@ -429,7 +430,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
 
       {/* Storage info section */}
       {downloadedCount > 0 && (
-        <div className="flex items-center justify-between rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800/50">
+        <NoteBox padding="sm" className="flex items-center justify-between">
           <span className="ui-text-xs text-zinc-600 dark:text-zinc-400">
             Storage used: {formatStorageSize(storageUsed)} ({downloadedCount}{" "}
             {downloadedCount === 1 ? "voice" : "voices"})
@@ -443,7 +444,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
               Delete All
             </button>
           )}
-        </div>
+        </NoteBox>
       )}
 
       {/* Info text */}

--- a/src/components/settings/ApiKeySettings.tsx
+++ b/src/components/settings/ApiKeySettings.tsx
@@ -14,6 +14,7 @@ import { CheckIcon } from "@/components/ui/icon-button";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TextLink } from "@/components/ui/text-link";
+import { InlineCode } from "@/components/ui/inline-code";
 import {
   DEFAULT_SUMMARIZATION_MODEL,
   DEFAULT_SUMMARIZATION_MAX_WORDS,
@@ -70,16 +71,19 @@ export function GroqApiKeySettings() {
   }, [updatePreferences]);
 
   return (
-    <SettingsSection title="AI Text Processing">
-      <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
-        Add a{" "}
-        <TextLink href="https://console.groq.com/keys" external>
-          Groq API key
-        </TextLink>{" "}
-        to enable AI-powered text processing for narration. This improves narration quality by
-        expanding abbreviations and formatting content for text-to-speech.
-      </p>
-
+    <SettingsSection
+      title="AI Text Processing"
+      description={
+        <>
+          Add a{" "}
+          <TextLink href="https://console.groq.com/keys" external>
+            Groq API key
+          </TextLink>{" "}
+          to enable AI-powered text processing for narration. This improves narration quality by
+          expanding abbreviations and formatting content for text-to-speech.
+        </>
+      }
+    >
       {preferencesQuery.isLoading ? (
         <div className="h-10 w-full animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
       ) : isEditing ? (
@@ -297,15 +301,18 @@ export function SummarizationApiKeySettings() {
   }, [updatePreferences]);
 
   return (
-    <SettingsSection title="Summaries">
-      <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
-        Add an{" "}
-        <TextLink href="https://console.anthropic.com/settings/keys" external>
-          Anthropic API key
-        </TextLink>{" "}
-        to enable AI-powered article summaries.
-      </p>
-
+    <SettingsSection
+      title="Summaries"
+      description={
+        <>
+          Add an{" "}
+          <TextLink href="https://console.anthropic.com/settings/keys" external>
+            Anthropic API key
+          </TextLink>{" "}
+          to enable AI-powered article summaries.
+        </>
+      }
+    >
       {preferencesQuery.isLoading ? (
         <div className="h-10 w-full animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
       ) : (
@@ -503,16 +510,9 @@ export function SummarizationApiKeySettings() {
                   className="ui-text-sm block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
                 />
                 <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
-                  Available template variables:{" "}
-                  <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">{"{{content}}"}</code>
-                  , <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">{"{{title}}"}</code>
-                  ,{" "}
-                  <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">
-                    {"{{maxWords}}"}
-                  </code>
-                  . The response should be wrapped in{" "}
-                  <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">{"<summary>"}</code>{" "}
-                  tags.
+                  Available template variables: <InlineCode>{"{{content}}"}</InlineCode>,{" "}
+                  <InlineCode>{"{{title}}"}</InlineCode>, <InlineCode>{"{{maxWords}}"}</InlineCode>.
+                  The response should be wrapped in <InlineCode>{"<summary>"}</InlineCode> tags.
                 </p>
                 <div className="flex gap-2">
                   <Button

--- a/src/components/settings/AppearanceSettings.tsx
+++ b/src/components/settings/AppearanceSettings.tsx
@@ -149,11 +149,10 @@ export function AppearanceSettings() {
       </SettingsSection>
 
       {/* Article Text Section */}
-      <SettingsSection title="Article Text">
-        <p className="ui-text-sm mb-6 text-zinc-600 dark:text-zinc-400">
-          These settings affect how article content is displayed in the entry view.
-        </p>
-
+      <SettingsSection
+        title="Article Text"
+        description="These settings affect how article content is displayed in the entry view."
+      >
         <div className="space-y-6">
           <OptionGroup
             label="Text Size"

--- a/src/components/settings/BookmarkletSettings.tsx
+++ b/src/components/settings/BookmarkletSettings.tsx
@@ -10,6 +10,7 @@
 import { useState, useMemo, useEffect, useRef } from "react";
 import { SettingsSection } from "@/components/settings/SettingsSection";
 import { CardSection } from "@/components/ui/card";
+import { NoteBox } from "@/components/ui/note-box";
 import {
   BookmarkIcon,
   ChevronRightIcon,
@@ -45,13 +46,10 @@ export function BookmarkletSettings() {
   }, [bookmarkletHref]);
 
   return (
-    <SettingsSection title="Save to Lion Reader">
-      {/* Description */}
-      <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-        Save any webpage to Lion Reader with one click. The article will be added to your Saved
-        section where you can read it later.
-      </p>
-
+    <SettingsSection
+      title="Save to Lion Reader"
+      description="Save any webpage to Lion Reader with one click. The article will be added to your Saved section where you can read it later."
+    >
       {/* Browser Extensions */}
       <div className="mt-6">
         <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
@@ -110,7 +108,7 @@ export function BookmarkletSettings() {
       </div>
 
       {/* Installation Instructions */}
-      <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+      <NoteBox className="mt-6">
         <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
           Installation Instructions
         </h3>
@@ -128,7 +126,7 @@ export function BookmarkletSettings() {
           </li>
           <li>A popup will appear confirming the article has been saved</li>
         </ol>
-      </div>
+      </NoteBox>
 
       {/* Show/Hide Code Section */}
       <CardSection>

--- a/src/components/settings/DiscordBotSettings.tsx
+++ b/src/components/settings/DiscordBotSettings.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { trpc } from "@/lib/trpc/client";
 import { SettingsSection } from "@/components/settings/SettingsSection";
 import { CardSection } from "@/components/ui/card";
+import { NoteBox } from "@/components/ui/note-box";
 import { InlineCode } from "@/components/ui/inline-code";
 import { DiscordIcon, ExternalLinkIcon } from "@/components/ui/icon-button";
 
@@ -60,13 +61,10 @@ export function DiscordBotSettings() {
   const errorEmoji = botConfig.errorEmoji ? formatEmoji(botConfig.errorEmoji) : null;
 
   return (
-    <SettingsSection title="Discord Bot">
-      {/* Description */}
-      <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-        Save articles to Lion Reader by reacting to Discord messages. When you react to a message
-        containing a URL, the article will be saved to your account.
-      </p>
-
+    <SettingsSection
+      title="Discord Bot"
+      description="Save articles to Lion Reader by reacting to Discord messages. When you react to a message containing a URL, the article will be saved to your account."
+    >
       {/* Invite Button */}
       <div className="mt-6">
         <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
@@ -156,7 +154,7 @@ export function DiscordBotSettings() {
       </CardSection>
 
       {/* Bot Commands */}
-      <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+      <NoteBox className="mt-6">
         <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Bot Commands</h3>
         <dl className="ui-text-sm mt-2 space-y-2 text-zinc-600 dark:text-zinc-400">
           <div>
@@ -172,7 +170,7 @@ export function DiscordBotSettings() {
             <dd className="ml-2 inline">- Remove your linked API token</dd>
           </div>
         </dl>
-      </div>
+      </NoteBox>
     </SettingsSection>
   );
 }

--- a/src/components/settings/GoogleReaderApiSettings.tsx
+++ b/src/components/settings/GoogleReaderApiSettings.tsx
@@ -12,6 +12,7 @@ import { SettingsSection } from "@/components/settings/SettingsSection";
 import { CardSection } from "@/components/ui/card";
 import { CopyButton } from "@/components/ui/copy-button";
 import { InlineCode } from "@/components/ui/inline-code";
+import { NoteBox } from "@/components/ui/note-box";
 import { TextLink } from "@/components/ui/text-link";
 
 export function GoogleReaderApiSettings() {
@@ -25,16 +26,18 @@ export function GoogleReaderApiSettings() {
   const apiBase = `${baseUrl}/api/greader.php/reader/api/0`;
 
   return (
-    <SettingsSection title="Google Reader API">
-      {/* Description */}
-      <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-        Lion Reader exposes a{" "}
-        <TextLink href="https://feedhq.readthedocs.io/en/latest/api/" external>
-          Google Reader-compatible API
-        </TextLink>{" "}
-        so you can use third-party RSS reader apps to sync with your Lion Reader account.
-      </p>
-
+    <SettingsSection
+      title="Google Reader API"
+      description={
+        <>
+          Lion Reader exposes a{" "}
+          <TextLink href="https://feedhq.readthedocs.io/en/latest/api/" external>
+            Google Reader-compatible API
+          </TextLink>{" "}
+          so you can use third-party RSS reader apps to sync with your Lion Reader account.
+        </>
+      }
+    >
       {/* Supported Clients */}
       <div className="mt-6">
         <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Compatible Apps</h3>
@@ -107,12 +110,12 @@ export function GoogleReaderApiSettings() {
       </CardSection>
 
       {/* Note */}
-      <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+      <NoteBox className="mt-6">
         <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
           The API uses your regular Lion Reader credentials for authentication. All your
           subscriptions, tags, read state, and starred articles sync automatically.
         </p>
-      </div>
+      </NoteBox>
 
       {/* API base URL note */}
       {baseUrl && (

--- a/src/components/settings/IntegrationsSettings.tsx
+++ b/src/components/settings/IntegrationsSettings.tsx
@@ -44,16 +44,18 @@ export function IntegrationsSettings() {
   const claudeCodeCommand = `claude mcp add --transport http lionreader ${mcpUrl}`;
 
   return (
-    <SettingsSection title="AI Integrations">
-      {/* Description */}
-      <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-        Connect Lion Reader to AI assistants via{" "}
-        <TextLink href="https://modelcontextprotocol.io/" external>
-          MCP (Model Context Protocol)
-        </TextLink>
-        . This lets Claude read, search, and manage your feeds directly.
-      </p>
-
+    <SettingsSection
+      title="AI Integrations"
+      description={
+        <>
+          Connect Lion Reader to AI assistants via{" "}
+          <TextLink href="https://modelcontextprotocol.io/" external>
+            MCP (Model Context Protocol)
+          </TextLink>
+          . This lets Claude read, search, and manage your feeds directly.
+        </>
+      }
+    >
       {/* Claude Code */}
       <div className="mt-6">
         <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Claude Code</h3>

--- a/src/components/settings/KeyboardShortcutsSettings.tsx
+++ b/src/components/settings/KeyboardShortcutsSettings.tsx
@@ -11,6 +11,7 @@ import { useKeyboardShortcutsContext } from "@/components/keyboard/KeyboardShort
 import { SettingsSection } from "@/components/settings/SettingsSection";
 import { CardSection } from "@/components/ui/card";
 import { InfoCircleIcon } from "@/components/ui/icon-button";
+import { Kbd } from "@/components/ui/kbd";
 
 export function KeyboardShortcutsSettings() {
   const { enabled, setEnabled, openShortcutsModal } = useKeyboardShortcutsContext();
@@ -53,11 +54,7 @@ export function KeyboardShortcutsSettings() {
         >
           <InfoCircleIcon className="h-4 w-4" />
           View all keyboard shortcuts
-          {enabled && (
-            <kbd className="ui-text-xs ml-1 rounded border border-zinc-300 bg-zinc-100 px-1.5 py-0.5 font-mono font-medium text-zinc-600 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
-              ?
-            </kbd>
-          )}
+          {enabled && <Kbd className="ml-1">?</Kbd>}
         </button>
       </CardSection>
     </SettingsSection>

--- a/src/components/settings/LinkedAccounts.tsx
+++ b/src/components/settings/LinkedAccounts.tsx
@@ -17,6 +17,7 @@ import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
 import { useFormMessages } from "@/lib/hooks/useFormMessages";
 import { Button } from "@/components/ui/button";
+import { NoteBox } from "@/components/ui/note-box";
 import {
   type OAuthProvider,
   providerNames,
@@ -223,7 +224,7 @@ function LinkedAccountItem({ account, canUnlink, isUnlinking, onUnlink }: Linked
   });
 
   return (
-    <div className="flex items-center justify-between rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+    <NoteBox className="flex items-center justify-between">
       <div className="flex items-center gap-3">
         <ProviderIcon provider={account.provider} />
         <div>
@@ -241,7 +242,7 @@ function LinkedAccountItem({ account, canUnlink, isUnlinking, onUnlink }: Linked
       >
         Unlink
       </Button>
-    </div>
+    </NoteBox>
   );
 }
 

--- a/src/components/settings/OpmlImportExport.tsx
+++ b/src/components/settings/OpmlImportExport.tsx
@@ -407,7 +407,7 @@ function ImportPreview({ feeds, onImport, onCancel, isImporting }: ImportPreview
         <button
           type="button"
           onClick={() => setShowAll(true)}
-          className="ui-text-sm text-accent hover:text-accent-hover mb-4"
+          className="ui-text-sm text-accent hover:text-accent-hover mb-4 font-medium"
         >
           Show all {feeds.length} feeds
         </button>
@@ -466,7 +466,7 @@ function ImportResults({ imported, skipped, failed, results, onReset }: ImportRe
           <button
             type="button"
             onClick={() => setShowDetails(!showDetails)}
-            className="ui-text-sm text-accent hover:text-accent-hover"
+            className="ui-text-sm text-accent hover:text-accent-hover font-medium"
           >
             {showDetails ? "Hide details" : "Show details"}
           </button>

--- a/src/components/settings/SettingsSection.tsx
+++ b/src/components/settings/SettingsSection.tsx
@@ -83,7 +83,7 @@ export function SettingsSection({
       <SettingsSectionHeading>{title}</SettingsSectionHeading>
       <Card>
         {description && (
-          <p className="ui-text-sm mb-4 text-zinc-500 dark:text-zinc-400">{description}</p>
+          <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">{description}</p>
         )}
 
         {error && (

--- a/src/components/settings/TagManagement.tsx
+++ b/src/components/settings/TagManagement.tsx
@@ -21,6 +21,7 @@ import { Input } from "@/components/ui/input";
 import { ChevronDownIcon, EditIcon, TrashIcon } from "@/components/ui/icon-button";
 import { ColorPicker, ColorDot } from "@/components/ui/color-picker";
 import { CardSection } from "@/components/ui/card";
+import { NoteBox } from "@/components/ui/note-box";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { SettingsSection } from "./SettingsSection";
 
@@ -308,7 +309,7 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
 
   if (isEditing && editingValues) {
     return (
-      <div className="flex flex-col gap-3 rounded-md border border-zinc-300 bg-zinc-50 p-4 sm:flex-row sm:items-center dark:border-zinc-600 dark:bg-zinc-800/50">
+      <NoteBox className="flex flex-col gap-3 sm:flex-row sm:items-center">
         <div className="flex flex-1 items-center gap-3">
           <div className="relative">
             <button
@@ -352,12 +353,12 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
             Save
           </Button>
         </div>
-      </div>
+      </NoteBox>
     );
   }
 
   return (
-    <div className="flex items-center justify-between rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+    <NoteBox className="flex items-center justify-between">
       <div className="flex items-center gap-3">
         <ColorDot color={tag.color} size="lg" />
         <div>
@@ -381,6 +382,6 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
           <TrashIcon className="h-4 w-4" />
         </Button>
       </div>
-    </div>
+    </NoteBox>
   );
 }

--- a/src/components/settings/WallabagApiSettings.tsx
+++ b/src/components/settings/WallabagApiSettings.tsx
@@ -16,6 +16,7 @@ import { CardSection } from "@/components/ui/card";
 import { CopyButton } from "@/components/ui/copy-button";
 import { MobileIcon } from "@/components/ui/icon-button";
 import { InlineCode } from "@/components/ui/inline-code";
+import { NoteBox } from "@/components/ui/note-box";
 import { TextLink } from "@/components/ui/text-link";
 
 export function WallabagApiSettings() {
@@ -46,17 +47,19 @@ export function WallabagApiSettings() {
   }, [email, baseUrl, serverUrl]);
 
   return (
-    <SettingsSection title="Wallabag API (Save Articles)">
-      {/* Description */}
-      <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-        Lion Reader exposes a{" "}
-        <TextLink href="https://doc.wallabag.org/developer/api/methods/" external>
-          Wallabag-compatible API
-        </TextLink>{" "}
-        so you can use the Wallabag app on your phone or tablet to save articles directly to Lion
-        Reader.
-      </p>
-
+    <SettingsSection
+      title="Wallabag API (Save Articles)"
+      description={
+        <>
+          Lion Reader exposes a{" "}
+          <TextLink href="https://doc.wallabag.org/developer/api/methods/" external>
+            Wallabag-compatible API
+          </TextLink>{" "}
+          so you can use the Wallabag app on your phone or tablet to save articles directly to Lion
+          Reader.
+        </>
+      }
+    >
       {/* Supported Clients */}
       <div className="mt-6">
         <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Compatible Apps</h3>
@@ -86,14 +89,7 @@ export function WallabagApiSettings() {
           <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
             Scan this QR code with your phone or tap the button below to auto-configure the Wallabag
             Android app. You&apos;ll need to enter your password, and fix the username if the{" "}
-            <code className="ui-text-xs rounded bg-zinc-100 px-1 font-mono dark:bg-zinc-800">
-              @
-            </code>{" "}
-            shows as{" "}
-            <code className="ui-text-xs rounded bg-zinc-100 px-1 font-mono dark:bg-zinc-800">
-              %40
-            </code>
-            .
+            <InlineCode>@</InlineCode> shows as <InlineCode>%40</InlineCode>.
           </p>
 
           <div className="mt-4 flex flex-col items-center gap-4 sm:flex-row sm:items-start">
@@ -113,11 +109,7 @@ export function WallabagApiSettings() {
               </a>
               <p className="ui-text-xs max-w-xs text-zinc-400 dark:text-zinc-500">
                 The QR code and button pre-fill the server URL and your email address. Client ID and
-                secret are both{" "}
-                <code className="rounded bg-zinc-100 px-1 font-mono dark:bg-zinc-800">
-                  wallabag
-                </code>
-                .
+                secret are both <InlineCode>wallabag</InlineCode>.
               </p>
             </div>
           </div>
@@ -169,12 +161,12 @@ export function WallabagApiSettings() {
       </CardSection>
 
       {/* How it works */}
-      <div className="mt-6 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+      <NoteBox className="mt-6">
         <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
           When you share a URL to the Wallabag app, it will save it to your Lion Reader account as a
           saved article. You can also view, archive, star, and delete saved articles from the app.
         </p>
-      </div>
+      </NoteBox>
 
       {/* API base URL note */}
       {baseUrl && (

--- a/src/components/settings/pages/AccountSettingsContent.tsx
+++ b/src/components/settings/pages/AccountSettingsContent.tsx
@@ -249,14 +249,14 @@ function PasswordForm({ mode, onSuccess }: { mode: "set" | "change"; onSuccess: 
   };
 
   return (
-    <SettingsSection title={isSetMode ? "Set Password" : "Change Password"}>
-      {isSetMode && (
-        <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
-          Your account was created with OAuth. Set a password to also log in with your email and
-          password.
-        </p>
-      )}
-
+    <SettingsSection
+      title={isSetMode ? "Set Password" : "Change Password"}
+      description={
+        isSetMode
+          ? "Your account was created with OAuth. Set a password to also log in with your email and password."
+          : undefined
+      }
+    >
       {successMessage && (
         <Alert variant="success" className="mb-4">
           {successMessage}
@@ -339,11 +339,11 @@ export default function AccountSettingsContent() {
       <KeyboardShortcutsSettings />
 
       {/* Privacy & Legal Section - fully static */}
-      <SettingsSection title="Privacy & Legal">
-        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-          Learn more about how we collect, use, and protect your data.
-        </p>
-        <div className="mt-4 flex gap-4">
+      <SettingsSection
+        title="Privacy & Legal"
+        description="Learn more about how we collect, use, and protect your data."
+      >
+        <div className="flex gap-4">
           <TextLink href="/privacy" className="ui-text-sm">
             View Privacy Policy &rarr;
           </TextLink>

--- a/src/components/subscribe/SubscribeContent.tsx
+++ b/src/components/subscribe/SubscribeContent.tsx
@@ -400,7 +400,7 @@ export function SubscribeContent() {
           {/* Sample Entries */}
           {previewQuery.data?.feed.sampleEntries &&
             previewQuery.data.feed.sampleEntries.length > 0 && (
-              <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+              <Card padding="none">
                 <h3 className="ui-text-sm border-b border-zinc-200 px-4 py-3 font-medium text-zinc-900 dark:border-zinc-800 dark:text-zinc-50">
                   Recent Entries
                 </h3>
@@ -427,7 +427,7 @@ export function SubscribeContent() {
                     </li>
                   ))}
                 </ul>
-              </div>
+              </Card>
             )}
 
           {/* Error from subscribe */}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -8,8 +8,8 @@ import type { ReactNode } from "react";
 
 export interface CardProps {
   children: ReactNode;
-  /** Padding size */
-  padding?: "sm" | "md" | "lg";
+  /** Padding size ("none" for containers whose rows carry their own padding) */
+  padding?: "none" | "sm" | "md" | "lg";
   /** Additional class name */
   className?: string;
 }
@@ -29,6 +29,7 @@ export interface CardProps {
  */
 export function Card({ children, padding = "lg", className = "" }: CardProps) {
   const paddingStyles = {
+    none: "",
     sm: "p-3",
     md: "p-4",
     lg: "p-6",

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -1,0 +1,22 @@
+/**
+ * Kbd Component
+ *
+ * Keyboard key chip for displaying shortcut keys.
+ */
+
+import type { ReactNode } from "react";
+
+export interface KbdProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function Kbd({ children, className = "" }: KbdProps) {
+  return (
+    <kbd
+      className={`ui-text-xs inline-flex min-w-[24px] items-center justify-center rounded border border-zinc-300 bg-zinc-100 px-1.5 py-0.5 font-mono font-medium text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 ${className}`}
+    >
+      {children}
+    </kbd>
+  );
+}

--- a/src/components/ui/note-box.tsx
+++ b/src/components/ui/note-box.tsx
@@ -1,0 +1,32 @@
+/**
+ * NoteBox Component
+ *
+ * Subtle zinc-tinted box for notes, hints, and secondary content inside
+ * cards (e.g. "how to use" notes, linked-account rows). Use instead of
+ * copying the rounded-md zinc-50 box classes.
+ */
+
+import type { ReactNode } from "react";
+
+export interface NoteBoxProps {
+  children: ReactNode;
+  /** Padding size */
+  padding?: "sm" | "md";
+  /** Additional class name */
+  className?: string;
+}
+
+export function NoteBox({ children, padding = "md", className = "" }: NoteBoxProps) {
+  const paddingStyles = {
+    sm: "px-3 py-2",
+    md: "p-4",
+  };
+
+  return (
+    <div
+      className={`rounded-md border border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800/50 ${paddingStyles[padding]} ${className}`}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Follow-up to #1136 for #1016. That PR consolidated exact-match duplicates but deliberately preserved near-miss styles byte-for-byte; per feedback, those near-misses were unintentional drift, so this PR normalizes them onto the standard styles. Unlike #1136, small visual changes are **intended** here — everything below converges drifted copies onto one canonical look.

## New shared components

- **`NoteBox`** (`ui/note-box.tsx`) — the zinc-tinted note/hint box (`rounded-md border bg-zinc-50 … dark:bg-zinc-800/50`) that was hand-rolled 7 times: the Google Reader / Wallabag / Discord / Bookmarklet info boxes, linked-account rows, tag list/edit rows, and the voice storage bar (`padding="sm"`). TagManagement's copy had drifted to zinc-300/zinc-600 borders — now consistent with the rest.
- **`Kbd`** (`ui/kbd.tsx`) — unifies the two near-identical `<kbd>` chips; the settings one differed from the shortcuts modal only in text shade (zinc-600 vs zinc-700) and now matches.

## Normalizations onto existing components

- **`InlineCode`**: the `px-1` code chips that had drifted from the standard chip (Wallabag's `@` / `%40` / `wallabag`, ApiKeySettings' `{{content}}`-style template variables — the latter also gain the standard `font-mono`/`ui-text-xs`).
- **`TextLink` / `font-medium`**: privacy page's Groq link and terms page's `underline`-variant accent links now use the standard accent-link style (external `<a>`s become `TextLink`; the internal `<Link>`s keep Next's Link — intentional outside the SPA shell — but get the standard classes).  OPML's show-more/details buttons also gain `font-medium`.
- **`SettingsSection` `description` prop**: the 9 sections that hand-rolled a leading description paragraph now pass it as the prop. The prop's color changes zinc-500 → zinc-600 (the 9-vs-2 majority, and higher contrast), so all section descriptions now share one color and one `mb-4` margin (previously a mix of none/`mb-4`/`mb-6`).
- **`Card padding="none"`**: new option, used by the subscribe preview's "Recent Entries" list whose header/rows carry their own padding.

After this, the note-box, kbd, accent-link, and code-chip styles each grep to exactly one definition site under `src/`.

## Testing

- `pnpm typecheck`, `pnpm lint`, prettier all pass
- `pnpm test:unit`: 2163 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)