### PR TITLE
Fix rogue in-process job workers: bundled piscina resolved its bootstrap to dist/worker.js

### DIFF
--- a/scripts/build-discord-bot.mjs
+++ b/scripts/build-discord-bot.mjs
@@ -45,8 +45,13 @@ const buildOptions = {
   // External packages that can't/shouldn't be bundled:
   // - Native modules (argon2 uses node-gyp bindings)
   // - html-rewriter-wasm has WASM files and internal requires that break when bundled
+  // - piscina resolves its thread bootstrap as resolve(__dirname, "worker.js");
+  //   bundled, __dirname becomes the bundle's dir (dist/), so its threads load
+  //   dist/worker.js — the standalone job worker — instead of piscina's own
+  //   bootstrap, silently booting a rogue job worker inside this process and
+  //   hanging every offloaded task
   // We bundle everything else for a smaller, faster deployment
-  external: ["argon2", "html-rewriter-wasm"],
+  external: ["argon2", "html-rewriter-wasm", "piscina"],
 
   // Source maps for debugging production issues
   sourcemap: true,

--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -47,7 +47,9 @@ const buildOptions = {
   // - html-rewriter-wasm has WASM files and internal requires that break when bundled
   // - jsdom uses __dirname-relative fs.readFileSync for browser/default-stylesheet.css;
   //   bundling breaks the path resolution (required at runtime by isomorphic-dompurify)
-  external: ["next", "argon2", "html-rewriter-wasm", "jsdom"],
+  // - piscina resolves its thread bootstrap via __dirname; bundled it would load
+  //   dist/worker.js (the job worker) into its threads (see build-worker.mjs)
+  external: ["next", "argon2", "html-rewriter-wasm", "jsdom", "piscina"],
 
   // Source maps for debugging production issues
   sourcemap: true,

--- a/scripts/build-worker-thread.mjs
+++ b/scripts/build-worker-thread.mjs
@@ -39,8 +39,10 @@ const buildOptions = {
   alias,
 
   // html-rewriter-wasm has WASM files that break when bundled.
+  // piscina resolves its thread bootstrap via __dirname; bundled it would load
+  // dist/worker.js (the job worker) into its threads (see build-worker.mjs).
   // Everything else (linkedom, @mozilla/readability, htmlparser2, etc.) is bundled.
-  external: ["html-rewriter-wasm"],
+  external: ["html-rewriter-wasm", "piscina"],
 
   sourcemap: true,
   minify: true,

--- a/scripts/build-worker.mjs
+++ b/scripts/build-worker.mjs
@@ -45,8 +45,13 @@ const buildOptions = {
   // External packages that can't/shouldn't be bundled:
   // - Native modules (argon2 uses node-gyp bindings)
   // - html-rewriter-wasm has WASM files and internal requires that break when bundled
+  // - piscina resolves its thread bootstrap as resolve(__dirname, "worker.js");
+  //   bundled, __dirname becomes the bundle's dir (dist/), so its threads load
+  //   dist/worker.js — the standalone job worker — instead of piscina's own
+  //   bootstrap, silently booting a rogue job worker inside this process and
+  //   hanging every offloaded task
   // We bundle everything else for a smaller, faster deployment
-  external: ["argon2", "html-rewriter-wasm"],
+  external: ["argon2", "html-rewriter-wasm", "piscina"],
 
   // Source maps for debugging production issues
   sourcemap: true,

--- a/src/server/worker-thread/pool.ts
+++ b/src/server/worker-thread/pool.ts
@@ -54,6 +54,12 @@ let sanitizerVersionVerified = false;
  * version mismatch permanently disables the pool).
  */
 let sanitizerVersionProbe: Promise<"ok" | "mismatch" | "error"> | null = null;
+/**
+ * Upper bound on the version probe. A cold thread spawn answers in well under a
+ * second; 15s only trips when the thread is wedged (wrong module loaded, event
+ * loop blocked), where waiting longer can't help and inline is the right call.
+ */
+const PROBE_TIMEOUT_MS = 15_000;
 
 function resolveWorkerPath(): { filename: string; execArgv?: string[] } {
   // Use process.cwd() for all path resolution — __dirname gets replaced by
@@ -136,8 +142,25 @@ function getPool(): Piscina | null {
 async function verifyWorkerSanitizerVersion(p: Piscina): Promise<"ok" | "mismatch" | "error"> {
   let version: number;
   try {
-    const result = await p.run({ type: "sanitizerVersion" });
-    version = sanitizerVersionResultSchema.parse(result).version;
+    // The probe must be bounded: a thread whose entry module loads but never
+    // speaks piscina's task protocol (e.g. the wrong file resolved into the
+    // thread — bundled piscina once resolved its bootstrap to dist/worker.js,
+    // the standalone job worker) leaves p.run() pending forever, and every
+    // offload caller awaits this shared probe — so an unbounded probe freezes
+    // every save/sanitize in the process instead of degrading to inline.
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`sanitizer version probe timed out after ${PROBE_TIMEOUT_MS}ms`)),
+        PROBE_TIMEOUT_MS
+      );
+    });
+    try {
+      const result = await Promise.race([p.run({ type: "sanitizerVersion" }), timeout]);
+      version = sanitizerVersionResultSchema.parse(result).version;
+    } finally {
+      clearTimeout(timer);
+    }
   } catch (error) {
     // A transient worker crash/timeout (not a genuine version mismatch) must not
     // permanently disable offload — the caller retries on the next call.


### PR DESCRIPTION
## Root cause

Piscina spawns its worker threads with **its own bootstrap script**, resolved as `resolve(__dirname, "worker.js")` (`node_modules/piscina/dist/index.js:135`). We bundle piscina into `dist/discord-bot.js` and `dist/worker.js` — and in a bundle, `__dirname` at runtime is the bundle's directory (`/app/dist`). So every piscina thread loaded **`/app/dist/worker.js` — the standalone job worker — instead of piscina's bootstrap**.

Consequences, all observed in production over the past days (#1119, #1124, #1141 investigation):

- First >10 KB sanitize in the Discord bot (a save reaction) → pool init → a **full rogue job worker boots inside the bot process**: `Plugins registered` / `Starting standalone worker` with `flyProcessGroup: discord`, metrics on 9092, claiming real `fetch_feed` jobs on a 256 MB VM.
- The piscina task **hangs forever** (the job worker never speaks piscina's protocol), so `saveArticle` never resolved → no result emoji — the original "bot doesn't respond to reacts" bug.
- Memory pressure → VM restarts after saves ("discord bot starting again").
- `dist/worker.js` was worse: its piscina threads loaded **itself**, nesting job workers on the worker machine.
- The app server escaped only because Next's webpack build keeps `node_modules` external — its piscina loads from disk.

## Fix

- Mark `piscina` as `external` in the four esbuild bundle scripts whose graphs can reach it (`build-migrate.mjs` imports neither piscina nor the pool and is unchanged) (it ships in the image's `node_modules`, same as `argon2`/`html-rewriter-wasm`), so its `__dirname` points at `node_modules/piscina/dist/` and threads load the real bootstrap.
- Bound the sanitizer-version probe with a 15 s timeout: a thread that loads but never responds previously left the **shared** probe promise pending forever, freezing every offload caller in the process. Now it logs a warning and degrades to inline sanitization, retrying later.

## Verification

- Reproduced pre-fix: a bundled caller with `NODE_ENV=production` made piscina's thread attempt to load `dist/worker.js` (module-not-found locally; in prod it exists and boots).
- Post-fix: same repro completes the offloaded sanitize through the real bootstrap; `resolve(__dirname, "worker.js")` no longer appears in any bundle.
- `pnpm typecheck` and `pnpm test:unit` (2190 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
