### PR TITLE
Fix apex-origin registration_client_uri on the MCP host + log DCR outcomes

### DIFF
--- a/src/app/oauth/register/route.ts
+++ b/src/app/oauth/register/route.ts
@@ -27,7 +27,8 @@ export function OPTIONS() {
 }
 
 async function handleRegister(request: NextRequest): Promise<Response> {
-  logger.info("OAuth client registration requested");
+  const host = request.headers.get("host");
+  logger.info("OAuth client registration requested", { host });
 
   // Dynamic Client Registration is open (no auth) per RFC 7591, so rate-limit by
   // IP to prevent anonymous client-spam. Uses the generous "oauth" bucket (not
@@ -65,9 +66,28 @@ async function handleRegister(request: NextRequest): Promise<Response> {
   }
 
   // Register the client
-  const result = await registerClient(body);
+  const result = await registerClient(body, host);
+
+  // Log the OUTCOME either way — a client like claude.ai reports registration
+  // failures with an opaque error, so the server log is the only place that says
+  // what we actually returned and why. Everything logged here is public client
+  // metadata from the request (RFC 7591) or the issued client_id; never the
+  // client_secret.
+  const requested = {
+    host,
+    clientName: body.client_name,
+    redirectUris: body.redirect_uris,
+    grantTypes: body.grant_types,
+    scope: body.scope,
+    tokenEndpointAuthMethod: body.token_endpoint_auth_method,
+  };
 
   if (!result.success) {
+    logger.warn("OAuth client registration rejected", {
+      ...requested,
+      error: result.error.error,
+      errorDescription: result.error.error_description,
+    });
     return NextResponse.json(result.error, {
       status: 400,
       headers: {
@@ -77,6 +97,14 @@ async function handleRegister(request: NextRequest): Promise<Response> {
       },
     });
   }
+
+  logger.info("OAuth client registered", {
+    ...requested,
+    clientId: result.data.client_id,
+    grantedScope: result.data.scope,
+    registrationClientUri: result.data.registration_client_uri,
+    isPublic: result.data.client_secret === undefined,
+  });
 
   // Return successful registration response with HTTP 201 Created
   return NextResponse.json(result.data, {

--- a/src/server/oauth/config.ts
+++ b/src/server/oauth/config.ts
@@ -136,7 +136,6 @@ export function getAcceptedResourceIdentifiers(): string[] {
 }
 
 /**
- * OAuth 2.0 Authorization Server Metadata (RFC 8414)
  * The `registration_client_uri` returned from Dynamic Client Registration
  * (RFC 7591). Host-derived like the advertised endpoints: a registration on the
  * MCP host must not reference the apex origin — a cross-origin URI in the
@@ -151,6 +150,7 @@ export function getRegistrationClientUri(clientId: string, host?: string | null)
 }
 
 /**
+ * OAuth 2.0 Authorization Server Metadata (RFC 8414)
  * Used by /.well-known/oauth-authorization-server
  */
 export function getAuthorizationServerMetadata(host?: string | null) {

--- a/src/server/oauth/config.ts
+++ b/src/server/oauth/config.ts
@@ -137,6 +137,20 @@ export function getAcceptedResourceIdentifiers(): string[] {
 
 /**
  * OAuth 2.0 Authorization Server Metadata (RFC 8414)
+ * The `registration_client_uri` returned from Dynamic Client Registration
+ * (RFC 7591). Host-derived like the advertised endpoints: a registration on the
+ * MCP host must not reference the apex origin — a cross-origin URI in the
+ * registration response is an inconsistency a strict client can reject. The URI
+ * intentionally 404s on both surfaces (RFC 7592 client management is not
+ * implemented — see registerClient); only its origin-consistency matters.
+ */
+export function getRegistrationClientUri(clientId: string, host?: string | null): string {
+  const surface = resolveSurface(host);
+  const prefix = surface.rootOauthEndpoints ? "" : "/oauth";
+  return `${surface.issuer}${prefix}/register/${clientId}`;
+}
+
+/**
  * Used by /.well-known/oauth-authorization-server
  */
 export function getAuthorizationServerMetadata(host?: string | null) {

--- a/src/server/oauth/service.ts
+++ b/src/server/oauth/service.ts
@@ -30,7 +30,7 @@ import {
   OAUTH_SCOPES,
   SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS,
 } from "./utils";
-import { getIssuer, getResourceIdentifier } from "./config";
+import { getIssuer, getRegistrationClientUri, getResourceIdentifier } from "./config";
 import { logger } from "@/lib/logger";
 import { USER_AGENT } from "@/server/http/user-agent";
 import { fetchWithSsrfProtection } from "@/server/http/ssrf";
@@ -740,10 +740,13 @@ function generateClientId(): string {
  * Supports open registration (no initial access token required).
  *
  * @param request - Client registration request
+ * @param host - Request Host header; picks the OAuth surface (apex vs MCP host)
+ *   the `registration_client_uri` is expressed on
  * @returns Client registration response or error
  */
 export async function registerClient(
-  request: ClientRegistrationRequest
+  request: ClientRegistrationRequest,
+  host?: string | null
 ): Promise<
   | { success: true; data: ClientRegistrationResponse }
   | { success: false; error: ClientRegistrationError }
@@ -887,8 +890,9 @@ export async function registerClient(
     // Notion), which all include this field. RFC 7592 client management is not
     // implemented (theirs isn't either — Linear's URI 404s), and per RFC 7592 a
     // client can't use it anyway without a registration_access_token, which we
-    // don't issue.
-    registration_client_uri: `${getIssuer()}/oauth/register/${clientId}`,
+    // don't issue. Host-derived so a registration on the MCP host doesn't
+    // reference the apex origin.
+    registration_client_uri: getRegistrationClientUri(clientId, host),
   };
 
   // Add client_secret for confidential clients

--- a/tests/integration/oauth-register.test.ts
+++ b/tests/integration/oauth-register.test.ts
@@ -93,6 +93,34 @@ describe("OAuth Dynamic Client Registration auth methods", () => {
       );
     }
   });
+
+  it("expresses registration_client_uri on the requesting host's surface", async () => {
+    // A registration on the dedicated MCP host must not reference the apex
+    // origin — a cross-origin registration_client_uri is an inconsistency a
+    // strict client can reject.
+    process.env.MCP_HOST = "mcp.example.com";
+    try {
+      const result = await registerClient(
+        {
+          redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+          client_name: "MCP Host Test Client",
+          token_endpoint_auth_method: "none",
+        },
+        "mcp.example.com"
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        registeredClientIds.push(result.data.client_id);
+        // Origin root (no /oauth prefix), matching the MCP host's advertised
+        // registration_endpoint.
+        expect(result.data.registration_client_uri).toBe(
+          `https://mcp.example.com/register/${result.data.client_id}`
+        );
+      }
+    } finally {
+      delete process.env.MCP_HOST;
+    }
+  });
 });
 
 describe("OAuth Dynamic Client Registration scope handling", () => {

--- a/tests/unit/oauth-config.test.ts
+++ b/tests/unit/oauth-config.test.ts
@@ -15,6 +15,7 @@ import {
   getProtectedResourceMetadata,
   getProtectedResourceMetadataUrl,
   getAuthorizationServerMetadata,
+  getRegistrationClientUri,
 } from "../../src/server/oauth/config";
 import { SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS } from "../../src/server/oauth/utils";
 
@@ -154,6 +155,20 @@ describe("OAuth resource identifiers on the dedicated MCP host", () => {
     expect(metadata.registration_endpoint).toBe("https://mcp.example.com/register");
     // Served by the root alias in src/app/revoke/route.ts.
     expect(metadata.revocation_endpoint).toBe("https://mcp.example.com/revoke");
+  });
+
+  it("expresses registration_client_uri on the requesting host's surface", () => {
+    // Cross-origin registration_client_uri (apex origin in an MCP-host DCR
+    // response) is an inconsistency a strict client can reject.
+    expect(getRegistrationClientUri("abc123", "mcp.example.com")).toBe(
+      "https://mcp.example.com/register/abc123"
+    );
+    expect(getRegistrationClientUri("abc123", "reader.example.com")).toBe(
+      "https://reader.example.com/oauth/register/abc123"
+    );
+    expect(getRegistrationClientUri("abc123")).toBe(
+      "https://reader.example.com/oauth/register/abc123"
+    );
   });
 
   it("advertises the MCP host itself as its own authorization server", () => {


### PR DESCRIPTION
## What happened on the first live connect (#986)

The first claude.ai connect attempt against `mcp.lionreader.com` got further than the apex ever did — discovery completed cleanly on the right host and the DCR POST reached the handler — but claude.ai aborted **without ever opening `/authorize`** (no login screen, immediate error).

Reproducing claude.ai's DCR request against the live endpoint found a real server-side bug:

```
"registration_client_uri": "https://lionreader.com/oauth/register/…"
```

**Wrong origin.** `registerClient` built the URI with a host-less `getIssuer()`, so a registration performed on the MCP host referenced the apex — exactly the kind of cross-origin inconsistency in the OAuth flow that a strict client can reject (the same class as the root-vs-path-inserted metadata location issue from #974).

## Changes

- **`getRegistrationClientUri(clientId, host)`** in `oauth/config.ts`: expresses the URI on the requesting host's surface — `https://{mcpHost}/register/{id}` on the MCP host (matching its advertised root `registration_endpoint`), `{apex}/oauth/register/{id}` on the apex (unchanged). The register route threads the `Host` header through `registerClient`.
- **DCR outcome logging**: the register route logged the request but not the result, which is why today's logs couldn't say what claude.ai received. Now every rejection logs the OAuth error + description, and every success logs the issued `client_id`, granted scope, `registration_client_uri`, and public/confidential — plus the requested public client metadata (name, redirect URIs, grant types, scope, auth method). Never the `client_secret`. This also directly catches the known claude.ai `offline_access` scope-mangling failure mode (anthropics/claude-ai-mcp#453), since our handler rejects registrations whose requested scopes are all unrecognized.

## Testing

- Unit: `getRegistrationClientUri` host matrix (MCP host / apex / no host).
- Integration: registration on the MCP host returns the MCP-host URI at the origin root; existing DCR suite still green (10/10).
- `pnpm typecheck` clean.

## Caveat

Whether the cross-origin `registration_client_uri` is what makes claude.ai abort is **plausible but unproven** — it's the one concrete server-side inconsistency found, and it's a bug regardless. If the next connect attempt still fails, the new outcome log line will say exactly what we returned, closing today's observability gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)