### PR TITLE
Add LegalProse components for the legal pages (#1016)

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -7,6 +7,14 @@
 
 import type { Metadata } from "next";
 import Link from "next/link";
+import {
+  LegalList,
+  LegalPage,
+  LegalParagraph,
+  LegalSection,
+  LegalSubsection,
+} from "@/components/legal/LegalProse";
+import { Card } from "@/components/ui/card";
 import { TextLink } from "@/components/ui/text-link";
 
 export const metadata: Metadata = {
@@ -16,397 +24,316 @@ export const metadata: Metadata = {
 
 export default function PrivacyPolicyPage() {
   return (
-    <div className="min-h-screen bg-zinc-50 px-4 py-12 dark:bg-zinc-950">
-      <main className="mx-auto max-w-3xl">
-        {/* Header */}
-        <div className="mb-8">
-          <Link
-            href="/"
-            className="ui-text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
-          >
-            &larr; Back to Lion Reader
-          </Link>
-          <h1 className="mt-4 text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
-            Privacy Policy
-          </h1>
-          <p className="ui-text-sm mt-2 text-zinc-500 dark:text-zinc-400">
-            Last updated: February 2026
-          </p>
+    <LegalPage title="Privacy Policy" lastUpdated="February 2026">
+      <LegalSection title="Overview">
+        <LegalParagraph>
+          Lion Reader is committed to protecting your privacy. We collect only the data necessary to
+          provide our feed reading service. We do not sell, rent, or share your personal information
+          with third parties for marketing purposes.
+        </LegalParagraph>
+        <LegalParagraph>
+          This policy explains what information we collect, how we use it, what third-party services
+          we use, and your rights regarding your data.
+        </LegalParagraph>
+      </LegalSection>
+
+      <LegalSection title="Information We Collect">
+        <div className="mt-4 space-y-4">
+          <LegalSubsection title="Account Information">
+            <LegalParagraph tight>
+              When you create an account, we collect your email address and password. Passwords are
+              securely hashed using argon2 (industry-standard). If you sign in with Google or Apple,
+              we receive only your email address and profile ID from those providers—we do not
+              access any other data from your OAuth accounts.
+            </LegalParagraph>
+          </LegalSubsection>
+          <LegalSubsection title="Session Information">
+            <LegalParagraph tight>
+              We store session tokens (SHA-256 hashed), IP addresses, and user agent strings to
+              maintain your login sessions and prevent unauthorized access. You can view and revoke
+              active sessions from your account settings.
+            </LegalParagraph>
+          </LegalSubsection>
+          <LegalSubsection title="Feed Data">
+            <LegalParagraph tight>
+              We store the RSS/Atom feeds you subscribe to, articles from those feeds, and your
+              reading history (read/unread status, starred items, folder organization). This data is
+              used to provide the core feed reading functionality.
+            </LegalParagraph>
+          </LegalSubsection>
+          <LegalSubsection title="Saved Articles">
+            <LegalParagraph tight>
+              When you save articles using our bookmarklet or save feature, we store the article
+              content and metadata on our servers for your later access.
+            </LegalParagraph>
+          </LegalSubsection>
+          <LegalSubsection title="Email Newsletter Subscriptions">
+            <LegalParagraph tight>
+              Each account has a unique email address for forwarding newsletters to your feed. If
+              you use this feature, we receive and store the newsletters sent to that address,
+              including sender information and email content.
+            </LegalParagraph>
+          </LegalSubsection>
         </div>
+      </LegalSection>
 
-        {/* Content */}
-        <div className="prose prose-zinc dark:prose-invert max-w-none">
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">Overview</h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              Lion Reader is committed to protecting your privacy. We collect only the data
-              necessary to provide our feed reading service. We do not sell, rent, or share your
-              personal information with third parties for marketing purposes.
-            </p>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              This policy explains what information we collect, how we use it, what third-party
-              services we use, and your rights regarding your data.
-            </p>
-          </section>
+      <LegalSection title="How We Use Your Data">
+        <LegalParagraph>
+          We use the information we collect to provide, operate, and improve the Lion Reader
+          service. This includes:
+        </LegalParagraph>
+        <LegalList>
+          <li>To maintain your account and authenticate you when you sign in</li>
+          <li>To fetch, store, and display RSS/Atom feeds you subscribe to</li>
+          <li>To track your reading progress (read/unread status, starred items)</li>
+          <li>To enable optional features like audio narration and saved articles</li>
+          <li>
+            To monitor service health, diagnose errors, and improve performance (via Sentry and
+            Grafana)
+          </li>
+          <li>To prevent abuse and maintain security of the service</li>
+          <li>
+            To administer the service, including managing user accounts, monitoring feed health, and
+            managing invite codes (see Administrative Access below)
+          </li>
+        </LegalList>
+        <LegalParagraph>
+          <strong>
+            We do not use your data for advertising, marketing to third parties, or any purpose
+            unrelated to providing the Lion Reader service.
+          </strong>
+        </LegalParagraph>
+      </LegalSection>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Information We Collect
-            </h2>
-            <div className="mt-4 space-y-4">
-              <div>
-                <h3 className="font-medium text-zinc-800 dark:text-zinc-200">
-                  Account Information
-                </h3>
-                <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-                  When you create an account, we collect your email address and password. Passwords
-                  are securely hashed using argon2 (industry-standard). If you sign in with Google
-                  or Apple, we receive only your email address and profile ID from those
-                  providers—we do not access any other data from your OAuth accounts.
-                </p>
-              </div>
-              <div>
-                <h3 className="font-medium text-zinc-800 dark:text-zinc-200">
-                  Session Information
-                </h3>
-                <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-                  We store session tokens (SHA-256 hashed), IP addresses, and user agent strings to
-                  maintain your login sessions and prevent unauthorized access. You can view and
-                  revoke active sessions from your account settings.
-                </p>
-              </div>
-              <div>
-                <h3 className="font-medium text-zinc-800 dark:text-zinc-200">Feed Data</h3>
-                <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-                  We store the RSS/Atom feeds you subscribe to, articles from those feeds, and your
-                  reading history (read/unread status, starred items, folder organization). This
-                  data is used to provide the core feed reading functionality.
-                </p>
-              </div>
-              <div>
-                <h3 className="font-medium text-zinc-800 dark:text-zinc-200">Saved Articles</h3>
-                <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-                  When you save articles using our bookmarklet or save feature, we store the article
-                  content and metadata on our servers for your later access.
-                </p>
-              </div>
-              <div>
-                <h3 className="font-medium text-zinc-800 dark:text-zinc-200">
-                  Email Newsletter Subscriptions
-                </h3>
-                <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-                  Each account has a unique email address for forwarding newsletters to your feed.
-                  If you use this feature, we receive and store the newsletters sent to that
-                  address, including sender information and email content.
-                </p>
-              </div>
-            </div>
-          </section>
+      <LegalSection title="Administrative Access">
+        <LegalParagraph>
+          Lion Reader administrators have access to an internal admin portal used to operate and
+          maintain the service. This portal is protected by a separate secret and is not accessible
+          to regular users. Through the admin portal, administrators can view:
+        </LegalParagraph>
+        <LegalList>
+          <li>
+            <strong>User information:</strong> Email addresses, account creation dates, linked
+            sign-in providers (e.g., Google, Apple, Discord), number of feed subscriptions, number
+            of entries, and scoring model statistics
+          </li>
+          <li>
+            <strong>Feed health data:</strong> Feed URLs, titles, fetch error details, subscriber
+            counts, entry counts, and fetch sizes — used to diagnose and resolve feed issues
+          </li>
+          <li>
+            <strong>Invite management:</strong> Invite codes, their status (pending, used, expired),
+            and which user claimed each invite
+          </li>
+        </LegalList>
+        <LegalParagraph>
+          Administrative access is used solely for service operation, troubleshooting, and user
+          support.
+        </LegalParagraph>
+      </LegalSection>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              How We Use Your Data
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              We use the information we collect to provide, operate, and improve the Lion Reader
-              service. This includes:
-            </p>
-            <ul className="mt-2 list-disc space-y-1 pl-6 text-zinc-600 dark:text-zinc-400">
-              <li>To maintain your account and authenticate you when you sign in</li>
-              <li>To fetch, store, and display RSS/Atom feeds you subscribe to</li>
-              <li>To track your reading progress (read/unread status, starred items)</li>
-              <li>To enable optional features like audio narration and saved articles</li>
-              <li>
-                To monitor service health, diagnose errors, and improve performance (via Sentry and
-                Grafana)
-              </li>
-              <li>To prevent abuse and maintain security of the service</li>
-              <li>
-                To administer the service, including managing user accounts, monitoring feed health,
-                and managing invite codes (see Administrative Access below)
-              </li>
-            </ul>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              <strong>
-                We do not use your data for advertising, marketing to third parties, or any purpose
-                unrelated to providing the Lion Reader service.
-              </strong>
-            </p>
-          </section>
+      <LegalSection title="Data Sharing and Disclosure">
+        <LegalParagraph>
+          We do not sell, rent, or share your personal information with third parties for their
+          marketing purposes. We only share data with third-party service providers as necessary to
+          operate the service (see Third-Party Services section below).
+        </LegalParagraph>
+        <LegalParagraph>
+          We may disclose your information if required by law, such as in response to a valid
+          subpoena or court order, or to protect the security and integrity of our service.
+        </LegalParagraph>
+      </LegalSection>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Administrative Access
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              Lion Reader administrators have access to an internal admin portal used to operate and
-              maintain the service. This portal is protected by a separate secret and is not
-              accessible to regular users. Through the admin portal, administrators can view:
-            </p>
-            <ul className="mt-2 list-disc space-y-1 pl-6 text-zinc-600 dark:text-zinc-400">
-              <li>
-                <strong>User information:</strong> Email addresses, account creation dates, linked
-                sign-in providers (e.g., Google, Apple, Discord), number of feed subscriptions,
-                number of entries, and scoring model statistics
-              </li>
-              <li>
-                <strong>Feed health data:</strong> Feed URLs, titles, fetch error details,
-                subscriber counts, entry counts, and fetch sizes — used to diagnose and resolve feed
-                issues
-              </li>
-              <li>
-                <strong>Invite management:</strong> Invite codes, their status (pending, used,
-                expired), and which user claimed each invite
-              </li>
-            </ul>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              Administrative access is used solely for service operation, troubleshooting, and user
-              support.
-            </p>
-          </section>
+      <LegalSection title="Third-Party Services">
+        <LegalParagraph>
+          We use the following third-party services to operate Lion Reader:
+        </LegalParagraph>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Data Sharing and Disclosure
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              We do not sell, rent, or share your personal information with third parties for their
-              marketing purposes. We only share data with third-party service providers as necessary
-              to operate the service (see Third-Party Services section below).
-            </p>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              We may disclose your information if required by law, such as in response to a valid
-              subpoena or court order, or to protect the security and integrity of our service.
-            </p>
-          </section>
+        <div className="mt-4 space-y-6">
+          <Card padding="md">
+            <LegalSubsection title="Audio Narration (Groq) — Optional">
+              <LegalParagraph>
+                <strong>This feature is optional and disabled by default.</strong> When you enable
+                AI text processing in narration settings, article content is sent to Groq (using
+                their Llama 3.1 8B model) to convert it into speakable text. This preprocessing
+                expands abbreviations, formats numbers for speech, and improves pronunciation. The
+                processed text is cached on our servers to avoid repeated processing.
+              </LegalParagraph>
+              <LegalParagraph>
+                When AI processing is disabled, we use simple HTML-to-text conversion that happens
+                entirely on our servers. Either way, the actual audio generation happens entirely on
+                your device using your browser&apos;s built-in text-to-speech. No audio data is sent
+                to external servers.
+              </LegalParagraph>
+              <p className="mt-2">
+                <TextLink href="https://groq.com/privacy-policy/" external className="ui-text-sm">
+                  View Groq&apos;s Privacy Policy &rarr;
+                </TextLink>
+              </p>
+            </LegalSubsection>
+          </Card>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Third-Party Services
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              We use the following third-party services to operate Lion Reader:
-            </p>
+          <LegalSubsection title="Hosting (Fly.io)">
+            <LegalParagraph tight>
+              Our application and databases are hosted on Fly.io infrastructure in the United
+              States. All data at rest is encrypted using Fly.io&apos;s managed PostgreSQL service.
+              Fly.io has access to server data as part of providing infrastructure services.
+            </LegalParagraph>
+          </LegalSubsection>
 
-            <div className="mt-4 space-y-6">
-              <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
-                <h3 className="font-medium text-zinc-800 dark:text-zinc-200">
-                  Audio Narration (Groq) — Optional
-                </h3>
-                <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-                  <strong>This feature is optional and disabled by default.</strong> When you enable
-                  AI text processing in narration settings, article content is sent to Groq (using
-                  their Llama 3.1 8B model) to convert it into speakable text. This preprocessing
-                  expands abbreviations, formats numbers for speech, and improves pronunciation. The
-                  processed text is cached on our servers to avoid repeated processing.
-                </p>
-                <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-                  When AI processing is disabled, we use simple HTML-to-text conversion that happens
-                  entirely on our servers. Either way, the actual audio generation happens entirely
-                  on your device using your browser&apos;s built-in text-to-speech. No audio data is
-                  sent to external servers.
-                </p>
-                <p className="mt-2">
-                  <TextLink href="https://groq.com/privacy-policy/" external className="ui-text-sm">
-                    View Groq&apos;s Privacy Policy &rarr;
-                  </TextLink>
-                </p>
-              </div>
+          <LegalSubsection title="Error Tracking (Sentry)">
+            <LegalParagraph tight>
+              We use Sentry to track application errors and performance issues. Sentry may receive
+              error messages, stack traces, and limited context about the operation that failed
+              (e.g., which page you were on). We do not send article content or feed data to Sentry.
+            </LegalParagraph>
+          </LegalSubsection>
 
-              <div>
-                <h3 className="font-medium text-zinc-800 dark:text-zinc-200">Hosting (Fly.io)</h3>
-                <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-                  Our application and databases are hosted on Fly.io infrastructure in the United
-                  States. All data at rest is encrypted using Fly.io&apos;s managed PostgreSQL
-                  service. Fly.io has access to server data as part of providing infrastructure
-                  services.
-                </p>
-              </div>
+          <LegalSubsection title="Monitoring (Grafana Cloud)">
+            <LegalParagraph tight>
+              We use Grafana Cloud for application metrics and logs to monitor service health and
+              performance. This includes anonymized usage metrics (e.g., number of API requests) and
+              system logs. We do not send personal information or article content to Grafana.
+            </LegalParagraph>
+          </LegalSubsection>
 
-              <div>
-                <h3 className="font-medium text-zinc-800 dark:text-zinc-200">
-                  Error Tracking (Sentry)
-                </h3>
-                <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-                  We use Sentry to track application errors and performance issues. Sentry may
-                  receive error messages, stack traces, and limited context about the operation that
-                  failed (e.g., which page you were on). We do not send article content or feed data
-                  to Sentry.
-                </p>
-              </div>
-
-              <div>
-                <h3 className="font-medium text-zinc-800 dark:text-zinc-200">
-                  Monitoring (Grafana Cloud)
-                </h3>
-                <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-                  We use Grafana Cloud for application metrics and logs to monitor service health
-                  and performance. This includes anonymized usage metrics (e.g., number of API
-                  requests) and system logs. We do not send personal information or article content
-                  to Grafana.
-                </p>
-              </div>
-
-              <div>
-                <h3 className="font-medium text-zinc-800 dark:text-zinc-200">
-                  Authentication Providers (Google, Apple)
-                </h3>
-                <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-                  If you choose to sign in with Google or Apple, we use their OAuth services. We
-                  only receive your email address and profile ID—we do not access any other data
-                  from these providers.
-                </p>
-              </div>
-            </div>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Cookies and Local Storage
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              We use essential cookies for authentication and session management. We also use
-              browser storage to save your preferences and cached data:
-            </p>
-            <ul className="mt-2 list-disc space-y-1 pl-6 text-zinc-600 dark:text-zinc-400">
-              <li>
-                <strong>localStorage:</strong> Narration voice settings, reading preferences
-                (show/hide read items, sort order), and keyboard shortcut preferences
-              </li>
-              <li>
-                <strong>IndexedDB:</strong> Enhanced narration voices (if you download optional
-                high-quality voices using Piper TTS). These voice files are stored locally on your
-                device and never sent to our servers.
-              </li>
-            </ul>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              We do not use third-party tracking cookies, analytics, or advertising cookies.
-            </p>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Data Security
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              We implement industry-standard security measures to protect your data:
-            </p>
-            <ul className="mt-2 list-disc space-y-1 pl-6 text-zinc-600 dark:text-zinc-400">
-              <li>
-                <strong>Encrypted connections:</strong> All data transmitted between your device and
-                our servers uses HTTPS encryption
-              </li>
-              <li>
-                <strong>Secure password storage:</strong> Passwords are hashed using argon2, a
-                memory-hard algorithm resistant to brute-force attacks
-              </li>
-              <li>
-                <strong>Session token security:</strong> Session tokens are SHA-256 hashed before
-                storage and never stored in plain text
-              </li>
-              <li>
-                <strong>Database encryption:</strong> All data at rest is encrypted using
-                Fly.io&apos;s managed PostgreSQL encryption
-              </li>
-              <li>
-                <strong>Regular security updates:</strong> We keep our dependencies and
-                infrastructure up to date with security patches
-              </li>
-            </ul>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Data Retention
-            </h2>
-            <ul className="mt-2 list-disc space-y-1 pl-6 text-zinc-600 dark:text-zinc-400">
-              <li>
-                <strong>Account data:</strong> Retained as long as your account is active
-              </li>
-              <li>
-                <strong>Sessions:</strong> Active sessions remain until you log out or they expire
-                (configurable expiration). Revoked sessions are deleted immediately.
-              </li>
-              <li>
-                <strong>Feed content:</strong> Shared feed data is retained as long as any user is
-                subscribed to that feed. When you unsubscribe, your personal reading state is
-                retained (soft delete) so you can resubscribe and maintain your history.
-              </li>
-              <li>
-                <strong>Saved articles:</strong> Retained until you delete them
-              </li>
-              <li>
-                <strong>Narration cache:</strong> Preprocessed narration text is cached indefinitely
-                to avoid repeated processing
-              </li>
-              <li>
-                <strong>Logs and metrics:</strong> Application logs and error reports are retained
-                for 30 days for troubleshooting and performance monitoring
-              </li>
-            </ul>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Your Rights
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              You have the following rights regarding your personal data:
-            </p>
-            <ul className="mt-2 list-disc space-y-1 pl-6 text-zinc-600 dark:text-zinc-400">
-              <li>
-                <strong>Access:</strong> View all your personal data through your account settings
-              </li>
-              <li>
-                <strong>Export:</strong> Download your feed subscriptions in OPML format for import
-                into other RSS readers
-              </li>
-              <li>
-                <strong>Correct:</strong> Update your email address and other account information at
-                any time
-              </li>
-              <li>
-                <strong>Revoke access:</strong> Disconnect OAuth accounts (Google, Apple) and revoke
-                individual login sessions from your account settings
-              </li>
-              <li>
-                <strong>Control features:</strong> Disable optional features like AI text processing
-                for narration at any time
-              </li>
-              <li>
-                <strong>Delete:</strong> Delete your account and all associated data at any time
-                from your{" "}
-                <Link
-                  href="/settings/delete-account"
-                  className="text-accent hover:text-accent-hover font-medium"
-                >
-                  account settings
-                </Link>
-                . Account deletion is permanent and cannot be undone.
-              </li>
-            </ul>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Changes to This Policy
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              We may update this privacy policy from time to time. We will notify users of any
-              material changes by posting the updated policy on this page with a new &quot;Last
-              updated&quot; date.
-            </p>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">Contact</h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              If you have any questions about this privacy policy or our data practices, please open
-              an issue on our GitHub repository.
-            </p>
-          </section>
+          <LegalSubsection title="Authentication Providers (Google, Apple)">
+            <LegalParagraph tight>
+              If you choose to sign in with Google or Apple, we use their OAuth services. We only
+              receive your email address and profile ID—we do not access any other data from these
+              providers.
+            </LegalParagraph>
+          </LegalSubsection>
         </div>
-      </main>
-    </div>
+      </LegalSection>
+
+      <LegalSection title="Cookies and Local Storage">
+        <LegalParagraph>
+          We use essential cookies for authentication and session management. We also use browser
+          storage to save your preferences and cached data:
+        </LegalParagraph>
+        <LegalList>
+          <li>
+            <strong>localStorage:</strong> Narration voice settings, reading preferences (show/hide
+            read items, sort order), and keyboard shortcut preferences
+          </li>
+          <li>
+            <strong>IndexedDB:</strong> Enhanced narration voices (if you download optional
+            high-quality voices using Piper TTS). These voice files are stored locally on your
+            device and never sent to our servers.
+          </li>
+        </LegalList>
+        <LegalParagraph>
+          We do not use third-party tracking cookies, analytics, or advertising cookies.
+        </LegalParagraph>
+      </LegalSection>
+
+      <LegalSection title="Data Security">
+        <LegalParagraph>
+          We implement industry-standard security measures to protect your data:
+        </LegalParagraph>
+        <LegalList>
+          <li>
+            <strong>Encrypted connections:</strong> All data transmitted between your device and our
+            servers uses HTTPS encryption
+          </li>
+          <li>
+            <strong>Secure password storage:</strong> Passwords are hashed using argon2, a
+            memory-hard algorithm resistant to brute-force attacks
+          </li>
+          <li>
+            <strong>Session token security:</strong> Session tokens are SHA-256 hashed before
+            storage and never stored in plain text
+          </li>
+          <li>
+            <strong>Database encryption:</strong> All data at rest is encrypted using Fly.io&apos;s
+            managed PostgreSQL encryption
+          </li>
+          <li>
+            <strong>Regular security updates:</strong> We keep our dependencies and infrastructure
+            up to date with security patches
+          </li>
+        </LegalList>
+      </LegalSection>
+
+      <LegalSection title="Data Retention">
+        <LegalList>
+          <li>
+            <strong>Account data:</strong> Retained as long as your account is active
+          </li>
+          <li>
+            <strong>Sessions:</strong> Active sessions remain until you log out or they expire
+            (configurable expiration). Revoked sessions are deleted immediately.
+          </li>
+          <li>
+            <strong>Feed content:</strong> Shared feed data is retained as long as any user is
+            subscribed to that feed. When you unsubscribe, your personal reading state is retained
+            (soft delete) so you can resubscribe and maintain your history.
+          </li>
+          <li>
+            <strong>Saved articles:</strong> Retained until you delete them
+          </li>
+          <li>
+            <strong>Narration cache:</strong> Preprocessed narration text is cached indefinitely to
+            avoid repeated processing
+          </li>
+          <li>
+            <strong>Logs and metrics:</strong> Application logs and error reports are retained for
+            30 days for troubleshooting and performance monitoring
+          </li>
+        </LegalList>
+      </LegalSection>
+
+      <LegalSection title="Your Rights">
+        <LegalParagraph>You have the following rights regarding your personal data:</LegalParagraph>
+        <LegalList>
+          <li>
+            <strong>Access:</strong> View all your personal data through your account settings
+          </li>
+          <li>
+            <strong>Export:</strong> Download your feed subscriptions in OPML format for import into
+            other RSS readers
+          </li>
+          <li>
+            <strong>Correct:</strong> Update your email address and other account information at any
+            time
+          </li>
+          <li>
+            <strong>Revoke access:</strong> Disconnect OAuth accounts (Google, Apple) and revoke
+            individual login sessions from your account settings
+          </li>
+          <li>
+            <strong>Control features:</strong> Disable optional features like AI text processing for
+            narration at any time
+          </li>
+          <li>
+            <strong>Delete:</strong> Delete your account and all associated data at any time from
+            your{" "}
+            <Link
+              href="/settings/delete-account"
+              className="text-accent hover:text-accent-hover font-medium"
+            >
+              account settings
+            </Link>
+            . Account deletion is permanent and cannot be undone.
+          </li>
+        </LegalList>
+      </LegalSection>
+
+      <LegalSection title="Changes to This Policy">
+        <LegalParagraph>
+          We may update this privacy policy from time to time. We will notify users of any material
+          changes by posting the updated policy on this page with a new &quot;Last updated&quot;
+          date.
+        </LegalParagraph>
+      </LegalSection>
+
+      <LegalSection title="Contact">
+        <LegalParagraph>
+          If you have any questions about this privacy policy or our data practices, please open an
+          issue on our GitHub repository.
+        </LegalParagraph>
+      </LegalSection>
+    </LegalPage>
   );
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -7,6 +7,8 @@
 
 import type { Metadata } from "next";
 import Link from "next/link";
+import { LegalList, LegalPage, LegalParagraph, LegalSection } from "@/components/legal/LegalProse";
+import { Card } from "@/components/ui/card";
 import { TextLink } from "@/components/ui/text-link";
 
 export const metadata: Metadata = {
@@ -16,220 +18,167 @@ export const metadata: Metadata = {
 
 export default function TermsOfServicePage() {
   return (
-    <div className="min-h-screen bg-zinc-50 px-4 py-12 dark:bg-zinc-950">
-      <main className="mx-auto max-w-3xl">
-        {/* Header */}
-        <div className="mb-8">
-          <Link
-            href="/"
-            className="ui-text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
-          >
-            &larr; Back to Lion Reader
+    <LegalPage title="Terms of Service" lastUpdated="February 2026">
+      <LegalSection title="Overview">
+        <LegalParagraph>
+          Lion Reader is a free, open-source feed reader service. By creating an account or using
+          the service, you agree to these Terms of Service. If you do not agree to these terms, you
+          may not use the service.
+        </LegalParagraph>
+        <LegalParagraph>
+          Please also review our{" "}
+          <Link href="/privacy" className="text-accent hover:text-accent-hover font-medium">
+            Privacy Policy
           </Link>
-          <h1 className="mt-4 text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
-            Terms of Service
-          </h1>
-          <p className="ui-text-sm mt-2 text-zinc-500 dark:text-zinc-400">
-            Last updated: February 2026
-          </p>
-        </div>
+          , which describes how we collect and use your data.
+        </LegalParagraph>
+      </LegalSection>
 
-        {/* Content */}
-        <div className="prose prose-zinc dark:prose-invert max-w-none">
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">Overview</h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              Lion Reader is a free, open-source feed reader service. By creating an account or
-              using the service, you agree to these Terms of Service. If you do not agree to these
-              terms, you may not use the service.
-            </p>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              Please also review our{" "}
-              <Link href="/privacy" className="text-accent hover:text-accent-hover font-medium">
-                Privacy Policy
-              </Link>
-              , which describes how we collect and use your data.
-            </p>
-          </section>
+      <LegalSection title="Eligibility and Geographic Restrictions">
+        <LegalParagraph>
+          Lion Reader is available only to users located in the United States. By using this
+          service, you represent that you are located in the United States.
+        </LegalParagraph>
+        <LegalParagraph>
+          <strong>Use of Lion Reader from the European Union is explicitly prohibited.</strong> This
+          service is not designed to comply with the General Data Protection Regulation (GDPR) or
+          other EU data protection laws. If you are located in the EU, you must not create an
+          account or use this service.
+        </LegalParagraph>
+      </LegalSection>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Eligibility and Geographic Restrictions
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              Lion Reader is available only to users located in the United States. By using this
-              service, you represent that you are located in the United States.
-            </p>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              <strong>Use of Lion Reader from the European Union is explicitly prohibited.</strong>{" "}
-              This service is not designed to comply with the General Data Protection Regulation
-              (GDPR) or other EU data protection laws. If you are located in the EU, you must not
-              create an account or use this service.
-            </p>
-          </section>
+      <LegalSection title="The Service">
+        <LegalParagraph>
+          Lion Reader is a free service provided on an &quot;as is&quot; and &quot;as
+          available&quot; basis. We make no warranties or guarantees regarding uptime, availability,
+          or reliability. The service may be modified, suspended, or discontinued at any time
+          without notice.
+        </LegalParagraph>
+      </LegalSection>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              The Service
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              Lion Reader is a free service provided on an &quot;as is&quot; and &quot;as
-              available&quot; basis. We make no warranties or guarantees regarding uptime,
-              availability, or reliability. The service may be modified, suspended, or discontinued
-              at any time without notice.
-            </p>
-          </section>
+      <LegalSection title="Acceptable Use">
+        <LegalParagraph>
+          You agree to use Lion Reader only for lawful purposes and in a manner consistent with its
+          intended use as a personal feed reader. You must not:
+        </LegalParagraph>
+        <LegalList>
+          <li>Use the service for any illegal activity</li>
+          <li>Attempt to gain unauthorized access to other users&apos; accounts or data</li>
+          <li>Use the service to distribute malware, spam, or other harmful content</li>
+          <li>
+            Interfere with or disrupt the service, servers, or networks connected to the service
+          </li>
+          <li>
+            Use automated tools, bots, or scripts to access the service in a manner that exceeds
+            reasonable personal use
+          </li>
+          <li>Scrape, harvest, or collect data from the service beyond your own account data</li>
+          <li>Resell, redistribute, or sublicense access to the service</li>
+          <li>Use the service in any way that violates applicable laws or regulations</li>
+        </LegalList>
+      </LegalSection>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Acceptable Use
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              You agree to use Lion Reader only for lawful purposes and in a manner consistent with
-              its intended use as a personal feed reader. You must not:
-            </p>
-            <ul className="mt-2 list-disc space-y-1 pl-6 text-zinc-600 dark:text-zinc-400">
-              <li>Use the service for any illegal activity</li>
-              <li>Attempt to gain unauthorized access to other users&apos; accounts or data</li>
-              <li>Use the service to distribute malware, spam, or other harmful content</li>
-              <li>
-                Interfere with or disrupt the service, servers, or networks connected to the service
-              </li>
-              <li>
-                Use automated tools, bots, or scripts to access the service in a manner that exceeds
-                reasonable personal use
-              </li>
-              <li>
-                Scrape, harvest, or collect data from the service beyond your own account data
-              </li>
-              <li>Resell, redistribute, or sublicense access to the service</li>
-              <li>Use the service in any way that violates applicable laws or regulations</li>
-            </ul>
-          </section>
+      <LegalSection title="Usage Limits">
+        <LegalParagraph>
+          To ensure fair usage and maintain service stability, Lion Reader enforces the following
+          limits. These limits are subject to change at any time.
+        </LegalParagraph>
+        <Card padding="md" className="mt-4">
+          <ul className="list-disc space-y-2 pl-6 text-zinc-600 dark:text-zinc-400">
+            <li>
+              <strong>Subscriptions:</strong> Up to 500 active feed subscriptions per account
+            </li>
+            <li>
+              <strong>Feed size:</strong> Individual feed responses are limited to 10 MB
+            </li>
+            <li>
+              <strong>Feed entries:</strong> Up to 100 entries parsed per feed update
+            </li>
+            <li>
+              <strong>Saved articles:</strong> Individual saved article pages are limited to 5 MB
+            </li>
+            <li>
+              <strong>Email newsletters:</strong> Individual newsletter emails are limited to 2 MB
+            </li>
+            <li>
+              <strong>API rate limits:</strong> Requests are rate-limited to prevent abuse
+            </li>
+          </ul>
+        </Card>
+        <LegalParagraph>
+          Exceeding these limits may result in requests being rejected. Persistent or deliberate
+          attempts to circumvent these limits may result in account suspension or termination.
+        </LegalParagraph>
+      </LegalSection>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Usage Limits
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              To ensure fair usage and maintain service stability, Lion Reader enforces the
-              following limits. These limits are subject to change at any time.
-            </p>
-            <div className="mt-4 rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
-              <ul className="list-disc space-y-2 pl-6 text-zinc-600 dark:text-zinc-400">
-                <li>
-                  <strong>Subscriptions:</strong> Up to 500 active feed subscriptions per account
-                </li>
-                <li>
-                  <strong>Feed size:</strong> Individual feed responses are limited to 10 MB
-                </li>
-                <li>
-                  <strong>Feed entries:</strong> Up to 100 entries parsed per feed update
-                </li>
-                <li>
-                  <strong>Saved articles:</strong> Individual saved article pages are limited to 5
-                  MB
-                </li>
-                <li>
-                  <strong>Email newsletters:</strong> Individual newsletter emails are limited to 2
-                  MB
-                </li>
-                <li>
-                  <strong>API rate limits:</strong> Requests are rate-limited to prevent abuse
-                </li>
-              </ul>
-            </div>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              Exceeding these limits may result in requests being rejected. Persistent or deliberate
-              attempts to circumvent these limits may result in account suspension or termination.
-            </p>
-          </section>
+      <LegalSection title="Account Termination">
+        <LegalParagraph>
+          <strong>
+            We reserve the right to suspend or terminate any account at any time and for any reason,
+            with or without notice.
+          </strong>{" "}
+          This is a free service and access is provided at our discretion. Reasons for termination
+          may include, but are not limited to:
+        </LegalParagraph>
+        <LegalList>
+          <li>Violation of these Terms of Service</li>
+          <li>Violation of the Acceptable Use policy above</li>
+          <li>Abusive or excessive usage that impacts the service for other users</li>
+          <li>Inactivity for an extended period</li>
+          <li>Any reason at our sole discretion</li>
+        </LegalList>
+        <LegalParagraph>
+          You may also delete your account at any time. Upon termination, your personal data will be
+          handled according to our{" "}
+          <Link href="/privacy" className="text-accent hover:text-accent-hover font-medium">
+            Privacy Policy
+          </Link>
+          .
+        </LegalParagraph>
+      </LegalSection>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Account Termination
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              <strong>
-                We reserve the right to suspend or terminate any account at any time and for any
-                reason, with or without notice.
-              </strong>{" "}
-              This is a free service and access is provided at our discretion. Reasons for
-              termination may include, but are not limited to:
-            </p>
-            <ul className="mt-2 list-disc space-y-1 pl-6 text-zinc-600 dark:text-zinc-400">
-              <li>Violation of these Terms of Service</li>
-              <li>Violation of the Acceptable Use policy above</li>
-              <li>Abusive or excessive usage that impacts the service for other users</li>
-              <li>Inactivity for an extended period</li>
-              <li>Any reason at our sole discretion</li>
-            </ul>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              You may also delete your account at any time. Upon termination, your personal data
-              will be handled according to our{" "}
-              <Link href="/privacy" className="text-accent hover:text-accent-hover font-medium">
-                Privacy Policy
-              </Link>
-              .
-            </p>
-          </section>
+      <LegalSection title="Intellectual Property">
+        <LegalParagraph>
+          Lion Reader is open-source software. The source code is available on{" "}
+          <TextLink href="https://github.com/brendanlong/lion-reader" external>
+            GitHub
+          </TextLink>
+          . Content you subscribe to or save through the service remains the property of its
+          respective owners. We do not claim ownership of any content fetched from external feeds.
+        </LegalParagraph>
+      </LegalSection>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Intellectual Property
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              Lion Reader is open-source software. The source code is available on{" "}
-              <TextLink href="https://github.com/brendanlong/lion-reader" external>
-                GitHub
-              </TextLink>
-              . Content you subscribe to or save through the service remains the property of its
-              respective owners. We do not claim ownership of any content fetched from external
-              feeds.
-            </p>
-          </section>
+      <LegalSection title="Limitation of Liability">
+        <LegalParagraph>
+          To the maximum extent permitted by law, Lion Reader and its operators shall not be liable
+          for any indirect, incidental, special, consequential, or punitive damages, or any loss of
+          data, use, or profits, arising out of or related to your use of the service.
+        </LegalParagraph>
+        <LegalParagraph>
+          The service is provided &quot;as is&quot; without warranty of any kind, express or
+          implied, including but not limited to warranties of merchantability, fitness for a
+          particular purpose, or non-infringement.
+        </LegalParagraph>
+      </LegalSection>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Limitation of Liability
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              To the maximum extent permitted by law, Lion Reader and its operators shall not be
-              liable for any indirect, incidental, special, consequential, or punitive damages, or
-              any loss of data, use, or profits, arising out of or related to your use of the
-              service.
-            </p>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              The service is provided &quot;as is&quot; without warranty of any kind, express or
-              implied, including but not limited to warranties of merchantability, fitness for a
-              particular purpose, or non-infringement.
-            </p>
-          </section>
+      <LegalSection title="Changes to These Terms">
+        <LegalParagraph>
+          We may update these Terms of Service from time to time. We will notify users of material
+          changes by posting the updated terms on this page with a new &quot;Last updated&quot;
+          date. Your continued use of the service after changes are posted constitutes acceptance of
+          the updated terms.
+        </LegalParagraph>
+      </LegalSection>
 
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-              Changes to These Terms
-            </h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              We may update these Terms of Service from time to time. We will notify users of
-              material changes by posting the updated terms on this page with a new &quot;Last
-              updated&quot; date. Your continued use of the service after changes are posted
-              constitutes acceptance of the updated terms.
-            </p>
-          </section>
-
-          <section className="mb-8">
-            <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">Contact</h2>
-            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-              If you have any questions about these Terms of Service, please open an issue on our{" "}
-              <TextLink href="https://github.com/brendanlong/lion-reader" external>
-                GitHub repository
-              </TextLink>
-              .
-            </p>
-          </section>
-        </div>
-      </main>
-    </div>
+      <LegalSection title="Contact">
+        <LegalParagraph>
+          If you have any questions about these Terms of Service, please open an issue on our{" "}
+          <TextLink href="https://github.com/brendanlong/lion-reader" external>
+            GitHub repository
+          </TextLink>
+          .
+        </LegalParagraph>
+      </LegalSection>
+    </LegalPage>
   );
 }

--- a/src/components/admin/AdminFeedsContent.tsx
+++ b/src/components/admin/AdminFeedsContent.tsx
@@ -13,6 +13,7 @@ import { useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { formatRelativeTime, formatFutureTime, formatBytes } from "@/lib/format";
 import {
@@ -426,7 +427,7 @@ export default function AdminFeedsContent() {
       ) : feeds.length === 0 ? (
         <EmptyState hasFilters={hasFilters} />
       ) : (
-        <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+        <Card padding="none">
           {feeds.map((feed) => (
             <FeedRow
               key={feed.feedId}
@@ -453,7 +454,7 @@ export default function AdminFeedsContent() {
               No more feeds
             </p>
           )}
-        </div>
+        </Card>
       )}
     </div>
   );

--- a/src/components/admin/AdminInvitesContent.tsx
+++ b/src/components/admin/AdminInvitesContent.tsx
@@ -12,7 +12,7 @@ import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { StatusCard } from "@/components/ui/card";
+import { Card, StatusCard } from "@/components/ui/card";
 import { ClientLink } from "@/components/ui/client-link";
 import { CopyIcon, SpinnerIcon } from "@/components/ui/icon-button";
 
@@ -353,7 +353,7 @@ export default function AdminInvitesContent() {
       ) : invites.length === 0 ? (
         <EmptyState hasSearch={debouncedSearch.length > 0} />
       ) : (
-        <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+        <Card padding="none">
           {invites.map((invite) => (
             <InviteRow
               key={invite.id}
@@ -380,7 +380,7 @@ export default function AdminInvitesContent() {
               No more invites
             </p>
           )}
-        </div>
+        </Card>
       )}
     </div>
   );

--- a/src/components/admin/AdminUsersContent.tsx
+++ b/src/components/admin/AdminUsersContent.tsx
@@ -13,6 +13,7 @@ import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc/client";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { ClientLink } from "@/components/ui/client-link";
 import { SpinnerIcon, GoogleIcon, AppleIcon, DiscordIcon } from "@/components/ui/icon-button";
@@ -282,7 +283,7 @@ export default function AdminUsersContent() {
       ) : users.length === 0 ? (
         <EmptyState hasSearch={debouncedSearch.length > 0} />
       ) : (
-        <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+        <Card padding="none">
           {users.map((user) => (
             <UserRow key={user.id} user={user} />
           ))}
@@ -304,7 +305,7 @@ export default function AdminUsersContent() {
               No more users
             </p>
           )}
-        </div>
+        </Card>
       )}
     </div>
   );

--- a/src/components/legal/LegalProse.tsx
+++ b/src/components/legal/LegalProse.tsx
@@ -1,0 +1,111 @@
+/**
+ * LegalProse Components
+ *
+ * Shared building blocks for the public legal pages (privacy policy, terms
+ * of service): the page scaffold and the prose styles for sections,
+ * subsections, paragraphs, and lists. Use these instead of hand-styling
+ * each element so the two pages can't drift apart.
+ *
+ * These pages intentionally use Next.js <Link> (not ClientLink) — they are
+ * standalone routes outside the SPA shell.
+ */
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+/**
+ * Full legal-page scaffold: background, centered column, back link,
+ * page title, and "Last updated" line, wrapping the prose content.
+ */
+export interface LegalPageProps {
+  title: string;
+  lastUpdated: string;
+  children: ReactNode;
+}
+
+export function LegalPage({ title, lastUpdated, children }: LegalPageProps) {
+  return (
+    <div className="min-h-screen bg-zinc-50 px-4 py-12 dark:bg-zinc-950">
+      <main className="mx-auto max-w-3xl">
+        <div className="mb-8">
+          <Link
+            href="/"
+            className="ui-text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+          >
+            &larr; Back to Lion Reader
+          </Link>
+          <h1 className="mt-4 text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+            {title}
+          </h1>
+          <p className="ui-text-sm mt-2 text-zinc-500 dark:text-zinc-400">
+            Last updated: {lastUpdated}
+          </p>
+        </div>
+
+        <div className="prose prose-zinc dark:prose-invert max-w-none">{children}</div>
+      </main>
+    </div>
+  );
+}
+
+/**
+ * Top-level section with the standard heading.
+ */
+export interface LegalSectionProps {
+  title: string;
+  children: ReactNode;
+}
+
+export function LegalSection({ title, children }: LegalSectionProps) {
+  return (
+    <section className="mb-8">
+      <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * Titled subsection within a section (h3 + body).
+ */
+export interface LegalSubsectionProps {
+  title: string;
+  children: ReactNode;
+}
+
+export function LegalSubsection({ title, children }: LegalSubsectionProps) {
+  return (
+    <div>
+      <h3 className="font-medium text-zinc-800 dark:text-zinc-200">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Body paragraph. `tight` uses the smaller top margin for paragraphs
+ * directly under a subsection heading.
+ */
+export interface LegalParagraphProps {
+  children: ReactNode;
+  tight?: boolean;
+}
+
+export function LegalParagraph({ children, tight = false }: LegalParagraphProps) {
+  return (
+    <p className={`${tight ? "mt-1" : "mt-2"} text-zinc-600 dark:text-zinc-400`}>{children}</p>
+  );
+}
+
+/**
+ * Bulleted list.
+ */
+export interface LegalListProps {
+  children: ReactNode;
+}
+
+export function LegalList({ children }: LegalListProps) {
+  return (
+    <ul className="mt-2 list-disc space-y-1 pl-6 text-zinc-600 dark:text-zinc-400">{children}</ul>
+  );
+}

--- a/src/components/settings/SettingsListContainer.tsx
+++ b/src/components/settings/SettingsListContainer.tsx
@@ -12,6 +12,7 @@
 
 import type { ReactNode } from "react";
 import { Alert } from "@/components/ui/alert";
+import { Card } from "@/components/ui/card";
 import { SettingsListSkeleton } from "@/components/settings/SettingsListSkeleton";
 
 interface SettingsListContainerProps<T> {
@@ -65,7 +66,7 @@ export function SettingsListContainer<T>({
   }
 
   return (
-    <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+    <Card padding="none">
       {isLoading ? (
         <SettingsListSkeleton count={skeletonCount} height={skeletonHeight} />
       ) : error ? (
@@ -78,6 +79,6 @@ export function SettingsListContainer<T>({
         <div className="divide-y divide-zinc-200 dark:divide-zinc-800">{items.map(renderItem)}</div>
       )}
       {footer}
-    </div>
+    </Card>
   );
 }

--- a/src/components/settings/pages/FeedStatsSettingsContent.tsx
+++ b/src/components/settings/pages/FeedStatsSettingsContent.tsx
@@ -17,6 +17,7 @@ import {
   formatBytes,
 } from "@/lib/format";
 import { Alert } from "@/components/ui/alert";
+import { Card } from "@/components/ui/card";
 import { SettingsListSkeleton } from "@/components/settings/SettingsListSkeleton";
 import {
   RssIcon,
@@ -163,7 +164,7 @@ export default function FeedStatsSettingsContent() {
       )}
 
       {/* Feed Stats List */}
-      <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+      <Card padding="none">
         {statsQuery.isLoading ? (
           <SettingsListSkeleton />
         ) : statsQuery.error ? (
@@ -197,7 +198,7 @@ export default function FeedStatsSettingsContent() {
             )}
           </div>
         )}
-      </div>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
Final follow-up for #1016 (after #1136 and #1138), covering the last known duplication hotspots.

## LegalProse

The privacy and terms pages hand-styled every element: 22 identical section shells, 32 paragraphs, the lists, privacy's h3 subsections, and the entire page scaffold duplicated between the two files. `src/components/legal/LegalProse.tsx` now provides:

- **`LegalPage`** — scaffold (background, centered column, back link, title, "Last updated") wrapping the prose container
- **`LegalSection`** — `mb-8` section with the standard `ui-text-xl` heading
- **`LegalSubsection`** — h3 subsection used by privacy's "Information We Collect" and "Third-Party Services" blocks
- **`LegalParagraph`** — body paragraph (`tight` for the smaller margin under subsection headings)
- **`LegalList`** — the standard bulleted list

Both pages are rewritten on top of these with the legal text preserved verbatim; the rendered DOM is unchanged. The two hand-rolled card boxes (terms' usage-limits box, privacy's Groq narration box) become `Card padding="md"`.

## Card padding="none" adoption

The five remaining hand-rolled padding-less card shells (admin users/feeds/invites lists, `SettingsListContainer`'s divide variant, and the feed-stats list) now use `Card padding="none"` from #1138 — that class string now greps to only `card.tsx`.

## Testing

- `pnpm typecheck`, `pnpm lint`, prettier all pass
- `pnpm test:unit`: 2163 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)