### PR TITLE
Drop the vestigial entry-scoring columns (#1101, release 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Use the database views for frontend queries instead of manual joins:
 - **`user_feeds`**: Active subscriptions with feed data merged. Use for `subscriptions.list/get/export`. Already filters out unsubscribed entries and resolves title (custom or original).
 - **`visible_entries`**: Entries with visibility rules applied. Use for `entries.list/get/count`. Includes read/starred state and subscription_id. An entry is visible if a `user_entries` row exists for the `(user, entry)` pair AND (the entry is from an active subscription OR is starred OR is a saved article). Privacy gating happens when `user_entries` rows are inserted (subscribe-time / fetch-time), not in the view. See "Entry Visibility" in docs/DESIGN.md.
 
-These views were introduced in `migrations/0035_subscription_views.sql` (current `visible_entries` definition: `migrations/0087_visible_entries_subscription_id.sql`) and have Drizzle schemas in `src/server/db/schema.ts`.
+These views were introduced in `migrations/0035_subscription_views.sql` (current `visible_entries` definition: `migrations/0090_drop_entry_scoring_columns.sql`) and have Drizzle schemas in `src/server/db/schema.ts`.
 
 ## API Conventions
 

--- a/migrations/0090_drop_entry_scoring_columns.sql
+++ b/migrations/0090_drop_entry_scoring_columns.sql
@@ -1,0 +1,78 @@
+-- Drop the vestigial entry-scoring columns (issue #1101, release 2).
+--
+-- The ML entry-scoring feature was removed in migration 0073 (#953), but the
+-- per-user-entry columns (score, score_changed_at, has_marked_read_on_list,
+-- has_marked_unread, has_starred) were left behind, and visible_entries kept
+-- selecting four of them. The previous release (#1135) removed every read and
+-- write of these columns, so the view can now be rebuilt without them and the
+-- columns dropped.
+--
+-- Expand/contract: safe for the previous release. It selects explicit column
+-- lists everywhere (never SELECT *) and no longer references any of these
+-- columns in code or in its Drizzle definitions of user_entries and
+-- visible_entries.
+--
+-- Dropping the score column also drops the user_entries_score_range CHECK
+-- constraint that depended on it.
+
+DROP VIEW visible_entries;
+
+--> statement-breakpoint
+
+ALTER TABLE user_entries
+  DROP COLUMN score,
+  DROP COLUMN score_changed_at,
+  DROP COLUMN has_marked_read_on_list,
+  DROP COLUMN has_marked_unread,
+  DROP COLUMN has_starred;
+
+--> statement-breakpoint
+
+-- Identical to the 0087 definition minus the scoring columns.
+CREATE VIEW visible_entries AS
+ SELECT ue.user_id,
+    e.id,
+    e.feed_id,
+    e.type,
+    e.guid,
+    e.url,
+    e.title,
+    e.author,
+    e.content_original,
+    e.content_cleaned,
+    e.summary,
+    e.site_name,
+    e.image_url,
+    e.published_at,
+    e.fetched_at,
+    e.last_seen_at,
+    e.content_hash,
+    e.full_content_hash,
+    e.spam_score,
+    e.is_spam,
+    e.list_unsubscribe_mailto,
+    e.list_unsubscribe_https,
+    e.list_unsubscribe_post,
+    e.created_at,
+    GREATEST(e.updated_at, ue.updated_at) AS updated_at,
+    e.full_content_original,
+    e.full_content_cleaned,
+    e.full_content_fetched_at,
+    e.full_content_error,
+    ue.read,
+    ue.starred,
+    s.id AS subscription_id,
+    e.unsubscribe_url,
+    ue.read_changed_at,
+    e.wallabag_id,
+    ue.published_or_fetched_at,
+    e.content_original_sanitized,
+    e.content_cleaned_sanitized,
+    e.content_sanitized_version,
+    e.full_content_original_sanitized,
+    e.full_content_cleaned_sanitized,
+    e.full_content_sanitized_version
+   FROM ((user_entries ue
+     JOIN entries e ON ((e.id = ue.entry_id)))
+     LEFT JOIN subscriptions s ON ((s.id = ue.subscription_id)))
+  WHERE (((s.id IS NOT NULL) AND (s.unsubscribed_at IS NULL)) OR (ue.starred = true) OR (e.type = 'saved'::feed_type));

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -624,6 +624,13 @@
       "when": 1782952200000,
       "tag": "0089_drop_resanitize_entries_job",
       "breakpoints": true
+    },
+    {
+      "idx": 89,
+      "version": "7",
+      "when": 1782952300000,
+      "tag": "0090_drop_entry_scoring_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -350,16 +350,10 @@ CREATE TABLE public.user_entries (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     read_changed_at timestamp with time zone,
     starred_changed_at timestamp with time zone DEFAULT now() NOT NULL,
-    score smallint,
-    score_changed_at timestamp with time zone,
-    has_marked_read_on_list boolean DEFAULT false NOT NULL,
-    has_marked_unread boolean DEFAULT false NOT NULL,
-    has_starred boolean DEFAULT false NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     published_or_fetched_at timestamp with time zone NOT NULL,
     subscription_id uuid,
-    is_spam boolean NOT NULL,
-    CONSTRAINT user_entries_score_range CHECK (((score >= '-2'::integer) AND (score <= 2)))
+    is_spam boolean NOT NULL
 );
 
 CREATE VIEW public.user_feeds AS
@@ -432,10 +426,6 @@ CREATE VIEW public.visible_entries AS
     e.full_content_error,
     ue.read,
     ue.starred,
-    ue.score,
-    ue.has_marked_read_on_list,
-    ue.has_marked_unread,
-    ue.has_starred,
     s.id AS subscription_id,
     e.unsubscribe_url,
     ue.read_changed_at,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -653,11 +653,6 @@ export const userEntries = pgTable(
     read: boolean("read").notNull().default(false),
     starred: boolean("starred").notNull().default(false),
 
-    // The vestigial entry-scoring columns (score, score_changed_at,
-    // has_marked_read_on_list, has_marked_unread, has_starred) still exist in
-    // the database but are no longer read or written (issue #1101); they are
-    // dropped in a follow-up release.
-
     // Timestamps for idempotent updates - tracks when each field was last set
     // Used for conditional updates: only apply if incoming timestamp is newer
     // NULL means the user has never explicitly changed the read state
@@ -745,7 +740,7 @@ export const userFeeds = pgView("user_feeds", {
  *    OR it is a saved article (saved feeds have no subscription rows)
  *
  * Note: This view is defined in migration 0035_subscription_views.sql
- * (most recently redefined in 0087_visible_entries_subscription_id.sql).
+ * (most recently redefined in 0090_drop_entry_scoring_columns.sql).
  * The Drizzle definition here allows type-safe queries against the view.
  */
 export const visibleEntries = pgView("visible_entries", {
@@ -780,9 +775,6 @@ export const visibleEntries = pgView("visible_entries", {
   fullContentError: text("full_content_error"),
   read: boolean("read").notNull(),
   starred: boolean("starred").notNull(),
-  // The view also still selects the vestigial scoring columns (score, has_*);
-  // they are deliberately omitted here so nothing can reference them before
-  // they are removed from the view in a follow-up release (issue #1101).
   subscriptionId: uuid("subscription_id"), // nullable - null for orphaned starred entries
   unsubscribeUrl: text("unsubscribe_url"), // extracted from email HTML body
   readChangedAt: timestamp("read_changed_at", { withTimezone: true }),


### PR DESCRIPTION
## Summary

Release 2 (the contract step) of #1101, following #1135 which removed every read and write of the dead entry-scoring columns. Migration `0090_drop_entry_scoring_columns`:

1. rebuilds `visible_entries` without the four scoring columns it still selected (`score`, `has_marked_read_on_list`, `has_marked_unread`, `has_starred`) — otherwise identical to the `0087` definition, and
2. drops all five vestigial `user_entries` columns (the four above plus `score_changed_at`), which also drops the `user_entries_score_range` CHECK constraint.

Also removes the release-1 transition comments from `schema.ts`, updates the current-view-definition pointers in CLAUDE.md/`schema.ts` to `0090`, and refreshes `migrations/schema.sql` via `pnpm db:schema`.

**Closes #1101.**

## Expand/contract safety

Backward-compatible with the previous release (current master, which includes #1135): it selects explicit column lists everywhere (never `SELECT *`), and no code or Drizzle definition references any of the dropped columns. **Merge only after the current master deploy completes** — the release running when this migration executes must include #1135.

Note: the `schema.sql` refresh was dumped from the throwaway local-services Postgres; I reverted two unrelated dump artifacts (PG 18's named NOT-NULL-constraint rendering on `user_entries`, and `sessions.scopes` column position in a from-scratch database) so the diff shows only what the migration changes.

## Testing

- `pnpm db:migrate:local` applies `0090` cleanly on the local-services database
- `pnpm typecheck`, `pnpm test:unit` (2163 passed, includes the migrations-journal check)
- `pnpm test:integration:local` (574 passed) and `pnpm test:e2e:local` (39 passed) against the migrated schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)