### PR TITLE
DCR/metadata parity with the working remote MCP servers (#986)

### DIFF
--- a/src/server/oauth/config.ts
+++ b/src/server/oauth/config.ts
@@ -181,7 +181,7 @@ export function getAuthorizationServerMetadata(host?: string | null) {
     // settings) unsupported. Shared with /oauth/register validation so the two
     // can't drift apart again.
     token_endpoint_auth_methods_supported: SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS,
-    // NB: we intentionally do NOT advertise `client_id_metadata_document_supported`.
+    // NB: we intentionally do NOT advertise CIMD *support* (i.e. never `true`).
     // Clients pick their registration method by priority: pre-registered → CIMD →
     // DCR. claude.ai treats CIMD (when advertised alongside `"none"` auth) as
     // preferred and sets up the client entirely client-side (its own metadata-doc
@@ -193,6 +193,12 @@ export function getAuthorizationServerMetadata(host?: string | null) {
     // (and other clients) to Dynamic Client Registration, which works. The
     // server-side CIMD resolution in `resolveClient` is retained, so a client that
     // explicitly presents a URL client_id still works.
+    //
+    // The flag is set to an EXPLICIT `false` (rather than omitted) for parity
+    // with Sentry, which works with the claude.ai connector while advertising
+    // exactly this. Omission and false should read the same to a spec-correct
+    // client, but a strict/buggy one may treat a missing key differently.
+    client_id_metadata_document_supported: false,
   };
 }
 
@@ -206,5 +212,8 @@ export function getProtectedResourceMetadata(host?: string | null) {
     authorization_servers: [getIssuer(host)],
     scopes_supported: Object.values(OAUTH_SCOPES),
     bearer_methods_supported: ["header"],
+    // RFC 9728 §2 display name; Notion includes it and clients may show it in
+    // their connect UI.
+    resource_name: "Lion Reader",
   };
 }

--- a/src/server/oauth/service.ts
+++ b/src/server/oauth/service.ts
@@ -701,6 +701,7 @@ export interface ClientRegistrationResponse {
   client_secret?: string;
   client_id_issued_at?: number;
   client_secret_expires_at?: number;
+  client_secret_issued_at?: number;
   registration_client_uri?: string;
   redirect_uris: string[];
   token_endpoint_auth_method: string;
@@ -899,6 +900,12 @@ export async function registerClient(
   if (clientSecret) {
     response.client_secret = clientSecret;
     response.client_secret_expires_at = 0; // 0 means it doesn't expire
+    // Not an RFC 7591 field, but BOTH Notion and Linear include it in
+    // confidential-client registrations and they are the reference targets the
+    // claude.ai connector demonstrably works against — a strict client response
+    // model built against them could require it whenever client_secret is
+    // present. Cheap parity; observed during the #986 subdomain debugging.
+    response.client_secret_issued_at = Math.floor(now.getTime() / 1000);
   }
 
   // Add optional fields if provided

--- a/tests/integration/oauth-register.test.ts
+++ b/tests/integration/oauth-register.test.ts
@@ -54,6 +54,9 @@ describe("OAuth Dynamic Client Registration auth methods", () => {
         expect(result.data.token_endpoint_auth_method).toBe(method);
         expect(result.data.client_secret).toBeTruthy();
         expect(result.data.client_secret_expires_at).toBe(0);
+        // Notion and Linear both include this alongside client_secret; a strict
+        // client response model built against them may require it (#986).
+        expect(result.data.client_secret_issued_at).toBe(result.data.client_id_issued_at);
       }
     }
   );

--- a/tests/unit/oauth-config.test.ts
+++ b/tests/unit/oauth-config.test.ts
@@ -74,14 +74,15 @@ describe("OAuth resource identifiers", () => {
   });
 
   it("does NOT advertise Client ID Metadata Document support", () => {
-    // Advertising `client_id_metadata_document_supported` makes claude.ai prefer
-    // CIMD over Dynamic Client Registration; its CIMD setup fails inside the
-    // connector flow (it never calls /oauth/register or /oauth/authorize) and
-    // surfaces as "Couldn't register with the sign-in service". Omitting the flag
-    // drops clients to DCR, which works. Do not re-add without confirming
+    // Advertising `client_id_metadata_document_supported: true` makes claude.ai
+    // prefer CIMD over Dynamic Client Registration; its CIMD setup fails inside
+    // the connector flow (it never calls /oauth/register or /oauth/authorize) and
+    // surfaces as "Couldn't register with the sign-in service". The flag must be
+    // an EXPLICIT false (Sentry parity — see getAuthorizationServerMetadata), so
+    // clients drop to DCR, which works. Do not flip to true without confirming
     // claude.ai's CIMD flow actually completes.
     const metadata = getAuthorizationServerMetadata();
-    expect("client_id_metadata_document_supported" in metadata).toBe(false);
+    expect(metadata.client_id_metadata_document_supported).toBe(false);
   });
 
   it("advertises the endpoints and PKCE claude.ai requires for DCR", () => {


### PR DESCRIPTION
## Context: second live connect attempt (2026-07-12 19:46 UTC)

After #1148 deployed, the claude.ai retry got a **provably clean registration** — 201, same-origin `registration_client_uri`, correct client metadata (confidential, `client_secret_post`) — and claude.ai **still aborted without ever calling `/authorize`** (no browser request arrived at all; it re-POSTed `/mcp` tokenless 2s after registering, got the 401, and errored).

To find any remaining server-side delta, I registered an identically-shaped confidential client against the live `/register` endpoints of Notion and Linear and diffed every response claude.ai touched in our flow against theirs. Three deltas remained; this PR closes all of them:

1. **`client_secret_issued_at`** in confidential DCR responses. Not an RFC 7591 field, but **both** Notion and Linear include it alongside `client_secret`. A strict client response model built against those servers could require it — and a parse failure there would be silent and land exactly where the abort is observed. This was the only remaining response-body delta on the whole path.
2. **`client_id_metadata_document_supported: false`** — explicit, instead of omitting the key (Sentry advertises exactly this and works). Never `true`: claude.ai's CIMD flow is still broken (see the code comment).
3. **`resource_name: "Lion Reader"`** in the protected-resource metadata (RFC 9728 §2; Notion includes it, clients may display it).

## Ruled out during the same session (so nobody re-chases these)

- **401 body shape** — already byte-identical to Notion/Linear (shipped 2026-07-10, confirmed live during the retry).
- **Colon-scopes** in `scopes_supported` (`saved:write`) — Sentry advertises `org:read`/`project:write` and works.
- **CIMD being required** — Sentry advertises `false` and works.
- **Root-level OAuth paths being required** — Sentry advertises `/oauth/*` endpoints and works.

## Testing

Typecheck clean; unit oauth-config suite (15) and integration DCR suite (10, incl. new `client_secret_issued_at` assertion) pass.

## Honest framing

The observed signature — DCR succeeds, `/authorize` never called, tokenless `initialize` → 401 → error — exactly matches the documented claude.ai broker bug variant ("never calls /token", sibling of anthropics/claude-ai-mcp#136). These parity fixes are cheap and principled, but if the next retry still fails, the server side is exhausted and the evidence package (ofid + UTC timestamps + this log trail) goes upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)