### PR TITLE
E-paper: make the page canvas pure white (bg-canvas token)

### DIFF
--- a/src/app/(app)/AppLayoutContent.tsx
+++ b/src/app/(app)/AppLayoutContent.tsx
@@ -181,7 +181,7 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
               <OfflineBanner />
 
               {/* Main content */}
-              <MainScrollContainer className="flex-1 overflow-y-auto bg-zinc-50 dark:bg-zinc-950">
+              <MainScrollContainer className="bg-canvas flex-1 overflow-y-auto">
                 <AppRouter />
               </MainScrollContainer>
             </LayoutShell>

--- a/src/app/(auth)/AuthLayoutContent.tsx
+++ b/src/app/(auth)/AuthLayoutContent.tsx
@@ -15,7 +15,7 @@ interface AuthLayoutContentProps {
 
 export function AuthLayoutContent({ children }: AuthLayoutContentProps) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 py-12 dark:bg-zinc-950">
+    <div className="bg-canvas flex min-h-screen flex-col items-center justify-center px-4 py-12">
       <div className="w-full max-w-md">
         {/* Logo / Brand */}
         <div className="mb-8 text-center">

--- a/src/app/complete-signup/layout.tsx
+++ b/src/app/complete-signup/layout.tsx
@@ -40,7 +40,7 @@ export default async function CompleteSignupLayout({ children }: CompleteSignupL
 
   return (
     <TRPCProvider>
-      <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 py-12 dark:bg-zinc-950">
+      <div className="bg-canvas flex min-h-screen flex-col items-center justify-center px-4 py-12">
         <div className="w-full max-w-md">
           <div className="mb-8 text-center">
             <h1 className="ui-text-2xl text-strong font-bold">Lion Reader</h1>

--- a/src/app/demo/DemoLayoutContent.tsx
+++ b/src/app/demo/DemoLayoutContent.tsx
@@ -88,7 +88,7 @@ export function DemoLayoutContent({ children }: DemoLayoutContentProps) {
                 </div>
               }
             >
-              <MainScrollContainer className="flex-1 overflow-y-auto bg-zinc-50 dark:bg-zinc-950">
+              <MainScrollContainer className="bg-canvas flex-1 overflow-y-auto">
                 {hydrated ? <DemoRouter /> : (children ?? <DemoListSkeleton />)}
               </MainScrollContainer>
             </LayoutShell>

--- a/src/app/extension/callback/page.tsx
+++ b/src/app/extension/callback/page.tsx
@@ -27,7 +27,7 @@ export default async function ExtensionCallbackPage({ searchParams }: PageProps)
   const isSuccess = status === "success";
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900">
+    <div className="bg-canvas flex min-h-screen items-center justify-center">
       <div className="max-w-md p-8 text-center">
         {isSuccess ? (
           <>

--- a/src/app/extension/save/client.tsx
+++ b/src/app/extension/save/client.tsx
@@ -15,7 +15,7 @@ interface Props {
 export function ExtensionSaveClient({ status, error, url, canRetry }: Props) {
   if (status === "loading") {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900">
+      <div className="bg-canvas flex min-h-screen items-center justify-center">
         <div className="p-8 text-center">
           <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2 border-zinc-900 dark:border-zinc-100" />
           <p className="text-muted">Saving article...</p>
@@ -26,7 +26,7 @@ export function ExtensionSaveClient({ status, error, url, canRetry }: Props) {
 
   if (status === "error") {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900">
+      <div className="bg-canvas flex min-h-screen items-center justify-center">
         <div className="max-w-md p-8 text-center">
           <div className="mb-4 text-5xl text-red-500">!</div>
           <h1 className="ui-text-xl text-strong mb-2 font-semibold">Failed to Save</h1>
@@ -54,7 +54,7 @@ export function ExtensionSaveClient({ status, error, url, canRetry }: Props) {
 
   // Success is handled by redirect, but just in case:
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900">
+    <div className="bg-canvas flex min-h-screen items-center justify-center">
       <div className="p-8 text-center">
         <div className="mb-4 text-5xl text-green-500">✓</div>
         <p className="text-muted">Article saved!</p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,6 +54,7 @@
   --text-faint: #a1a1aa; /* zinc-400 - de-emphasized notes, placeholders */
 
   /* Surfaces */
+  --canvas: #fafafa; /* zinc-50 - page background behind cards/app shell */
   --surface: #ffffff; /* white - cards, inputs, controls */
   --surface-muted: #f4f4f5; /* zinc-100 - chips, skeletons */
   --surface-subtle: #fafafa; /* zinc-50 - note boxes, subtle fills */
@@ -97,6 +98,7 @@
   --color-muted: var(--text-muted);
   --color-subtle: var(--text-subtle);
   --color-faint: var(--text-faint);
+  --color-canvas: var(--canvas);
   --color-surface: var(--surface);
   --color-surface-muted: var(--surface-muted);
   --color-surface-subtle: var(--surface-subtle);
@@ -138,6 +140,7 @@
   --text-muted: #a1a1aa; /* zinc-400 */
   --text-subtle: #a1a1aa; /* zinc-400 */
   --text-faint: #71717a; /* zinc-500 */
+  --canvas: #09090b; /* zinc-950 */
   --surface: #18181b; /* zinc-900 */
   --surface-muted: #27272a; /* zinc-800 */
   --surface-subtle: rgba(39, 39, 42, 0.5); /* zinc-800/50 */
@@ -194,6 +197,7 @@
   --text-faint: #71717a; /* zinc-500 */
 
   /* Pure white surfaces; separation comes from the darker borders below */
+  --canvas: #ffffff;
   --surface: #ffffff;
   --surface-muted: #e4e4e7; /* zinc-200 - chips/skeletons need a fill that survives dithering */
   --surface-subtle: #ffffff;
@@ -252,6 +256,7 @@
     --text-muted: #a1a1aa; /* zinc-400 */
     --text-subtle: #a1a1aa; /* zinc-400 */
     --text-faint: #71717a; /* zinc-500 */
+    --canvas: #09090b; /* zinc-950 */
     --surface: #18181b; /* zinc-900 */
     --surface-muted: #27272a; /* zinc-800 */
     --surface-subtle: rgba(39, 39, 42, 0.5); /* zinc-800/50 */

--- a/src/app/oauth/consent/page.tsx
+++ b/src/app/oauth/consent/page.tsx
@@ -120,7 +120,7 @@ export default async function ConsentPage({ searchParams }: ConsentPageProps) {
 
 function ConsentLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 py-12 dark:bg-zinc-950">
+    <div className="bg-canvas flex min-h-screen flex-col items-center justify-center px-4 py-12">
       <div className="w-full max-w-md">
         <div className="mb-8 text-center">
           <h1 className="ui-text-2xl text-strong font-bold">Lion Reader</h1>

--- a/src/app/save/page.tsx
+++ b/src/app/save/page.tsx
@@ -227,7 +227,7 @@ function SaveContent() {
     };
 
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 p-4 dark:bg-zinc-950">
+      <div className="bg-canvas flex min-h-screen flex-col items-center justify-center p-4">
         <div className="border-edge bg-surface w-full max-w-sm rounded-lg border p-6 shadow-sm">
           <div className="text-center">
             <h1 className="ui-text-lg text-strong font-semibold">Save to Lion Reader</h1>
@@ -246,7 +246,7 @@ function SaveContent() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 p-4 dark:bg-zinc-950">
+    <div className="bg-canvas flex min-h-screen flex-col items-center justify-center p-4">
       <div className="border-edge bg-surface w-full max-w-sm rounded-lg border p-6 shadow-sm">
         <div className="text-center">
           <h1 className="ui-text-lg text-strong font-semibold">Save to Lion Reader</h1>

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -67,6 +67,7 @@ The `ui-text-*` classes are defined in `src/app/globals.css` and provide respons
 | `text-muted`         | `text-zinc-600 dark:text-zinc-400`     | Descriptions, secondary text       |
 | `text-subtle`        | `text-zinc-500 dark:text-zinc-400`     | Metadata, hints                    |
 | `text-faint`         | `text-zinc-400 dark:text-zinc-500`     | De-emphasized notes, placeholders  |
+| `bg-canvas`          | `bg-zinc-50 dark:bg-zinc-950`          | Page background behind the shell   |
 | `bg-surface`         | `bg-white dark:bg-zinc-900`            | Cards, inputs, controls            |
 | `bg-surface-muted`   | `bg-zinc-100 dark:bg-zinc-800`         | Chips, skeletons                   |
 | `bg-surface-subtle`  | `bg-zinc-50 dark:bg-zinc-800/50`       | Note boxes, subtle fills           |

--- a/src/components/layout/LayoutShell.tsx
+++ b/src/components/layout/LayoutShell.tsx
@@ -39,7 +39,7 @@ export function LayoutShell({
   children,
 }: LayoutShellProps) {
   return (
-    <div className="flex h-screen bg-zinc-50 dark:bg-zinc-950">
+    <div className="bg-canvas flex h-screen">
       {/* Mobile sidebar overlay */}
       {sidebarOpen && sidebarOverlay}
 

--- a/src/components/legal/LegalProse.tsx
+++ b/src/components/legal/LegalProse.tsx
@@ -25,7 +25,7 @@ export interface LegalPageProps {
 
 export function LegalPage({ title, lastUpdated, children }: LegalPageProps) {
   return (
-    <div className="min-h-screen bg-zinc-50 px-4 py-12 dark:bg-zinc-950">
+    <div className="bg-canvas min-h-screen px-4 py-12">
       <main className="mx-auto max-w-3xl">
         <div className="mb-8">
           <Link


### PR DESCRIPTION
Follow-up to #1149 (issue #1017): the e-paper background wasn't actually pure white.

The app shell paints its page background with literal `bg-zinc-50 dark:bg-zinc-950` utilities (`LayoutShell`, the app/demo main scroll containers, and the auth/save/complete-signup/oauth-consent/extension full-page layouts). Those bypass the `.epaper` CSS variables, so the e-paper theme showed a zinc-50 (`#fafafa`) canvas — the slight grey Brendan spotted.

Per the semantic-color convention, this tokenizes the page-canvas color as `--canvas` / `bg-canvas`:

| Theme | `--canvas` |
| --- | --- |
| Light | `#fafafa` (zinc-50, unchanged) |
| Dark | `#09090b` (zinc-950, unchanged) |
| E-paper | `#ffffff` (pure white) |

All twelve canvas call sites now use `bg-canvas`. The extension save/callback pages previously used `dark:bg-zinc-900` where every other page used zinc-950; they now share the standard dark canvas (a subtle darkening, flagging in case it was deliberate). The unread entry-row tint (`bg-zinc-50`) is deliberately untouched — it's a state indicator, not the canvas, and quantizes to white on e-ink anyway.

Verified computed canvas colors in headless Chromium: e-paper `rgb(255,255,255)`, light `rgb(250,250,250)`, dark `rgb(9,9,11)`. Typecheck, lint, and unit tests pass; `src/components/CLAUDE.md` semantic-color table updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)