### PR TITLE
Stop logging every non-matching Discord reaction

### DIFF
--- a/src/server/discord/bot.ts
+++ b/src/server/discord/bot.ts
@@ -247,20 +247,11 @@ export async function startDiscordBot(): Promise<void> {
   client.on("messageReactionAdd", async (reaction, user) => {
     if (user.bot) return;
 
+    // Users can't react with application emojis (they're only usable by the
+    // bot itself), so the save trigger must be a server emoji whose name
+    // matches DISCORD_SAVE_EMOJI exactly.
     const emoji = reaction.emoji.name;
-    if (emoji !== DISCORD_SAVE_EMOJI) {
-      // Users can't react with application emojis (they're only usable by the
-      // bot itself), so the save trigger must be a server emoji whose name
-      // matches DISCORD_SAVE_EMOJI exactly. Log mismatches so a wrong or
-      // renamed server emoji is diagnosable instead of silently ignored.
-      logger.info("Ignoring reaction with non-save emoji", {
-        emoji,
-        emojiId: reaction.emoji.id,
-        expected: DISCORD_SAVE_EMOJI,
-        userId: user.id,
-      });
-      return;
-    }
+    if (emoji !== DISCORD_SAVE_EMOJI) return;
 
     logger.info("Save reaction received", {
       userId: user.id,


### PR DESCRIPTION
Removes the per-reaction "Ignoring reaction with non-save emoji" info log added while debugging the broken save flow (root-caused and fixed in #1145). It fires for every reaction with any emoji in every channel the bot can see — pure noise now. The comment explaining the application-vs-server-emoji subtlety stays, as do the low-volume diagnostics that only fire on actual save attempts (`Save reaction received`, unlinked user, no URLs in message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)