### PR TITLE
Add e-paper theme mode for e-ink screens (#1017)

### DIFF
--- a/src/app/demo/articles/appearance.ts
+++ b/src/app/demo/articles/appearance.ts
@@ -8,13 +8,13 @@ const article: DemoArticle = {
   title: "Appearance & Themes",
   author: null,
   summary:
-    "Customize fonts, text size, alignment, and switch between light and a sleep-friendly, low-blue-light dark theme.",
+    "Customize fonts, text size, alignment, and switch between light, a sleep-friendly low-blue-light dark theme, and an e-paper theme for e-ink screens.",
   publishedAt: new Date("2025-12-28T12:00:00Z"),
   starred: false,
   heroImage: "/demo/appearance.png",
   heroImageAlt:
     "The Lion Reader lion holding a card split into a light half with a sun and a dark half with a moon, with a paintbrush and color swatches.",
-  summaryHtml: `<p>Lion Reader provides comprehensive appearance customization including a <strong>sleep-friendly dark mode</strong> that swaps blue accents for a warm red accent and neutral zinc tones to reduce blue light, multiple font families (serif and sans-serif), adjustable text sizes, and alignment choices. All settings save locally and apply instantly, and the app installs as a Progressive Web App.</p>`,
+  summaryHtml: `<p>Lion Reader provides comprehensive appearance customization including a <strong>sleep-friendly dark mode</strong> that swaps blue accents for a warm red accent and neutral zinc tones to reduce blue light, an <strong>e-paper theme</strong> with a pure white background and grayscale-safe colors for e-ink readers, multiple font families (serif and sans-serif), adjustable text sizes, and alignment choices. All settings save locally and apply instantly, and the app installs as a Progressive Web App.</p>`,
   contentHtml: `
     <p>Reading comfort is personal. What works for one person might strain another&rsquo;s eyes. That&rsquo;s why Lion Reader gives you comprehensive control over how your content appears, letting you create the perfect reading environment for your preferences and lighting conditions.</p>
 
@@ -27,6 +27,10 @@ const article: DemoArticle = {
     <p>Lion Reader&rsquo;s dark theme is designed for late-night reading. Rather than the usual blue-accented dark mode, it deliberately minimizes blue light: the accent color switches from blue to a warm <strong>red</strong> (red-400, <code>#f87171</code>), and informational highlights use neutral <strong>zinc</strong> grays (zinc-400, <code>#a1a1aa</code>) instead of blue. In light mode those same elements stay blue, where blue light is a non-issue in a bright environment.</p>
 
     <p>The motivation is simple: blue light in the evening is the wavelength most associated with suppressing melatonin, the hormone that helps you wind down for sleep. By steering the dark theme toward warm and neutral tones, Lion Reader aims to be gentler on your eyes and your circadian rhythm when you&rsquo;re reading in bed with the lights off. This is a design choice to reduce blue light, not a medical claim &mdash; but if you read at night, it&rsquo;s one less thing keeping you awake.</p>
+
+    <h3>E-paper theme</h3>
+
+    <p>Reading on a Kindle, Kobo, or Onyx Boox? The <strong>E-paper</strong> theme is built for e-ink screens: a pure white background, near-black text, and colors chosen so everything stays readable even when the display forces the page to grayscale. Borders and highlights are darker than in the regular light theme because e-ink panels can&rsquo;t render faint grays. When your theme is set to <strong>Auto</strong>, Lion Reader even tries to detect e-reader devices and switches to the e-paper theme automatically.</p>
 
     <h3>Typography Controls</h3>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -145,9 +145,83 @@
   --edge-strong: #3f3f46; /* zinc-700 */
 }
 
+/* =================================
+   E-paper theme (issue #1017)
+
+   For e-ink screens: pure white background, near-black text, and colors
+   chosen to keep working when the display forces everything to grayscale.
+   Guidelines for editing this palette:
+   - Accents stay colored (dark blue) but must gray to a tone clearly darker
+     than mid-gray, so links/highlights survive a grayscale conversion.
+   - E-ink panels have few gray levels and dither light grays badly, so
+     borders and fills sit several steps darker than in light mode
+     (edge zinc-400 vs zinc-200) and subtle "tint" backgrounds are avoided
+     or darkened.
+   - Never encode meaning in hue alone; pair color with contrast.
+   ================================= */
+.epaper {
+  /* next-themes only sets color-scheme for light/dark, so declare it here */
+  color-scheme: light;
+
+  --background: #ffffff;
+  --foreground: #000000;
+
+  /* Dark blue accent: grays to a dark tone, still readable on white */
+  --accent: #1e40af; /* blue-800 */
+  --accent-hover: #1e3a8a; /* blue-900 */
+  --accent-muted: #1e40af; /* blue-800 */
+  --accent-subtle: #dbeafe; /* blue-100 - one step darker than light mode's blue-50 so it survives e-ink dithering */
+  --accent-subtle-foreground: #1e3a8a; /* blue-900 */
+  --accent-border: #60a5fa; /* blue-400 - grays to a visible mid tone */
+
+  /* Pure black primary: maximum contrast for buttons and "on" states */
+  --primary-solid: #000000;
+  --primary-solid-foreground: #ffffff;
+
+  --info: #1e40af; /* blue-800 */
+  --info-muted: #1e40af; /* blue-800 */
+  --info-subtle: #dbeafe; /* blue-100 */
+  --info-subtle-foreground: #1e3a8a; /* blue-900 */
+  --info-foreground: #1e3a8a; /* blue-900 */
+  --info-border: #60a5fa; /* blue-400 */
+
+  /* Text tones shifted darker than light mode: e-ink can't render faint grays */
+  --text-strong: #000000;
+  --text-emphasis: #000000;
+  --text-body: #18181b; /* zinc-900 */
+  --text-muted: #3f3f46; /* zinc-700 */
+  --text-subtle: #52525b; /* zinc-600 */
+  --text-faint: #71717a; /* zinc-500 */
+
+  /* Pure white surfaces; separation comes from the darker borders below */
+  --surface: #ffffff;
+  --surface-muted: #e4e4e7; /* zinc-200 - chips/skeletons need a fill that survives dithering */
+  --surface-subtle: #ffffff;
+  --edge: #a1a1aa; /* zinc-400 */
+  --edge-strong: #71717a; /* zinc-500 */
+}
+
+/* Darken Tailwind Typography's prose palette to match the e-paper text tones */
+.epaper .prose {
+  --tw-prose-body: var(--text-body);
+  --tw-prose-headings: var(--text-strong);
+  --tw-prose-lead: var(--text-body);
+  --tw-prose-links: var(--text-strong);
+  --tw-prose-bold: var(--text-strong);
+  --tw-prose-counters: var(--text-muted);
+  --tw-prose-bullets: var(--text-muted);
+  --tw-prose-hr: var(--edge);
+  --tw-prose-quotes: var(--text-body);
+  --tw-prose-quote-borders: var(--edge);
+  --tw-prose-captions: var(--text-muted);
+  --tw-prose-code: var(--text-strong);
+  --tw-prose-th-borders: var(--edge);
+  --tw-prose-td-borders: var(--edge);
+}
+
 /* Fallback to system preference when no class is set */
 @media (prefers-color-scheme: dark) {
-  :root:not(.dark):not(.light) {
+  :root:not(.dark):not(.light):not(.epaper) {
     --background: #0a0a0a;
     --foreground: #ededed;
 
@@ -366,6 +440,19 @@ body {
   border-bottom-color: #3f3f46; /* zinc-700 */
 }
 
+/* E-paper: zinc-200 borders and zinc-50 fills vanish on e-ink, so use the
+   theme's darker edge color and a plain white card */
+.epaper .reader-prose details {
+  border-color: var(--edge);
+  background-color: #ffffff;
+}
+.epaper .reader-prose summary:hover {
+  background-color: #e4e4e7; /* zinc-200 */
+}
+.epaper .reader-prose details[open] summary {
+  border-bottom-color: var(--edge);
+}
+
 /* =================================
    Reader Prose Video Embeds
 
@@ -410,9 +497,15 @@ body {
 }
 
 @media (prefers-color-scheme: dark) {
-  [data-para-id].narration-highlight {
+  :root:not(.light):not(.epaper) [data-para-id].narration-highlight {
     background-color: rgba(113, 63, 18, 0.3); /* yellow-900/30 for dark mode */
   }
+}
+
+/* E-paper highlight: a 30% yellow tint grays to near-invisible on e-ink,
+   so use a solid gray fill instead */
+.epaper [data-para-id].narration-highlight {
+  background-color: #e4e4e7; /* zinc-200 */
 }
 
 /* Smooth scroll to highlighted paragraph - account for sticky header */

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -57,7 +57,7 @@ The `ui-text-*` classes are defined in `src/app/globals.css` and provide respons
 
 ### Semantic Colors
 
-**Use the semantic color tokens instead of raw zinc light/dark pairs.** Each token is one utility class covering both modes; the palette lives in `src/app/globals.css` (`:root` + `.dark`), so retheming means editing CSS variables, not call sites:
+**Use the semantic color tokens instead of raw zinc light/dark pairs.** Each token is one utility class covering all themes; the palettes live in `src/app/globals.css` (`:root` for light, `.dark`, and `.epaper` for e-ink screens), so retheming means editing CSS variables, not call sites:
 
 | Token                | Replaces                               | Use for                            |
 | -------------------- | -------------------------------------- | ---------------------------------- |
@@ -85,7 +85,7 @@ Settings pages are built from `SettingsSection` (`@/components/settings/Settings
 - **Use existing icons** - Check the icon list above before adding inline SVGs
 - **Watch for patterns** - If you see the same UI pattern 3+ times, consider extracting a component
 - **44px touch targets** - Ensure interactive elements meet WCAG touch target guidelines (handled by UI components)
-- **Dark mode** - All UI components support dark mode via `dark:` Tailwind classes
+- **Dark mode** - All UI components support dark mode via `dark:` Tailwind classes. The e-paper theme (`.epaper` on `<html>`) is light-like, so `dark:` variants don't apply to it; it restyles the app purely through the semantic-color CSS variables, plus colors that must gray safely (see the `.epaper` block in `globals.css`)
 
 ### When to Keep Icons Local
 

--- a/src/components/narration/NarrationHighlightStyles.tsx
+++ b/src/components/narration/NarrationHighlightStyles.tsx
@@ -44,50 +44,64 @@ function generateHighlightCSS(paragraphIds: Set<number>): string {
   }
 
   // Build selectors for text elements (everything except img)
-  const textSelectors = Array.from(paragraphIds)
-    .map((id) => `[data-para-id="para-${id}"]:not(img)`)
-    .join(",\n");
+  const textSelectors = Array.from(paragraphIds).map(
+    (id) => `[data-para-id="para-${id}"]:not(img)`
+  );
 
   // Build selectors for images specifically
-  const imageSelectors = Array.from(paragraphIds)
-    .map((id) => `img[data-para-id="para-${id}"]`)
-    .join(",\n");
+  const imageSelectors = Array.from(paragraphIds).map((id) => `img[data-para-id="para-${id}"]`);
 
-  // Return CSS rules that apply the highlight styles
-  // Text elements get background color, images get border
+  // Prefix every selector in the list, not just the first
+  const scoped = (prefix: string, selectors: string[]) =>
+    selectors.map((selector) => `${prefix} ${selector}`).join(",\n");
+
+  // Return CSS rules that apply the highlight styles.
+  // Text elements get background color, images get border.
+  // The prefers-color-scheme fallback (for "system" with no class applied yet)
+  // must not override an explicit .light/.epaper theme, mirroring the
+  // narration-highlight rules in globals.css. E-paper uses solid grays: the
+  // translucent yellow tints are near-invisible when forced to grayscale.
   return `
-${textSelectors} {
+${textSelectors.join(",\n")} {
   background-color: rgba(253, 230, 138, 0.3);
   border-radius: 0.25rem;
   transition: background-color 0.3s ease, box-shadow 0.3s ease;
   scroll-margin-top: 100px;
 }
 
-.dark ${textSelectors} {
+${scoped(".dark", textSelectors)} {
   background-color: rgba(113, 63, 18, 0.3);
 }
 
 @media (prefers-color-scheme: dark) {
-  ${textSelectors} {
+  ${scoped(":root:not(.light):not(.epaper)", textSelectors)} {
     background-color: rgba(113, 63, 18, 0.3);
   }
 }
 
-${imageSelectors} {
+${scoped(".epaper", textSelectors)} {
+  background-color: #e4e4e7; /* zinc-200 */
+}
+
+${imageSelectors.join(",\n")} {
   box-shadow: 0 0 0 3px rgba(253, 230, 138, 0.5);
   border-radius: 0.25rem;
   transition: box-shadow 0.3s ease;
   scroll-margin-top: 100px;
 }
 
-.dark ${imageSelectors} {
+${scoped(".dark", imageSelectors)} {
   box-shadow: 0 0 0 3px rgba(113, 63, 18, 0.5);
 }
 
 @media (prefers-color-scheme: dark) {
-  ${imageSelectors} {
+  ${scoped(":root:not(.light):not(.epaper)", imageSelectors)} {
     box-shadow: 0 0 0 3px rgba(113, 63, 18, 0.5);
   }
+}
+
+${scoped(".epaper", imageSelectors)} {
+  box-shadow: 0 0 0 3px #a1a1aa; /* zinc-400 */
 }
 `;
 }

--- a/src/components/settings/AppearanceSettings.tsx
+++ b/src/components/settings/AppearanceSettings.tsx
@@ -2,7 +2,7 @@
  * AppearanceSettings Component
  *
  * Settings UI for appearance preferences including:
- * - Theme mode (system/light/dark) - powered by next-themes
+ * - Theme mode (system/light/dark/e-paper) - powered by next-themes
  * - Text size for entry content
  * - Text justification for entry content
  * - Font family for entry content
@@ -12,6 +12,7 @@
 
 import { useTheme } from "next-themes";
 import { SettingsSection } from "@/components/settings/SettingsSection";
+import { useIsEInkDisplay } from "@/lib/theme/eink";
 import { useAppearance, useEntryTextStyles } from "@/lib/appearance/AppearanceProvider";
 import type { TextSize, TextJustification, FontFamily } from "@/lib/appearance/settings";
 
@@ -78,6 +79,7 @@ const THEME_OPTIONS: { value: string; label: string }[] = [
   { value: "system", label: "Auto" },
   { value: "light", label: "Light" },
   { value: "dark", label: "Dark" },
+  { value: "epaper", label: "E-paper" },
 ];
 
 const TEXT_SIZE_OPTIONS: { value: TextSize; label: string }[] = [
@@ -122,6 +124,8 @@ function TextPreview() {
 export function AppearanceSettings() {
   const { settings, updateSettings } = useAppearance();
   const { theme, setTheme, resolvedTheme } = useTheme();
+  // On e-ink displays, "Auto" resolves to the e-paper theme (see ThemeProvider)
+  const isEInk = useIsEInkDisplay();
 
   return (
     <div className="space-y-8">
@@ -130,11 +134,13 @@ export function AppearanceSettings() {
         <OptionGroup
           label="Color Mode"
           description={
-            theme === "system" && resolvedTheme
-              ? `Following system preference (currently ${resolvedTheme})`
+            theme === "system" && (isEInk || resolvedTheme)
+              ? `Following system preference (currently ${isEInk ? "e-paper" : resolvedTheme})`
               : theme === "system"
                 ? "Following system preference"
-                : undefined
+                : theme === "epaper"
+                  ? "Pure white background with high-contrast colors designed for e-ink screens"
+                  : undefined
           }
           value={theme || "system"}
           options={THEME_OPTIONS}

--- a/src/lib/appearance/AppearanceProvider.tsx
+++ b/src/lib/appearance/AppearanceProvider.tsx
@@ -19,9 +19,9 @@ import {
 interface AppearanceContextValue {
   settings: AppearanceSettings;
   updateSettings: (settings: Partial<AppearanceSettings>) => void;
-  /** The resolved theme (always "light" or "dark", never "system"). Undefined during SSR. */
-  resolvedTheme: "light" | "dark" | undefined;
-  /** Set the theme ("light", "dark", or "system") */
+  /** The resolved theme (never "system"). Undefined during SSR. */
+  resolvedTheme: "light" | "dark" | "epaper" | undefined;
+  /** Set the theme ("light", "dark", "epaper", or "system") */
   setTheme: (theme: string) => void;
 }
 
@@ -46,7 +46,7 @@ export function AppearanceProvider({ children }: AppearanceProviderProps) {
     () => ({
       settings,
       updateSettings,
-      resolvedTheme: resolvedTheme as "light" | "dark" | undefined,
+      resolvedTheme: resolvedTheme as "light" | "dark" | "epaper" | undefined,
       setTheme,
     }),
     [settings, updateSettings, resolvedTheme, setTheme]

--- a/src/lib/theme/ThemeProvider.tsx
+++ b/src/lib/theme/ThemeProvider.tsx
@@ -2,23 +2,68 @@
  * Theme Provider
  *
  * Wraps next-themes ThemeProvider with our preferred configuration.
- * Handles dark/light mode switching with system preference support.
+ * Handles dark/light/e-paper mode switching with system preference support.
  */
 
 "use client";
 
-import { ThemeProvider as NextThemesProvider } from "next-themes";
-import type { ReactNode } from "react";
+import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
+import { useEffect, type ReactNode } from "react";
+import { useIsEInkDisplay } from "./eink";
 
 interface ThemeProviderProps {
   children: ReactNode;
 }
 
 /**
+ * Resolves the "system" theme to e-paper on e-ink displays (issue #1017).
+ *
+ * next-themes only knows how to resolve "system" to light/dark via
+ * `prefers-color-scheme`, so this component re-asserts the `epaper` class on
+ * <html> whenever the user is on Auto and the display looks like an e-reader.
+ * A MutationObserver (rather than a plain effect) is required because
+ * next-themes applies its theme class from the provider's own effect, which
+ * runs *after* child effects — and also re-applies it imperatively on system
+ * preference changes. When the user picks an explicit theme, next-themes
+ * removes the `epaper` class itself (it's in the configured themes list).
+ */
+function EInkSystemThemeOverride() {
+  const { theme } = useTheme();
+  const isEInk = useIsEInkDisplay();
+  const active = isEInk && theme === "system";
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    const root = document.documentElement;
+    const apply = () => {
+      // Only mutate when needed so the observer doesn't loop on its own writes
+      if (
+        root.classList.contains("light") ||
+        root.classList.contains("dark") ||
+        !root.classList.contains("epaper")
+      ) {
+        root.classList.remove("light", "dark");
+        root.classList.add("epaper");
+      }
+    };
+    apply();
+    const observer = new MutationObserver(apply);
+    observer.observe(root, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, [active]);
+
+  return null;
+}
+
+/**
  * Theme provider that wraps the app with next-themes.
  *
  * Configuration:
- * - attribute="class": Uses .dark class on <html> (matches our Tailwind config)
+ * - attribute="class": Uses .dark/.light/.epaper class on <html> (matches our Tailwind config)
+ * - themes: light/dark plus the e-paper theme for e-ink screens ("system" is
+ *   appended automatically because enableSystem is set)
  * - defaultTheme="system": Follows system preference by default
  * - enableSystem: Allows "system" as a theme option
  * - disableTransitionOnChange: Prevents flash by disabling CSS transitions during theme change
@@ -30,9 +75,11 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       attribute="class"
       defaultTheme="system"
       enableSystem
+      themes={["light", "dark", "epaper"]}
       disableTransitionOnChange
       storageKey="lion-reader-theme"
     >
+      <EInkSystemThemeOverride />
       {children}
     </NextThemesProvider>
   );

--- a/src/lib/theme/ThemeProvider.tsx
+++ b/src/lib/theme/ThemeProvider.tsx
@@ -47,6 +47,15 @@ function EInkSystemThemeOverride() {
         root.classList.remove("light", "dark");
         root.classList.add("epaper");
       }
+      // next-themes writes the resolved system theme's color-scheme as an
+      // inline style (e.g. "dark" when the OS prefers dark), which would beat
+      // the `.epaper { color-scheme: light }` rule. It always rewrites this
+      // together with the class, so re-asserting here covers every path; when
+      // the user later picks an explicit theme, next-themes overwrites or
+      // clears it again.
+      if (root.style.colorScheme !== "light") {
+        root.style.colorScheme = "light";
+      }
     };
     apply();
     const observer = new MutationObserver(apply);

--- a/src/lib/theme/eink.ts
+++ b/src/lib/theme/eink.ts
@@ -1,0 +1,61 @@
+/**
+ * E-ink display detection.
+ *
+ * Used to resolve the "Auto" theme to the e-paper theme on e-reader screens
+ * (issue #1017). Detection is best-effort: there is no standard "e-ink" media
+ * query, so we combine the `(monochrome)` media query (matches greyscale e-ink
+ * panels) with a user-agent check for known e-reader devices and browsers.
+ * False negatives are fine — users can always select E-paper manually.
+ */
+
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * Known e-reader devices and e-ink browsers that identify themselves in the
+ * user-agent string. EinkBro is the de-facto browser on Onyx Boox devices,
+ * which otherwise don't mention e-ink in their UA.
+ */
+const EINK_USER_AGENT_PATTERN =
+  /\b(?:Kobo|Kindle|EinkBro|Tolino|PocketBook|InkPalm|Likebook|Boyue|BOOX|reMarkable)\b/i;
+
+/**
+ * Pure user-agent check for known e-reader devices/browsers.
+ */
+export function isEInkUserAgent(userAgent: string): boolean {
+  return EINK_USER_AGENT_PATTERN.test(userAgent);
+}
+
+/**
+ * Detects whether the current display is (likely) an e-ink screen.
+ * Client-only; returns false during SSR.
+ */
+function isEInkDisplay(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    if (window.matchMedia("(monochrome)").matches) {
+      return true;
+    }
+  } catch {
+    // matchMedia unavailable (very old browser) - fall through to UA check
+  }
+  return isEInkUserAgent(navigator.userAgent);
+}
+
+// The display type never changes within a session, so there's nothing to watch
+function subscribeNever(): () => void {
+  return () => {};
+}
+
+/**
+ * React hook version of {@link isEInkDisplay}.
+ *
+ * Uses useSyncExternalStore so the server snapshot is false (SSR-safe) and the
+ * client snapshot reflects the real display after hydration.
+ */
+export function useIsEInkDisplay(): boolean {
+  return useSyncExternalStore(subscribeNever, isEInkDisplay, () => false);
+}

--- a/tests/unit/frontend/eink-detection.test.ts
+++ b/tests/unit/frontend/eink-detection.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isEInkUserAgent } from "@/lib/theme/eink";
+
+describe("isEInkUserAgent", () => {
+  it("matches known e-reader device user agents", () => {
+    const eReaderUserAgents = [
+      // Kindle Paperwhite experimental browser
+      "Mozilla/5.0 (X11; U; Linux armv7l like Android; en-us) AppleWebKit/531.2+ (KHTML, like Gecko) Version/5.0 Safari/533.2+ Kindle/3.0+",
+      // Kobo eReader browser
+      "Mozilla/5.0 (Linux; U; Android 2.0; en-us;) AppleWebKit/538.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/538.1 (Kobo Touch 0373/4.38.23171)",
+      // EinkBro on an Onyx Boox device
+      "Mozilla/5.0 (Linux; Android 11; NoteAir2P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 EinkBro/11.4.0",
+      // Tolino
+      "Mozilla/5.0 (Linux; U; Android 4.4.4; de-de; tolino tab 8 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36",
+      // PocketBook InkPad
+      "Mozilla/5.0 (X11; Linux; PocketBook) AppleWebKit/601.1 (KHTML, like Gecko) Version/8.0 Safari/601.1",
+    ];
+    for (const userAgent of eReaderUserAgents) {
+      expect(isEInkUserAgent(userAgent), userAgent).toBe(true);
+    }
+  });
+
+  it("does not match ordinary browser user agents", () => {
+    const ordinaryUserAgents = [
+      // Desktop Chrome
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+      // Desktop Firefox
+      "Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0",
+      // iOS Safari
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+      // Android Chrome
+      "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36",
+    ];
+    for (const userAgent of ordinaryUserAgents) {
+      expect(isEInkUserAgent(userAgent), userAgent).toBe(false);
+    }
+  });
+
+  it("requires word boundaries so substrings inside other words don't match", () => {
+    expect(isEInkUserAgent("Mozilla/5.0 (SomeKindleryDevice)")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1017.

Adds an **E-paper** theme alongside Light/Dark, and resolves **Auto** to it when the display looks like an e-reader.

## What it does

- **New `.epaper` palette** in `globals.css`: pure white background, near-black text, and colors chosen to survive a forced grayscale conversion — accents stay colored (blue-800, grays to a clearly dark tone; links remain underlined in prose), borders sit several zinc steps darker than light mode (`--edge` zinc-400 vs zinc-200) because e-ink panels dither faint grays into invisibility, and the primary button / "on" states are pure black-on-white. The block documents these rules for future palette edits.
- **Grayscale-safe overrides** for the few hardcoded colors: Tailwind Typography prose variables, the `reader-prose` `<details>` cards, and the narration highlight (a 30% yellow tint is near-invisible in grayscale, so e-paper uses a solid gray fill).
- **Auto-detection on e-readers**: when the theme is Auto, `EInkSystemThemeOverride` (in `ThemeProvider`) applies the e-paper theme if the `(monochrome)` media query matches or the user agent is a known e-reader/e-ink browser (Kindle, Kobo, EinkBro, Tolino, PocketBook, …). Detection is best-effort — false negatives just mean picking E-paper manually. It re-asserts the class through a MutationObserver because next-themes applies its own theme class from the provider's effect (which runs after child effects) and re-applies it imperatively on system-preference changes.
- **Settings UI**: new E-paper option in Appearance → Color Mode, with "Following system preference (currently e-paper)" shown when Auto resolves to it.
- The system-dark `prefers-color-scheme` CSS fallbacks now exclude `.epaper`; the narration-highlight fallback also now correctly excludes an explicit `.light` class (pre-existing latent bug).
- `.epaper` declares `color-scheme: light` itself since next-themes only sets it for light/dark.
- Demo appearance article and `src/components/CLAUDE.md` updated.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` all pass (new unit test covers the e-reader UA detection).
- Verified in headless Chromium against a dev server:
  - explicit `epaper` theme → `<html class="epaper">`, white background, `color-scheme: light`, new palette variables active;
  - Auto + EinkBro user agent → resolves to e-paper;
  - Auto + normal Chrome UA → still resolves to light/dark (no `(monochrome)` false positive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)