### PR TITLE
Add semantic color tokens and adopt them app-wide (#1016)

### DIFF
--- a/src/app/(app)/AppLayoutContent.tsx
+++ b/src/app/(app)/AppLayoutContent.tsx
@@ -89,7 +89,7 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
               sidebarCloseButton={
                 <button
                   onClick={() => setSidebarOpen(false)}
-                  className="flex h-10 w-10 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:text-zinc-400 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                  className="text-subtle flex h-10 w-10 items-center justify-center rounded-md hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                   aria-label="Close navigation menu"
                 >
                   <CloseIcon className="h-5 w-5" />
@@ -98,7 +98,7 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
               mobileMenuButton={
                 <button
                   onClick={() => setSidebarOpen(true)}
-                  className="flex h-10 w-10 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:text-zinc-400 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                  className="text-subtle flex h-10 w-10 items-center justify-center rounded-md hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                   aria-label="Open navigation menu"
                 >
                   <MenuIcon className="h-5 w-5" />
@@ -122,7 +122,7 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
                   <div className="relative">
                     <button
                       onClick={() => setUserMenuOpen(!userMenuOpen)}
-                      className="ui-text-sm flex min-h-[40px] items-center gap-2 rounded-md border border-zinc-200 bg-white px-3 text-zinc-700 transition-colors hover:bg-zinc-50 active:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                      className="ui-text-sm border-edge-strong bg-surface text-body flex min-h-[40px] items-center gap-2 rounded-md border px-3 transition-colors hover:bg-zinc-50 active:bg-zinc-100 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                       aria-expanded={userMenuOpen}
                       aria-haspopup="true"
                     >
@@ -144,29 +144,29 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
                           className="fixed inset-0 z-10"
                           onClick={() => setUserMenuOpen(false)}
                         />
-                        <div className="absolute right-0 z-20 mt-1 w-48 rounded-md border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+                        <div className="border-edge-strong bg-surface absolute right-0 z-20 mt-1 w-48 rounded-md border py-1 shadow-lg">
                           <ClientLink
                             href="/settings"
                             onNavigate={() => setUserMenuOpen(false)}
-                            className="ui-text-sm flex min-h-[44px] items-center px-4 text-zinc-700 hover:bg-zinc-100 active:bg-zinc-200 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                            className="ui-text-sm text-body flex min-h-[44px] items-center px-4 hover:bg-zinc-100 active:bg-zinc-200 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                           >
                             Settings
                           </ClientLink>
                           <ClientLink
                             href="/settings/sessions"
                             onNavigate={() => setUserMenuOpen(false)}
-                            className="ui-text-sm flex min-h-[44px] items-center px-4 text-zinc-700 hover:bg-zinc-100 active:bg-zinc-200 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                            className="ui-text-sm text-body flex min-h-[44px] items-center px-4 hover:bg-zinc-100 active:bg-zinc-200 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                           >
                             Sessions
                           </ClientLink>
-                          <hr className="my-1 border-zinc-200 dark:border-zinc-700" />
+                          <hr className="border-edge-strong my-1" />
                           <button
                             onClick={() => {
                               setUserMenuOpen(false);
                               handleLogout();
                             }}
                             disabled={logoutMutation.isPending}
-                            className="ui-text-sm flex min-h-[44px] w-full items-center px-4 text-left text-zinc-700 hover:bg-zinc-100 active:bg-zinc-200 disabled:opacity-50 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                            className="ui-text-sm text-body flex min-h-[44px] w-full items-center px-4 text-left hover:bg-zinc-100 active:bg-zinc-200 disabled:opacity-50 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                           >
                             {logoutMutation.isPending ? "Signing out..." : "Sign out"}
                           </button>

--- a/src/app/(auth)/AuthLayoutContent.tsx
+++ b/src/app/(auth)/AuthLayoutContent.tsx
@@ -19,14 +19,12 @@ export function AuthLayoutContent({ children }: AuthLayoutContentProps) {
       <div className="w-full max-w-md">
         {/* Logo / Brand */}
         <div className="mb-8 text-center">
-          <h1 className="ui-text-2xl font-bold text-zinc-900 dark:text-zinc-50">Lion Reader</h1>
-          <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">A modern feed reader</p>
+          <h1 className="ui-text-2xl text-strong font-bold">Lion Reader</h1>
+          <p className="ui-text-sm text-muted mt-2">A modern feed reader</p>
         </div>
 
         {/* Auth card */}
-        <div className="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-          {children}
-        </div>
+        <div className="border-edge bg-surface rounded-lg border p-6 shadow-sm">{children}</div>
       </div>
     </div>
   );

--- a/src/app/(auth)/auth/oauth/callback/page.tsx
+++ b/src/app/(auth)/auth/oauth/callback/page.tsx
@@ -287,7 +287,7 @@ function OAuthCallbackContent() {
 
   return (
     <div className="flex flex-col items-center justify-center">
-      <h2 className="ui-text-xl mb-6 font-semibold text-zinc-900 dark:text-zinc-50">
+      <h2 className="ui-text-xl text-strong mb-6 font-semibold">
         {errorMessage
           ? isSaveMode
             ? "Permission Error"
@@ -300,14 +300,14 @@ function OAuthCallbackContent() {
       {errorMessage ? (
         <div className="text-center">
           <p className="ui-text-sm mb-4 text-red-600 dark:text-red-400">{errorMessage}</p>
-          <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+          <p className="ui-text-sm text-muted">
             Redirecting to {isSaveMode ? "save" : isLinkMode ? "settings" : "login"} page...
           </p>
         </div>
       ) : (
         <div className="flex flex-col items-center gap-4">
-          <SpinnerIcon className="h-8 w-8 text-zinc-900 dark:text-zinc-100" />
-          <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+          <SpinnerIcon className="text-strong h-8 w-8" />
+          <p className="ui-text-sm text-muted">
             Please wait while we complete{" "}
             {isSaveMode
               ? "granting permissions"

--- a/src/app/(auth)/auth/oauth/complete/page.tsx
+++ b/src/app/(auth)/auth/oauth/complete/page.tsx
@@ -53,12 +53,10 @@ function OAuthCompleteContent() {
 
   return (
     <div className="flex flex-col items-center justify-center">
-      <h2 className="ui-text-xl mb-6 font-semibold text-zinc-900 dark:text-zinc-50">
-        Sign-in successful
-      </h2>
+      <h2 className="ui-text-xl text-strong mb-6 font-semibold">Sign-in successful</h2>
       <div className="flex flex-col items-center gap-4">
-        <SpinnerIcon className="h-8 w-8 text-zinc-900 dark:text-zinc-100" />
-        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">Redirecting...</p>
+        <SpinnerIcon className="text-strong h-8 w-8" />
+        <p className="ui-text-sm text-muted">Redirecting...</p>
       </div>
     </div>
   );

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -140,9 +140,7 @@ function LoginForm() {
 
   return (
     <div>
-      <h2 className="ui-text-xl mb-6 font-semibold text-zinc-900 dark:text-zinc-50">
-        Sign in to your account
-      </h2>
+      <h2 className="ui-text-xl text-strong mb-6 font-semibold">Sign in to your account</h2>
 
       {registered && (
         <Alert variant="success" className="mb-4">
@@ -171,9 +169,7 @@ function LoginForm() {
           <div className="w-full border-t border-zinc-300 dark:border-zinc-700" />
         </div>
         <div className="ui-text-sm relative flex justify-center">
-          <span className="bg-white px-2 text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400">
-            Or continue with email
-          </span>
+          <span className="bg-surface text-subtle px-2">Or continue with email</span>
         </div>
       </div>
 
@@ -208,12 +204,9 @@ function LoginForm() {
       </form>
 
       {!signupConfigData?.requiresInvite && (
-        <p className="ui-text-sm mt-6 text-center text-zinc-600 dark:text-zinc-400">
+        <p className="ui-text-sm text-muted mt-6 text-center">
           Don&apos;t have an account?{" "}
-          <Link
-            href="/register"
-            className="font-medium text-zinc-900 hover:underline dark:text-zinc-50"
-          >
+          <Link href="/register" className="text-strong font-medium hover:underline">
             Create one
           </Link>
         </p>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -130,10 +130,8 @@ function RegisterForm() {
   if (isLoadingConfig) {
     return (
       <div>
-        <h2 className="ui-text-xl mb-6 font-semibold text-zinc-900 dark:text-zinc-50">
-          Create your account
-        </h2>
-        <div className="text-center text-zinc-600 dark:text-zinc-400">Loading...</div>
+        <h2 className="ui-text-xl text-strong mb-6 font-semibold">Create your account</h2>
+        <div className="text-muted text-center">Loading...</div>
       </div>
     );
   }
@@ -144,19 +142,14 @@ function RegisterForm() {
   if (effectiveProviders.length === 0) {
     return (
       <div>
-        <h2 className="ui-text-xl mb-6 font-semibold text-zinc-900 dark:text-zinc-50">
-          Invite Required
-        </h2>
+        <h2 className="ui-text-xl text-strong mb-6 font-semibold">Invite Required</h2>
         <Alert variant="error" className="mb-4">
           This instance requires an invite to sign up. Please contact an administrator to request an
           invite.
         </Alert>
-        <p className="ui-text-sm mt-6 text-center text-zinc-600 dark:text-zinc-400">
+        <p className="ui-text-sm text-muted mt-6 text-center">
           Already have an account?{" "}
-          <Link
-            href="/login"
-            className="font-medium text-zinc-900 hover:underline dark:text-zinc-50"
-          >
+          <Link href="/login" className="text-strong font-medium hover:underline">
             Sign in
           </Link>
         </p>
@@ -168,9 +161,7 @@ function RegisterForm() {
 
   return (
     <div>
-      <h2 className="ui-text-xl mb-6 font-semibold text-zinc-900 dark:text-zinc-50">
-        Create your account
-      </h2>
+      <h2 className="ui-text-xl text-strong mb-6 font-semibold">Create your account</h2>
 
       {errors.form && (
         <Alert variant="error" className="mb-4">
@@ -194,9 +185,7 @@ function RegisterForm() {
               <div className="w-full border-t border-zinc-300 dark:border-zinc-700" />
             </div>
             <div className="ui-text-sm relative flex justify-center">
-              <span className="bg-white px-2 text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400">
-                Or continue with email
-              </span>
+              <span className="bg-surface text-subtle px-2">Or continue with email</span>
             </div>
           </div>
 
@@ -244,7 +233,7 @@ function RegisterForm() {
         </>
       )}
 
-      <p className="ui-text-xs mt-4 text-center text-zinc-500 dark:text-zinc-400">
+      <p className="ui-text-xs text-subtle mt-4 text-center">
         By creating an account, you agree to our{" "}
         <Link href="/terms" className="underline hover:text-zinc-700 dark:hover:text-zinc-300">
           Terms of Service
@@ -255,9 +244,9 @@ function RegisterForm() {
         </Link>
       </p>
 
-      <p className="ui-text-sm mt-6 text-center text-zinc-600 dark:text-zinc-400">
+      <p className="ui-text-sm text-muted mt-6 text-center">
         Already have an account?{" "}
-        <Link href="/login" className="font-medium text-zinc-900 hover:underline dark:text-zinc-50">
+        <Link href="/login" className="text-strong font-medium hover:underline">
           Sign in
         </Link>
       </p>

--- a/src/app/complete-signup/layout.tsx
+++ b/src/app/complete-signup/layout.tsx
@@ -43,15 +43,11 @@ export default async function CompleteSignupLayout({ children }: CompleteSignupL
       <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 py-12 dark:bg-zinc-950">
         <div className="w-full max-w-md">
           <div className="mb-8 text-center">
-            <h1 className="ui-text-2xl font-bold text-zinc-900 dark:text-zinc-50">Lion Reader</h1>
-            <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">
-              Complete your account setup
-            </p>
+            <h1 className="ui-text-2xl text-strong font-bold">Lion Reader</h1>
+            <p className="ui-text-sm text-muted mt-2">Complete your account setup</p>
           </div>
 
-          <div className="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-            {children}
-          </div>
+          <div className="border-edge bg-surface rounded-lg border p-6 shadow-sm">{children}</div>
         </div>
       </div>
     </TRPCProvider>

--- a/src/app/complete-signup/page.tsx
+++ b/src/app/complete-signup/page.tsx
@@ -64,10 +64,8 @@ export default function CompleteSignupPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-          Before you continue
-        </h2>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+        <h2 className="ui-text-lg text-strong font-semibold">Before you continue</h2>
+        <p className="ui-text-sm text-muted mt-1">
           Please review and accept the following to complete your account setup.
         </p>
       </div>
@@ -80,15 +78,15 @@ export default function CompleteSignupPage() {
             type="checkbox"
             checked={acceptedTos}
             onChange={(e) => setAcceptedTos(e.target.checked)}
-            className="mt-0.5 h-5 w-5 shrink-0 rounded border-zinc-300 text-zinc-900 focus:ring-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-50 dark:focus:ring-zinc-400"
+            className="text-strong mt-0.5 h-5 w-5 shrink-0 rounded border-zinc-300 focus:ring-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:focus:ring-zinc-400"
           />
-          <span className="ui-text-sm text-zinc-700 dark:text-zinc-300">
+          <span className="ui-text-sm text-body">
             I have read and agree to the{" "}
             <a
               href="/terms"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-zinc-900 underline hover:text-zinc-700 dark:text-zinc-100 dark:hover:text-zinc-300"
+              className="text-strong underline hover:text-zinc-700 dark:hover:text-zinc-300"
             >
               Terms of Service
             </a>
@@ -100,15 +98,15 @@ export default function CompleteSignupPage() {
             type="checkbox"
             checked={acceptedPrivacy}
             onChange={(e) => setAcceptedPrivacy(e.target.checked)}
-            className="mt-0.5 h-5 w-5 shrink-0 rounded border-zinc-300 text-zinc-900 focus:ring-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-50 dark:focus:ring-zinc-400"
+            className="text-strong mt-0.5 h-5 w-5 shrink-0 rounded border-zinc-300 focus:ring-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:focus:ring-zinc-400"
           />
-          <span className="ui-text-sm text-zinc-700 dark:text-zinc-300">
+          <span className="ui-text-sm text-body">
             I have read and agree to the{" "}
             <a
               href="/privacy"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-zinc-900 underline hover:text-zinc-700 dark:text-zinc-100 dark:hover:text-zinc-300"
+              className="text-strong underline hover:text-zinc-700 dark:hover:text-zinc-300"
             >
               Privacy Policy
             </a>
@@ -120,9 +118,9 @@ export default function CompleteSignupPage() {
             type="checkbox"
             checked={confirmedNotInEu}
             onChange={(e) => setConfirmedNotInEu(e.target.checked)}
-            className="mt-0.5 h-5 w-5 shrink-0 rounded border-zinc-300 text-zinc-900 focus:ring-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-50 dark:focus:ring-zinc-400"
+            className="text-strong mt-0.5 h-5 w-5 shrink-0 rounded border-zinc-300 focus:ring-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:focus:ring-zinc-400"
           />
-          <span className="ui-text-sm text-zinc-700 dark:text-zinc-300">
+          <span className="ui-text-sm text-body">
             I confirm that I am not located in the European Union
           </span>
         </label>
@@ -141,7 +139,7 @@ export default function CompleteSignupPage() {
         {!showDeleteConfirm ? (
           <button
             onClick={() => setShowDeleteConfirm(true)}
-            className="ui-text-sm w-full text-center text-zinc-500 underline hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
+            className="ui-text-sm text-subtle w-full text-center underline hover:text-zinc-700 dark:hover:text-zinc-300"
           >
             Delete my account instead
           </button>

--- a/src/app/demo/DemoEntryListSSR.tsx
+++ b/src/app/demo/DemoEntryListSSR.tsx
@@ -20,9 +20,7 @@ export function DemoEntryListSSR({ entries, backHref, title }: DemoEntryListSSRP
   return (
     <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
       <div className="mb-4 flex items-center justify-between sm:mb-6">
-        <h1 className="ui-text-xl sm:ui-text-2xl font-bold text-zinc-900 dark:text-zinc-50">
-          {title}
-        </h1>
+        <h1 className="ui-text-xl sm:ui-text-2xl text-strong font-bold">{title}</h1>
       </div>
       <div className="space-y-3">
         {entries.map((entry) => {
@@ -44,10 +42,10 @@ export function DemoEntryListSSR({ entries, backHref, title }: DemoEntryListSSRP
                   />
                 </div>
                 <div className="min-w-0 flex-1">
-                  <h3 className="ui-text-sm line-clamp-2 font-medium text-zinc-900 dark:text-zinc-100">
+                  <h3 className="ui-text-sm text-strong line-clamp-2 font-medium">
                     {displayTitle}
                   </h3>
-                  <div className="ui-text-xs mt-1 flex items-center gap-2 text-zinc-500 dark:text-zinc-400">
+                  <div className="ui-text-xs text-subtle mt-1 flex items-center gap-2">
                     <span className="truncate">{source}</span>
                     <span aria-hidden="true">&middot;</span>
                     <time dateTime={date.toISOString()} className="shrink-0">
@@ -55,9 +53,7 @@ export function DemoEntryListSSR({ entries, backHref, title }: DemoEntryListSSRP
                     </time>
                   </div>
                   {entry.summary && (
-                    <p className="ui-text-sm mt-2 line-clamp-2 text-zinc-600 dark:text-zinc-400">
-                      {entry.summary}
-                    </p>
+                    <p className="ui-text-sm text-muted mt-2 line-clamp-2">{entry.summary}</p>
                   )}
                 </div>
               </div>

--- a/src/app/demo/DemoLayoutContent.tsx
+++ b/src/app/demo/DemoLayoutContent.tsx
@@ -56,7 +56,7 @@ export function DemoLayoutContent({ children }: DemoLayoutContentProps) {
               sidebarCloseButton={
                 <button
                   onClick={() => setSidebarOpen(false)}
-                  className="flex h-10 w-10 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:text-zinc-400 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                  className="text-subtle flex h-10 w-10 items-center justify-center rounded-md hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                   aria-label="Close navigation menu"
                 >
                   <CloseIcon className="h-5 w-5" />
@@ -65,7 +65,7 @@ export function DemoLayoutContent({ children }: DemoLayoutContentProps) {
               mobileMenuButton={
                 <button
                   onClick={() => setSidebarOpen(true)}
-                  className="flex h-10 w-10 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:text-zinc-400 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                  className="text-subtle flex h-10 w-10 items-center justify-center rounded-md hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                   aria-label="Open navigation menu"
                 >
                   <MenuIcon className="h-5 w-5" />
@@ -81,7 +81,7 @@ export function DemoLayoutContent({ children }: DemoLayoutContentProps) {
                   </Link>
                   <Link
                     href="/login"
-                    className="ui-text-sm inline-flex min-h-[40px] items-center gap-1.5 rounded-md border border-zinc-200 bg-white px-3 font-medium text-zinc-700 transition-colors hover:bg-zinc-50 active:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                    className="ui-text-sm border-edge-strong bg-surface text-body inline-flex min-h-[40px] items-center gap-1.5 rounded-md border px-3 font-medium transition-colors hover:bg-zinc-50 active:bg-zinc-100 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
                   >
                     Sign In
                   </Link>

--- a/src/app/demo/DemoListSkeleton.tsx
+++ b/src/app/demo/DemoListSkeleton.tsx
@@ -13,7 +13,7 @@ export function DemoListSkeleton() {
       </div>
       <div className="space-y-4">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="h-24 animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-800" />
+          <div key={i} className="bg-surface-muted h-24 animate-pulse rounded-lg" />
         ))}
       </div>
     </div>

--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -239,7 +239,7 @@ function DemoRouterContent() {
           backButton={
             <ClientLink
               href={backHref}
-              className="ui-text-sm mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
+              className="ui-text-sm text-muted mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 transition-colors hover:bg-zinc-100 hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
             >
               <ArrowLeftIcon className="h-4 w-4" />
               <span>Back to list</span>
@@ -318,10 +318,8 @@ function DemoRouterContent() {
                 />
               )}
               {selectedEntry.id === "welcome" && (
-                <div className="mb-6 rounded-lg border border-zinc-200 bg-zinc-50 p-6 text-center dark:border-zinc-700 dark:bg-zinc-800/50">
-                  <h2 className="mb-4 text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
-                    Get Started
-                  </h2>
+                <div className="border-edge-strong bg-surface-subtle mb-6 rounded-lg border p-6 text-center">
+                  <h2 className="text-strong mb-4 text-2xl font-semibold">Get Started</h2>
                   <div className="flex flex-col justify-center gap-3 sm:flex-row sm:items-center">
                     <Link
                       href="/register"
@@ -331,7 +329,7 @@ function DemoRouterContent() {
                     </Link>
                     <Link
                       href="/login"
-                      className="ui-text-base inline-flex h-12 w-full items-center justify-center rounded-md border border-zinc-300 bg-white px-6 font-medium text-zinc-900 transition-colors hover:bg-zinc-50 sm:w-auto dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800"
+                      className="ui-text-base bg-surface text-strong inline-flex h-12 w-full items-center justify-center rounded-md border border-zinc-300 px-6 font-medium transition-colors hover:bg-zinc-50 sm:w-auto dark:border-zinc-700 dark:hover:bg-zinc-800"
                     >
                       Sign in
                     </Link>
@@ -342,12 +340,10 @@ function DemoRouterContent() {
           }
           afterContent={
             selectedEntry.id === "appearance" && (
-              <div className="mt-8 border-t border-zinc-200 pt-8 dark:border-zinc-700">
+              <div className="border-edge-strong mt-8 border-t pt-8">
                 <div className="mb-4">
-                  <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
-                    Try it yourself
-                  </h2>
-                  <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+                  <h2 className="text-strong text-xl font-semibold">Try it yourself</h2>
+                  <p className="ui-text-sm text-muted mt-1">
                     These are the real appearance settings from the app. Switch to the dark theme to
                     see the warm, low-blue-light palette, or adjust the fonts and text size &mdash;
                     changes apply live to this article. Your choices are saved in this browser.
@@ -366,9 +362,7 @@ function DemoRouterContent() {
     <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
       {/* Header with title and action buttons */}
       <div className="mb-4 flex items-center justify-between sm:mb-6">
-        <h1 className="ui-text-xl sm:ui-text-2xl font-bold text-zinc-900 dark:text-zinc-50">
-          {pageTitle}
-        </h1>
+        <h1 className="ui-text-xl sm:ui-text-2xl text-strong font-bold">{pageTitle}</h1>
         {!isHighlights && (
           <div className="flex gap-2">
             <MarkAllReadButton

--- a/src/app/demo/DemoSidebar.tsx
+++ b/src/app/demo/DemoSidebar.tsx
@@ -60,7 +60,7 @@ export function DemoSidebar({ onClose }: DemoSidebarProps) {
   const highlightCount = demoState.countUnreadStarred();
 
   return (
-    <nav className="flex h-full flex-col bg-white dark:bg-zinc-900">
+    <nav className="bg-surface flex h-full flex-col">
       {/* Top navigation */}
       <div className="space-y-1 p-3">
         <NavLink
@@ -68,9 +68,7 @@ export function DemoSidebar({ onClose }: DemoSidebarProps) {
           isActive={isAllActive}
           countElement={
             totalUnread > 0 ? (
-              <span className="ui-text-xs ml-2 shrink-0 text-zinc-500 dark:text-zinc-400">
-                ({totalUnread})
-              </span>
+              <span className="ui-text-xs text-subtle ml-2 shrink-0">({totalUnread})</span>
             ) : undefined
           }
           onClick={onClose}
@@ -83,9 +81,7 @@ export function DemoSidebar({ onClose }: DemoSidebarProps) {
           isActive={isHighlightsActive}
           countElement={
             highlightCount > 0 ? (
-              <span className="ui-text-xs ml-2 shrink-0 text-zinc-500 dark:text-zinc-400">
-                ({highlightCount})
-              </span>
+              <span className="ui-text-xs text-subtle ml-2 shrink-0">({highlightCount})</span>
             ) : undefined
           }
           onClick={onClose}
@@ -95,7 +91,7 @@ export function DemoSidebar({ onClose }: DemoSidebarProps) {
       </div>
 
       {/* Divider */}
-      <div className="mx-3 border-t border-zinc-200 dark:border-zinc-700" />
+      <div className="border-edge-strong mx-3 border-t" />
 
       {/* Tags and subscriptions */}
       <div className="flex-1 overflow-y-auto p-3">
@@ -118,7 +114,7 @@ export function DemoSidebar({ onClose }: DemoSidebarProps) {
                       e.stopPropagation();
                       toggleTag(tag.id);
                     }}
-                    className="flex h-6 w-6 shrink-0 items-center justify-center text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
+                    className="text-subtle flex h-6 w-6 shrink-0 items-center justify-center hover:text-zinc-700 dark:hover:text-zinc-300"
                     aria-label={expanded ? "Collapse" : "Expand"}
                   >
                     {expanded ? <ChevronDownIcon /> : <ChevronRightIcon />}

--- a/src/app/extension/callback/page.tsx
+++ b/src/app/extension/callback/page.tsx
@@ -32,10 +32,8 @@ export default async function ExtensionCallbackPage({ searchParams }: PageProps)
         {isSuccess ? (
           <>
             <div className="mb-4 text-5xl text-green-500">✓</div>
-            <h1 className="ui-text-xl mb-2 font-semibold text-zinc-900 dark:text-zinc-100">
-              Article Saved!
-            </h1>
-            {title && <p className="mb-4 text-zinc-600 dark:text-zinc-400">{title}</p>}
+            <h1 className="ui-text-xl text-strong mb-2 font-semibold">Article Saved!</h1>
+            {title && <p className="text-muted mb-4">{title}</p>}
             <p className="ui-text-sm text-zinc-400 dark:text-zinc-600">
               This tab will close automatically.
               <br />
@@ -45,12 +43,8 @@ export default async function ExtensionCallbackPage({ searchParams }: PageProps)
         ) : (
           <>
             <div className="mb-4 text-5xl text-red-500">!</div>
-            <h1 className="ui-text-xl mb-2 font-semibold text-zinc-900 dark:text-zinc-100">
-              Something Went Wrong
-            </h1>
-            <p className="mb-4 text-zinc-600 dark:text-zinc-400">
-              {error || "Failed to complete the save operation."}
-            </p>
+            <h1 className="ui-text-xl text-strong mb-2 font-semibold">Something Went Wrong</h1>
+            <p className="text-muted mb-4">{error || "Failed to complete the save operation."}</p>
             <p className="ui-text-sm text-zinc-400 dark:text-zinc-600">
               Please close this tab and try again.
             </p>

--- a/src/app/extension/save/client.tsx
+++ b/src/app/extension/save/client.tsx
@@ -18,7 +18,7 @@ export function ExtensionSaveClient({ status, error, url, canRetry }: Props) {
       <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900">
         <div className="p-8 text-center">
           <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2 border-zinc-900 dark:border-zinc-100" />
-          <p className="text-zinc-600 dark:text-zinc-400">Saving article...</p>
+          <p className="text-muted">Saving article...</p>
         </div>
       </div>
     );
@@ -29,10 +29,8 @@ export function ExtensionSaveClient({ status, error, url, canRetry }: Props) {
       <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900">
         <div className="max-w-md p-8 text-center">
           <div className="mb-4 text-5xl text-red-500">!</div>
-          <h1 className="ui-text-xl mb-2 font-semibold text-zinc-900 dark:text-zinc-100">
-            Failed to Save
-          </h1>
-          <p className="mb-4 text-zinc-600 dark:text-zinc-400">
+          <h1 className="ui-text-xl text-strong mb-2 font-semibold">Failed to Save</h1>
+          <p className="text-muted mb-4">
             {error || "An error occurred while saving the article."}
           </p>
           {url && (
@@ -59,7 +57,7 @@ export function ExtensionSaveClient({ status, error, url, canRetry }: Props) {
     <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900">
       <div className="p-8 text-center">
         <div className="mb-4 text-5xl text-green-500">✓</div>
-        <p className="text-zinc-600 dark:text-zinc-400">Article saved!</p>
+        <p className="text-muted">Article saved!</p>
       </div>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,6 +38,32 @@
   --info-border: #bfdbfe; /* blue-200 */
 
   /* =================================
+     Neutral Semantic Colors
+
+     One utility class per role (e.g. `text-muted`) instead of a light/dark
+     zinc pair (`text-zinc-600 dark:text-zinc-400`) at every call site.
+     Change a value here to retheme every consumer at once.
+     ================================= */
+
+  /* Text tones, strongest to faintest */
+  --text-strong: #18181b; /* zinc-900 - headings, primary values */
+  --text-emphasis: #18181b; /* zinc-900 - <strong> inside muted prose (dimmer than strong in dark) */
+  --text-body: #3f3f46; /* zinc-700 - body copy, labels */
+  --text-muted: #52525b; /* zinc-600 - descriptions, secondary text */
+  --text-subtle: #71717a; /* zinc-500 - metadata, hints */
+  --text-faint: #a1a1aa; /* zinc-400 - de-emphasized notes, placeholders */
+
+  /* Surfaces */
+  --surface: #ffffff; /* white - cards, inputs, controls */
+  --surface-muted: #f4f4f5; /* zinc-100 - chips, skeletons */
+  --surface-subtle: #fafafa; /* zinc-50 - note boxes, subtle fills */
+
+  /* Borders: `edge` for card outlines, `edge-strong` for dividers/note boxes
+     (more visible in dark mode) */
+  --edge: #e4e4e7; /* zinc-200 */
+  --edge-strong: #e4e4e7; /* zinc-200 (dark mode differs: zinc-700 vs zinc-800) */
+
+  /* =================================
      UI Typography Scale (16px baseline)
      ================================= */
   --ui-text-xs: 0.875rem; /* 14px - badges, status indicators */
@@ -65,6 +91,17 @@
   --color-info-subtle-foreground: var(--info-subtle-foreground);
   --color-info-foreground: var(--info-foreground);
   --color-info-border: var(--info-border);
+  --color-strong: var(--text-strong);
+  --color-emphasis: var(--text-emphasis);
+  --color-body: var(--text-body);
+  --color-muted: var(--text-muted);
+  --color-subtle: var(--text-subtle);
+  --color-faint: var(--text-faint);
+  --color-surface: var(--surface);
+  --color-surface-muted: var(--surface-muted);
+  --color-surface-subtle: var(--surface-subtle);
+  --color-edge: var(--edge);
+  --color-edge-strong: var(--edge-strong);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -93,6 +130,19 @@
   --info-subtle-foreground: #e4e4e7; /* zinc-200 */
   --info-foreground: #d4d4d8; /* zinc-300 */
   --info-border: #3f3f46; /* zinc-700 */
+
+  /* Dark mode: neutral semantic colors */
+  --text-strong: #fafafa; /* zinc-50 */
+  --text-emphasis: #e4e4e7; /* zinc-200 - dimmer than strong so bold prose doesn't glare */
+  --text-body: #d4d4d8; /* zinc-300 */
+  --text-muted: #a1a1aa; /* zinc-400 */
+  --text-subtle: #a1a1aa; /* zinc-400 */
+  --text-faint: #71717a; /* zinc-500 */
+  --surface: #18181b; /* zinc-900 */
+  --surface-muted: #27272a; /* zinc-800 */
+  --surface-subtle: rgba(39, 39, 42, 0.5); /* zinc-800/50 */
+  --edge: #27272a; /* zinc-800 */
+  --edge-strong: #3f3f46; /* zinc-700 */
 }
 
 /* Fallback to system preference when no class is set */
@@ -120,6 +170,19 @@
     --info-subtle-foreground: #e4e4e7; /* zinc-200 */
     --info-foreground: #d4d4d8; /* zinc-300 */
     --info-border: #3f3f46; /* zinc-700 */
+
+    /* Dark mode: neutral semantic colors */
+    --text-strong: #fafafa; /* zinc-50 */
+    --text-emphasis: #e4e4e7; /* zinc-200 - dimmer than strong so bold prose doesn't glare */
+    --text-body: #d4d4d8; /* zinc-300 */
+    --text-muted: #a1a1aa; /* zinc-400 */
+    --text-subtle: #a1a1aa; /* zinc-400 */
+    --text-faint: #71717a; /* zinc-500 */
+    --surface: #18181b; /* zinc-900 */
+    --surface-muted: #27272a; /* zinc-800 */
+    --surface-subtle: rgba(39, 39, 42, 0.5); /* zinc-800/50 */
+    --edge: #27272a; /* zinc-800 */
+    --edge-strong: #3f3f46; /* zinc-700 */
   }
 }
 

--- a/src/app/oauth/consent/ConsentForm.tsx
+++ b/src/app/oauth/consent/ConsentForm.tsx
@@ -39,29 +39,25 @@ export function ConsentForm({
     <div>
       {/* Application info */}
       <div className="mb-6 text-center">
-        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-          <ShieldCheckIcon className="h-8 w-8 text-zinc-600 dark:text-zinc-400" />
+        <div className="bg-surface-muted mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+          <ShieldCheckIcon className="text-muted h-8 w-8" />
         </div>
-        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-          Authorize {clientName}
-        </h2>
-        <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">
+        <h2 className="ui-text-lg text-strong font-semibold">Authorize {clientName}</h2>
+        <p className="ui-text-sm text-muted mt-2">
           This application wants to access your Lion Reader account
         </p>
       </div>
 
       {/* Requested permissions */}
-      <div className="mb-6 rounded-lg border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
-        <h3 className="ui-text-sm mb-3 font-medium text-zinc-900 dark:text-zinc-100">
+      <div className="border-edge-strong bg-surface-subtle mb-6 rounded-lg border p-4">
+        <h3 className="ui-text-sm text-strong mb-3 font-medium">
           This will allow {clientName} to:
         </h3>
         <ul className="space-y-2">
           {scopes.map((scope) => (
             <li key={scope.name} className="flex items-start gap-2">
               <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-green-600 dark:text-green-400" />
-              <span className="ui-text-sm text-zinc-700 dark:text-zinc-300">
-                {scope.description}
-              </span>
+              <span className="ui-text-sm text-body">{scope.description}</span>
             </li>
           ))}
         </ul>
@@ -89,7 +85,7 @@ export function ConsentForm({
             type="submit"
             name="user_action"
             value="deny"
-            className="ui-text-sm flex-1 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+            className="ui-text-sm text-body flex-1 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 font-medium transition-colors hover:bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:bg-zinc-700"
           >
             Deny
           </button>

--- a/src/app/oauth/consent/page.tsx
+++ b/src/app/oauth/consent/page.tsx
@@ -123,12 +123,10 @@ function ConsentLayout({ children }: { children: React.ReactNode }) {
     <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 py-12 dark:bg-zinc-950">
       <div className="w-full max-w-md">
         <div className="mb-8 text-center">
-          <h1 className="ui-text-2xl font-bold text-zinc-900 dark:text-zinc-50">Lion Reader</h1>
-          <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">Authorization Request</p>
+          <h1 className="ui-text-2xl text-strong font-bold">Lion Reader</h1>
+          <p className="ui-text-sm text-muted mt-2">Authorization Request</p>
         </div>
-        <div className="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-          {children}
-        </div>
+        <div className="border-edge bg-surface rounded-lg border p-6 shadow-sm">{children}</div>
       </div>
     </div>
   );
@@ -140,8 +138,8 @@ function ErrorMessage({ title, message }: { title: string; message: string }) {
       <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/20">
         <WarningTriangleIcon className="h-6 w-6 text-red-600 dark:text-red-400" />
       </div>
-      <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">{title}</h2>
-      <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">{message}</p>
+      <h2 className="ui-text-lg text-strong font-semibold">{title}</h2>
+      <p className="ui-text-sm text-muted mt-2">{message}</p>
     </div>
   );
 }

--- a/src/app/save/page.tsx
+++ b/src/app/save/page.tsx
@@ -228,11 +228,9 @@ function SaveContent() {
 
     return (
       <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 p-4 dark:bg-zinc-950">
-        <div className="w-full max-w-sm rounded-lg border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="border-edge bg-surface w-full max-w-sm rounded-lg border p-6 shadow-sm">
           <div className="text-center">
-            <h1 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-              Save to Lion Reader
-            </h1>
+            <h1 className="ui-text-lg text-strong font-semibold">Save to Lion Reader</h1>
             <Alert variant="error" className="mt-4">
               {shareError
                 ? errorMessages[shareError] || "An error occurred."
@@ -249,19 +247,17 @@ function SaveContent() {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 p-4 dark:bg-zinc-950">
-      <div className="w-full max-w-sm rounded-lg border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="border-edge bg-surface w-full max-w-sm rounded-lg border p-6 shadow-sm">
         <div className="text-center">
-          <h1 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-            Save to Lion Reader
-          </h1>
+          <h1 className="ui-text-lg text-strong font-semibold">Save to Lion Reader</h1>
 
           {/* Saving State (includes idle and pending) */}
           {(activeMutation.isIdle || activeMutation.isPending) && (
             <div className="mt-6">
               <div className="flex justify-center">
-                <SpinnerIcon className="h-8 w-8 text-zinc-600 dark:text-zinc-400" />
+                <SpinnerIcon className="text-muted h-8 w-8" />
               </div>
-              <p className="ui-text-sm mt-3 text-zinc-600 dark:text-zinc-400">
+              <p className="ui-text-sm text-muted mt-3">
                 {shareType === "file" ? "Uploading file..." : "Saving article..."}
               </p>
               {urlToSave && (
@@ -282,9 +278,7 @@ function SaveContent() {
                 Saved successfully!
               </p>
               {articleTitle && (
-                <p className="ui-text-sm mt-2 line-clamp-2 text-zinc-600 dark:text-zinc-400">
-                  {articleTitle}
-                </p>
+                <p className="ui-text-sm text-muted mt-2 line-clamp-2">{articleTitle}</p>
               )}
               <p className="ui-text-xs mt-4 text-zinc-500 dark:text-zinc-500">
                 Closing in {countdown}...

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -84,7 +84,7 @@ export default function TermsOfServicePage() {
           limits. These limits are subject to change at any time.
         </LegalParagraph>
         <Card padding="md" className="mt-4">
-          <ul className="list-disc space-y-2 pl-6 text-zinc-600 dark:text-zinc-400">
+          <ul className="text-muted list-disc space-y-2 pl-6">
             <li>
               <strong>Subscriptions:</strong> Up to 500 active feed subscriptions per account
             </li>

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -55,6 +55,26 @@ Icons are in `@/components/ui/icon-button`. Use these instead of duplicating SVG
 
 The `ui-text-*` classes are defined in `src/app/globals.css` and provide responsive scaling.
 
+### Semantic Colors
+
+**Use the semantic color tokens instead of raw zinc light/dark pairs.** Each token is one utility class covering both modes; the palette lives in `src/app/globals.css` (`:root` + `.dark`), so retheming means editing CSS variables, not call sites:
+
+| Token                | Replaces                               | Use for                            |
+| -------------------- | -------------------------------------- | ---------------------------------- |
+| `text-strong`        | `text-zinc-900 dark:text-zinc-50`      | Headings, primary values           |
+| `text-emphasis`      | `text-zinc-900 dark:text-zinc-200`     | `<strong>` inside muted prose      |
+| `text-body`          | `text-zinc-700 dark:text-zinc-300`     | Body copy, labels                  |
+| `text-muted`         | `text-zinc-600 dark:text-zinc-400`     | Descriptions, secondary text       |
+| `text-subtle`        | `text-zinc-500 dark:text-zinc-400`     | Metadata, hints                    |
+| `text-faint`         | `text-zinc-400 dark:text-zinc-500`     | De-emphasized notes, placeholders  |
+| `bg-surface`         | `bg-white dark:bg-zinc-900`            | Cards, inputs, controls            |
+| `bg-surface-muted`   | `bg-zinc-100 dark:bg-zinc-800`         | Chips, skeletons                   |
+| `bg-surface-subtle`  | `bg-zinc-50 dark:bg-zinc-800/50`       | Note boxes, subtle fills           |
+| `border-edge`        | `border-zinc-200 dark:border-zinc-800` | Card outlines (also `divide-edge`) |
+| `border-edge-strong` | `border-zinc-200 dark:border-zinc-700` | Dividers, note-box borders         |
+
+Interactive-state colors (`hover:bg-zinc-50`, focus rings, input borders) are not tokenized yet — keep using raw utilities with `dark:` variants for those.
+
 ### Settings Sections
 
 Settings pages are built from `SettingsSection` (`@/components/settings/SettingsSection`), which renders the standard heading + `Card` shell and handles loading/error/success states. Don't hand-roll the `<section><h2>…</h2><div className="rounded-lg border …">` pattern — use `SettingsSection`, or `SettingsSectionHeading` + `Card` when the content doesn't fit the wrapper.

--- a/src/components/admin/AdminApp.tsx
+++ b/src/components/admin/AdminApp.tsx
@@ -77,9 +77,7 @@ function AdminLoginForm({ onLogin }: { onLogin: () => void }) {
   return (
     <div className="flex min-h-screen items-center justify-center px-4">
       <Card className="w-full max-w-sm">
-        <h1 className="ui-text-lg mb-6 text-center font-bold text-zinc-900 dark:text-zinc-50">
-          Admin Login
-        </h1>
+        <h1 className="ui-text-lg text-strong mb-6 text-center font-bold">Admin Login</h1>
         <form onSubmit={handleSubmit} className="space-y-4">
           <Input
             id="admin-secret"
@@ -107,7 +105,7 @@ function AdminTabNav() {
   const pathname = usePathname();
 
   return (
-    <nav className="border-b border-zinc-200 dark:border-zinc-800">
+    <nav className="border-edge border-b">
       <div className="flex gap-1 overflow-x-auto px-4">
         {adminTabs.map((tab) => {
           const isActive = pathname === tab.href;
@@ -117,8 +115,8 @@ function AdminTabNav() {
               href={tab.href}
               className={`ui-text-sm block shrink-0 border-b-2 px-4 py-3 font-medium whitespace-nowrap transition-colors ${
                 isActive
-                  ? "border-zinc-900 text-zinc-900 dark:border-zinc-50 dark:text-zinc-50"
-                  : "border-transparent text-zinc-500 hover:border-zinc-300 hover:text-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:text-zinc-200"
+                  ? "text-strong border-zinc-900 dark:border-zinc-50"
+                  : "text-subtle border-transparent hover:border-zinc-300 hover:text-zinc-700 dark:hover:border-zinc-600 dark:hover:text-zinc-200"
               }`}
             >
               {tab.label}
@@ -137,8 +135,8 @@ function AdminShell({ onLogout, children }: { onLogout: () => void; children: Re
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <header className="flex items-center justify-between border-b border-zinc-200 px-6 py-4 dark:border-zinc-800">
-        <h1 className="ui-text-lg font-bold text-zinc-900 dark:text-zinc-50">Lion Reader Admin</h1>
+      <header className="border-edge flex items-center justify-between border-b px-6 py-4">
+        <h1 className="ui-text-lg text-strong font-bold">Lion Reader Admin</h1>
         <Button variant="ghost" size="sm" onClick={onLogout}>
           Logout
         </Button>
@@ -215,7 +213,7 @@ export function AdminApp({ children }: AdminAppProps) {
   if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <p className="ui-text-sm text-zinc-500 dark:text-zinc-400">Verifying credentials...</p>
+        <p className="ui-text-sm text-subtle">Verifying credentials...</p>
       </div>
     );
   }

--- a/src/components/admin/AdminFeedsContent.tsx
+++ b/src/components/admin/AdminFeedsContent.tsx
@@ -153,13 +153,13 @@ function FeedRow({ feed, onRetry, isRetrying }: FeedRowProps) {
   const displayTitle = getFeedDisplayTitle(feed);
 
   return (
-    <div className="border-b border-zinc-200 p-4 last:border-b-0 dark:border-zinc-800">
+    <div className="border-edge border-b p-4 last:border-b-0">
       {/* Title, Status, and URL */}
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 flex-1">
           {/* Title and badges */}
           <div className="flex flex-wrap items-center gap-2">
-            <p className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">{displayTitle}</p>
+            <p className="ui-text-sm text-strong font-medium">{displayTitle}</p>
             <FeedStatusBadge feed={feed} />
             {feed.websubActive && <WebSubBadge />}
           </div>
@@ -170,7 +170,7 @@ function FeedRow({ feed, onRetry, isRetrying }: FeedRowProps) {
               href={feed.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="ui-text-xs mt-0.5 inline-flex items-center gap-1 text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+              className="ui-text-xs text-subtle mt-0.5 inline-flex items-center gap-1 hover:text-zinc-700 dark:hover:text-zinc-200"
             >
               <span className="truncate">{truncateUrl(feed.url)}</span>
               <ExternalLinkIcon className="h-3 w-3 shrink-0" />
@@ -197,7 +197,7 @@ function FeedRow({ feed, onRetry, isRetrying }: FeedRowProps) {
       {feed.lastError && <ExpandableError error={feed.lastError} />}
 
       {/* Stats grid */}
-      <div className="ui-text-xs mt-3 grid grid-cols-2 gap-x-6 gap-y-1.5 text-zinc-500 sm:grid-cols-3 lg:grid-cols-4 dark:text-zinc-400">
+      <div className="ui-text-xs text-subtle mt-3 grid grid-cols-2 gap-x-6 gap-y-1.5 sm:grid-cols-3 lg:grid-cols-4">
         <StatItem
           label="Last fetched"
           value={feed.lastFetchedAt ? formatRelativeTime(new Date(feed.lastFetchedAt)) : "Never"}
@@ -226,7 +226,7 @@ function FeedRow({ feed, onRetry, isRetrying }: FeedRowProps) {
 function StatItem({ label, value }: { label: string; value: string }) {
   return (
     <span>
-      <span className="font-medium text-zinc-700 dark:text-zinc-300">{label}:</span> {value}
+      <span className="text-body font-medium">{label}:</span> {value}
     </span>
   );
 }
@@ -238,13 +238,13 @@ function StatItem({ label, value }: { label: string; value: string }) {
 function EmptyState({ hasFilters }: { hasFilters: boolean }) {
   return (
     <div className="p-8 text-center">
-      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-        <RssIcon className="h-6 w-6 text-zinc-400 dark:text-zinc-500" />
+      <div className="bg-surface-muted mx-auto flex h-12 w-12 items-center justify-center rounded-full">
+        <RssIcon className="text-faint h-6 w-6" />
       </div>
-      <h3 className="ui-text-sm mt-4 font-medium text-zinc-900 dark:text-zinc-50">
+      <h3 className="ui-text-sm text-strong mt-4 font-medium">
         {hasFilters ? "No matching feeds" : "No feeds"}
       </h3>
-      <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+      <p className="ui-text-sm text-subtle mt-1">
         {hasFilters ? "Try adjusting your filters." : "No feeds have been added to the system yet."}
       </p>
     </div>
@@ -364,7 +364,7 @@ export default function AdminFeedsContent() {
     <div>
       {/* Header */}
       <div className="mb-6">
-        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">Feed Health</h2>
+        <h2 className="ui-text-lg text-strong font-semibold">Feed Health</h2>
       </div>
 
       {/* Filter Controls */}
@@ -386,7 +386,7 @@ export default function AdminFeedsContent() {
           />
         </div>
         <div className="flex shrink-0 items-center gap-3">
-          <label className="ui-text-sm flex cursor-pointer items-center gap-2 text-zinc-600 dark:text-zinc-400">
+          <label className="ui-text-sm text-muted flex cursor-pointer items-center gap-2">
             <input
               type="checkbox"
               checked={hasSubscribers}
@@ -444,15 +444,13 @@ export default function AdminFeedsContent() {
           {feedsQuery.isFetchingNextPage && (
             <div className="flex items-center justify-center p-4">
               <SpinnerIcon className="mr-2 h-4 w-4 text-zinc-400" />
-              <span className="ui-text-sm text-zinc-500 dark:text-zinc-400">Loading more...</span>
+              <span className="ui-text-sm text-subtle">Loading more...</span>
             </div>
           )}
 
           {/* End of list */}
           {!feedsQuery.hasNextPage && feeds.length > 0 && (
-            <p className="ui-text-xs p-3 text-center text-zinc-400 dark:text-zinc-500">
-              No more feeds
-            </p>
+            <p className="ui-text-xs text-faint p-3 text-center">No more feeds</p>
           )}
         </Card>
       )}

--- a/src/components/admin/AdminInvitesContent.tsx
+++ b/src/components/admin/AdminInvitesContent.tsx
@@ -54,7 +54,7 @@ function StatusBadge({ status }: StatusBadgeProps) {
   const styles = {
     pending: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
     used: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
-    expired: "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400",
+    expired: "bg-surface-muted text-subtle",
   };
 
   return (
@@ -92,9 +92,7 @@ function CreatedInviteDisplay({ inviteUrl, onDismiss }: CreatedInviteProps) {
   return (
     <StatusCard variant="info" className="mb-6">
       <div className="flex flex-col gap-2">
-        <p className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
-          Invite created successfully
-        </p>
+        <p className="ui-text-sm text-strong font-medium">Invite created successfully</p>
         <div className="flex items-center gap-2">
           <code className="ui-text-sm flex-1 truncate rounded bg-white/60 px-2 py-1 dark:bg-zinc-800/60">
             {inviteUrl}
@@ -106,7 +104,7 @@ function CreatedInviteDisplay({ inviteUrl, onDismiss }: CreatedInviteProps) {
         </div>
         <button
           onClick={onDismiss}
-          className="ui-text-sm self-start text-zinc-500 underline hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+          className="ui-text-sm text-subtle self-start underline hover:text-zinc-700 dark:hover:text-zinc-200"
         >
           Dismiss
         </button>
@@ -137,16 +135,14 @@ interface InviteRowProps {
 
 function InviteRow({ invite, onRevoke, isRevoking }: InviteRowProps) {
   return (
-    <div className="flex flex-col gap-2 border-b border-zinc-200 p-4 last:border-b-0 sm:flex-row sm:items-center sm:justify-between dark:border-zinc-800">
+    <div className="border-edge flex flex-col gap-2 border-b p-4 last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <StatusBadge status={invite.status} />
-          <code className="ui-text-sm text-zinc-600 dark:text-zinc-400">
-            {truncateToken(invite.token)}
-          </code>
+          <code className="ui-text-sm text-muted">{truncateToken(invite.token)}</code>
         </div>
 
-        <div className="ui-text-xs mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-zinc-500 dark:text-zinc-400">
+        <div className="ui-text-xs text-subtle mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5">
           <span>Created: {formatDate(invite.createdAt)}</span>
           <span>Expires: {formatDate(invite.expiresAt)}</span>
           {invite.usedAt && <span>Used: {formatDate(invite.usedAt)}</span>}
@@ -154,7 +150,7 @@ function InviteRow({ invite, onRevoke, isRevoking }: InviteRowProps) {
 
         {invite.status === "used" && invite.usedByEmail && (
           <p className="ui-text-sm mt-1">
-            <span className="text-zinc-500 dark:text-zinc-400">Used by: </span>
+            <span className="text-subtle">Used by: </span>
             <ClientLink
               href={`/admin/users?search=${encodeURIComponent(invite.usedByEmail)}`}
               className="text-blue-600 underline hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
@@ -189,10 +185,10 @@ function InviteRow({ invite, onRevoke, isRevoking }: InviteRowProps) {
 function EmptyState({ hasSearch }: { hasSearch: boolean }) {
   return (
     <div className="p-8 text-center">
-      <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
+      <h3 className="ui-text-sm text-strong font-medium">
         {hasSearch ? "No matching invites" : "No invites yet"}
       </h3>
-      <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+      <p className="ui-text-sm text-subtle mt-1">
         {hasSearch ? "Try a different search term." : "Generate an invite to get started."}
       </p>
     </div>
@@ -304,7 +300,7 @@ export default function AdminInvitesContent() {
     <div>
       {/* Header */}
       <div className="mb-6 flex items-center justify-between">
-        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">Invites</h2>
+        <h2 className="ui-text-lg text-strong font-semibold">Invites</h2>
         <Button
           onClick={() => createInviteMutation.mutate({})}
           loading={createInviteMutation.isPending}
@@ -370,15 +366,13 @@ export default function AdminInvitesContent() {
           {invitesQuery.isFetchingNextPage && (
             <div className="flex items-center justify-center p-4">
               <SpinnerIcon className="mr-2 h-4 w-4 text-zinc-400" />
-              <span className="ui-text-sm text-zinc-500 dark:text-zinc-400">Loading more...</span>
+              <span className="ui-text-sm text-subtle">Loading more...</span>
             </div>
           )}
 
           {/* End of list */}
           {!invitesQuery.hasNextPage && invites.length > 0 && (
-            <p className="ui-text-xs p-3 text-center text-zinc-400 dark:text-zinc-500">
-              No more invites
-            </p>
+            <p className="ui-text-xs text-faint p-3 text-center">No more invites</p>
           )}
         </Card>
       )}

--- a/src/components/admin/AdminOverviewContent.tsx
+++ b/src/components/admin/AdminOverviewContent.tsx
@@ -25,12 +25,12 @@ function StatCard({
   detail?: string;
 }) {
   return (
-    <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
-      <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">{label}</p>
-      <p className="ui-text-lg mt-1 font-semibold text-zinc-900 dark:text-zinc-50">
+    <div className="border-edge bg-surface rounded-lg border p-4">
+      <p className="ui-text-xs text-subtle">{label}</p>
+      <p className="ui-text-lg text-strong mt-1 font-semibold">
         {typeof value === "number" ? value.toLocaleString() : value}
       </p>
-      {detail && <p className="ui-text-xs mt-1 text-zinc-400 dark:text-zinc-500">{detail}</p>}
+      {detail && <p className="ui-text-xs text-faint mt-1">{detail}</p>}
     </div>
   );
 }
@@ -73,11 +73,11 @@ export default function AdminOverviewContent() {
   return (
     <div>
       <div className="mb-6">
-        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">Overview</h2>
+        <h2 className="ui-text-lg text-strong font-semibold">Overview</h2>
       </div>
 
       {/* Users */}
-      <h3 className="ui-text-sm mb-3 font-medium text-zinc-700 dark:text-zinc-300">Users</h3>
+      <h3 className="ui-text-sm text-body mb-3 font-medium">Users</h3>
       <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
         <StatCard label="Total Users" value={data.totalUsers} />
         <StatCard label="Active (7 days)" value={data.activeUsersLast7Days} />
@@ -85,7 +85,7 @@ export default function AdminOverviewContent() {
       </div>
 
       {/* Feeds */}
-      <h3 className="ui-text-sm mb-3 font-medium text-zinc-700 dark:text-zinc-300">Feeds</h3>
+      <h3 className="ui-text-sm text-body mb-3 font-medium">Feeds</h3>
       <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
         <StatCard label="Total Feeds" value={data.totalFeeds} />
         <StatCard
@@ -101,9 +101,7 @@ export default function AdminOverviewContent() {
       </div>
 
       {/* Content & Activity */}
-      <h3 className="ui-text-sm mb-3 font-medium text-zinc-700 dark:text-zinc-300">
-        Content & Activity
-      </h3>
+      <h3 className="ui-text-sm text-body mb-3 font-medium">Content & Activity</h3>
       <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
         <StatCard label="Total Entries" value={data.totalEntries} />
         <StatCard label="Active Subscriptions" value={data.totalSubscriptions} />

--- a/src/components/admin/AdminUsersContent.tsx
+++ b/src/components/admin/AdminUsersContent.tsx
@@ -67,7 +67,7 @@ function ProviderBadge({ provider }: { provider: string }) {
   const config = providerConfig[provider];
   if (!config) {
     return (
-      <span className="ui-text-xs inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+      <span className="ui-text-xs bg-surface-muted text-muted inline-flex items-center rounded-full px-2 py-0.5 font-medium">
         {provider}
       </span>
     );
@@ -75,7 +75,7 @@ function ProviderBadge({ provider }: { provider: string }) {
 
   const Icon = config.icon;
   return (
-    <span className="ui-text-xs inline-flex items-center gap-1 rounded-full bg-zinc-100 px-2 py-0.5 font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+    <span className="ui-text-xs bg-surface-muted text-muted inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-medium">
       <Icon className="h-3 w-3" />
       {config.label}
     </span>
@@ -99,13 +99,11 @@ interface User {
 
 function UserRow({ user }: { user: User }) {
   return (
-    <div className="flex flex-col gap-2 border-b border-zinc-200 p-4 last:border-b-0 dark:border-zinc-800">
+    <div className="border-edge flex flex-col gap-2 border-b p-4 last:border-b-0">
       {/* Email and ID */}
       <div className="flex flex-wrap items-center gap-2">
-        <span className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">{user.email}</span>
-        <code className="ui-text-xs font-mono text-zinc-400 dark:text-zinc-500">
-          {truncateId(user.id)}
-        </code>
+        <span className="ui-text-sm text-strong font-medium">{user.email}</span>
+        <code className="ui-text-xs text-faint font-mono">{truncateId(user.id)}</code>
       </div>
 
       {/* OAuth providers */}
@@ -118,7 +116,7 @@ function UserRow({ user }: { user: User }) {
       )}
 
       {/* Stats row */}
-      <div className="ui-text-xs flex flex-wrap gap-x-4 gap-y-1 text-zinc-500 dark:text-zinc-400">
+      <div className="ui-text-xs text-subtle flex flex-wrap gap-x-4 gap-y-1">
         <span>Member since {formatDate(user.createdAt)}</span>
         <span>Last active: {user.lastActiveAt ? formatDate(user.lastActiveAt) : "Never"}</span>
         <span>
@@ -146,10 +144,10 @@ function UserRow({ user }: { user: User }) {
 function EmptyState({ hasSearch }: { hasSearch: boolean }) {
   return (
     <div className="p-8 text-center">
-      <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
+      <h3 className="ui-text-sm text-strong font-medium">
         {hasSearch ? "No matching users" : "No users yet"}
       </h3>
-      <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+      <p className="ui-text-sm text-subtle mt-1">
         {hasSearch ? "Try a different search term." : "No users have registered yet."}
       </p>
     </div>
@@ -229,7 +227,7 @@ export default function AdminUsersContent() {
     <div>
       {/* Header */}
       <div className="mb-6">
-        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">Users</h2>
+        <h2 className="ui-text-lg text-strong font-semibold">Users</h2>
       </div>
 
       {/* Search + sort */}
@@ -243,14 +241,14 @@ export default function AdminUsersContent() {
           />
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          <label htmlFor="user-sort" className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+          <label htmlFor="user-sort" className="ui-text-sm text-muted">
             Sort by
           </label>
           <select
             id="user-sort"
             value={sort}
             onChange={(e) => setSort(e.target.value as UserSort)}
-            className="ui-text-sm block rounded-md border border-zinc-300 bg-white px-3 py-2 text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+            className="ui-text-sm bg-surface text-strong block rounded-md border border-zinc-300 px-3 py-2 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none dark:border-zinc-700 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
           >
             {SORT_OPTIONS.map((option) => (
               <option key={option.value} value={option.value}>
@@ -295,15 +293,13 @@ export default function AdminUsersContent() {
           {usersQuery.isFetchingNextPage && (
             <div className="flex items-center justify-center p-4">
               <SpinnerIcon className="mr-2 h-4 w-4 text-zinc-400" />
-              <span className="ui-text-sm text-zinc-500 dark:text-zinc-400">Loading more...</span>
+              <span className="ui-text-sm text-subtle">Loading more...</span>
             </div>
           )}
 
           {/* End of list */}
           {!usersQuery.hasNextPage && users.length > 0 && (
-            <p className="ui-text-xs p-3 text-center text-zinc-400 dark:text-zinc-500">
-              No more users
-            </p>
+            <p className="ui-text-xs text-faint p-3 text-center">No more users</p>
           )}
         </Card>
       )}

--- a/src/components/app/AppRouter.tsx
+++ b/src/components/app/AppRouter.tsx
@@ -30,7 +30,7 @@ function PageSkeleton() {
       </div>
       <div className="space-y-4">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="h-24 animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-800" />
+          <div key={i} className="bg-surface-muted h-24 animate-pulse rounded-lg" />
         ))}
       </div>
     </div>

--- a/src/components/auth/AuthFooter.tsx
+++ b/src/components/auth/AuthFooter.tsx
@@ -8,7 +8,7 @@ import Link from "next/link";
 
 export function AuthFooter() {
   return (
-    <footer className="mt-8 border-t border-zinc-200 pt-6 dark:border-zinc-800">
+    <footer className="border-edge mt-8 border-t pt-6">
       <p className="ui-text-xs text-center text-zinc-500 dark:text-zinc-500">
         <Link
           href="/terms"

--- a/src/components/auth/OAuthSignInButton.tsx
+++ b/src/components/auth/OAuthSignInButton.tsx
@@ -24,7 +24,7 @@ interface OAuthSignInButtonProps {
 }
 
 const defaultButtonClassName =
-  "ui-text-sm flex min-h-[44px] w-full items-center justify-center gap-3 rounded-md border border-zinc-300 bg-white px-4 font-medium text-zinc-900 transition-colors hover:bg-zinc-50 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400";
+  "ui-text-sm flex min-h-[44px] w-full items-center justify-center gap-3 rounded-md border border-zinc-300 bg-surface px-4 font-medium text-strong transition-colors hover:bg-zinc-50 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400";
 
 const appleButtonClassName =
   "ui-text-sm flex min-h-[44px] w-full items-center justify-center gap-3 rounded-md bg-black px-4 font-medium text-white transition-colors hover:bg-zinc-800 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-black dark:hover:bg-zinc-200 dark:focus:ring-zinc-400";

--- a/src/components/entries/EntryArticle.tsx
+++ b/src/components/entries/EntryArticle.tsx
@@ -107,19 +107,19 @@ export function EntryArticle({
                 href={url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="ui-text-xl sm:ui-text-2xl hover:text-accent block leading-tight font-bold text-zinc-900 underline-offset-2 transition-colors hover:underline md:text-3xl dark:text-zinc-100"
+                className="ui-text-xl sm:ui-text-2xl hover:text-accent block leading-tight font-bold text-strong underline-offset-2 transition-colors hover:underline md:text-3xl"
               >
                 {title}
               </a>
             ) : (
-              <h1 className="ui-text-xl sm:ui-text-2xl leading-tight font-bold text-zinc-900 md:text-3xl dark:text-zinc-100">
+              <h1 className="ui-text-xl sm:ui-text-2xl leading-tight font-bold text-strong md:text-3xl">
                 {title}
               </h1>
             )}
           </div>
 
           {/* Meta row: Source, Author, Date */}
-          <div className="ui-text-xs sm:ui-text-sm flex flex-wrap items-center gap-x-3 gap-y-1 text-zinc-600 sm:gap-x-4 sm:gap-y-2 dark:text-zinc-400">
+          <div className="ui-text-xs sm:ui-text-sm flex flex-wrap items-center gap-x-3 gap-y-1 text-muted sm:gap-x-4 sm:gap-y-2">
             <span className="font-medium">{source}</span>
             {author && author.toLowerCase().trim() !== source.toLowerCase().trim() && (
               <>
@@ -148,7 +148,7 @@ export function EntryArticle({
       </header>
 
       {/* Divider */}
-      <hr className="mb-6 border-zinc-200 sm:mb-8 dark:border-zinc-700" />
+      <hr className="mb-6 border-edge-strong sm:mb-8" />
 
       {/* Before content slot (summary card, narration highlight styles) */}
       {beforeContent}
@@ -171,7 +171,7 @@ export function EntryArticle({
 
       {/* Footer with original link and unsubscribe link */}
       {(url || unsubscribeUrl) && (
-        <footer className="mt-8 border-t border-zinc-200 pt-6 sm:mt-12 sm:pt-8 dark:border-zinc-700">
+        <footer className="mt-8 border-t border-edge-strong pt-6 sm:mt-12 sm:pt-8">
           <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
             {url && (
               <a
@@ -189,7 +189,7 @@ export function EntryArticle({
                 href={unsubscribeUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="ui-text-sm inline-flex min-h-[44px] items-center gap-2 font-medium text-zinc-500 transition-colors hover:text-zinc-700 active:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-300 dark:active:text-zinc-200"
+                className="ui-text-sm inline-flex min-h-[44px] items-center gap-2 font-medium text-subtle transition-colors hover:text-zinc-700 active:text-zinc-800 dark:hover:text-zinc-300 dark:active:text-zinc-200"
               >
                 <ExternalLinkIcon className="h-4 w-4" />
                 Unsubscribe

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -337,7 +337,7 @@ export function EntryContentBody({
         onBack ? (
           <button
             onClick={onBack}
-            className="ui-text-sm mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
+            className="ui-text-sm text-muted mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 transition-colors hover:bg-zinc-100 hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
           >
             <ArrowLeftIcon className="h-4 w-4" />
             <span>Back to list</span>

--- a/src/components/entries/EntryContentFallback.tsx
+++ b/src/components/entries/EntryContentFallback.tsx
@@ -93,7 +93,7 @@ export function EntryContentFallback({ entryId, onBack }: EntryContentFallbackPr
         {onBack && (
           <button
             onClick={onBack}
-            className="ui-text-sm mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
+            className="ui-text-sm text-muted mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 transition-colors hover:bg-zinc-100 hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
           >
             <ArrowLeftIcon className="h-4 w-4" />
             <span>Back to list</span>
@@ -113,19 +113,19 @@ export function EntryContentFallback({ entryId, onBack }: EntryContentFallbackPr
                     href={url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="ui-text-xl sm:ui-text-2xl hover:text-accent block leading-tight font-bold text-zinc-900 underline-offset-2 transition-colors hover:underline md:text-3xl dark:text-zinc-100"
+                    className="ui-text-xl sm:ui-text-2xl hover:text-accent text-strong block leading-tight font-bold underline-offset-2 transition-colors hover:underline md:text-3xl"
                   >
                     {title}
                   </a>
                 ) : (
-                  <h1 className="ui-text-xl sm:ui-text-2xl leading-tight font-bold text-zinc-900 md:text-3xl dark:text-zinc-100">
+                  <h1 className="ui-text-xl sm:ui-text-2xl text-strong leading-tight font-bold md:text-3xl">
                     {title}
                   </h1>
                 )}
               </div>
 
               {/* Meta row: Source, Author, Date */}
-              <div className="ui-text-xs sm:ui-text-sm flex flex-wrap items-center gap-x-3 gap-y-1 text-zinc-600 sm:gap-x-4 sm:gap-y-2 dark:text-zinc-400">
+              <div className="ui-text-xs sm:ui-text-sm text-muted flex flex-wrap items-center gap-x-3 gap-y-1 sm:gap-x-4 sm:gap-y-2">
                 <span className="font-medium">{source}</span>
                 {cachedEntry.author &&
                   cachedEntry.author.toLowerCase().trim() !== source.toLowerCase().trim() && (
@@ -201,14 +201,14 @@ export function EntryContentFallback({ entryId, onBack }: EntryContentFallbackPr
         </header>
 
         {/* Divider - always show */}
-        <hr className="mb-6 border-zinc-200 sm:mb-8 dark:border-zinc-700" />
+        <hr className="border-edge-strong mb-6 sm:mb-8" />
 
         {/* Content skeleton */}
         <ContentSkeleton />
 
         {/* Footer with original link - show if URL available */}
         {url && (
-          <footer className="mt-8 border-t border-zinc-200 pt-6 sm:mt-12 sm:pt-8 dark:border-zinc-700">
+          <footer className="border-edge-strong mt-8 border-t pt-6 sm:mt-12 sm:pt-8">
             <a
               href={url}
               target="_blank"

--- a/src/components/entries/EntryContentRenderer.tsx
+++ b/src/components/entries/EntryContentRenderer.tsx
@@ -47,14 +47,11 @@ export const EntryContentRenderer = React.memo(function EntryContentRenderer({
 
   if (fallbackContent) {
     return (
-      <p
-        className="ui-text-base leading-relaxed text-zinc-700 dark:text-zinc-300"
-        style={textStyle}
-      >
+      <p className="ui-text-base text-body leading-relaxed" style={textStyle}>
         {fallbackContent}
       </p>
     );
   }
 
-  return <p className="text-zinc-500 italic dark:text-zinc-400">No content available.</p>;
+  return <p className="text-subtle italic">No content available.</p>;
 });

--- a/src/components/entries/EntryContentStates.tsx
+++ b/src/components/entries/EntryContentStates.tsx
@@ -46,7 +46,7 @@ export function EntryContentSkeleton() {
       </header>
 
       {/* Divider - always show (not animated) */}
-      <hr className="mb-6 border-zinc-200 sm:mb-8 dark:border-zinc-700" />
+      <hr className="border-edge-strong mb-6 sm:mb-8" />
 
       {/* Content placeholders */}
       <ContentSkeleton />

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -70,12 +70,12 @@ export function getItemClasses(read: boolean, selected: boolean): string {
   if (selected) {
     // Selected state takes priority - accent ring indicator
     return `${baseClasses} border-accent ring-2 ring-accent ring-offset-1 dark:ring-offset-zinc-900 ${
-      read ? "bg-white dark:bg-zinc-900" : "bg-zinc-50 dark:bg-zinc-800"
+      read ? "bg-surface" : "bg-zinc-50 dark:bg-zinc-800"
     }`;
   }
 
   if (read) {
-    return `${baseClasses} border-zinc-200 bg-white hover:bg-zinc-50 active:bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800/50 dark:active:bg-zinc-800`;
+    return `${baseClasses} border-edge bg-surface hover:bg-zinc-50 active:bg-zinc-100 dark:hover:bg-zinc-800/50 dark:active:bg-zinc-800`;
   }
 
   return `${baseClasses} border-zinc-300 bg-zinc-50 hover:bg-zinc-100 active:bg-zinc-200 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:bg-zinc-700/50 dark:active:bg-zinc-700`;
@@ -187,9 +187,7 @@ export const EntryListItem = memo(function EntryListItem({
           <div className="flex items-start justify-between gap-2">
             <h3
               className={`ui-text-sm line-clamp-2 ${
-                read
-                  ? "font-normal text-zinc-700 dark:text-zinc-300"
-                  : "font-medium text-zinc-900 dark:text-zinc-100"
+                read ? "text-body font-normal" : "text-strong font-medium"
               }`}
             >
               {displayTitle}
@@ -226,7 +224,7 @@ export const EntryListItem = memo(function EntryListItem({
           </div>
 
           {/* Meta Row: Source and Date */}
-          <div className="ui-text-xs mt-1 flex items-center gap-2 text-zinc-500 dark:text-zinc-400">
+          <div className="ui-text-xs text-subtle mt-1 flex items-center gap-2">
             <span className="truncate">{source}</span>
             <span aria-hidden="true">·</span>
             <time dateTime={date.toISOString()} className="shrink-0">
@@ -235,11 +233,7 @@ export const EntryListItem = memo(function EntryListItem({
           </div>
 
           {/* Preview */}
-          {summary && (
-            <p className="ui-text-sm mt-2 line-clamp-2 text-zinc-600 dark:text-zinc-400">
-              {summary}
-            </p>
-          )}
+          {summary && <p className="ui-text-sm text-muted mt-2 line-clamp-2">{summary}</p>}
         </div>
       </div>
     </article>

--- a/src/components/entries/EntryListSkeleton.tsx
+++ b/src/components/entries/EntryListSkeleton.tsx
@@ -24,7 +24,7 @@ const EntryListItemSkeleton = memo(function EntryListItemSkeleton({
   hasLongSummary = true,
 }: EntryListItemSkeletonProps) {
   return (
-    <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+    <div className="border-edge bg-surface rounded-lg border p-4">
       <div className="flex items-start gap-3">
         {/* Read indicator skeleton */}
         <div className="mt-1.5 shrink-0">

--- a/src/components/entries/EntryListStates.tsx
+++ b/src/components/entries/EntryListStates.tsx
@@ -27,8 +27,8 @@ export interface EntryListEmptyProps {
 export function EntryListEmpty({ message, icon }: EntryListEmptyProps) {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
-      {icon ?? <DefaultEmptyIcon className="mb-4 h-12 w-12 text-zinc-400 dark:text-zinc-500" />}
-      <p className="ui-text-sm text-zinc-500 dark:text-zinc-400">{message}</p>
+      {icon ?? <DefaultEmptyIcon className="text-faint mb-4 h-12 w-12" />}
+      <p className="ui-text-sm text-subtle">{message}</p>
     </div>
   );
 }
@@ -50,7 +50,7 @@ export function EntryListError({ message, onRetry }: EntryListErrorProps) {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
       <AlertIcon className="mb-4 h-12 w-12 text-red-400 dark:text-red-500" />
-      <p className="ui-text-sm mb-4 text-zinc-500 dark:text-zinc-400">{message}</p>
+      <p className="ui-text-sm text-subtle mb-4">{message}</p>
       <Button onClick={onRetry}>Try again</Button>
     </div>
   );
@@ -72,5 +72,5 @@ export function EntryListLoadingMore({ label = "Loading more..." }: { label?: st
  * End of list indicator.
  */
 export function EntryListEnd({ message = "No more entries" }: { message?: string }) {
-  return <p className="ui-text-sm py-4 text-center text-zinc-400 dark:text-zinc-500">{message}</p>;
+  return <p className="ui-text-sm text-faint py-4 text-center">{message}</p>;
 }

--- a/src/components/entries/EntryPageLayout.tsx
+++ b/src/components/entries/EntryPageLayout.tsx
@@ -29,11 +29,7 @@ export function TitleSkeleton() {
  * Title text component - renders the h1 with proper styling.
  */
 export function TitleText({ children }: { children: ReactNode }) {
-  return (
-    <h1 className="ui-text-xl sm:ui-text-2xl font-bold text-zinc-900 dark:text-zinc-50">
-      {children}
-    </h1>
-  );
+  return <h1 className="ui-text-xl sm:ui-text-2xl text-strong font-bold">{children}</h1>;
 }
 
 interface EntryPageLayoutProps {

--- a/src/components/entries/MarkAllReadButton.tsx
+++ b/src/components/entries/MarkAllReadButton.tsx
@@ -32,7 +32,7 @@ export function MarkAllReadButton({
       <button
         type="button"
         onClick={() => setShowDialog(true)}
-        className="inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
+        className="text-subtle inline-flex items-center justify-center rounded-md p-2 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
         title="Mark all as read"
         aria-label="Mark all as read"
       >

--- a/src/components/entries/StickyEntryControls.tsx
+++ b/src/components/entries/StickyEntryControls.tsx
@@ -63,14 +63,14 @@ export function StickyEntryControls({
 
   return (
     <div className="pointer-events-none sticky bottom-0 -mx-4 flex justify-center px-4 pb-4">
-      <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-zinc-200 bg-white/95 px-3 py-1.5 shadow-lg backdrop-blur-sm dark:border-zinc-700 dark:bg-zinc-900/95">
+      <div className="border-edge-strong pointer-events-auto flex items-center gap-2 rounded-full border bg-white/95 px-3 py-1.5 shadow-lg backdrop-blur-sm dark:bg-zinc-900/95">
         {/* Star button */}
         <button
           onClick={onToggleStar}
           className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full transition-colors ${
             starred
               ? "text-amber-500 hover:bg-amber-50 dark:hover:bg-amber-950"
-              : "text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+              : "text-subtle hover:bg-zinc-100 dark:hover:bg-zinc-800"
           }`}
           aria-label={starred ? "Remove from starred" : "Add to starred"}
         >
@@ -86,7 +86,7 @@ export function StickyEntryControls({
           className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full transition-colors ${
             !read
               ? "text-accent hover:bg-accent-subtle"
-              : "text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+              : "text-subtle hover:bg-zinc-100 dark:hover:bg-zinc-800"
           }`}
           aria-label={read ? "Mark as unread" : "Mark as read"}
           title="Keyboard shortcut: m"

--- a/src/components/feeds/EditSubscriptionDialog.tsx
+++ b/src/components/feeds/EditSubscriptionDialog.tsx
@@ -146,8 +146,8 @@ function EditSubscriptionForm({
       <DialogTitle id="edit-subscription-title">Edit Subscription</DialogTitle>
 
       <DialogBody>
-        <p className="ui-text-sm mb-4 text-zinc-500 dark:text-zinc-400">
-          Feed: <span className="font-medium text-zinc-700 dark:text-zinc-300">{currentTitle}</span>
+        <p className="ui-text-sm text-subtle mb-4">
+          Feed: <span className="text-body font-medium">{currentTitle}</span>
         </p>
 
         {error && (
@@ -170,13 +170,11 @@ function EditSubscriptionForm({
 
         {/* Tags */}
         <div className="mb-2">
-          <label className="ui-text-sm mb-2 block font-medium text-zinc-700 dark:text-zinc-300">
-            Tags
-          </label>
+          <label className="ui-text-sm text-body mb-2 block font-medium">Tags</label>
           {tags.length === 0 ? (
-            <p className="ui-text-sm text-zinc-500 dark:text-zinc-400">
+            <p className="ui-text-sm text-subtle">
               No tags created yet. Create tags in{" "}
-              <ClientLink href="/settings" className="text-zinc-900 underline dark:text-zinc-50">
+              <ClientLink href="/settings" className="text-strong underline">
                 Settings
               </ClientLink>
               .
@@ -194,7 +192,7 @@ function EditSubscriptionForm({
                     className={`ui-text-sm flex items-center gap-1.5 rounded-full border px-3 py-1.5 transition-colors ${
                       isSelected
                         ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
-                        : "border-zinc-300 bg-white text-zinc-700 hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:bg-zinc-700"
+                        : "text-body border-zinc-300 bg-white hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:border-zinc-500 dark:hover:bg-zinc-700"
                     }`}
                   >
                     <ColorDot color={tag.color} size="sm" />

--- a/src/components/feeds/UnsubscribeDialog.tsx
+++ b/src/components/feeds/UnsubscribeDialog.tsx
@@ -46,8 +46,8 @@ export function UnsubscribeDialog({
 
       <DialogDescription>
         Are you sure you want to unsubscribe from{" "}
-        <span className="font-medium text-zinc-900 dark:text-zinc-50">{feedTitle}</span>? You can
-        always resubscribe later.
+        <span className="text-strong font-medium">{feedTitle}</span>? You can always resubscribe
+        later.
       </DialogDescription>
 
       <DialogFooter>

--- a/src/components/keyboard/KeyboardShortcutsModal.tsx
+++ b/src/components/keyboard/KeyboardShortcutsModal.tsx
@@ -94,10 +94,7 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsMod
     >
       {/* Header */}
       <DialogHeader className="flex items-center justify-between">
-        <h2
-          id="shortcuts-title"
-          className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50"
-        >
+        <h2 id="shortcuts-title" className="ui-text-lg text-strong font-semibold">
           Keyboard Shortcuts
         </h2>
         <IconButton
@@ -112,21 +109,15 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsMod
       <DialogBody className="space-y-6">
         {SHORTCUT_SECTIONS.map((section) => (
           <div key={section.title}>
-            <h3 className="ui-text-sm mb-3 font-medium text-zinc-500 dark:text-zinc-400">
-              {section.title}
-            </h3>
+            <h3 className="ui-text-sm text-subtle mb-3 font-medium">{section.title}</h3>
             <div className="space-y-2">
               {section.shortcuts.map((shortcut) => (
                 <div key={shortcut.description} className="flex items-center justify-between py-1">
-                  <span className="ui-text-sm text-zinc-700 dark:text-zinc-300">
-                    {shortcut.description}
-                  </span>
+                  <span className="ui-text-sm text-body">{shortcut.description}</span>
                   <div className="flex items-center gap-1">
                     {shortcut.keys.map((key, index) => (
                       <span key={index} className="flex items-center gap-1">
-                        {index > 0 && (
-                          <span className="ui-text-xs text-zinc-400 dark:text-zinc-500">then</span>
-                        )}
+                        {index > 0 && <span className="ui-text-xs text-faint">then</span>}
                         <Kbd>{key}</Kbd>
                       </span>
                     ))}
@@ -139,8 +130,8 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsMod
       </DialogBody>
 
       {/* Footer */}
-      <DialogFooter className="flex-col items-stretch border-t border-zinc-200 pt-4 dark:border-zinc-700">
-        <p className="ui-text-xs mb-4 text-zinc-500 dark:text-zinc-400">
+      <DialogFooter className="border-edge-strong flex-col items-stretch border-t pt-4">
+        <p className="ui-text-xs text-subtle mb-4">
           Keyboard shortcuts can be disabled in Settings.
         </p>
         <div className="flex justify-end">

--- a/src/components/layout/ConnectionStatusIndicator.tsx
+++ b/src/components/layout/ConnectionStatusIndicator.tsx
@@ -36,7 +36,7 @@ export function ConnectionStatusIndicator({ status, onReconnect }: ConnectionSta
 
   return (
     <div
-      className="ui-text-sm fixed right-4 bottom-4 z-50 flex items-center gap-2 rounded-full bg-white px-3 py-2 shadow-lg ring-1 ring-zinc-200 dark:bg-zinc-900 dark:ring-zinc-700"
+      className="ui-text-sm bg-surface fixed right-4 bottom-4 z-50 flex items-center gap-2 rounded-full px-3 py-2 shadow-lg ring-1 ring-zinc-200 dark:ring-zinc-700"
       role="status"
       aria-live="polite"
     >
@@ -46,7 +46,7 @@ export function ConnectionStatusIndicator({ status, onReconnect }: ConnectionSta
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-yellow-400 opacity-75" />
             <span className="relative inline-flex h-2 w-2 rounded-full bg-yellow-500" />
           </span>
-          <span className="text-zinc-600 dark:text-zinc-400">Connecting...</span>
+          <span className="text-muted">Connecting...</span>
         </>
       )}
 
@@ -55,14 +55,11 @@ export function ConnectionStatusIndicator({ status, onReconnect }: ConnectionSta
           <span className="relative flex h-2 w-2">
             <span className="relative inline-flex h-2 w-2 rounded-full bg-red-500" />
           </span>
-          <span className="text-zinc-600 dark:text-zinc-400">
+          <span className="text-muted">
             {status === "error" ? "Connection error" : "Disconnected"}
           </span>
           {onReconnect && (
-            <button
-              onClick={onReconnect}
-              className="ml-1 text-zinc-900 underline hover:no-underline dark:text-zinc-50"
-            >
+            <button onClick={onReconnect} className="text-strong ml-1 underline hover:no-underline">
               Retry
             </button>
           )}

--- a/src/components/layout/LayoutShell.tsx
+++ b/src/components/layout/LayoutShell.tsx
@@ -45,16 +45,13 @@ export function LayoutShell({
 
       {/* Sidebar */}
       <aside
-        className={`fixed inset-y-0 left-0 z-50 w-64 transform border-r border-zinc-200 bg-white transition-transform duration-200 ease-in-out lg:static lg:translate-x-0 dark:border-zinc-800 dark:bg-zinc-900 ${
+        className={`border-edge bg-surface fixed inset-y-0 left-0 z-50 w-64 transform border-r transition-transform duration-200 ease-in-out lg:static lg:translate-x-0 ${
           sidebarOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >
         {/* Sidebar header */}
-        <div className="flex h-14 items-center justify-between border-b border-zinc-200 px-4 dark:border-zinc-800">
-          <ClientLink
-            href={sidebarTitleHref}
-            className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50"
-          >
+        <div className="border-edge flex h-14 items-center justify-between border-b px-4">
+          <ClientLink href={sidebarTitleHref} className="ui-text-lg text-strong font-semibold">
             Lion Reader
           </ClientLink>
           {sidebarCloseButton}
@@ -67,7 +64,7 @@ export function LayoutShell({
       {/* Main content area */}
       <div className="flex flex-1 flex-col overflow-hidden">
         {/* Header */}
-        <header className="flex h-14 items-center justify-between border-b border-zinc-200 bg-white px-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <header className="border-edge bg-surface flex h-14 items-center justify-between border-b px-4">
           {/* Mobile menu button */}
           {mobileMenuButton}
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -113,15 +113,13 @@ export function Sidebar({ onClose }: SidebarProps) {
 
   return (
     <>
-      <nav className="flex h-full flex-col bg-white dark:bg-zinc-900">
+      <nav className="bg-surface flex h-full flex-col">
         {/* Main Navigation with streaming counts */}
         <SidebarNav onNavigate={handleNavigate} onPrefetch={handlePrefetchRoute} />
 
         {/* Divider with unread toggle */}
-        <div className="mx-3 flex items-center gap-2 border-t border-zinc-200 pt-2 dark:border-zinc-700">
-          <span className="ui-text-xs flex-1 font-medium text-zinc-500 dark:text-zinc-400">
-            Feeds
-          </span>
+        <div className="border-edge-strong mx-3 flex items-center gap-2 border-t pt-2">
+          <span className="ui-text-xs text-subtle flex-1 font-medium">Feeds</span>
           <SidebarUnreadToggle unreadOnly={sidebarUnreadOnly} onToggle={toggleSidebarUnreadOnly} />
         </div>
 

--- a/src/components/layout/SidebarNav.tsx
+++ b/src/components/layout/SidebarNav.tsx
@@ -25,9 +25,7 @@ interface SidebarNavProps {
  */
 function CountBadge({ count }: { count: number }) {
   if (count === 0) return null;
-  return (
-    <span className="ui-text-xs ml-2 shrink-0 text-zinc-500 dark:text-zinc-400">({count})</span>
-  );
+  return <span className="ui-text-xs text-subtle ml-2 shrink-0">({count})</span>;
 }
 
 /**

--- a/src/components/layout/SidebarUnreadToggle.tsx
+++ b/src/components/layout/SidebarUnreadToggle.tsx
@@ -71,7 +71,7 @@ export function SidebarUnreadToggle({ unreadOnly, onToggle }: SidebarUnreadToggl
     <button
       type="button"
       onClick={onToggle}
-      className="rounded p-1 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+      className="text-faint rounded p-1 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
       title={label}
       aria-label={label}
       aria-pressed={unreadOnly}

--- a/src/components/layout/SubscriptionItem.tsx
+++ b/src/components/layout/SubscriptionItem.tsx
@@ -55,13 +55,13 @@ export function SubscriptionItem({
         onPrefetch={onPrefetch}
         className={`ui-text-sm flex min-h-[44px] items-center justify-between rounded-md px-3 py-2 transition-colors ${
           isActive
-            ? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
-            : "text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            ? "bg-surface-muted text-strong"
+            : "text-body hover:bg-zinc-100 dark:hover:bg-zinc-800"
         }`}
       >
         <span className="truncate pr-8">{displayTitle}</span>
         {subscription.unreadCount > 0 && (
-          <span className="ui-text-xs shrink-0 text-zinc-500 group-hover:hidden dark:text-zinc-400">
+          <span className="ui-text-xs text-subtle shrink-0 group-hover:hidden">
             ({subscription.unreadCount})
           </span>
         )}

--- a/src/components/layout/TagList.tsx
+++ b/src/components/layout/TagList.tsx
@@ -80,7 +80,7 @@ function TagListContent({
   };
 
   if (!hasTags) {
-    return <p className="ui-text-sm px-3 text-zinc-500 dark:text-zinc-400">No unread feeds</p>;
+    return <p className="ui-text-sm text-subtle px-3">No unread feeds</p>;
   }
 
   return (
@@ -101,7 +101,7 @@ function TagListContent({
                   e.stopPropagation();
                   toggleExpanded(tag.id);
                 }}
-                className="flex h-6 w-6 shrink-0 items-center justify-center text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
+                className="text-subtle flex h-6 w-6 shrink-0 items-center justify-center hover:text-zinc-700 dark:hover:text-zinc-300"
                 aria-label={expanded ? "Collapse" : "Expand"}
               >
                 {expanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
@@ -146,7 +146,7 @@ function TagListContent({
                 e.stopPropagation();
                 toggleExpanded("uncategorized");
               }}
-              className="flex h-6 w-6 shrink-0 items-center justify-center text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
+              className="text-subtle flex h-6 w-6 shrink-0 items-center justify-center hover:text-zinc-700 dark:hover:text-zinc-300"
               aria-label={isExpanded("uncategorized") ? "Collapse" : "Expand"}
             >
               {isExpanded("uncategorized") ? <ChevronDownIcon /> : <ChevronRightIcon />}
@@ -189,7 +189,7 @@ function TagListSkeleton() {
   return (
     <div className="space-y-2">
       {[1, 2, 3].map((i) => (
-        <div key={i} className="h-9 animate-pulse rounded-md bg-zinc-100 dark:bg-zinc-800" />
+        <div key={i} className="bg-surface-muted h-9 animate-pulse rounded-md" />
       ))}
     </div>
   );

--- a/src/components/layout/TagSubscriptionList.tsx
+++ b/src/components/layout/TagSubscriptionList.tsx
@@ -84,7 +84,7 @@ export function TagSubscriptionList({
       <ul className="mt-1 ml-6 space-y-1">
         {[1, 2].map((i) => (
           <li key={i}>
-            <div className="h-9 animate-pulse rounded-md bg-zinc-100 dark:bg-zinc-800" />
+            <div className="bg-surface-muted h-9 animate-pulse rounded-md" />
           </li>
         ))}
       </ul>

--- a/src/components/legal/LegalProse.tsx
+++ b/src/components/legal/LegalProse.tsx
@@ -30,16 +30,12 @@ export function LegalPage({ title, lastUpdated, children }: LegalPageProps) {
         <div className="mb-8">
           <Link
             href="/"
-            className="ui-text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+            className="ui-text-sm text-muted hover:text-zinc-900 dark:hover:text-zinc-100"
           >
             &larr; Back to Lion Reader
           </Link>
-          <h1 className="mt-4 text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
-            {title}
-          </h1>
-          <p className="ui-text-sm mt-2 text-zinc-500 dark:text-zinc-400">
-            Last updated: {lastUpdated}
-          </p>
+          <h1 className="text-strong mt-4 text-3xl font-bold tracking-tight">{title}</h1>
+          <p className="ui-text-sm text-subtle mt-2">Last updated: {lastUpdated}</p>
         </div>
 
         <div className="prose prose-zinc dark:prose-invert max-w-none">{children}</div>
@@ -59,7 +55,7 @@ export interface LegalSectionProps {
 export function LegalSection({ title, children }: LegalSectionProps) {
   return (
     <section className="mb-8">
-      <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">{title}</h2>
+      <h2 className="ui-text-xl text-strong font-semibold">{title}</h2>
       {children}
     </section>
   );
@@ -76,7 +72,7 @@ export interface LegalSubsectionProps {
 export function LegalSubsection({ title, children }: LegalSubsectionProps) {
   return (
     <div>
-      <h3 className="font-medium text-zinc-800 dark:text-zinc-200">{title}</h3>
+      <h3 className="text-emphasis font-medium">{title}</h3>
       {children}
     </div>
   );
@@ -92,9 +88,7 @@ export interface LegalParagraphProps {
 }
 
 export function LegalParagraph({ children, tight = false }: LegalParagraphProps) {
-  return (
-    <p className={`${tight ? "mt-1" : "mt-2"} text-zinc-600 dark:text-zinc-400`}>{children}</p>
-  );
+  return <p className={`${tight ? "mt-1" : "mt-2"} text-muted`}>{children}</p>;
 }
 
 /**
@@ -105,7 +99,5 @@ export interface LegalListProps {
 }
 
 export function LegalList({ children }: LegalListProps) {
-  return (
-    <ul className="mt-2 list-disc space-y-1 pl-6 text-zinc-600 dark:text-zinc-400">{children}</ul>
-  );
+  return <ul className="text-muted mt-2 list-disc space-y-1 pl-6">{children}</ul>;
 }

--- a/src/components/narration/EnhancedVoiceList.tsx
+++ b/src/components/narration/EnhancedVoiceList.tsx
@@ -70,7 +70,7 @@ function ProgressBar({ progress, size }: { progress: number; size: number }) {
           style={{ width: `${percent}%` }}
         />
       </div>
-      <p className="ui-text-xs mt-1 text-zinc-500 dark:text-zinc-400">
+      <p className="ui-text-xs text-subtle mt-1">
         {percent}% ({downloadedMB} MB / {totalMB} MB)
       </p>
     </div>
@@ -134,8 +134,8 @@ function VoiceItem({
         isSelected
           ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
           : isDownloaded
-            ? "cursor-pointer border-zinc-200 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50"
-            : "border-zinc-200 dark:border-zinc-700"
+            ? "border-edge-strong cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+            : "border-edge-strong"
       }`}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
@@ -162,12 +162,8 @@ function VoiceItem({
           {/* Voice info */}
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
-              <span className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                {voice.displayName}
-              </span>
-              <span className="ui-text-xs text-zinc-500 dark:text-zinc-400">
-                - {voice.description}
-              </span>
+              <span className="ui-text-sm text-strong font-medium">{voice.displayName}</span>
+              <span className="ui-text-xs text-subtle">- {voice.description}</span>
             </div>
 
             {/* Status line */}
@@ -185,15 +181,11 @@ function VoiceItem({
                   {errorInfo.message}
                 </div>
                 {errorInfo.suggestion && (
-                  <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
-                    {errorInfo.suggestion}
-                  </p>
+                  <p className="ui-text-xs text-subtle">{errorInfo.suggestion}</p>
                 )}
               </div>
             ) : (
-              <p className="ui-text-xs mt-1 text-zinc-500 dark:text-zinc-400">
-                {formatSize(voice.sizeBytes)}
-              </p>
+              <p className="ui-text-xs text-subtle mt-1">{formatSize(voice.sizeBytes)}</p>
             )}
           </div>
         </div>
@@ -202,7 +194,7 @@ function VoiceItem({
         <div className="flex flex-shrink-0 items-center gap-2">
           {isDownloading ? (
             // Cancel button during download (optional - just showing spinner for now)
-            <div className="ui-text-xs flex items-center gap-2 text-zinc-500 dark:text-zinc-400">
+            <div className="ui-text-xs text-subtle flex items-center gap-2">
               <SpinnerIcon className="h-4 w-4" />
               Downloading...
             </div>
@@ -243,7 +235,7 @@ function VoiceItem({
                   e.stopPropagation();
                   onDelete();
                 }}
-                className="rounded-md p-2 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                className="text-faint rounded-md p-2 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
                 title="Delete voice"
               >
                 <TrashIcon className="h-4 w-4" />
@@ -361,7 +353,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
     return (
       <div className="flex items-center justify-center py-8">
         <SpinnerIcon className="h-6 w-6 text-zinc-400" />
-        <span className="ui-text-sm ml-2 text-zinc-500 dark:text-zinc-400">Loading voices...</span>
+        <span className="ui-text-sm text-subtle ml-2">Loading voices...</span>
       </div>
     );
   }
@@ -431,7 +423,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
       {/* Storage info section */}
       {downloadedCount > 0 && (
         <NoteBox padding="sm" className="flex items-center justify-between">
-          <span className="ui-text-xs text-zinc-600 dark:text-zinc-400">
+          <span className="ui-text-xs text-muted">
             Storage used: {formatStorageSize(storageUsed)} ({downloadedCount}{" "}
             {downloadedCount === 1 ? "voice" : "voices"})
           </span>
@@ -439,7 +431,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
             <button
               type="button"
               onClick={handleDeleteAllVoices}
-              className="ui-text-xs text-zinc-500 underline hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+              className="ui-text-xs text-subtle underline hover:text-zinc-700 dark:hover:text-zinc-200"
             >
               Delete All
             </button>
@@ -448,7 +440,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
       )}
 
       {/* Info text */}
-      <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+      <p className="ui-text-xs text-subtle">
         Enhanced voices run entirely in your browser. Once downloaded, they work offline.
       </p>
     </div>

--- a/src/components/narration/EnhancedVoicesHelp.tsx
+++ b/src/components/narration/EnhancedVoicesHelp.tsx
@@ -69,25 +69,23 @@ function FAQItemComponent({
   onToggle: () => void;
 }) {
   return (
-    <div className="border-b border-zinc-200 last:border-b-0 dark:border-zinc-700">
+    <div className="border-edge-strong border-b last:border-b-0">
       <button
         type="button"
         onClick={onToggle}
         className="flex w-full items-center justify-between py-3 text-left"
         aria-expanded={isOpen}
       >
-        <span className="ui-text-sm font-medium text-zinc-700 dark:text-zinc-300">
-          {item.question}
-        </span>
+        <span className="ui-text-sm text-body font-medium">{item.question}</span>
         <ChevronDownIcon
-          className={`h-4 w-4 flex-shrink-0 text-zinc-500 transition-transform duration-200 dark:text-zinc-400 ${
+          className={`text-subtle h-4 w-4 flex-shrink-0 transition-transform duration-200 ${
             isOpen ? "rotate-180" : ""
           }`}
         />
       </button>
       {isOpen && (
         <div className="pr-8 pb-3">
-          <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">{item.answer}</p>
+          <p className="ui-text-sm text-muted">{item.answer}</p>
         </div>
       )}
     </div>
@@ -123,7 +121,7 @@ export function EnhancedVoicesHelp() {
   };
 
   return (
-    <div className="rounded-lg border border-zinc-200 dark:border-zinc-700">
+    <div className="border-edge-strong rounded-lg border">
       {/* Header button */}
       <button
         type="button"
@@ -132,13 +130,11 @@ export function EnhancedVoicesHelp() {
         aria-expanded={isExpanded}
       >
         <div className="flex items-center gap-2">
-          <QuestionCircleIcon className="h-4 w-4 text-zinc-500 dark:text-zinc-400" />
-          <span className="ui-text-sm font-medium text-zinc-700 dark:text-zinc-300">
-            Help with enhanced voices
-          </span>
+          <QuestionCircleIcon className="text-subtle h-4 w-4" />
+          <span className="ui-text-sm text-body font-medium">Help with enhanced voices</span>
         </div>
         <ChevronDownIcon
-          className={`h-4 w-4 text-zinc-500 transition-transform duration-200 dark:text-zinc-400 ${
+          className={`text-subtle h-4 w-4 transition-transform duration-200 ${
             isExpanded ? "rotate-180" : ""
           }`}
         />
@@ -146,7 +142,7 @@ export function EnhancedVoicesHelp() {
 
       {/* Expandable FAQ content */}
       {isExpanded && (
-        <div className="border-t border-zinc-200 px-4 dark:border-zinc-700">
+        <div className="border-edge-strong border-t px-4">
           {FAQ_ITEMS.map((item, index) => (
             <FAQItemComponent
               key={index}

--- a/src/components/narration/NarrationControls.tsx
+++ b/src/components/narration/NarrationControls.tsx
@@ -196,7 +196,7 @@ export function NarrationControlsImpl({
 
       {/* Paragraph indicator - only show when active */}
       {isActive && totalParagraphs > 0 && (
-        <span className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+        <span className="ui-text-xs text-subtle">
           {currentParagraph + 1} of {totalParagraphs}
         </span>
       )}

--- a/src/components/narration/NarrationSettings.tsx
+++ b/src/components/narration/NarrationSettings.tsx
@@ -180,13 +180,11 @@ export function NarrationSettings() {
     return (
       <SettingsSection title="Narration">
         <div className="flex items-start gap-3">
-          <AlertIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-zinc-400 dark:text-zinc-500" />
+          <AlertIcon className="text-faint mt-0.5 h-5 w-5 flex-shrink-0" />
           <div>
-            <p className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-              Narration Unavailable
-            </p>
-            <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">{supportInfo.reason}</p>
-            <p className="ui-text-xs mt-2 text-zinc-400 dark:text-zinc-500">
+            <p className="ui-text-sm text-strong font-medium">Narration Unavailable</p>
+            <p className="ui-text-sm text-subtle mt-1">{supportInfo.reason}</p>
+            <p className="ui-text-xs text-faint mt-2">
               Try using Chrome, Safari, or Edge for the best narration experience.
             </p>
           </div>
@@ -200,12 +198,8 @@ export function NarrationSettings() {
       {/* Enable/Disable Toggle */}
       <div className="flex items-center justify-between">
         <div>
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
-            Enable narration
-          </h3>
-          <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
-            Listen to articles using text-to-speech.
-          </p>
+          <h3 className="ui-text-sm text-strong font-medium">Enable narration</h3>
+          <p className="ui-text-sm text-subtle mt-1">Listen to articles using text-to-speech.</p>
         </div>
         <button
           type="button"
@@ -218,7 +212,7 @@ export function NarrationSettings() {
         >
           <span
             aria-hidden="true"
-            className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
+            className={`bg-surface pointer-events-none inline-block h-5 w-5 transform rounded-full shadow ring-0 transition duration-200 ease-in-out ${
               settings.enabled ? "translate-x-5" : "translate-x-0"
             }`}
           />
@@ -230,16 +224,14 @@ export function NarrationSettings() {
         <CardSection className="space-y-6">
           {/* Voice Provider Selection */}
           <div>
-            <h3 className="ui-text-sm mb-3 font-medium text-zinc-900 dark:text-zinc-50">
-              Voice Provider
-            </h3>
+            <h3 className="ui-text-sm text-strong mb-3 font-medium">Voice Provider</h3>
             <div className="space-y-3">
               {/* Browser Voices Option */}
               <label
                 className={`relative flex cursor-pointer rounded-lg border p-4 transition-colors ${
                   settings.provider === "browser"
                     ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
-                    : "border-zinc-200 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50"
+                    : "border-edge-strong hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
                 }`}
               >
                 <input
@@ -263,10 +255,8 @@ export function NarrationSettings() {
                     )}
                   </div>
                   <div>
-                    <span className="ui-text-sm block font-medium text-zinc-900 dark:text-zinc-100">
-                      Browser Voices
-                    </span>
-                    <span className="ui-text-xs mt-0.5 block text-zinc-500 dark:text-zinc-400">
+                    <span className="ui-text-sm text-strong block font-medium">Browser Voices</span>
+                    <span className="ui-text-xs text-subtle mt-0.5 block">
                       Uses your browser&apos;s built-in text-to-speech
                     </span>
                   </div>
@@ -278,7 +268,7 @@ export function NarrationSettings() {
                 className={`relative flex cursor-pointer rounded-lg border p-4 transition-colors ${
                   settings.provider === "piper"
                     ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
-                    : "border-zinc-200 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50"
+                    : "border-edge-strong hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
                 }`}
               >
                 <input
@@ -302,10 +292,10 @@ export function NarrationSettings() {
                     )}
                   </div>
                   <div>
-                    <span className="ui-text-sm block font-medium text-zinc-900 dark:text-zinc-100">
+                    <span className="ui-text-sm text-strong block font-medium">
                       Enhanced Voices
                     </span>
-                    <span className="ui-text-xs mt-0.5 block text-zinc-500 dark:text-zinc-400">
+                    <span className="ui-text-xs text-subtle mt-0.5 block">
                       Higher quality voices (requires download)
                     </span>
                   </div>
@@ -319,7 +309,7 @@ export function NarrationSettings() {
             <div>
               <label
                 htmlFor="narration-voice"
-                className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
+                className="ui-text-sm text-body mb-1.5 block font-medium"
               >
                 Voice
               </label>
@@ -329,7 +319,7 @@ export function NarrationSettings() {
                   value={settings.voiceId || ""}
                   onChange={handleVoiceChange}
                   disabled={isLoadingVoices}
-                  className="ui-text-sm block flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+                  className="ui-text-sm bg-surface text-strong block flex-1 rounded-md border border-zinc-300 px-3 py-2 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
                 >
                   {isLoadingVoices ? (
                     <option value="">Loading voices...</option>
@@ -356,7 +346,7 @@ export function NarrationSettings() {
                   {isPreviewing ? "Stop" : "Preview"}
                 </Button>
               </div>
-              <p className="ui-text-xs mt-1.5 text-zinc-500 dark:text-zinc-400">
+              <p className="ui-text-xs text-subtle mt-1.5">
                 Voices are provided by your browser. Chrome and Safari typically offer higher
                 quality voices.
               </p>
@@ -367,9 +357,7 @@ export function NarrationSettings() {
           {settings.provider === "piper" && (
             <div className="space-y-4">
               <div>
-                <label className="ui-text-sm mb-3 block font-medium text-zinc-700 dark:text-zinc-300">
-                  Select Voice
-                </label>
+                <label className="ui-text-sm text-body mb-3 block font-medium">Select Voice</label>
                 <EnhancedVoiceList settings={settings} setSettings={setSettings} />
               </div>
               <EnhancedVoicesHelp />
@@ -380,7 +368,7 @@ export function NarrationSettings() {
           <div>
             <label
               htmlFor="narration-rate"
-              className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
+              className="ui-text-sm text-body mb-1.5 block font-medium"
             >
               Speed: {settings.rate.toFixed(1)}x
             </label>
@@ -394,7 +382,7 @@ export function NarrationSettings() {
               onChange={handleRateChange}
               className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-zinc-200 accent-zinc-900 dark:bg-zinc-700 dark:accent-zinc-400"
             />
-            <div className="ui-text-xs mt-1 flex justify-between text-zinc-400 dark:text-zinc-500">
+            <div className="ui-text-xs text-faint mt-1 flex justify-between">
               <span>0.5x</span>
               <span>1.0x</span>
               <span>1.5x</span>
@@ -407,7 +395,7 @@ export function NarrationSettings() {
             <div>
               <label
                 htmlFor="narration-pitch"
-                className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
+                className="ui-text-sm text-body mb-1.5 block font-medium"
               >
                 Pitch: {settings.pitch.toFixed(1)}x
               </label>
@@ -421,7 +409,7 @@ export function NarrationSettings() {
                 onChange={handlePitchChange}
                 className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-zinc-200 accent-zinc-900 dark:bg-zinc-700 dark:accent-zinc-400"
               />
-              <div className="ui-text-xs mt-1 flex justify-between text-zinc-400 dark:text-zinc-500">
+              <div className="ui-text-xs text-faint mt-1 flex justify-between">
                 <span>0.5x</span>
                 <span>1.0x</span>
                 <span>1.5x</span>
@@ -433,15 +421,13 @@ export function NarrationSettings() {
           {/* Processing Settings - only shown if AI text processing is available */}
           {isAiTextProcessingAvailable && (
             <div className="space-y-4">
-              <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">Processing</h3>
+              <h3 className="ui-text-sm text-strong font-medium">Processing</h3>
 
               {/* LLM Normalization Toggle */}
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="ui-text-sm text-zinc-700 dark:text-zinc-300">
-                    Use AI text processing
-                  </p>
-                  <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+                  <p className="ui-text-sm text-body">Use AI text processing</p>
+                  <p className="ui-text-xs text-subtle">
                     Improves narration quality by expanding abbreviations and formatting content
                   </p>
                 </div>
@@ -463,7 +449,7 @@ export function NarrationSettings() {
                 >
                   <span
                     aria-hidden="true"
-                    className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
+                    className={`bg-surface pointer-events-none inline-block h-5 w-5 transform rounded-full shadow ring-0 transition duration-200 ease-in-out ${
                       settings.useLlmNormalization ? "translate-x-5" : "translate-x-0"
                     }`}
                   />
@@ -474,15 +460,13 @@ export function NarrationSettings() {
 
           {/* Highlighting Settings */}
           <div className="space-y-4">
-            <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">Highlighting</h3>
+            <h3 className="ui-text-sm text-strong font-medium">Highlighting</h3>
 
             {/* Highlight Current Paragraph Toggle */}
             <div className="flex items-center justify-between">
               <div>
-                <p className="ui-text-sm text-zinc-700 dark:text-zinc-300">
-                  Highlight current paragraph
-                </p>
-                <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+                <p className="ui-text-sm text-body">Highlight current paragraph</p>
+                <p className="ui-text-xs text-subtle">
                   Visually highlight the paragraph being read
                 </p>
               </div>
@@ -499,7 +483,7 @@ export function NarrationSettings() {
               >
                 <span
                   aria-hidden="true"
-                  className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
+                  className={`bg-surface pointer-events-none inline-block h-5 w-5 transform rounded-full shadow ring-0 transition duration-200 ease-in-out ${
                     settings.highlightEnabled ? "translate-x-5" : "translate-x-0"
                   }`}
                 />
@@ -509,10 +493,8 @@ export function NarrationSettings() {
             {/* Auto-scroll to Current Paragraph Toggle */}
             <div className="flex items-center justify-between">
               <div>
-                <p className="ui-text-sm text-zinc-700 dark:text-zinc-300">
-                  Auto-scroll to current paragraph
-                </p>
-                <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+                <p className="ui-text-sm text-body">Auto-scroll to current paragraph</p>
+                <p className="ui-text-xs text-subtle">
                   Automatically scroll the page to keep the current paragraph visible
                 </p>
               </div>
@@ -529,7 +511,7 @@ export function NarrationSettings() {
               >
                 <span
                   aria-hidden="true"
-                  className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
+                  className={`bg-surface pointer-events-none inline-block h-5 w-5 transform rounded-full shadow ring-0 transition duration-200 ease-in-out ${
                     settings.autoScrollEnabled ? "translate-x-5" : "translate-x-0"
                   }`}
                 />
@@ -553,7 +535,7 @@ export function NarrationSettings() {
       {/* Media Session Info */}
       {settings.enabled && supportInfo.mediaSession && (
         <CardSection>
-          <div className="ui-text-xs flex items-start gap-2 text-zinc-500 dark:text-zinc-400">
+          <div className="ui-text-xs text-subtle flex items-start gap-2">
             <InfoCircleIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
             <span>
               Your browser supports media controls. You can control playback using your keyboard

--- a/src/components/narration/index.tsx
+++ b/src/components/narration/index.tsx
@@ -14,7 +14,7 @@ import dynamic from "next/dynamic";
 
 function NarrationControlsSkeleton() {
   return (
-    <div className="min-h-[36px] w-[88px] animate-pulse rounded-lg bg-zinc-100 sm:min-h-[32px] dark:bg-zinc-800" />
+    <div className="bg-surface-muted min-h-[36px] w-[88px] animate-pulse rounded-lg sm:min-h-[32px]" />
   );
 }
 

--- a/src/components/saved/FileUploadButton.tsx
+++ b/src/components/saved/FileUploadButton.tsx
@@ -177,7 +177,7 @@ export function FileUploadButton({ className = "", onSuccess }: FileUploadButton
       <button
         type="button"
         onClick={handleOpen}
-        className={`ui-text-sm inline-flex min-h-[40px] items-center gap-1.5 rounded-md border border-zinc-200 bg-white px-3 font-medium text-zinc-700 transition-colors hover:bg-zinc-50 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none active:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400 dark:active:bg-zinc-700 ${className}`}
+        className={`ui-text-sm border-edge-strong bg-surface text-body inline-flex min-h-[40px] items-center gap-1.5 rounded-md border px-3 font-medium transition-colors hover:bg-zinc-50 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none active:bg-zinc-100 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400 dark:active:bg-zinc-700 ${className}`}
         title="Upload file"
         aria-label="Upload file"
       >
@@ -210,7 +210,7 @@ export function FileUploadButton({ className = "", onSuccess }: FileUploadButton
             onClick={handleBrowseClick}
             className={`cursor-pointer rounded-lg border-2 border-dashed p-8 text-center transition-colors ${
               isDragging
-                ? "border-zinc-500 bg-zinc-100 dark:border-zinc-400 dark:bg-zinc-800"
+                ? "bg-surface-muted border-zinc-500 dark:border-zinc-400"
                 : selectedFile
                   ? "border-green-500 bg-green-50 dark:border-green-600 dark:bg-green-900/20"
                   : "border-zinc-300 hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-600 dark:hover:border-zinc-500 dark:hover:bg-zinc-800"
@@ -227,25 +227,17 @@ export function FileUploadButton({ className = "", onSuccess }: FileUploadButton
             {selectedFile ? (
               <div className="flex flex-col items-center">
                 <DocumentIcon className="h-10 w-10 text-green-600 dark:text-green-500" />
-                <p className="mt-2 font-medium text-zinc-900 dark:text-zinc-50">
-                  {selectedFile.name}
-                </p>
-                <p className="ui-text-sm text-zinc-500 dark:text-zinc-400">
-                  {formatFileSize(selectedFile.size)}
-                </p>
-                <p className="ui-text-xs mt-2 text-zinc-400 dark:text-zinc-500">
+                <p className="text-strong mt-2 font-medium">{selectedFile.name}</p>
+                <p className="ui-text-sm text-subtle">{formatFileSize(selectedFile.size)}</p>
+                <p className="ui-text-xs text-faint mt-2">
                   Click or drop a different file to replace
                 </p>
               </div>
             ) : (
               <div className="flex flex-col items-center">
-                <UploadIcon className="h-10 w-10 text-zinc-400 dark:text-zinc-500" />
-                <p className="mt-2 font-medium text-zinc-900 dark:text-zinc-50">
-                  Drop file here or click to browse
-                </p>
-                <p className="ui-text-sm text-zinc-500 dark:text-zinc-400">
-                  .docx, .html, .md up to 10MB
-                </p>
+                <UploadIcon className="text-faint h-10 w-10" />
+                <p className="text-strong mt-2 font-medium">Drop file here or click to browse</p>
+                <p className="ui-text-sm text-subtle">.docx, .html, .md up to 10MB</p>
               </div>
             )}
           </div>

--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -9,13 +9,13 @@ import { SettingsSection } from "@/components/settings/SettingsSection";
 export function AboutSection() {
   return (
     <SettingsSection title="About">
-      <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+      <p className="ui-text-sm text-muted">
         Lion Reader was created by{" "}
         <a
           href="https://www.brendanlong.com"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-zinc-900 hover:underline dark:text-zinc-50"
+          className="text-strong hover:underline"
         >
           Brendan Long
         </a>{" "}
@@ -24,19 +24,19 @@ export function AboutSection() {
           href="https://www.brendanlong.com/claude-wrote-me-a-400-commit-rss-reader-app.html"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-zinc-900 hover:underline dark:text-zinc-50"
+          className="text-strong hover:underline"
         >
           Claude
         </a>
         .
       </p>
-      <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">
+      <p className="ui-text-sm text-muted mt-2">
         View the source code on{" "}
         <a
           href="https://github.com/brendanlong/lion-reader"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-zinc-900 hover:underline dark:text-zinc-50"
+          className="text-strong hover:underline"
         >
           GitHub
         </a>

--- a/src/components/settings/ApiKeySettings.tsx
+++ b/src/components/settings/ApiKeySettings.tsx
@@ -85,7 +85,7 @@ export function GroqApiKeySettings() {
       }
     >
       {preferencesQuery.isLoading ? (
-        <div className="h-10 w-full animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+        <div className="bg-surface-muted h-10 w-full animate-pulse rounded" />
       ) : isEditing ? (
         <div className="space-y-3">
           <Input
@@ -314,7 +314,7 @@ export function SummarizationApiKeySettings() {
       }
     >
       {preferencesQuery.isLoading ? (
-        <div className="h-10 w-full animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+        <div className="bg-surface-muted h-10 w-full animate-pulse rounded" />
       ) : (
         <div className="space-y-4">
           {/* API Key */}
@@ -381,7 +381,7 @@ export function SummarizationApiKeySettings() {
           <div>
             <label
               htmlFor="summarization-model"
-              className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
+              className="ui-text-sm text-body mb-1.5 block font-medium"
             >
               Model
             </label>
@@ -390,7 +390,7 @@ export function SummarizationApiKeySettings() {
               value={currentModel ?? defaultModelId}
               onChange={handleModelChange}
               disabled={updatePreferences.isPending || modelsQuery.isLoading}
-              className="ui-text-sm block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+              className="ui-text-sm bg-surface text-strong block w-full rounded-md border border-zinc-300 px-3 py-2 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
             >
               {modelsQuery.isLoading ? (
                 <option value={currentModel ?? defaultModelId}>Loading models...</option>
@@ -412,7 +412,7 @@ export function SummarizationApiKeySettings() {
                   <option value={currentModel}>{currentModel}</option>
                 )}
             </select>
-            <p className="ui-text-xs mt-1.5 text-zinc-500 dark:text-zinc-400">
+            <p className="ui-text-xs text-subtle mt-1.5">
               Choose the Anthropic model used for generating article summaries. Sonnet models offer
               the best balance of quality and cost.
             </p>
@@ -422,7 +422,7 @@ export function SummarizationApiKeySettings() {
           <div>
             <label
               htmlFor="summarization-max-words"
-              className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
+              className="ui-text-sm text-body mb-1.5 block font-medium"
             >
               Max words
             </label>
@@ -460,7 +460,7 @@ export function SummarizationApiKeySettings() {
               </div>
             ) : (
               <div className="flex items-center gap-3">
-                <span className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+                <span className="ui-text-sm text-muted">
                   {currentMaxWords ?? `${DEFAULT_SUMMARIZATION_MAX_WORDS} (default)`}
                 </span>
                 <Button
@@ -485,7 +485,7 @@ export function SummarizationApiKeySettings() {
                 )}
               </div>
             )}
-            <p className="ui-text-xs mt-1.5 text-zinc-500 dark:text-zinc-400">
+            <p className="ui-text-xs text-subtle mt-1.5">
               Maximum number of words for generated summaries.
             </p>
           </div>
@@ -494,7 +494,7 @@ export function SummarizationApiKeySettings() {
           <div>
             <label
               htmlFor="summarization-prompt"
-              className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
+              className="ui-text-sm text-body mb-1.5 block font-medium"
             >
               Custom prompt
             </label>
@@ -507,9 +507,9 @@ export function SummarizationApiKeySettings() {
                   value={promptInput}
                   onChange={(e) => setPromptInput(e.target.value)}
                   disabled={updatePreferences.isPending}
-                  className="ui-text-sm block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+                  className="ui-text-sm bg-surface text-strong block w-full rounded-md border border-zinc-300 px-3 py-2 font-mono focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
                 />
-                <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+                <p className="ui-text-xs text-subtle">
                   Available template variables: <InlineCode>{"{{content}}"}</InlineCode>,{" "}
                   <InlineCode>{"{{title}}"}</InlineCode>, <InlineCode>{"{{maxWords}}"}</InlineCode>.
                   The response should be wrapped in <InlineCode>{"<summary>"}</InlineCode> tags.
@@ -536,7 +536,7 @@ export function SummarizationApiKeySettings() {
               </div>
             ) : (
               <div className="flex items-center gap-3">
-                <span className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+                <span className="ui-text-sm text-muted">
                   {currentPrompt ? "Custom prompt configured" : "Using default prompt"}
                 </span>
                 <Button
@@ -561,7 +561,7 @@ export function SummarizationApiKeySettings() {
                 )}
               </div>
             )}
-            <p className="ui-text-xs mt-1.5 text-zinc-500 dark:text-zinc-400">
+            <p className="ui-text-xs text-subtle mt-1.5">
               Override the default prompt sent to the AI model when generating summaries.
             </p>
           </div>

--- a/src/components/settings/AppearanceSettings.tsx
+++ b/src/components/settings/AppearanceSettings.tsx
@@ -30,7 +30,7 @@ function OptionButton<T extends string>({ selected, onClick, children }: OptionB
       className={`ui-text-sm rounded-md px-4 py-2 font-medium transition-colors ${
         selected
           ? "bg-primary-solid text-primary-solid-foreground"
-          : "bg-zinc-100 text-zinc-700 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+          : "bg-surface-muted text-body hover:bg-zinc-200 dark:hover:bg-zinc-700"
       }`}
     >
       {children}
@@ -55,9 +55,7 @@ function OptionGroup<T extends string>({
 }: OptionGroupProps<T>) {
   return (
     <div>
-      <label className="ui-text-sm block font-medium text-zinc-900 dark:text-zinc-50">
-        {label}
-      </label>
+      <label className="ui-text-sm text-strong block font-medium">{label}</label>
       <div className="mt-2 flex flex-wrap gap-2">
         {options.map((option) => (
           <OptionButton
@@ -70,9 +68,7 @@ function OptionGroup<T extends string>({
           </OptionButton>
         ))}
       </div>
-      {description && (
-        <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">{description}</p>
-      )}
+      {description && <p className="ui-text-sm text-subtle mt-1">{description}</p>}
     </div>
   );
 }
@@ -112,11 +108,9 @@ function TextPreview() {
   const { style } = useEntryTextStyles();
 
   return (
-    <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
-      <p className="ui-text-xs mb-2 font-medium tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-        Preview
-      </p>
-      <p className="text-zinc-700 dark:text-zinc-300" style={style}>
+    <div className="border-edge-strong rounded-lg border bg-white p-4 dark:bg-zinc-800">
+      <p className="ui-text-xs text-subtle mb-2 font-medium tracking-wide uppercase">Preview</p>
+      <p className="text-body" style={style}>
         The quick brown fox jumps over the lazy dog. This sample text demonstrates how your articles
         will appear with the current settings. Adjusting the text size, font, and justification can
         help improve readability based on your preferences.

--- a/src/components/settings/BookmarkletSettings.tsx
+++ b/src/components/settings/BookmarkletSettings.tsx
@@ -52,10 +52,8 @@ export function BookmarkletSettings() {
     >
       {/* Browser Extensions */}
       <div className="mt-6">
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-          Browser Extensions
-        </h3>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+        <h3 className="ui-text-sm text-strong font-medium">Browser Extensions</h3>
+        <p className="ui-text-sm text-muted mt-1">
           The easiest way to save articles from your browser.
         </p>
         <div className="mt-3 flex flex-wrap gap-3">
@@ -82,19 +80,15 @@ export function BookmarkletSettings() {
 
       {/* Bookmarklet Section */}
       <CardSection>
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-          Bookmarklet (Other Browsers)
-        </h3>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+        <h3 className="ui-text-sm text-strong font-medium">Bookmarklet (Other Browsers)</h3>
+        <p className="ui-text-sm text-muted mt-1">
           For Safari and other browsers, use the bookmarklet.
         </p>
       </CardSection>
 
       {/* Draggable Bookmarklet Link */}
       <div className="mt-4">
-        <p className="ui-text-sm mb-3 text-zinc-700 dark:text-zinc-300">
-          Drag this button to your bookmarks bar:
-        </p>
+        <p className="ui-text-sm text-body mb-3">Drag this button to your bookmarks bar:</p>
         <a
           ref={bookmarkletRef}
           href="#"
@@ -109,16 +103,11 @@ export function BookmarkletSettings() {
 
       {/* Installation Instructions */}
       <NoteBox className="mt-6">
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-          Installation Instructions
-        </h3>
-        <ol className="ui-text-sm mt-2 list-inside list-decimal space-y-2 text-zinc-600 dark:text-zinc-400">
+        <h3 className="ui-text-sm text-strong font-medium">Installation Instructions</h3>
+        <ol className="ui-text-sm text-muted mt-2 list-inside list-decimal space-y-2">
           <li>Make sure your browser&apos;s bookmarks bar is visible</li>
           <li>
-            Drag the{" "}
-            <strong className="text-zinc-900 dark:text-zinc-200">
-              &quot;Save to Lion Reader&quot;
-            </strong>{" "}
+            Drag the <strong className="text-emphasis">&quot;Save to Lion Reader&quot;</strong>{" "}
             button above to your bookmarks bar
           </li>
           <li>
@@ -133,7 +122,7 @@ export function BookmarkletSettings() {
         <button
           type="button"
           onClick={() => setShowCode(!showCode)}
-          className="ui-text-sm inline-flex items-center gap-2 font-medium text-zinc-700 transition-colors hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-50"
+          className="ui-text-sm text-body inline-flex items-center gap-2 font-medium transition-colors hover:text-zinc-900 dark:hover:text-zinc-50"
         >
           <ChevronRightIcon
             className={`h-4 w-4 transition-transform ${showCode ? "rotate-90" : ""}`}
@@ -143,11 +132,11 @@ export function BookmarkletSettings() {
 
         {showCode && (
           <div className="mt-4">
-            <p className="ui-text-sm mb-2 text-zinc-500 dark:text-zinc-400">
+            <p className="ui-text-sm text-subtle mb-2">
               If you prefer, you can manually create a bookmark with this JavaScript code:
             </p>
             <div className="relative">
-              <pre className="ui-text-xs overflow-x-auto rounded-md border border-zinc-200 bg-zinc-100 p-3 font-mono text-zinc-800 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
+              <pre className="ui-text-xs border-edge-strong bg-surface-muted text-emphasis overflow-x-auto rounded-md border p-3 font-mono">
                 <code className="break-all whitespace-pre-wrap">{bookmarkletHref}</code>
               </pre>
               <button
@@ -165,11 +154,7 @@ export function BookmarkletSettings() {
       </CardSection>
 
       {/* Note about app URL */}
-      {appUrl && (
-        <p className="ui-text-xs mt-4 text-zinc-400 dark:text-zinc-500">
-          Bookmarklet configured for: {appUrl}
-        </p>
-      )}
+      {appUrl && <p className="ui-text-xs text-faint mt-4">Bookmarklet configured for: {appUrl}</p>}
     </SettingsSection>
   );
 }

--- a/src/components/settings/DiscordBotSettings.tsx
+++ b/src/components/settings/DiscordBotSettings.tsx
@@ -67,10 +67,8 @@ export function DiscordBotSettings() {
     >
       {/* Invite Button */}
       <div className="mt-6">
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">
-          Add Bot to Server
-        </h3>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+        <h3 className="ui-text-sm text-strong font-medium">Add Bot to Server</h3>
+        <p className="ui-text-sm text-muted mt-1">
           Invite the Lion Reader bot to your Discord server to enable saving articles.
         </p>
         <div className="mt-3 flex flex-wrap gap-3">
@@ -87,7 +85,7 @@ export function DiscordBotSettings() {
           <button
             type="button"
             onClick={copyInviteUrl}
-            className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 font-medium text-zinc-700 shadow-sm transition-all hover:border-zinc-400 hover:bg-zinc-50 hover:shadow dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:bg-zinc-700"
+            className="ui-text-sm text-body inline-flex items-center gap-2 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 font-medium shadow-sm transition-all hover:border-zinc-400 hover:bg-zinc-50 hover:shadow dark:border-zinc-600 dark:bg-zinc-800 dark:hover:border-zinc-500 dark:hover:bg-zinc-700"
           >
             {copied ? "Copied!" : "Copy Link"}
           </button>
@@ -96,14 +94,14 @@ export function DiscordBotSettings() {
 
       {/* Usage Instructions */}
       <CardSection>
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">How to Use</h3>
-        <ol className="ui-text-sm mt-2 list-inside list-decimal space-y-2 text-zinc-600 dark:text-zinc-400">
+        <h3 className="ui-text-sm text-strong font-medium">How to Use</h3>
+        <ol className="ui-text-sm text-muted mt-2 list-inside list-decimal space-y-2">
           <li>
-            <strong className="text-zinc-900 dark:text-zinc-200">Link your account</strong> - Sign
-            in to Lion Reader with Discord, or use <InlineCode>/link</InlineCode> with an API token
+            <strong className="text-emphasis">Link your account</strong> - Sign in to Lion Reader
+            with Discord, or use <InlineCode>/link</InlineCode> with an API token
           </li>
           <li>
-            <strong className="text-zinc-900 dark:text-zinc-200">React to messages</strong> -{" "}
+            <strong className="text-emphasis">React to messages</strong> -{" "}
             {emoji ? (
               <>
                 React with{" "}
@@ -119,7 +117,7 @@ export function DiscordBotSettings() {
             )}
           </li>
           <li>
-            <strong className="text-zinc-900 dark:text-zinc-200">Look for the reaction</strong> -{" "}
+            <strong className="text-emphasis">Look for the reaction</strong> -{" "}
             {successEmoji ? (
               <>
                 The bot will react with{" "}
@@ -147,26 +145,26 @@ export function DiscordBotSettings() {
             )}
           </li>
           <li>
-            <strong className="text-zinc-900 dark:text-zinc-200">Check your Saved</strong> - The
-            article will appear in your Saved section
+            <strong className="text-emphasis">Check your Saved</strong> - The article will appear in
+            your Saved section
           </li>
         </ol>
       </CardSection>
 
       {/* Bot Commands */}
       <NoteBox className="mt-6">
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Bot Commands</h3>
-        <dl className="ui-text-sm mt-2 space-y-2 text-zinc-600 dark:text-zinc-400">
+        <h3 className="ui-text-sm text-strong font-medium">Bot Commands</h3>
+        <dl className="ui-text-sm text-muted mt-2 space-y-2">
           <div>
-            <dt className="inline font-mono text-zinc-800 dark:text-zinc-200">/status</dt>
+            <dt className="text-emphasis inline font-mono">/status</dt>
             <dd className="ml-2 inline">- Check if your Discord account is linked</dd>
           </div>
           <div>
-            <dt className="inline font-mono text-zinc-800 dark:text-zinc-200">/link [token]</dt>
+            <dt className="text-emphasis inline font-mono">/link [token]</dt>
             <dd className="ml-2 inline">- Link your account using an API token</dd>
           </div>
           <div>
-            <dt className="inline font-mono text-zinc-800 dark:text-zinc-200">/unlink</dt>
+            <dt className="text-emphasis inline font-mono">/unlink</dt>
             <dd className="ml-2 inline">- Remove your linked API token</dd>
           </div>
         </dl>

--- a/src/components/settings/GoogleReaderApiSettings.tsx
+++ b/src/components/settings/GoogleReaderApiSettings.tsx
@@ -40,11 +40,11 @@ export function GoogleReaderApiSettings() {
     >
       {/* Supported Clients */}
       <div className="mt-6">
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Compatible Apps</h3>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+        <h3 className="ui-text-sm text-strong font-medium">Compatible Apps</h3>
+        <p className="ui-text-sm text-muted mt-1">
           Any app that supports the Google Reader API should work, including:
         </p>
-        <ul className="ui-text-sm mt-2 list-inside list-disc space-y-1 text-zinc-600 dark:text-zinc-400">
+        <ul className="ui-text-sm text-muted mt-2 list-inside list-disc space-y-1">
           <li>
             <TextLink href="https://reederapp.com/classic/" external>
               Reeder Classic
@@ -83,14 +83,14 @@ export function GoogleReaderApiSettings() {
 
       {/* Setup Instructions */}
       <CardSection>
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Setup</h3>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+        <h3 className="ui-text-sm text-strong font-medium">Setup</h3>
+        <p className="ui-text-sm text-muted mt-1">
           In your app&apos;s account settings, choose &ldquo;FreshRSS&rdquo; as the service type,
           then enter:
         </p>
-        <ul className="ui-text-sm mt-3 space-y-2 text-zinc-600 dark:text-zinc-400">
+        <ul className="ui-text-sm text-muted mt-3 space-y-2">
           <li>
-            <strong className="text-zinc-900 dark:text-zinc-200">Server URL:</strong>{" "}
+            <strong className="text-emphasis">Server URL:</strong>{" "}
             <InlineCode>{baseUrl}/api/greader.php</InlineCode>
             <CopyButton
               value={`${baseUrl}/api/greader.php`}
@@ -99,28 +99,24 @@ export function GoogleReaderApiSettings() {
             />
           </li>
           <li>
-            <strong className="text-zinc-900 dark:text-zinc-200">Email:</strong> Your Lion Reader
-            email address
+            <strong className="text-emphasis">Email:</strong> Your Lion Reader email address
           </li>
           <li>
-            <strong className="text-zinc-900 dark:text-zinc-200">Password:</strong> Your Lion Reader
-            password
+            <strong className="text-emphasis">Password:</strong> Your Lion Reader password
           </li>
         </ul>
       </CardSection>
 
       {/* Note */}
       <NoteBox className="mt-6">
-        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+        <p className="ui-text-sm text-muted">
           The API uses your regular Lion Reader credentials for authentication. All your
           subscriptions, tags, read state, and starred articles sync automatically.
         </p>
       </NoteBox>
 
       {/* API base URL note */}
-      {baseUrl && (
-        <p className="ui-text-xs mt-4 text-zinc-400 dark:text-zinc-500">API endpoint: {apiBase}</p>
-      )}
+      {baseUrl && <p className="ui-text-xs text-faint mt-4">API endpoint: {apiBase}</p>}
     </SettingsSection>
   );
 }

--- a/src/components/settings/IntegrationsSettings.tsx
+++ b/src/components/settings/IntegrationsSettings.tsx
@@ -58,16 +58,14 @@ export function IntegrationsSettings() {
     >
       {/* Claude Code */}
       <div className="mt-6">
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Claude Code</h3>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
-          Run this command in your terminal:
-        </p>
+        <h3 className="ui-text-sm text-strong font-medium">Claude Code</h3>
+        <p className="ui-text-sm text-muted mt-1">Run this command in your terminal:</p>
         <CodeBlock code={claudeCodeCommand} className="mt-3" />
       </div>
 
       {/* Claude.ai */}
       <CardSection>
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Claude.ai</h3>
+        <h3 className="ui-text-sm text-strong font-medium">Claude.ai</h3>
         <div className="mt-2">
           <Alert variant="warning">
             The claude.ai <strong>web</strong> connector is currently broken due to a bug on
@@ -83,17 +81,17 @@ export function IntegrationsSettings() {
             . The MCP server should work with other tools, including Claude Code.
           </Alert>
         </div>
-        <ol className="ui-text-sm mt-2 list-inside list-decimal space-y-2 text-zinc-600 dark:text-zinc-400">
+        <ol className="ui-text-sm text-muted mt-2 list-inside list-decimal space-y-2">
           <li>Click your name in the bottom-left corner</li>
           <li>
-            Go to <strong className="text-zinc-900 dark:text-zinc-200">Settings</strong> &rarr;{" "}
-            <strong className="text-zinc-900 dark:text-zinc-200">Connectors</strong>
+            Go to <strong className="text-emphasis">Settings</strong> &rarr;{" "}
+            <strong className="text-emphasis">Connectors</strong>
           </li>
           <li>
-            Click <strong className="text-zinc-900 dark:text-zinc-200">Add Custom Connector</strong>
+            Click <strong className="text-emphasis">Add Custom Connector</strong>
           </li>
           <li>
-            Enter Name: <strong className="text-zinc-900 dark:text-zinc-200">Lion Reader</strong>
+            Enter Name: <strong className="text-emphasis">Lion Reader</strong>
           </li>
           <li>
             Enter Remote MCP server URL: <InlineCode>{mcpUrl}</InlineCode>
@@ -104,17 +102,15 @@ export function IntegrationsSettings() {
 
       {/* Claude Desktop */}
       <CardSection>
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Claude Desktop</h3>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+        <h3 className="ui-text-sm text-strong font-medium">Claude Desktop</h3>
+        <p className="ui-text-sm text-muted mt-1">
           Add this to your <InlineCode>claude_desktop_config.json</InlineCode>:
         </p>
         <CodeBlock code={claudeDesktopConfig} className="mt-3" />
       </CardSection>
 
       {/* Note about MCP URL */}
-      {baseUrl && (
-        <p className="ui-text-xs mt-4 text-zinc-400 dark:text-zinc-500">MCP server URL: {mcpUrl}</p>
-      )}
+      {baseUrl && <p className="ui-text-xs text-faint mt-4">MCP server URL: {mcpUrl}</p>}
     </SettingsSection>
   );
 }

--- a/src/components/settings/KeyboardShortcutsSettings.tsx
+++ b/src/components/settings/KeyboardShortcutsSettings.tsx
@@ -21,10 +21,8 @@ export function KeyboardShortcutsSettings() {
       {/* Enable/Disable Toggle */}
       <div className="flex items-center justify-between">
         <div>
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
-            Enable keyboard shortcuts
-          </h3>
-          <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+          <h3 className="ui-text-sm text-strong font-medium">Enable keyboard shortcuts</h3>
+          <p className="ui-text-sm text-subtle mt-1">
             Use keyboard shortcuts to navigate entries and perform actions quickly.
           </p>
         </div>
@@ -39,7 +37,7 @@ export function KeyboardShortcutsSettings() {
         >
           <span
             aria-hidden="true"
-            className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
+            className={`bg-surface pointer-events-none inline-block h-5 w-5 transform rounded-full shadow ring-0 transition duration-200 ease-in-out ${
               enabled ? "translate-x-5" : "translate-x-0"
             }`}
           />
@@ -50,7 +48,7 @@ export function KeyboardShortcutsSettings() {
       <CardSection>
         <button
           onClick={openShortcutsModal}
-          className="ui-text-sm inline-flex items-center gap-2 font-medium text-zinc-700 transition-colors hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-50"
+          className="ui-text-sm text-body inline-flex items-center gap-2 font-medium transition-colors hover:text-zinc-900 dark:hover:text-zinc-50"
         >
           <InfoCircleIcon className="h-4 w-4" />
           View all keyboard shortcuts

--- a/src/components/settings/LinkedAccounts.tsx
+++ b/src/components/settings/LinkedAccounts.tsx
@@ -189,14 +189,14 @@ export function LinkedAccounts() {
 
         {/* Show message if no providers available */}
         {enabledProviders.length === 0 && linkedAccounts.length === 0 && (
-          <p className="ui-text-sm text-zinc-500 dark:text-zinc-400">
+          <p className="ui-text-sm text-subtle">
             No OAuth providers are configured on this server.
           </p>
         )}
       </div>
 
       {!hasPassword && linkedAccounts.length > 0 && (
-        <p className="ui-text-xs mt-4 text-zinc-500 dark:text-zinc-400">
+        <p className="ui-text-xs text-subtle mt-4">
           Tip: Add a password to your account so you can unlink OAuth providers if needed.
         </p>
       )}
@@ -228,8 +228,8 @@ function LinkedAccountItem({ account, canUnlink, isUnlinking, onUnlink }: Linked
       <div className="flex items-center gap-3">
         <ProviderIcon provider={account.provider} />
         <div>
-          <p className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">{name}</p>
-          <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">Linked on {linkedDate}</p>
+          <p className="ui-text-sm text-strong font-medium">{name}</p>
+          <p className="ui-text-xs text-subtle">Linked on {linkedDate}</p>
         </div>
       </div>
       <Button
@@ -264,7 +264,7 @@ function LinkableProviderItem({ provider, isLinking, onLink }: LinkableProviderI
       <div className="flex items-center gap-3">
         <ProviderIcon provider={provider} muted />
         <div>
-          <p className="ui-text-sm font-medium text-zinc-600 dark:text-zinc-400">{name}</p>
+          <p className="ui-text-sm text-muted font-medium">{name}</p>
           <p className="ui-text-xs text-zinc-500 dark:text-zinc-500">Not connected</p>
         </div>
       </div>

--- a/src/components/settings/OpmlImportExport.tsx
+++ b/src/components/settings/OpmlImportExport.tsx
@@ -254,10 +254,8 @@ function ImportSection() {
 
   return (
     <Card>
-      <h3 className="ui-text-sm mb-2 font-medium text-zinc-900 dark:text-zinc-50">
-        Import from OPML
-      </h3>
-      <p className="ui-text-sm mb-4 text-zinc-500 dark:text-zinc-400">
+      <h3 className="ui-text-sm text-strong mb-2 font-medium">Import from OPML</h3>
+      <p className="ui-text-sm text-subtle mb-4">
         Import your feed subscriptions from another RSS reader by uploading an OPML file.
       </p>
 
@@ -284,8 +282,8 @@ function ImportSection() {
             className="absolute inset-0 cursor-pointer opacity-0"
           />
           <div className="pointer-events-none">
-            <UploadIcon className="mx-auto h-12 w-12 text-zinc-400 dark:text-zinc-500" />
-            <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">
+            <UploadIcon className="text-faint mx-auto h-12 w-12" />
+            <p className="ui-text-sm text-muted mt-2">
               Drag and drop your OPML file here, or{" "}
               <span className="text-accent font-medium">browse</span>
             </p>
@@ -299,9 +297,7 @@ function ImportSection() {
       {importState.type === "parsing" && (
         <div className="flex items-center justify-center py-8">
           <SpinnerIcon className="h-6 w-6 text-zinc-400" />
-          <span className="ui-text-sm ml-2 text-zinc-600 dark:text-zinc-400">
-            Parsing OPML file...
-          </span>
+          <span className="ui-text-sm text-muted ml-2">Parsing OPML file...</span>
         </div>
       )}
 
@@ -318,9 +314,7 @@ function ImportSection() {
         <div className="py-4">
           <div className="mb-2 flex items-center">
             <SpinnerIcon className="text-accent h-5 w-5" />
-            <span className="ui-text-sm ml-2 font-medium text-zinc-700 dark:text-zinc-300">
-              Importing feeds...
-            </span>
+            <span className="ui-text-sm text-body ml-2 font-medium">Importing feeds...</span>
           </div>
           {importState.type === "importing" && importQuery.data && (
             <div className="mb-2">
@@ -332,7 +326,7 @@ function ImportSection() {
                   }}
                 />
               </div>
-              <p className="ui-text-xs mt-1 text-zinc-500 dark:text-zinc-400">
+              <p className="ui-text-xs text-subtle mt-1">
                 {importQuery.data.importedCount +
                   importQuery.data.skippedCount +
                   importQuery.data.failedCount}{" "}
@@ -340,7 +334,7 @@ function ImportSection() {
               </p>
             </div>
           )}
-          <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+          <p className="ui-text-xs text-subtle">
             This may take a moment depending on the number of feeds.
           </p>
         </div>
@@ -378,25 +372,19 @@ function ImportPreview({ feeds, onImport, onCancel, isImporting }: ImportPreview
   return (
     <div>
       <div className="mb-4 flex items-center justify-between">
-        <p className="ui-text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <p className="ui-text-sm text-body font-medium">
           Found {feeds.length} feed{feeds.length !== 1 ? "s" : ""} to import
         </p>
       </div>
 
-      <div className="mb-4 max-h-64 overflow-y-auto rounded-md border border-zinc-200 dark:border-zinc-700">
+      <div className="border-edge-strong mb-4 max-h-64 overflow-y-auto rounded-md border">
         <ul className="divide-y divide-zinc-200 dark:divide-zinc-700">
           {displayedFeeds.map((feed, index) => (
             <li key={`${feed.xmlUrl}-${index}`} className="px-4 py-3">
-              <p className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
-                {feed.title || "Untitled Feed"}
-              </p>
-              <p className="ui-text-xs mt-0.5 truncate text-zinc-500 dark:text-zinc-400">
-                {feed.xmlUrl}
-              </p>
+              <p className="ui-text-sm text-strong font-medium">{feed.title || "Untitled Feed"}</p>
+              <p className="ui-text-xs text-subtle mt-0.5 truncate">{feed.xmlUrl}</p>
               {feed.category && feed.category.length > 0 && (
-                <p className="ui-text-xs mt-1 text-zinc-400 dark:text-zinc-500">
-                  Folder: {feed.category.join(" / ")}
-                </p>
+                <p className="ui-text-xs text-faint mt-1">Folder: {feed.category.join(" / ")}</p>
               )}
             </li>
           ))}
@@ -472,18 +460,16 @@ function ImportResults({ imported, skipped, failed, results, onReset }: ImportRe
           </button>
 
           {showDetails && (
-            <div className="mt-2 max-h-64 overflow-y-auto rounded-md border border-zinc-200 dark:border-zinc-700">
+            <div className="border-edge-strong mt-2 max-h-64 overflow-y-auto rounded-md border">
               <ul className="divide-y divide-zinc-200 dark:divide-zinc-700">
                 {results.map((result, index) => (
                   <li key={`${result.url}-${index}`} className="px-4 py-2">
                     <div className="flex items-start justify-between">
                       <div className="min-w-0 flex-1">
-                        <p className="ui-text-sm truncate font-medium text-zinc-900 dark:text-zinc-50">
+                        <p className="ui-text-sm text-strong truncate font-medium">
                           {result.title || "Untitled Feed"}
                         </p>
-                        <p className="ui-text-xs truncate text-zinc-500 dark:text-zinc-400">
-                          {result.url}
-                        </p>
+                        <p className="ui-text-xs text-subtle truncate">{result.url}</p>
                         {result.error && (
                           <p className="ui-text-xs mt-1 text-red-600 dark:text-red-400">
                             {result.error}
@@ -558,10 +544,8 @@ function ExportSection() {
 
   return (
     <Card>
-      <h3 className="ui-text-sm mb-2 font-medium text-zinc-900 dark:text-zinc-50">
-        Export to OPML
-      </h3>
-      <p className="ui-text-sm mb-4 text-zinc-500 dark:text-zinc-400">
+      <h3 className="ui-text-sm text-strong mb-2 font-medium">Export to OPML</h3>
+      <p className="ui-text-sm text-subtle mb-4">
         Download your subscriptions as an OPML file to import into another RSS reader.
       </p>
 

--- a/src/components/settings/SettingsListContainer.tsx
+++ b/src/components/settings/SettingsListContainer.tsx
@@ -43,9 +43,7 @@ export function SettingsListContainer<T>({
   skeletonHeight,
   footer,
 }: SettingsListContainerProps<T>) {
-  const defaultEmpty = (
-    <p className="ui-text-sm text-center text-zinc-500 dark:text-zinc-400">{emptyMessage}</p>
-  );
+  const defaultEmpty = <p className="ui-text-sm text-subtle text-center">{emptyMessage}</p>;
 
   const resolvedEmptyState = emptyState ?? defaultEmpty;
 
@@ -76,7 +74,7 @@ export function SettingsListContainer<T>({
       ) : !items || items.length === 0 ? (
         resolvedEmptyState
       ) : (
-        <div className="divide-y divide-zinc-200 dark:divide-zinc-800">{items.map(renderItem)}</div>
+        <div className="divide-edge divide-y">{items.map(renderItem)}</div>
       )}
       {footer}
     </Card>

--- a/src/components/settings/SettingsListSkeleton.tsx
+++ b/src/components/settings/SettingsListSkeleton.tsx
@@ -25,7 +25,7 @@ export function SettingsListSkeleton({
         {items.map((i) => (
           <div
             key={i}
-            className={`${height} animate-pulse rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900`}
+            className={`${height} border-edge bg-surface animate-pulse rounded-lg border`}
           />
         ))}
       </>
@@ -37,7 +37,7 @@ export function SettingsListSkeleton({
       {items.map((i) => (
         <div
           key={i}
-          className={`mb-4 ${height} animate-pulse rounded bg-zinc-100 last:mb-0 dark:bg-zinc-800`}
+          className={`mb-4 ${height} bg-surface-muted animate-pulse rounded last:mb-0`}
         />
       ))}
     </div>

--- a/src/components/settings/SettingsSection.tsx
+++ b/src/components/settings/SettingsSection.tsx
@@ -70,7 +70,7 @@ export function SettingsSection({
         <Card>
           <div className="space-y-4">
             {Array.from({ length: skeletonRows }).map((_, i) => (
-              <div key={i} className="h-10 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+              <div key={i} className="bg-surface-muted h-10 animate-pulse rounded" />
             ))}
           </div>
         </Card>
@@ -82,9 +82,7 @@ export function SettingsSection({
     <section>
       <SettingsSectionHeading>{title}</SettingsSectionHeading>
       <Card>
-        {description && (
-          <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">{description}</p>
-        )}
+        {description && <p className="ui-text-sm text-muted mb-4">{description}</p>}
 
         {error && (
           <Alert variant="error" className="mb-4">
@@ -109,7 +107,5 @@ export function SettingsSection({
  * content doesn't fit the SettingsSection wrapper.
  */
 export function SettingsSectionHeading({ children }: { children: ReactNode }) {
-  return (
-    <h2 className="ui-text-lg mb-4 font-semibold text-zinc-900 dark:text-zinc-50">{children}</h2>
-  );
+  return <h2 className="ui-text-lg text-strong mb-4 font-semibold">{children}</h2>;
 }

--- a/src/components/settings/TagManagement.tsx
+++ b/src/components/settings/TagManagement.tsx
@@ -61,7 +61,7 @@ function TagManagementContent() {
       {/* Tag list */}
       <CardSection>
         {tags.length === 0 ? (
-          <p className="ui-text-sm text-zinc-500 dark:text-zinc-400">
+          <p className="ui-text-sm text-subtle">
             No tags created yet. Create your first tag above.
           </p>
         ) : (
@@ -157,17 +157,15 @@ function CreateTagForm({ onSuccess, onError }: CreateTagFormProps) {
       </div>
 
       <div className="relative">
-        <label className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300">
-          Color
-        </label>
+        <label className="ui-text-sm text-body mb-1.5 block font-medium">Color</label>
         <button
           type="button"
           onClick={() => setShowColorPicker(!showColorPicker)}
-          className="ui-text-sm flex h-[38px] items-center gap-2 rounded-md border border-zinc-300 bg-white px-3 py-2 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+          className="ui-text-sm bg-surface flex h-[38px] items-center gap-2 rounded-md border border-zinc-300 px-3 py-2 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
           disabled={createMutation.isPending}
         >
           <ColorDot color={color} size="md" />
-          <span className="text-zinc-700 dark:text-zinc-300">
+          <span className="text-body">
             {TAG_COLORS.find((c) => c.value === color)?.name ?? "Select"}
           </span>
           <ChevronDownIcon className="h-4 w-4 text-zinc-400" />
@@ -276,10 +274,8 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
         <div className="flex items-center gap-3">
           <ColorDot color={tag.color} size="lg" />
           <div>
-            <p className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
-              Delete &quot;{tag.name}&quot;?
-            </p>
-            <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+            <p className="ui-text-sm text-strong font-medium">Delete &quot;{tag.name}&quot;?</p>
+            <p className="ui-text-xs text-subtle">
               This will remove the tag from all {tag.feedCount} subscription
               {tag.feedCount !== 1 ? "s" : ""}.
             </p>
@@ -335,7 +331,7 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
             type="text"
             value={editingValues.name}
             onChange={(e) => setEditingValues({ ...editingValues, name: e.target.value })}
-            className="ui-text-sm flex-1 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-zinc-900 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+            className="ui-text-sm bg-surface text-strong flex-1 rounded-md border border-zinc-300 px-3 py-1.5 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none dark:border-zinc-600 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
             disabled={updateMutation.isPending}
             autoFocus
           />
@@ -362,8 +358,8 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
       <div className="flex items-center gap-3">
         <ColorDot color={tag.color} size="lg" />
         <div>
-          <p className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">{tag.name}</p>
-          <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+          <p className="ui-text-sm text-strong font-medium">{tag.name}</p>
+          <p className="ui-text-xs text-subtle">
             {tag.feedCount} feed{tag.feedCount !== 1 ? "s" : ""}
           </p>
         </div>

--- a/src/components/settings/UnifiedSettingsContent.tsx
+++ b/src/components/settings/UnifiedSettingsContent.tsx
@@ -88,12 +88,12 @@ export function UnifiedSettingsContent() {
       <div className="mb-8">
         <ClientLink
           href="/all"
-          className="ui-text-sm mb-4 inline-flex items-center text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+          className="ui-text-sm text-subtle mb-4 inline-flex items-center hover:text-zinc-700 dark:hover:text-zinc-200"
         >
           <ChevronLeftIcon className="mr-1 h-4 w-4" />
           Back to feeds
         </ClientLink>
-        <h1 className="ui-text-2xl font-bold text-zinc-900 dark:text-zinc-50">Settings</h1>
+        <h1 className="ui-text-2xl text-strong font-bold">Settings</h1>
       </div>
 
       <div className="flex flex-col gap-8 md:flex-row">
@@ -108,8 +108,8 @@ export function UnifiedSettingsContent() {
                     href={link.href}
                     className={`ui-text-sm block rounded-md px-3 py-2 font-medium whitespace-nowrap transition-colors ${
                       isActive
-                        ? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
-                        : "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
+                        ? "bg-surface-muted text-strong"
+                        : "text-muted hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
                     }`}
                   >
                     {link.label}

--- a/src/components/settings/WallabagApiSettings.tsx
+++ b/src/components/settings/WallabagApiSettings.tsx
@@ -62,8 +62,8 @@ export function WallabagApiSettings() {
     >
       {/* Supported Clients */}
       <div className="mt-6">
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Compatible Apps</h3>
-        <ul className="ui-text-sm mt-2 list-inside list-disc space-y-1 text-zinc-600 dark:text-zinc-400">
+        <h3 className="ui-text-sm text-strong font-medium">Compatible Apps</h3>
+        <ul className="ui-text-sm text-muted mt-2 list-inside list-disc space-y-1">
           <li>
             <TextLink
               href="https://play.google.com/store/apps/details?id=fr.gaulupeau.apps.InThePoche"
@@ -85,8 +85,8 @@ export function WallabagApiSettings() {
       {/* Quick Setup: QR Code + Deep Link */}
       {wallabagDeepLink && (
         <CardSection>
-          <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Quick Setup</h3>
-          <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+          <h3 className="ui-text-sm text-strong font-medium">Quick Setup</h3>
+          <p className="ui-text-sm text-muted mt-1">
             Scan this QR code with your phone or tap the button below to auto-configure the Wallabag
             Android app. You&apos;ll need to enter your password, and fix the username if the{" "}
             <InlineCode>@</InlineCode> shows as <InlineCode>%40</InlineCode>.
@@ -94,7 +94,7 @@ export function WallabagApiSettings() {
 
           <div className="mt-4 flex flex-col items-center gap-4 sm:flex-row sm:items-start">
             {/* QR Code */}
-            <div className="rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-white">
+            <div className="border-edge-strong rounded-lg border bg-white p-3 dark:bg-white">
               <QRCodeSVG value={wallabagDeepLink} size={160} level="M" />
             </div>
 
@@ -107,7 +107,7 @@ export function WallabagApiSettings() {
                 <MobileIcon className="h-4 w-4" />
                 Open in Wallabag App
               </a>
-              <p className="ui-text-xs max-w-xs text-zinc-400 dark:text-zinc-500">
+              <p className="ui-text-xs text-faint max-w-xs">
                 The QR code and button pre-fill the server URL and your email address. Client ID and
                 secret are both <InlineCode>wallabag</InlineCode>.
               </p>
@@ -118,23 +118,22 @@ export function WallabagApiSettings() {
 
       {/* Manual Setup Instructions */}
       <CardSection>
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-100">Manual Setup</h3>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+        <h3 className="ui-text-sm text-strong font-medium">Manual Setup</h3>
+        <p className="ui-text-sm text-muted mt-1">
           In the Wallabag app, go to Settings and enter the following:
         </p>
-        <ul className="ui-text-sm mt-3 space-y-2 text-zinc-600 dark:text-zinc-400">
+        <ul className="ui-text-sm text-muted mt-3 space-y-2">
           <li>
-            <strong className="text-zinc-900 dark:text-zinc-200">Server URL:</strong>{" "}
+            <strong className="text-emphasis">Server URL:</strong>{" "}
             <InlineCode>{serverUrl}</InlineCode>
             <CopyButton value={serverUrl} className="ml-2 px-1.5 py-0.5" title="Copy server URL" />
           </li>
           <li>
-            <strong className="text-zinc-900 dark:text-zinc-200">Client ID:</strong>{" "}
-            <InlineCode>wallabag</InlineCode>
+            <strong className="text-emphasis">Client ID:</strong> <InlineCode>wallabag</InlineCode>
             <CopyButton value="wallabag" className="ml-2 px-1.5 py-0.5" title="Copy client ID" />
           </li>
           <li>
-            <strong className="text-zinc-900 dark:text-zinc-200">Client Secret:</strong>{" "}
+            <strong className="text-emphasis">Client Secret:</strong>{" "}
             <InlineCode>wallabag</InlineCode>
             <CopyButton
               value="wallabag"
@@ -143,7 +142,7 @@ export function WallabagApiSettings() {
             />
           </li>
           <li>
-            <strong className="text-zinc-900 dark:text-zinc-200">Username:</strong>{" "}
+            <strong className="text-emphasis">Username:</strong>{" "}
             {email ? (
               <>
                 <InlineCode>{email}</InlineCode>
@@ -154,26 +153,21 @@ export function WallabagApiSettings() {
             )}
           </li>
           <li>
-            <strong className="text-zinc-900 dark:text-zinc-200">Password:</strong> Your Lion Reader
-            password
+            <strong className="text-emphasis">Password:</strong> Your Lion Reader password
           </li>
         </ul>
       </CardSection>
 
       {/* How it works */}
       <NoteBox className="mt-6">
-        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+        <p className="ui-text-sm text-muted">
           When you share a URL to the Wallabag app, it will save it to your Lion Reader account as a
           saved article. You can also view, archive, star, and delete saved articles from the app.
         </p>
       </NoteBox>
 
       {/* API base URL note */}
-      {baseUrl && (
-        <p className="ui-text-xs mt-4 text-zinc-400 dark:text-zinc-500">
-          API endpoint: {serverUrl}
-        </p>
-      )}
+      {baseUrl && <p className="ui-text-xs text-faint mt-4">API endpoint: {serverUrl}</p>}
     </SettingsSection>
   );
 }

--- a/src/components/settings/pages/AccountSettingsContent.tsx
+++ b/src/components/settings/pages/AccountSettingsContent.tsx
@@ -90,8 +90,8 @@ function AccountInfoSection() {
     <SettingsSection title="Account Information">
       {userQuery.isLoading ? (
         <div className="space-y-4">
-          <div className="h-5 w-48 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
-          <div className="h-5 w-32 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+          <div className="bg-surface-muted h-5 w-48 animate-pulse rounded" />
+          <div className="bg-surface-muted h-5 w-32 animate-pulse rounded" />
         </div>
       ) : userQuery.error ? (
         <p className="ui-text-sm text-red-600 dark:text-red-400">
@@ -100,16 +100,12 @@ function AccountInfoSection() {
       ) : (
         <dl className="space-y-4">
           <div>
-            <dt className="ui-text-sm font-medium text-zinc-500 dark:text-zinc-400">Email</dt>
-            <dd className="ui-text-sm mt-1 text-zinc-900 dark:text-zinc-50">
-              {userQuery.data?.user.email}
-            </dd>
+            <dt className="ui-text-sm text-subtle font-medium">Email</dt>
+            <dd className="ui-text-sm text-strong mt-1">{userQuery.data?.user.email}</dd>
           </div>
           <div>
-            <dt className="ui-text-sm font-medium text-zinc-500 dark:text-zinc-400">
-              Member since
-            </dt>
-            <dd className="ui-text-sm mt-1 text-zinc-900 dark:text-zinc-50">
+            <dt className="ui-text-sm text-subtle font-medium">Member since</dt>
+            <dd className="ui-text-sm text-strong mt-1">
               {userQuery.data?.user.createdAt
                 ? new Date(userQuery.data.user.createdAt).toLocaleDateString("en-US", {
                     year: "numeric",
@@ -120,17 +116,15 @@ function AccountInfoSection() {
             </dd>
           </div>
           <div>
-            <dt className="ui-text-sm font-medium text-zinc-500 dark:text-zinc-400">
-              Email verified
-            </dt>
-            <dd className="ui-text-sm mt-1 text-zinc-900 dark:text-zinc-50">
+            <dt className="ui-text-sm text-subtle font-medium">Email verified</dt>
+            <dd className="ui-text-sm text-strong mt-1">
               {userQuery.data?.user.emailVerifiedAt ? (
                 <span className="inline-flex items-center text-green-600 dark:text-green-400">
                   <CheckIcon className="mr-1 h-4 w-4" />
                   Verified
                 </span>
               ) : (
-                <span className="text-zinc-500 dark:text-zinc-400">Not verified</span>
+                <span className="text-subtle">Not verified</span>
               )}
             </dd>
           </div>
@@ -147,7 +141,7 @@ function PasswordSection() {
   if (linkedAccountsQuery.isLoading) {
     return (
       <SettingsSection title="Password">
-        <div className="h-32 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
+        <div className="bg-surface-muted h-32 animate-pulse rounded" />
       </SettingsSection>
     );
   }

--- a/src/components/settings/pages/ApiTokensSettingsContent.tsx
+++ b/src/components/settings/pages/ApiTokensSettingsContent.tsx
@@ -124,7 +124,7 @@ export default function ApiTokensSettingsContent() {
   return (
     <div>
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">API Tokens</h2>
+        <h2 className="ui-text-lg text-strong font-semibold">API Tokens</h2>
         {!showCreateForm && (
           <Button onClick={() => setShowCreateForm(true)} size="sm">
             Create New Token
@@ -132,7 +132,7 @@ export default function ApiTokensSettingsContent() {
         )}
       </div>
 
-      <p className="ui-text-sm mb-6 text-zinc-600 dark:text-zinc-400">
+      <p className="ui-text-sm text-muted mb-6">
         API tokens allow you to connect third-party applications like Claude Desktop, browser
         extensions, and other integrations. Tokens are only shown once when created.
       </p>
@@ -171,35 +171,31 @@ export default function ApiTokensSettingsContent() {
       {/* Create Token Form */}
       {showCreateForm && (
         <Card className="mb-6">
-          <h3 className="mb-4 font-medium text-zinc-900 dark:text-zinc-50">Create New Token</h3>
+          <h3 className="text-strong mb-4 font-medium">Create New Token</h3>
 
           <div className="space-y-4">
             {/* Token Name */}
             <div>
-              <label className="ui-text-sm mb-1 block font-medium text-zinc-700 dark:text-zinc-300">
-                Token Name
-              </label>
+              <label className="ui-text-sm text-body mb-1 block font-medium">Token Name</label>
               <Input
                 value={tokenName}
                 onChange={(e) => setTokenName(e.target.value)}
                 placeholder="e.g., Claude Desktop, Browser Extension"
                 className="w-full"
               />
-              <p className="ui-text-xs mt-1 text-zinc-500 dark:text-zinc-400">
+              <p className="ui-text-xs text-subtle mt-1">
                 A descriptive name to help you identify this token
               </p>
             </div>
 
             {/* Scopes */}
             <div>
-              <label className="ui-text-sm mb-2 block font-medium text-zinc-700 dark:text-zinc-300">
-                Scopes
-              </label>
+              <label className="ui-text-sm text-body mb-2 block font-medium">Scopes</label>
               <div className="space-y-2">
                 {Object.entries(scopeLabels).map(([scope, { label, description }]) => (
                   <label
                     key={scope}
-                    className="flex cursor-pointer items-start gap-3 rounded-lg border border-zinc-200 p-3 hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-800"
+                    className="border-edge flex cursor-pointer items-start gap-3 rounded-lg border p-3 hover:bg-zinc-50 dark:hover:bg-zinc-800"
                   >
                     <input
                       type="checkbox"
@@ -208,8 +204,8 @@ export default function ApiTokensSettingsContent() {
                       className="text-accent focus:ring-accent mt-1 h-4 w-4 rounded border-zinc-300 dark:border-zinc-700 dark:bg-zinc-800"
                     />
                     <div className="flex-1">
-                      <p className="font-medium text-zinc-900 dark:text-zinc-50">{label}</p>
-                      <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">{description}</p>
+                      <p className="text-strong font-medium">{label}</p>
+                      <p className="ui-text-xs text-subtle">{description}</p>
                     </div>
                   </label>
                 ))}
@@ -218,7 +214,7 @@ export default function ApiTokensSettingsContent() {
 
             {/* Expiration (Optional) */}
             <div>
-              <label className="ui-text-sm mb-1 block font-medium text-zinc-700 dark:text-zinc-300">
+              <label className="ui-text-sm text-body mb-1 block font-medium">
                 Expiration (Optional)
               </label>
               <Input
@@ -229,7 +225,7 @@ export default function ApiTokensSettingsContent() {
                 className="w-full"
                 min="1"
               />
-              <p className="ui-text-xs mt-1 text-zinc-500 dark:text-zinc-400">
+              <p className="ui-text-xs text-subtle mt-1">
                 Leave empty for a token that never expires
               </p>
             </div>
@@ -262,7 +258,7 @@ export default function ApiTokensSettingsContent() {
 
       {/* Active Tokens List */}
       <div className="mb-6">
-        <h3 className="ui-text-sm mb-3 font-medium text-zinc-700 dark:text-zinc-300">
+        <h3 className="ui-text-sm text-body mb-3 font-medium">
           Active Tokens ({activeTokens.length})
         </h3>
         <SettingsListContainer
@@ -287,14 +283,14 @@ export default function ApiTokensSettingsContent() {
       {/* Revoked/Expired Tokens */}
       {inactiveTokens.length > 0 && (
         <div>
-          <h3 className="ui-text-sm mb-3 font-medium text-zinc-700 dark:text-zinc-300">
+          <h3 className="ui-text-sm text-body mb-3 font-medium">
             Revoked/Expired Tokens ({inactiveTokens.length})
           </h3>
           <div className="space-y-3">
             {inactiveTokens.map((token) => (
               <div
                 key={token.id}
-                className="rounded-lg border border-zinc-200 bg-zinc-50 p-4 opacity-60 dark:border-zinc-800 dark:bg-zinc-900"
+                className="border-edge rounded-lg border bg-zinc-50 p-4 opacity-60 dark:bg-zinc-900"
               >
                 <div className="flex items-center gap-2">
                   <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-200 dark:bg-zinc-800">
@@ -344,14 +340,12 @@ function ActiveTokenCard({ token, onRevoke, isRevoking }: ActiveTokenCardProps) 
         <div className="flex-1">
           <div className="flex items-center gap-2">
             {/* Key icon */}
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-              <KeyIcon className="h-4 w-4 text-zinc-600 dark:text-zinc-400" />
+            <div className="bg-surface-muted flex h-8 w-8 shrink-0 items-center justify-center rounded-full">
+              <KeyIcon className="text-muted h-4 w-4" />
             </div>
 
             <div className="min-w-0 flex-1">
-              <p className="font-medium text-zinc-900 dark:text-zinc-50">
-                {token.name || "Unnamed Token"}
-              </p>
+              <p className="text-strong font-medium">{token.name || "Unnamed Token"}</p>
               <div className="mt-1 flex flex-wrap gap-1">
                 {token.scopes.map((scope) => (
                   <span
@@ -365,7 +359,7 @@ function ActiveTokenCard({ token, onRevoke, isRevoking }: ActiveTokenCardProps) 
             </div>
           </div>
 
-          <div className="ui-text-xs mt-2 flex flex-wrap gap-x-4 gap-y-1 text-zinc-500 dark:text-zinc-400">
+          <div className="ui-text-xs text-subtle mt-2 flex flex-wrap gap-x-4 gap-y-1">
             <span>
               Created:{" "}
               {new Date(token.createdAt).toLocaleDateString("en-US", {

--- a/src/components/settings/pages/BlockedSendersSettingsContent.tsx
+++ b/src/components/settings/pages/BlockedSendersSettingsContent.tsx
@@ -46,10 +46,8 @@ export default function BlockedSendersSettingsContent() {
     <div>
       {/* Page Header */}
       <div className="mb-6">
-        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-          Blocked Senders
-        </h2>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+        <h2 className="ui-text-lg text-strong font-semibold">Blocked Senders</h2>
+        <p className="ui-text-sm text-muted mt-1">
           These senders were blocked when you unsubscribed from their newsletters. Emails from
           blocked senders are automatically rejected.
         </p>
@@ -77,13 +75,11 @@ export default function BlockedSendersSettingsContent() {
 function EmptyState() {
   return (
     <div className="p-8 text-center">
-      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-        <ProhibitionIcon className="h-6 w-6 text-zinc-400 dark:text-zinc-500" />
+      <div className="bg-surface-muted mx-auto flex h-12 w-12 items-center justify-center rounded-full">
+        <ProhibitionIcon className="text-faint h-6 w-6" />
       </div>
-      <h3 className="ui-text-sm mt-4 font-medium text-zinc-900 dark:text-zinc-50">
-        No blocked senders
-      </h3>
-      <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+      <h3 className="ui-text-sm text-strong mt-4 font-medium">No blocked senders</h3>
+      <p className="ui-text-sm text-subtle mt-1">
         When you unsubscribe from a newsletter, the sender will be added here to prevent future
         emails.
       </p>
@@ -154,10 +150,10 @@ function BlockedSenderRow({ sender }: BlockedSenderRowProps) {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 flex-1">
           {/* Sender Email */}
-          <p className="font-medium text-zinc-900 dark:text-zinc-50">{sender.senderEmail}</p>
+          <p className="text-strong font-medium">{sender.senderEmail}</p>
 
           {/* Metadata */}
-          <div className="ui-text-sm mt-1 flex flex-wrap gap-x-4 gap-y-1 text-zinc-500 dark:text-zinc-400">
+          <div className="ui-text-sm text-subtle mt-1 flex flex-wrap gap-x-4 gap-y-1">
             <span>Blocked {formatRelativeTime(sender.blockedAt)}</span>
             {sender.unsubscribeSentAt && (
               <span className="flex items-center gap-1">

--- a/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
+++ b/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
@@ -80,8 +80,8 @@ export default function BrokenFeedsSettingsContent() {
     <div>
       {/* Page Header */}
       <div className="mb-6">
-        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">Broken Feeds</h2>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+        <h2 className="ui-text-lg text-strong font-semibold">Broken Feeds</h2>
+        <p className="ui-text-sm text-muted mt-1">
           These feeds have failed to fetch recently. You can retry fetching immediately or wait for
           the next scheduled attempt.
         </p>
@@ -125,10 +125,8 @@ function EmptyState() {
       <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
         <CheckIcon className="h-6 w-6 text-green-600 dark:text-green-400" />
       </div>
-      <h3 className="ui-text-sm mt-4 font-medium text-zinc-900 dark:text-zinc-50">
-        All feeds are working
-      </h3>
-      <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+      <h3 className="ui-text-sm text-strong mt-4 font-medium">All feeds are working</h3>
+      <p className="ui-text-sm text-subtle mt-1">
         None of your subscribed feeds have fetch errors.
       </p>
     </div>
@@ -177,13 +175,11 @@ function BrokenFeedRow({ feed, onUnsubscribe }: BrokenFeedRowProps) {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 flex-1">
           {/* Feed Title */}
-          <p className="font-medium text-zinc-900 dark:text-zinc-50">{displayName}</p>
+          <p className="text-strong font-medium">{displayName}</p>
 
           {/* Feed URL */}
           {feed.url && feed.title && (
-            <p className="ui-text-sm mt-0.5 truncate text-zinc-500 dark:text-zinc-400">
-              {feed.url}
-            </p>
+            <p className="ui-text-sm text-subtle mt-0.5 truncate">{feed.url}</p>
           )}
 
           {/* Error Message */}
@@ -196,7 +192,7 @@ function BrokenFeedRow({ feed, onUnsubscribe }: BrokenFeedRowProps) {
           )}
 
           {/* Metadata */}
-          <div className="ui-text-sm mt-2 flex flex-wrap gap-x-4 gap-y-1 text-zinc-500 dark:text-zinc-400">
+          <div className="ui-text-sm text-subtle mt-2 flex flex-wrap gap-x-4 gap-y-1">
             <span className="flex items-center gap-1">
               <AlertCircleIcon className="h-4 w-4 text-red-500" />
               {feed.consecutiveFailures} consecutive failure

--- a/src/components/settings/pages/DeleteAccountSettingsContent.tsx
+++ b/src/components/settings/pages/DeleteAccountSettingsContent.tsx
@@ -75,11 +75,11 @@ export default function DeleteAccountSettingsContent() {
         <h2 className="ui-text-lg mb-4 font-semibold text-red-600 dark:text-red-400">
           Delete Account
         </h2>
-        <div className="rounded-lg border border-red-200 bg-white p-6 dark:border-red-900/50 dark:bg-zinc-900">
-          <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">
+        <div className="bg-surface rounded-lg border border-red-200 p-6 dark:border-red-900/50">
+          <p className="ui-text-sm text-muted">
             Permanently delete your account and all associated data. This action cannot be undone.
           </p>
-          <p className="ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400">
+          <p className="ui-text-sm text-muted mt-2">
             This will delete your subscriptions, reading history, starred items, tags, saved
             articles, email ingest addresses, AI summaries, sessions, API tokens, and all other
             account data.
@@ -113,10 +113,7 @@ export default function DeleteAccountSettingsContent() {
               {error}
             </Alert>
           )}
-          <label
-            htmlFor="delete-confirmation"
-            className="ui-text-sm text-zinc-700 dark:text-zinc-300"
-          >
+          <label htmlFor="delete-confirmation" className="ui-text-sm text-body">
             Type <span className="font-semibold">delete</span> to confirm:
           </label>
           <Input

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -47,10 +47,8 @@ export default function EmailSettingsContent() {
     <div className="space-y-8">
       {/* Page Header */}
       <div>
-        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-          Email Subscriptions
-        </h2>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+        <h2 className="ui-text-lg text-strong font-semibold">Email Subscriptions</h2>
+        <p className="ui-text-sm text-muted mt-1">
           Create ingest addresses to subscribe to email newsletters. Emails sent to these addresses
           will appear as entries in your feeds.
         </p>
@@ -110,8 +108,8 @@ function IngestAddressesSection() {
   return (
     <section>
       <div className="mb-4 flex items-center justify-between">
-        <h3 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">Ingest Addresses</h3>
-        <span className="ui-text-sm text-zinc-500 dark:text-zinc-400">{addresses.length} / 5</span>
+        <h3 className="ui-text-sm text-strong font-medium">Ingest Addresses</h3>
+        <span className="ui-text-sm text-subtle">{addresses.length} / 5</span>
       </div>
 
       <SettingsListContainer
@@ -126,7 +124,7 @@ function IngestAddressesSection() {
             <></>
           ) : (
             <div className="p-6 text-center">
-              <p className="ui-text-sm text-zinc-500 dark:text-zinc-400">
+              <p className="ui-text-sm text-subtle">
                 No ingest addresses yet. Create one to start receiving newsletter emails.
               </p>
             </div>
@@ -137,7 +135,7 @@ function IngestAddressesSection() {
           <>
             {/* Create Form */}
             {isCreating && (
-              <div className="border-t border-zinc-200 p-4 dark:border-zinc-800">
+              <div className="border-edge border-t p-4">
                 {createError && (
                   <Alert variant="error" className="mb-4">
                     {createError}
@@ -170,7 +168,7 @@ function IngestAddressesSection() {
 
             {/* Create Button */}
             {!isCreating && addresses.length < 5 && (
-              <div className="border-t border-zinc-200 p-4 dark:border-zinc-800">
+              <div className="border-edge border-t p-4">
                 <Button variant="secondary" onClick={() => setIsCreating(true)}>
                   <PlusIcon className="mr-2 h-4 w-4" />
                   Create New Address
@@ -289,13 +287,13 @@ function IngestAddressRow({ address }: IngestAddressRowProps) {
         <div className="min-w-0 flex-1">
           {/* Email Address */}
           <div className="flex items-center gap-2">
-            <code className="ui-text-sm rounded bg-zinc-100 px-2 py-1 break-all text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200">
+            <code className="ui-text-sm bg-surface-muted text-emphasis rounded px-2 py-1 break-all">
               {address.email}
             </code>
             <button
               type="button"
               onClick={handleCopy}
-              className="flex-shrink-0 rounded p-1 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+              className="text-subtle flex-shrink-0 rounded p-1 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
               title="Copy email address"
             >
               {copied ? (
@@ -332,14 +330,14 @@ function IngestAddressRow({ address }: IngestAddressRowProps) {
           ) : (
             <div className="mt-1 flex items-center gap-2">
               {address.label ? (
-                <span className="ui-text-sm text-zinc-600 dark:text-zinc-400">{address.label}</span>
+                <span className="ui-text-sm text-muted">{address.label}</span>
               ) : (
-                <span className="ui-text-sm text-zinc-400 dark:text-zinc-500">No label</span>
+                <span className="ui-text-sm text-faint">No label</span>
               )}
               <button
                 type="button"
                 onClick={() => setIsEditing(true)}
-                className="rounded p-0.5 text-zinc-400 transition-colors hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
+                className="text-faint rounded p-0.5 transition-colors hover:text-zinc-600 dark:hover:text-zinc-300"
                 title="Edit label"
               >
                 <EditIcon className="h-3.5 w-3.5" />
@@ -348,7 +346,7 @@ function IngestAddressRow({ address }: IngestAddressRowProps) {
           )}
 
           {/* Created Date */}
-          <p className="ui-text-xs mt-1 text-zinc-400 dark:text-zinc-500">
+          <p className="ui-text-xs text-faint mt-1">
             Created{" "}
             {new Date(address.createdAt).toLocaleDateString("en-US", {
               month: "short",
@@ -421,14 +419,12 @@ function SpamPreferenceSection() {
 
   return (
     <section>
-      <h3 className="ui-text-sm mb-4 font-medium text-zinc-900 dark:text-zinc-50">Preferences</h3>
+      <h3 className="ui-text-sm text-strong mb-4 font-medium">Preferences</h3>
       <Card>
         <div className="flex items-center justify-between">
           <div>
-            <h4 className="ui-text-sm font-medium text-zinc-900 dark:text-zinc-50">
-              Show spam entries
-            </h4>
-            <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+            <h4 className="ui-text-sm text-strong font-medium">Show spam entries</h4>
+            <p className="ui-text-sm text-subtle mt-1">
               Display entries that were flagged as spam by our email provider.
             </p>
           </div>
@@ -444,7 +440,7 @@ function SpamPreferenceSection() {
           >
             <span
               aria-hidden="true"
-              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-zinc-900 ${
+              className={`bg-surface pointer-events-none inline-block h-5 w-5 transform rounded-full shadow ring-0 transition duration-200 ease-in-out ${
                 showSpam ? "translate-x-5" : "translate-x-0"
               }`}
             />

--- a/src/components/settings/pages/FeedStatsSettingsContent.tsx
+++ b/src/components/settings/pages/FeedStatsSettingsContent.tsx
@@ -145,10 +145,8 @@ export default function FeedStatsSettingsContent() {
     <div>
       {/* Page Header */}
       <div className="mb-6">
-        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-          Feed Statistics
-        </h2>
-        <p className="ui-text-sm mt-1 text-zinc-600 dark:text-zinc-400">
+        <h2 className="ui-text-lg text-strong font-semibold">Feed Statistics</h2>
+        <p className="ui-text-sm text-muted mt-1">
           View fetch status and statistics for all your subscribed feeds.
         </p>
       </div>
@@ -174,7 +172,7 @@ export default function FeedStatsSettingsContent() {
         ) : feeds.length === 0 ? (
           <EmptyState />
         ) : (
-          <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
+          <div className="divide-edge divide-y">
             {feeds.map((feed) => (
               <FeedStatsRow key={feed.subscriptionId} feed={feed} />
             ))}
@@ -186,15 +184,13 @@ export default function FeedStatsSettingsContent() {
             {statsQuery.isFetchingNextPage && (
               <div className="flex items-center justify-center p-4">
                 <SpinnerIcon className="mr-2 h-4 w-4 text-zinc-400" />
-                <span className="ui-text-sm text-zinc-500 dark:text-zinc-400">Loading more...</span>
+                <span className="ui-text-sm text-subtle">Loading more...</span>
               </div>
             )}
 
             {/* End of list */}
             {!statsQuery.hasNextPage && feeds.length > 0 && (
-              <p className="ui-text-xs p-3 text-center text-zinc-400 dark:text-zinc-500">
-                All feeds loaded
-              </p>
+              <p className="ui-text-xs text-faint p-3 text-center">All feeds loaded</p>
             )}
           </div>
         )}
@@ -215,15 +211,15 @@ interface SummaryCardProps {
 
 function SummaryCard({ label, value, variant = "default" }: SummaryCardProps) {
   const variantClasses = {
-    default: "text-zinc-900 dark:text-zinc-50",
+    default: "text-strong",
     success: "text-green-600 dark:text-green-400",
     error: "text-red-600 dark:text-red-400",
     info: "text-purple-600 dark:text-purple-400",
   };
 
   return (
-    <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800">
-      <p className="ui-text-sm text-zinc-500 dark:text-zinc-400">{label}</p>
+    <div className="border-edge-strong rounded-lg border bg-zinc-50 p-4 dark:bg-zinc-800">
+      <p className="ui-text-sm text-subtle">{label}</p>
       <p className={`ui-text-2xl font-semibold ${variantClasses[variant]}`}>{value}</p>
     </div>
   );
@@ -236,13 +232,11 @@ function SummaryCard({ label, value, variant = "default" }: SummaryCardProps) {
 function EmptyState() {
   return (
     <div className="p-8 text-center">
-      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-        <RssIcon className="h-6 w-6 text-zinc-400 dark:text-zinc-500" />
+      <div className="bg-surface-muted mx-auto flex h-12 w-12 items-center justify-center rounded-full">
+        <RssIcon className="text-faint h-6 w-6" />
       </div>
-      <h3 className="ui-text-sm mt-4 font-medium text-zinc-900 dark:text-zinc-50">
-        No feeds subscribed
-      </h3>
-      <p className="ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400">
+      <h3 className="ui-text-sm text-strong mt-4 font-medium">No feeds subscribed</h3>
+      <p className="ui-text-sm text-subtle mt-1">
         Subscribe to some feeds to see their statistics here.
       </p>
     </div>
@@ -268,7 +262,7 @@ function FeedStatsRow({ feed }: FeedStatsRowProps) {
         <div className="min-w-0 flex-1">
           {/* Feed Title and Status */}
           <div className="flex items-center gap-2">
-            <p className="font-medium text-zinc-900 dark:text-zinc-50">{displayName}</p>
+            <p className="text-strong font-medium">{displayName}</p>
             <span
               className={`ui-text-xs inline-flex items-center rounded-full px-2 py-0.5 font-medium ${statusBadge.className}`}
             >
@@ -277,11 +271,7 @@ function FeedStatsRow({ feed }: FeedStatsRowProps) {
           </div>
 
           {/* Feed URL */}
-          {feed.url && (
-            <p className="ui-text-sm mt-0.5 truncate text-zinc-500 dark:text-zinc-400">
-              {feed.url}
-            </p>
-          )}
+          {feed.url && <p className="ui-text-sm text-subtle mt-0.5 truncate">{feed.url}</p>}
 
           {/* Error Message (if any) */}
           {feed.lastError && (
@@ -358,10 +348,10 @@ interface StatItemProps {
 
 function StatItem({ icon, label, value }: StatItemProps) {
   return (
-    <div className="flex items-center gap-1.5 text-zinc-500 dark:text-zinc-400">
+    <div className="text-subtle flex items-center gap-1.5">
       <span className="h-4 w-4 shrink-0">{icon}</span>
       <span className="truncate">
-        <span className="font-medium text-zinc-700 dark:text-zinc-300">{label}:</span> {value}
+        <span className="text-body font-medium">{label}:</span> {value}
       </span>
     </div>
   );

--- a/src/components/settings/pages/SessionsSettingsContent.tsx
+++ b/src/components/settings/pages/SessionsSettingsContent.tsx
@@ -85,15 +85,13 @@ export default function SessionsSettingsContent() {
   return (
     <div>
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-          Active Sessions
-        </h2>
-        <span className="ui-text-sm text-zinc-500 dark:text-zinc-400">
+        <h2 className="ui-text-lg text-strong font-semibold">Active Sessions</h2>
+        <span className="ui-text-sm text-subtle">
           {sessionsQuery.data?.sessions.length ?? 0} active
         </span>
       </div>
 
-      <p className="ui-text-sm mb-6 text-zinc-600 dark:text-zinc-400">
+      <p className="ui-text-sm text-muted mb-6">
         These are the devices that are currently logged into your account. You can revoke any
         session that you do not recognize.
       </p>
@@ -156,23 +154,23 @@ function SessionCard({ session, onRevoke, isRevoking }: SessionCardProps) {
       className={`rounded-lg border p-3 sm:p-4 ${
         session.isCurrent
           ? "border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950"
-          : "border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
+          : "border-edge bg-surface"
       }`}
     >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex-1">
           <div className="flex items-center gap-2">
             {/* Device icon */}
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
+            <div className="bg-surface-muted flex h-8 w-8 shrink-0 items-center justify-center rounded-full">
               {platform === "iOS" || platform === "Android" ? (
-                <MobileIcon className="h-4 w-4 text-zinc-600 dark:text-zinc-400" />
+                <MobileIcon className="text-muted h-4 w-4" />
               ) : (
-                <DesktopIcon className="h-4 w-4 text-zinc-600 dark:text-zinc-400" />
+                <DesktopIcon className="text-muted h-4 w-4" />
               )}
             </div>
 
             <div className="min-w-0 flex-1">
-              <p className="font-medium text-zinc-900 dark:text-zinc-50">
+              <p className="text-strong font-medium">
                 {browser} on {platform}
               </p>
               {session.isCurrent && (
@@ -180,13 +178,11 @@ function SessionCard({ session, onRevoke, isRevoking }: SessionCardProps) {
                   Current session
                 </span>
               )}
-              <p className="ui-text-sm text-zinc-500 dark:text-zinc-400">
-                {session.ipAddress || "Unknown IP"}
-              </p>
+              <p className="ui-text-sm text-subtle">{session.ipAddress || "Unknown IP"}</p>
             </div>
           </div>
 
-          <div className="ui-text-xs mt-2 flex flex-wrap gap-x-4 gap-y-1 text-zinc-500 dark:text-zinc-400">
+          <div className="ui-text-xs text-subtle mt-2 flex flex-wrap gap-x-4 gap-y-1">
             <span>Last active: {formatRelativeTime(lastActive)}</span>
             <span>
               Created:{" "}

--- a/src/components/subscribe/SubscribeContent.tsx
+++ b/src/components/subscribe/SubscribeContent.tsx
@@ -215,13 +215,13 @@ export function SubscribeContent() {
 
   return (
     <div className="mx-auto max-w-2xl px-4 py-4 sm:p-6">
-      <h1 className="ui-text-xl sm:ui-text-2xl mb-4 font-bold text-zinc-900 sm:mb-6 dark:text-zinc-50">
+      <h1 className="ui-text-xl sm:ui-text-2xl text-strong mb-4 font-bold sm:mb-6">
         Subscribe to Feed
       </h1>
 
       {step === "input" && (
         <Card>
-          <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
+          <p className="ui-text-sm text-muted mb-4">
             Enter the URL of an RSS or Atom feed, or a website that has a feed. We&apos;ll
             automatically discover the feed if possible.
           </p>
@@ -283,15 +283,13 @@ export function SubscribeContent() {
           <Card>
             <div className="mb-4 flex items-center gap-2">
               <CheckCircleIcon className="h-5 w-5 text-green-600 dark:text-green-400" />
-              <h2 className="ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+              <h2 className="ui-text-lg text-strong font-semibold">
                 We found {discoveredFeeds.length} feed{discoveredFeeds.length !== 1 ? "s" : ""} on
                 this site
               </h2>
             </div>
 
-            <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
-              Select a feed to preview and subscribe:
-            </p>
+            <p className="ui-text-sm text-muted mb-4">Select a feed to preview and subscribe:</p>
 
             {/* Show error if preview of selected feed failed */}
             {selectedFeedUrl && previewQuery.error && (
@@ -311,22 +309,18 @@ export function SubscribeContent() {
                   className={`w-full rounded-lg border p-4 text-left transition-colors ${
                     selectedFeedUrl === feed.url
                       ? "border-zinc-900 bg-zinc-50 dark:border-zinc-100 dark:bg-zinc-800"
-                      : "border-zinc-200 bg-white hover:border-zinc-300 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
+                      : "border-edge-strong bg-surface hover:border-zinc-300 hover:bg-zinc-50 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
                   } ${isLoading ? "cursor-not-allowed opacity-50" : ""}`}
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
-                        <p className="font-medium text-zinc-900 dark:text-zinc-50">
-                          {feed.title || "Untitled Feed"}
-                        </p>
-                        <span className="ui-text-xs inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 font-medium text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300">
+                        <p className="text-strong font-medium">{feed.title || "Untitled Feed"}</p>
+                        <span className="ui-text-xs text-body inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 font-medium dark:bg-zinc-700">
                           {getFeedTypeLabel(feed.type)}
                         </span>
                       </div>
-                      <p className="ui-text-xs mt-1 truncate font-mono text-zinc-500 dark:text-zinc-400">
-                        {feed.url}
-                      </p>
+                      <p className="ui-text-xs text-subtle mt-1 truncate font-mono">{feed.url}</p>
                     </div>
                     {selectedFeedUrl === feed.url && isLoading ? (
                       <SpinnerIcon className="h-5 w-5 text-zinc-500" />
@@ -340,13 +334,13 @@ export function SubscribeContent() {
 
             {/* Feed builder link from plugin */}
             {feedBuilderUrl && (
-              <p className="ui-text-sm mt-4 text-zinc-600 dark:text-zinc-400">
+              <p className="ui-text-sm text-muted mt-4">
                 Looking for a custom feed?{" "}
                 <a
                   href={feedBuilderUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-zinc-900 underline hover:text-zinc-700 dark:text-zinc-200 dark:hover:text-zinc-400"
+                  className="text-emphasis inline-flex items-center gap-1 underline hover:text-zinc-700 dark:hover:text-zinc-400"
                 >
                   Build a custom feed URL
                   <ExternalLinkIcon className="h-3.5 w-3.5" />
@@ -370,7 +364,7 @@ export function SubscribeContent() {
           <Card>
             <div className="mb-4 flex items-start justify-between">
               <div>
-                <h2 className="ui-text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+                <h2 className="ui-text-xl text-strong font-semibold">
                   {previewQuery.data?.feed.title ?? "Untitled Feed"}
                 </h2>
                 {previewQuery.data?.feed.siteUrl && (
@@ -378,7 +372,7 @@ export function SubscribeContent() {
                     href={previewQuery.data.feed.siteUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="ui-text-sm text-zinc-500 hover:underline dark:text-zinc-400"
+                    className="ui-text-sm text-subtle hover:underline"
                   >
                     {new URL(previewQuery.data.feed.siteUrl).hostname}
                   </a>
@@ -387,12 +381,10 @@ export function SubscribeContent() {
             </div>
 
             {previewQuery.data?.feed.description && (
-              <p className="ui-text-sm mb-4 text-zinc-600 dark:text-zinc-400">
-                {previewQuery.data.feed.description}
-              </p>
+              <p className="ui-text-sm text-muted mb-4">{previewQuery.data.feed.description}</p>
             )}
 
-            <p className="ui-text-xs text-zinc-500 dark:text-zinc-400">
+            <p className="ui-text-xs text-subtle">
               Feed URL: <span className="font-mono">{previewQuery.data?.feed.url}</span>
             </p>
           </Card>
@@ -401,25 +393,23 @@ export function SubscribeContent() {
           {previewQuery.data?.feed.sampleEntries &&
             previewQuery.data.feed.sampleEntries.length > 0 && (
               <Card padding="none">
-                <h3 className="ui-text-sm border-b border-zinc-200 px-4 py-3 font-medium text-zinc-900 dark:border-zinc-800 dark:text-zinc-50">
+                <h3 className="ui-text-sm border-edge text-strong border-b px-4 py-3 font-medium">
                   Recent Entries
                 </h3>
-                <ul className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                <ul className="divide-edge divide-y">
                   {previewQuery.data.feed.sampleEntries.map((entry, index) => (
                     <li key={entry.guid ?? index} className="px-4 py-3">
                       <div className="flex items-start justify-between gap-4">
                         <div className="min-w-0 flex-1">
-                          <p className="font-medium text-zinc-900 dark:text-zinc-50">
-                            {entry.title ?? "Untitled"}
-                          </p>
+                          <p className="text-strong font-medium">{entry.title ?? "Untitled"}</p>
                           {entry.summary && (
-                            <p className="ui-text-sm mt-1 line-clamp-2 text-zinc-600 dark:text-zinc-400">
+                            <p className="ui-text-sm text-muted mt-1 line-clamp-2">
                               {entry.summary}
                             </p>
                           )}
                         </div>
                         {entry.pubDate && (
-                          <span className="ui-text-xs shrink-0 text-zinc-500 dark:text-zinc-400">
+                          <span className="ui-text-xs text-subtle shrink-0">
                             {formatDate(entry.pubDate)}
                           </span>
                         )}

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -55,14 +55,12 @@ function DefaultErrorFallback({
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center" role="alert">
       <AlertIcon className="mb-4 h-12 w-12 text-red-400 dark:text-red-500" />
-      <h2 className="ui-text-lg mb-2 font-semibold text-zinc-900 dark:text-zinc-50">
-        Something went wrong
-      </h2>
-      <p className="ui-text-sm mb-4 max-w-sm text-zinc-500 dark:text-zinc-400">
+      <h2 className="ui-text-lg text-strong mb-2 font-semibold">Something went wrong</h2>
+      <p className="ui-text-sm text-subtle mb-4 max-w-sm">
         {message ?? "An unexpected error occurred. Please try again."}
       </p>
       {error && process.env.NODE_ENV === "development" && (
-        <pre className="ui-text-xs mb-4 max-w-md overflow-auto rounded-md bg-zinc-100 p-3 text-left text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+        <pre className="ui-text-xs bg-surface-muted text-body mb-4 max-w-md overflow-auto rounded-md p-3 text-left">
           {error.message}
         </pre>
       )}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -30,9 +30,9 @@ export function Button({
   const variantStyles = {
     primary: "btn-primary",
     secondary:
-      "border border-zinc-300 bg-white text-zinc-900 hover:bg-zinc-50 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400",
+      "border border-zinc-300 bg-surface text-strong hover:bg-zinc-50 focus:ring-zinc-900 dark:border-zinc-700 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400",
     ghost:
-      "text-zinc-900 hover:bg-zinc-100 focus:ring-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400",
+      "text-strong hover:bg-zinc-100 focus:ring-zinc-900 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400",
   };
 
   // Ensure minimum 44px height for touch targets on mobile (WCAG touch target guidelines)

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -37,7 +37,7 @@ export function Card({ children, padding = "lg", className = "" }: CardProps) {
 
   return (
     <div
-      className={`rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900 ${paddingStyles[padding]} ${className}`}
+      className={`border-edge bg-surface rounded-lg border ${paddingStyles[padding]} ${className}`}
     >
       {children}
     </div>
@@ -65,11 +65,7 @@ export interface CardTitleProps {
 }
 
 export function CardTitle({ children, className = "" }: CardTitleProps) {
-  return (
-    <h3 className={`ui-text-base font-semibold text-zinc-900 dark:text-zinc-50 ${className}`}>
-      {children}
-    </h3>
-  );
+  return <h3 className={`ui-text-base text-strong font-semibold ${className}`}>{children}</h3>;
 }
 
 /**
@@ -81,9 +77,7 @@ export interface CardDescriptionProps {
 }
 
 export function CardDescription({ children, className = "" }: CardDescriptionProps) {
-  return (
-    <p className={`ui-text-sm mt-1 text-zinc-500 dark:text-zinc-400 ${className}`}>{children}</p>
-  );
+  return <p className={`ui-text-sm text-subtle mt-1 ${className}`}>{children}</p>;
 }
 
 /**
@@ -120,11 +114,7 @@ export interface CardSectionProps {
 }
 
 export function CardSection({ children, className = "" }: CardSectionProps) {
-  return (
-    <div className={`mt-6 border-t border-zinc-200 pt-6 dark:border-zinc-700 ${className}`}>
-      {children}
-    </div>
-  );
+  return <div className={`border-edge-strong mt-6 border-t pt-6 ${className}`}>{children}</div>;
 }
 
 /**

--- a/src/components/ui/color-picker.tsx
+++ b/src/components/ui/color-picker.tsx
@@ -76,7 +76,7 @@ export function ColorPicker({ selectedColor, onSelect, onClose }: ColorPickerPro
       <div className="fixed inset-0 z-10" onClick={onClose} aria-hidden="true" />
 
       {/* Color picker dropdown */}
-      <div className="absolute top-full left-0 z-20 mt-1 w-48 rounded-md border border-zinc-200 bg-white p-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-800">
+      <div className="border-edge-strong absolute top-full left-0 z-20 mt-1 w-48 rounded-md border bg-white p-2 shadow-lg dark:bg-zinc-800">
         <div className="grid grid-cols-6 gap-1">
           {TAG_COLORS.map((colorOption) => (
             <button

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -72,7 +72,7 @@ interface CodeBlockProps {
 export function CodeBlock({ code, className = "" }: CodeBlockProps) {
   return (
     <div className={`relative ${className}`}>
-      <pre className="ui-text-xs overflow-x-auto rounded-md border border-zinc-200 bg-zinc-100 p-3 pr-20 font-mono text-zinc-800 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
+      <pre className="ui-text-xs border-edge-strong bg-surface-muted text-emphasis overflow-x-auto rounded-md border p-3 pr-20 font-mono">
         <code>{code}</code>
       </pre>
       <CopyButton value={code} className="absolute top-2 right-2 px-2 py-1" />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -152,7 +152,7 @@ export function Dialog({
       {/* Dialog container */}
       <div
         ref={dialogRef}
-        className={`relative z-10 mx-4 w-full ${sizeStyles[size]} rounded-lg border border-zinc-200 bg-white p-6 shadow-lg dark:border-zinc-700 dark:bg-zinc-900 ${className}`}
+        className={`relative z-10 mx-4 w-full ${sizeStyles[size]} border-edge-strong bg-surface rounded-lg border p-6 shadow-lg ${className}`}
       >
         {children}
       </div>
@@ -183,7 +183,7 @@ export interface DialogTitleProps {
 
 export function DialogTitle({ children, id, className = "" }: DialogTitleProps) {
   return (
-    <h2 id={id} className={`ui-text-lg font-semibold text-zinc-900 dark:text-zinc-50 ${className}`}>
+    <h2 id={id} className={`ui-text-lg text-strong font-semibold ${className}`}>
       {children}
     </h2>
   );
@@ -198,9 +198,7 @@ export interface DialogDescriptionProps {
 }
 
 export function DialogDescription({ children, className = "" }: DialogDescriptionProps) {
-  return (
-    <p className={`ui-text-sm mt-2 text-zinc-600 dark:text-zinc-400 ${className}`}>{children}</p>
-  );
+  return <p className={`ui-text-sm text-muted mt-2 ${className}`}>{children}</p>;
 }
 
 /**

--- a/src/components/ui/icon-button.tsx
+++ b/src/components/ui/icon-button.tsx
@@ -48,7 +48,7 @@ export function IconButton({
 
   const variantStyles = {
     ghost:
-      "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 active:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 dark:active:bg-zinc-700",
+      "text-subtle hover:bg-zinc-100 hover:text-zinc-700 active:bg-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 dark:active:bg-zinc-700",
     subtle:
       "text-zinc-400 hover:bg-zinc-200 hover:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-300",
   };
@@ -552,7 +552,7 @@ export function AppleIcon({
       <path
         d="M17.569 12.6254C17.597 15.6529 20.2179 16.6664 20.25 16.6804C20.2269 16.7524 19.8318 18.1419 18.8424 19.5749C17.9814 20.8234 17.0879 22.0654 15.6889 22.0924C14.3144 22.1189 13.8759 21.2894 12.3019 21.2894C10.7284 21.2894 10.2394 22.0654 8.93942 22.1189C7.58992 22.1724 6.55792 20.7694 5.68992 19.5274C3.91792 17.0004 2.55692 12.3654 4.37192 9.26839C5.27192 7.73289 6.87892 6.76039 8.61792 6.73389C9.94292 6.70739 11.1934 7.61239 12.0089 7.61239C12.8239 7.61239 14.3369 6.52239 15.9404 6.68489C16.6284 6.71439 18.4849 6.95989 19.6939 8.68489C19.5999 8.74239 17.5469 9.94739 17.569 12.6254ZM14.9069 4.63539C15.6219 3.77889 16.1079 2.58939 15.9729 1.40039C14.9484 1.44239 13.7029 2.09039 12.9634 2.94639C12.3014 3.70689 11.7134 4.92339 11.8724 6.08439C13.0109 6.17239 14.1919 5.49239 14.9069 4.63539Z"
         fill="currentColor"
-        className="text-zinc-900 dark:text-zinc-100"
+        className="text-strong"
       />
     </svg>
   );

--- a/src/components/ui/inline-code.tsx
+++ b/src/components/ui/inline-code.tsx
@@ -14,7 +14,7 @@ export interface InlineCodeProps extends HTMLAttributes<HTMLElement> {
 export function InlineCode({ className = "", children, ...props }: InlineCodeProps) {
   return (
     <code
-      className={`ui-text-xs rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800 ${className}`}
+      className={`ui-text-xs bg-surface-muted rounded px-1.5 py-0.5 font-mono ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -16,17 +16,14 @@ export function Input({ label, error, id, className = "", ref, ...props }: Input
   return (
     <div className="w-full">
       {label && (
-        <label
-          htmlFor={id}
-          className="ui-text-sm mb-1.5 block font-medium text-zinc-700 dark:text-zinc-300"
-        >
+        <label htmlFor={id} className="ui-text-sm text-body mb-1.5 block font-medium">
           {label}
         </label>
       )}
       <input
         ref={ref}
         id={id}
-        className={`ui-text-sm block w-full rounded-md border bg-white px-3 py-2 text-zinc-900 placeholder:text-zinc-400 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-500 ${
+        className={`ui-text-sm bg-surface text-strong block w-full rounded-md border px-3 py-2 placeholder:text-zinc-400 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-zinc-500 ${
           error
             ? "border-red-500 focus:border-red-500 focus:ring-red-500 dark:border-red-500"
             : "border-zinc-300 focus:border-zinc-900 focus:ring-zinc-900 dark:border-zinc-700 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -14,7 +14,7 @@ export interface KbdProps {
 export function Kbd({ children, className = "" }: KbdProps) {
   return (
     <kbd
-      className={`ui-text-xs inline-flex min-w-[24px] items-center justify-center rounded border border-zinc-300 bg-zinc-100 px-1.5 py-0.5 font-mono font-medium text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 ${className}`}
+      className={`ui-text-xs bg-surface-muted text-body inline-flex min-w-[24px] items-center justify-center rounded border border-zinc-300 px-1.5 py-0.5 font-mono font-medium dark:border-zinc-600 ${className}`}
     >
       {children}
     </kbd>

--- a/src/components/ui/nav-link.tsx
+++ b/src/components/ui/nav-link.tsx
@@ -58,8 +58,8 @@ export function NavLink({
       onPrefetch={onPrefetch}
       className={`ui-text-sm flex min-h-[44px] items-center justify-between rounded-md px-3 py-2 font-medium transition-colors ${
         isActive
-          ? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
-          : "text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          ? "bg-surface-muted text-strong"
+          : "text-body hover:bg-zinc-100 dark:hover:bg-zinc-800"
       } ${className}`}
     >
       <span className="truncate">{children}</span>
@@ -112,16 +112,14 @@ export function NavLinkWithIcon({
       onPrefetch={onPrefetch}
       className={`ui-text-sm flex min-h-[44px] flex-1 items-center gap-2 rounded-md px-3 py-2 transition-colors ${
         isActive
-          ? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
-          : "text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          ? "bg-surface-muted text-strong"
+          : "text-body hover:bg-zinc-100 dark:hover:bg-zinc-800"
       } ${className}`}
     >
       {icon && <span className="shrink-0">{icon}</span>}
       <span className="truncate">{label}</span>
       {count !== undefined && count > 0 && (
-        <span className="ui-text-xs ml-auto shrink-0 text-zinc-500 dark:text-zinc-400">
-          ({count})
-        </span>
+        <span className="ui-text-xs text-subtle ml-auto shrink-0">({count})</span>
       )}
     </ClientLink>
   );

--- a/src/components/ui/not-found-card.tsx
+++ b/src/components/ui/not-found-card.tsx
@@ -17,12 +17,12 @@ interface NotFoundCardProps {
 export function NotFoundCard({ title, message }: NotFoundCardProps) {
   return (
     <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
-      <div className="rounded-lg border border-zinc-200 bg-white p-6 text-center sm:p-8 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="border-edge bg-surface rounded-lg border p-6 text-center sm:p-8">
         <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/20">
           <AlertIcon className="h-6 w-6 text-red-500 dark:text-red-400" />
         </div>
-        <h2 className="ui-text-lg mb-2 font-medium text-zinc-900 dark:text-zinc-50">{title}</h2>
-        <p className="ui-text-sm text-zinc-600 dark:text-zinc-400">{message}</p>
+        <h2 className="ui-text-lg text-strong mb-2 font-medium">{title}</h2>
+        <p className="ui-text-sm text-muted">{message}</p>
       </div>
     </div>
   );

--- a/src/components/ui/note-box.tsx
+++ b/src/components/ui/note-box.tsx
@@ -24,7 +24,7 @@ export function NoteBox({ children, padding = "md", className = "" }: NoteBoxPro
 
   return (
     <div
-      className={`rounded-md border border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800/50 ${paddingStyles[padding]} ${className}`}
+      className={`border-edge-strong bg-surface-subtle rounded-md border ${paddingStyles[padding]} ${className}`}
     >
       {children}
     </div>

--- a/src/components/ui/state-toggle-button.tsx
+++ b/src/components/ui/state-toggle-button.tsx
@@ -70,7 +70,7 @@ export function StateToggleButton({
     <button
       type="button"
       onClick={handleClick}
-      className={`inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400 ${className}`}
+      className={`text-subtle inline-flex items-center justify-center rounded-md p-2 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400 ${className}`}
       title={ariaLabel}
       aria-label={ariaLabel}
       aria-pressed={isPressed}

--- a/tests/unit/frontend/components/Button.test.tsx
+++ b/tests/unit/frontend/components/Button.test.tsx
@@ -39,14 +39,14 @@ describe("Button", () => {
     it("applies secondary variant styles", () => {
       render(<Button variant="secondary">Secondary</Button>);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("border", "bg-white", "text-zinc-900");
+      expect(button).toHaveClass("border", "bg-surface", "text-strong");
     });
 
     it("applies ghost variant styles", () => {
       render(<Button variant="ghost">Ghost</Button>);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("text-zinc-900");
-      expect(button).not.toHaveClass("btn-primary", "bg-white");
+      expect(button).toHaveClass("text-strong");
+      expect(button).not.toHaveClass("btn-primary", "bg-surface");
     });
   });
 

--- a/tests/unit/frontend/components/Card.test.tsx
+++ b/tests/unit/frontend/components/Card.test.tsx
@@ -30,7 +30,7 @@ describe("Card", () => {
     it("applies base styles", () => {
       render(<Card>Content</Card>);
       const card = screen.getByText("Content").closest("div");
-      expect(card).toHaveClass("rounded-lg", "border", "bg-white");
+      expect(card).toHaveClass("rounded-lg", "border", "bg-surface");
     });
   });
 
@@ -97,7 +97,7 @@ describe("CardTitle", () => {
   it("applies title styles", () => {
     render(<CardTitle>Styled Title</CardTitle>);
     const title = screen.getByRole("heading");
-    expect(title).toHaveClass("font-semibold", "text-zinc-900");
+    expect(title).toHaveClass("font-semibold", "text-strong");
   });
 
   it("applies custom className", () => {
@@ -116,7 +116,7 @@ describe("CardDescription", () => {
   it("applies description styles", () => {
     render(<CardDescription>Styled description</CardDescription>);
     const description = screen.getByText("Styled description");
-    expect(description).toHaveClass("text-zinc-500", "mt-1");
+    expect(description).toHaveClass("text-subtle", "mt-1");
   });
 
   it("applies custom className", () => {

--- a/tests/unit/frontend/components/Dialog.test.tsx
+++ b/tests/unit/frontend/components/Dialog.test.tsx
@@ -243,7 +243,7 @@ describe("DialogTitle", () => {
   it("applies title styles", () => {
     render(<DialogTitle>Styled Title</DialogTitle>);
     const title = screen.getByRole("heading");
-    expect(title).toHaveClass("font-semibold", "text-zinc-900");
+    expect(title).toHaveClass("font-semibold", "text-strong");
   });
 
   it("applies custom id", () => {
@@ -267,7 +267,7 @@ describe("DialogDescription", () => {
   it("applies description styles", () => {
     render(<DialogDescription>Styled description</DialogDescription>);
     const description = screen.getByText("Styled description");
-    expect(description).toHaveClass("text-zinc-600", "mt-2");
+    expect(description).toHaveClass("text-muted", "mt-2");
   });
 
   it("applies custom className", () => {

--- a/tests/unit/frontend/components/Input.test.tsx
+++ b/tests/unit/frontend/components/Input.test.tsx
@@ -50,7 +50,7 @@ describe("Input", () => {
     it("applies label styles", () => {
       render(<Input label="Styled Label" id="styled" />);
       const label = screen.getByText("Styled Label");
-      expect(label).toHaveClass("font-medium", "text-zinc-700");
+      expect(label).toHaveClass("font-medium", "text-body");
     });
   });
 
@@ -191,7 +191,7 @@ describe("Input", () => {
     it("applies base input styles", () => {
       render(<Input />);
       const input = screen.getByRole("textbox");
-      expect(input).toHaveClass("rounded-md", "border", "bg-white", "px-3", "py-2");
+      expect(input).toHaveClass("rounded-md", "border", "bg-surface", "px-3", "py-2");
     });
 
     it("applies focus ring styles", () => {

--- a/tests/unit/frontend/entry-list-item.test.ts
+++ b/tests/unit/frontend/entry-list-item.test.ts
@@ -33,14 +33,11 @@ describe("getItemClasses", () => {
       const classes = getItemClasses(true, false);
 
       expect(classes).toContain(baseClasses);
-      // Read has lighter border and white background
-      expect(classes).toContain("border-zinc-200");
-      expect(classes).toContain("bg-white");
+      // Read has lighter border and card-surface background (light/dark via tokens)
+      expect(classes).toContain("border-edge");
+      expect(classes).toContain("bg-surface");
       expect(classes).toContain("hover:bg-zinc-50");
       expect(classes).toContain("active:bg-zinc-100");
-      // Dark mode variants
-      expect(classes).toContain("dark:border-zinc-800");
-      expect(classes).toContain("dark:bg-zinc-900");
     });
   });
 
@@ -72,11 +69,10 @@ describe("getItemClasses", () => {
       expect(classes).toContain("ring-2");
       expect(classes).toContain("ring-accent");
       expect(classes).toContain("ring-offset-1");
-      // Read background within selected state
-      expect(classes).toContain("bg-white");
+      // Read background within selected state (light/dark via token)
+      expect(classes).toContain("bg-surface");
       // Dark mode variants
       expect(classes).toContain("dark:ring-offset-zinc-900");
-      expect(classes).toContain("dark:bg-zinc-900");
     });
   });
 


### PR DESCRIPTION
This addresses the original trigger for #1016: changing colors consistently was hard because every neutral color was a hand-written zinc light/dark pair repeated at hundreds of call sites.

## Semantic color tokens

`globals.css` gains neutral tokens using the exact mechanism the existing `--accent` / `--info-*` tokens use (`:root` + `.dark` + media-query fallback + `@theme inline`), so each role is **one utility class** and retheming means editing one CSS file:

| Token | Replaces |
| --- | --- |
| `text-strong` | `text-zinc-900 dark:text-zinc-50` |
| `text-emphasis` | `text-zinc-900 dark:text-zinc-200` (bold-in-prose, dimmer than strong in dark) |
| `text-body` | `text-zinc-700 dark:text-zinc-300` |
| `text-muted` | `text-zinc-600 dark:text-zinc-400` |
| `text-subtle` | `text-zinc-500 dark:text-zinc-400` |
| `text-faint` | `text-zinc-400 dark:text-zinc-500` |
| `bg-surface` | `bg-white dark:bg-zinc-900` |
| `bg-surface-muted` | `bg-zinc-100 dark:bg-zinc-800` |
| `bg-surface-subtle` | `bg-zinc-50 dark:bg-zinc-800/50` |
| `border-edge` / `divide-edge` | `…zinc-200 dark:…zinc-800` |
| `border-edge-strong` | `border-zinc-200 dark:border-zinc-700` |

## Sweep

A scripted pass replaced every class string containing a known light+dark pair — 565 strings across ~90 files, including template literals. Two drifted pairs were folded into their token (both had identical values on one side already): `text-zinc-900 dark:text-zinc-100` → `text-strong` (44 sites, dark nudges 100→50) and `text-zinc-800 dark:text-zinc-200` → `text-emphasis` (7 sites, light nudges 800→900).

Deliberately **not** tokenized: interactive-state colors (hover fills, focus rings, input borders), unread-row backgrounds, and other pairs below the frequency bar — those can be added incrementally now that the pattern exists. Documented in `src/components/CLAUDE.md`.

## Verification

- Ran the app against a live dev server and probed every token's computed color in **both** light and dark via headless Chromium — each resolves to exactly the intended zinc value, and the dark-mode demo page renders identically to production (screenshot-compared, and the Sign In button computed background matches production's zinc-900 exactly).
- `pnpm typecheck`, `pnpm lint`, prettier pass; all 2163 unit tests pass (7 test assertions updated from raw zinc classes to the tokens they now render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)