### PR TITLE
Log thread identity in the standalone worker startup line

### DIFF
--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -14,6 +14,7 @@
  *   WORKER_CONCURRENCY - Max concurrent jobs (default: 3)
  */
 
+import { isMainThread, threadId } from "node:worker_threads";
 import { startWorkerWithSignalHandling } from "../src/server/jobs/worker";
 import { startMetricsServer, setHealthChecker } from "../src/server/metrics/server";
 import { startHeartbeat } from "../src/server/notifications/healthchecks";
@@ -49,6 +50,12 @@ logger.info("Starting standalone worker", {
   // process group is the smoking gun for a machine running the wrong binary.
   flyProcessGroup: process.env.FLY_PROCESS_GROUP,
   flyMachineId: process.env.FLY_MACHINE_ID,
+  // Thread identity: worker threads share the parent's pid, so pid alone can't
+  // distinguish "second OS process on this machine" from "this bundle was
+  // loaded inside another process's worker thread (e.g. a wrong piscina
+  // bundle)". isMainThread=false means the latter.
+  isMainThread,
+  threadId,
 });
 
 // Start internal metrics server on port 9092 (separate from Next.js on 9091)


### PR DESCRIPTION
## Context

Continuing the Discord-machine mystery: a full `dist/worker.js` boot signature (pool init → Plugins registered → Starting standalone worker → metrics 9092) appeared on the recreated discord machine (`2862d92c004438`), ~1s after a save reaction, logging `flyProcessGroup: discord, pid: 642`.

Rebuilt all five bundles from current master in the exact Dockerfile sequence: every artifact is clean (`dist/worker-thread.js` and `dist/discord-bot.js` contain zero job-worker code), the Dockerfile COPYs are correct, and nothing in the app spawns processes. So the remaining hypotheses are (a) a second OS process on the machine (Fly config drift again) or (b) the *deployed* artifact differing from what source builds (builder cache poisoning), loaded into a piscina thread.

`pid` can't distinguish these — worker threads share the parent's pid. `isMainThread`/`threadId` can: `isMainThread: false` on this line would prove the worker bundle was loaded inside another process's worker thread.

## Testing

`pnpm typecheck` passes; log-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)