### PR TITLE
Increase read/unread contrast in the entry list

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,13 @@
 /* Configure dark mode to use class-based approach (.dark on html) */
 @variant dark (&:where(.dark, .dark *));
 
+/* E-paper theme variant (.epaper on html) — lets components target e-ink
+   screens where every background is white and read/unread contrast has to come
+   from borders and text weight instead of fills. Registered with
+   @custom-variant (new variant) rather than @variant, which only overrides an
+   existing one like the built-in `dark` above. */
+@custom-variant epaper (&:where(.epaper, .epaper *));
+
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -86,7 +86,7 @@ Settings pages are built from `SettingsSection` (`@/components/settings/Settings
 - **Use existing icons** - Check the icon list above before adding inline SVGs
 - **Watch for patterns** - If you see the same UI pattern 3+ times, consider extracting a component
 - **44px touch targets** - Ensure interactive elements meet WCAG touch target guidelines (handled by UI components)
-- **Dark mode** - All UI components support dark mode via `dark:` Tailwind classes. The e-paper theme (`.epaper` on `<html>`) is light-like, so `dark:` variants don't apply to it; it restyles the app purely through the semantic-color CSS variables, plus colors that must gray safely (see the `.epaper` block in `globals.css`)
+- **Dark mode** - All UI components support dark mode via `dark:` Tailwind classes. The e-paper theme (`.epaper` on `<html>`) is light-like, so `dark:` variants don't apply to it; it restyles the app purely through the semantic-color CSS variables, plus colors that must gray safely (see the `.epaper` block in `globals.css`). When a component genuinely needs an e-paper-only override (e.g. a border that can't come from a token because e-paper has no background contrast), use the `epaper:` Tailwind variant — registered via `@custom-variant epaper` in `globals.css`, mirroring `dark:`. Reach for it sparingly; prefer the semantic tokens.
 
 ### When to Keep Icons Local
 

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -77,8 +77,9 @@ export function getItemClasses(read: boolean, selected: boolean): string {
   if (read) {
     // Read entries recede into the page canvas: no fill of their own and a
     // faint hairline border, so they read as "already handled". They lift to a
-    // surface fill on hover to signal they're still clickable.
-    return `${baseClasses} border-edge bg-canvas hover:bg-surface active:bg-surface-muted dark:hover:bg-zinc-900 dark:active:bg-zinc-800`;
+    // surface fill on hover to signal they're still clickable (the surface
+    // tokens already carry their own dark-mode values).
+    return `${baseClasses} border-edge bg-canvas hover:bg-surface active:bg-surface-muted`;
   }
 
   // Unread entries stand out as raised surface cards with a distinctly stronger

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -70,15 +70,21 @@ export function getItemClasses(read: boolean, selected: boolean): string {
   if (selected) {
     // Selected state takes priority - accent ring indicator
     return `${baseClasses} border-accent ring-2 ring-accent ring-offset-1 dark:ring-offset-zinc-900 ${
-      read ? "bg-surface" : "bg-zinc-50 dark:bg-zinc-800"
+      read ? "bg-canvas" : "bg-surface"
     }`;
   }
 
   if (read) {
-    return `${baseClasses} border-edge bg-surface hover:bg-zinc-50 active:bg-zinc-100 dark:hover:bg-zinc-800/50 dark:active:bg-zinc-800`;
+    // Read entries recede into the page canvas: no fill of their own and a
+    // faint hairline border, so they read as "already handled". They lift to a
+    // surface fill on hover to signal they're still clickable.
+    return `${baseClasses} border-edge bg-canvas hover:bg-surface active:bg-surface-muted dark:hover:bg-zinc-900 dark:active:bg-zinc-800`;
   }
 
-  return `${baseClasses} border-zinc-300 bg-zinc-50 hover:bg-zinc-100 active:bg-zinc-200 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:bg-zinc-700/50 dark:active:bg-zinc-700`;
+  // Unread entries stand out as raised surface cards with a distinctly stronger
+  // border (the only card/canvas separation available on e-paper, where every
+  // fill is white).
+  return `${baseClasses} border-zinc-300 bg-surface hover:bg-zinc-50 active:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-800 dark:active:bg-zinc-700 epaper:border-zinc-500`;
 }
 
 /**
@@ -187,7 +193,7 @@ export const EntryListItem = memo(function EntryListItem({
           <div className="flex items-start justify-between gap-2">
             <h3
               className={`ui-text-sm line-clamp-2 ${
-                read ? "text-body font-normal" : "text-strong font-medium"
+                read ? "text-muted font-normal" : "text-strong font-semibold"
               }`}
             >
               {displayTitle}

--- a/tests/unit/frontend/components/EntryListItem.test.tsx
+++ b/tests/unit/frontend/components/EntryListItem.test.tsx
@@ -176,11 +176,15 @@ describe("EntryListItem", () => {
 
       const { rerender } = render(<EntryListItem entry={unreadEntry} />);
       const unreadTitle = screen.getByText("Unread");
-      expect(unreadTitle).toHaveClass("font-medium");
+      // Unread titles are bold and use the strongest text tone to stand out
+      expect(unreadTitle).toHaveClass("font-semibold");
+      expect(unreadTitle).toHaveClass("text-strong");
 
       rerender(<EntryListItem entry={readEntry} />);
       const readTitle = screen.getByText("Read");
+      // Read titles are dimmed to recede
       expect(readTitle).toHaveClass("font-normal");
+      expect(readTitle).toHaveClass("text-muted");
     });
   });
 

--- a/tests/unit/frontend/entry-list-item.test.ts
+++ b/tests/unit/frontend/entry-list-item.test.ts
@@ -17,14 +17,16 @@ describe("getItemClasses", () => {
       const classes = getItemClasses(false, false);
 
       expect(classes).toContain(baseClasses);
-      // Unread has darker border and background
+      // Unread stands out: raised surface card with a distinctly stronger border
       expect(classes).toContain("border-zinc-300");
-      expect(classes).toContain("bg-zinc-50");
-      expect(classes).toContain("hover:bg-zinc-100");
-      expect(classes).toContain("active:bg-zinc-200");
+      expect(classes).toContain("bg-surface");
+      expect(classes).toContain("hover:bg-zinc-50");
+      expect(classes).toContain("active:bg-zinc-100");
       // Dark mode variants
-      expect(classes).toContain("dark:border-zinc-700");
-      expect(classes).toContain("dark:bg-zinc-800");
+      expect(classes).toContain("dark:border-zinc-600");
+      expect(classes).toContain("dark:hover:bg-zinc-800");
+      // E-paper (all fills white) leans on a darker border for card separation
+      expect(classes).toContain("epaper:border-zinc-500");
     });
   });
 
@@ -33,11 +35,12 @@ describe("getItemClasses", () => {
       const classes = getItemClasses(true, false);
 
       expect(classes).toContain(baseClasses);
-      // Read has lighter border and card-surface background (light/dark via tokens)
+      // Read recedes into the page canvas with a faint hairline border
       expect(classes).toContain("border-edge");
-      expect(classes).toContain("bg-surface");
-      expect(classes).toContain("hover:bg-zinc-50");
-      expect(classes).toContain("active:bg-zinc-100");
+      expect(classes).toContain("bg-canvas");
+      // Lifts to a surface fill on hover to signal it's still clickable
+      expect(classes).toContain("hover:bg-surface");
+      expect(classes).toContain("active:bg-surface-muted");
     });
   });
 
@@ -51,11 +54,10 @@ describe("getItemClasses", () => {
       expect(classes).toContain("ring-2");
       expect(classes).toContain("ring-accent");
       expect(classes).toContain("ring-offset-1");
-      // Unread background within selected state
-      expect(classes).toContain("bg-zinc-50");
+      // Unread background within selected state (raised surface)
+      expect(classes).toContain("bg-surface");
       // Dark mode variants
       expect(classes).toContain("dark:ring-offset-zinc-900");
-      expect(classes).toContain("dark:bg-zinc-800");
     });
   });
 
@@ -69,8 +71,8 @@ describe("getItemClasses", () => {
       expect(classes).toContain("ring-2");
       expect(classes).toContain("ring-accent");
       expect(classes).toContain("ring-offset-1");
-      // Read background within selected state (light/dark via token)
-      expect(classes).toContain("bg-surface");
+      // Read background within selected state recedes into the canvas
+      expect(classes).toContain("bg-canvas");
       // Dark mode variants
       expect(classes).toContain("dark:ring-offset-zinc-900");
     });
@@ -86,8 +88,8 @@ describe("getItemClasses", () => {
       expect(selectedRead).toContain("ring-accent");
 
       // Neither should have hover states that conflict with selection
-      expect(selectedUnread).not.toContain("hover:bg-zinc-100");
-      expect(selectedRead).not.toContain("hover:bg-zinc-50");
+      expect(selectedUnread).not.toContain("hover:bg-zinc-50");
+      expect(selectedRead).not.toContain("hover:bg-surface");
     });
   });
 });


### PR DESCRIPTION
Follow-up to the e-paper theme (#1017): the read vs unread distinction in the entry list was nearly invisible, and Brendan asked for more contrast — a little more in light mode too, and something that works on e-paper.

## The problem

Read entries used `bg-surface` (white) and unread `bg-zinc-50` — a ~2% background delta. Worse, now that the page canvas is itself zinc-50, the **unread** rows blended into the page while the **read** (white) rows stood out — backwards from the usual "read = dimmed" convention. On e-paper (every fill is white) the only thing separating them was the status dot.

## The change

Flip to the conventional direction and reinforce it across independent channels so it survives on e-paper and when the screen forces grayscale:

| | Read (recedes) | Unread (stands out) |
|---|---|---|
| Background | `bg-canvas` (blends into the page) | `bg-surface` (raised white/zinc-900 card) |
| Border | `border-edge` (faint) | zinc-300 / zinc-600 dark / **zinc-500 e-paper** |
| Title | `text-muted` normal | `text-strong` **semibold** |
| Hover | lifts to a surface fill | subtle zinc tint |

Read entries now fade into the canvas with a dimmed title; unread entries are crisp bordered cards with bold titles. The dot (filled vs hollow) is unchanged.

Adds a `@custom-variant epaper` to `globals.css` (mirroring the existing class-based `dark` override) so the unread border can be made distinctly darker specifically on e-ink, where there's no background contrast to lean on. `@variant` only overrides an existing variant like the built-in `dark`; a brand-new variant needs `@custom-variant` (confirmed against the Tailwind v4 docs — I hit exactly this: the first attempt with `@variant epaper` silently generated no utility and inverted the e-paper border).

## Screenshots

In each pair, **before is on the left, after on the right** (the read entries are "Plugin System" and "Full Content Fetching" — the ones with hollow dots).

**Light mode**
![Light mode before/after](https://raw.githubusercontent.com/brendanlong/lion-reader/screenshots/read-unread-contrast/light-compare.png)

**E-paper**
![E-paper before/after](https://raw.githubusercontent.com/brendanlong/lion-reader/screenshots/read-unread-contrast/epaper-compare.png)

**E-paper, forced to grayscale** (proves the distinction doesn't rely on hue — read entries still clearly recede)
![E-paper grayscale](https://raw.githubusercontent.com/brendanlong/lion-reader/screenshots/read-unread-contrast/epaper-after-grayscale.png)

**Dark mode (after)**
![Dark mode after](https://raw.githubusercontent.com/brendanlong/lion-reader/screenshots/read-unread-contrast/dark-after.png)

## Verification

Rendered light/dark/e-paper in headless Chromium with a read/unread mix, confirmed computed per-theme borders/backgrounds go the right direction, and checked the e-paper view **forced to grayscale** — read entries clearly recede (grey title, faint hollow dot, light border) and unread stand out (black title, solid dot, darker border), so nothing depends on hue. Typecheck, lint, and all 2209 unit tests pass (the two `EntryListItem` tests that pinned the old classes were updated to the new intent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
