### PR TITLE
Tokenize interactive-state colors and resolve neutral-pair drift (#1144)

### DIFF
--- a/src/app/(app)/AppLayoutContent.tsx
+++ b/src/app/(app)/AppLayoutContent.tsx
@@ -122,7 +122,7 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
                   <div className="relative">
                     <button
                       onClick={() => setUserMenuOpen(!userMenuOpen)}
-                      className="ui-text-sm border-edge-strong bg-surface text-body flex min-h-[40px] items-center gap-2 rounded-md border px-3 transition-colors hover:bg-zinc-50 active:bg-zinc-100 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                      className="ui-text-sm border-edge-strong bg-surface text-body hover:bg-surface-hover flex min-h-[40px] items-center gap-2 rounded-md border px-3 transition-colors active:bg-zinc-100 dark:active:bg-zinc-700"
                       aria-expanded={userMenuOpen}
                       aria-haspopup="true"
                     >

--- a/src/app/(app)/AppLayoutContent.tsx
+++ b/src/app/(app)/AppLayoutContent.tsx
@@ -89,7 +89,7 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
               sidebarCloseButton={
                 <button
                   onClick={() => setSidebarOpen(false)}
-                  className="text-subtle flex h-10 w-10 items-center justify-center rounded-md hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                  className="text-muted hover:bg-surface-muted flex h-10 w-10 items-center justify-center rounded-md active:bg-zinc-200 lg:hidden dark:active:bg-zinc-700"
                   aria-label="Close navigation menu"
                 >
                   <CloseIcon className="h-5 w-5" />
@@ -98,7 +98,7 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
               mobileMenuButton={
                 <button
                   onClick={() => setSidebarOpen(true)}
-                  className="text-subtle flex h-10 w-10 items-center justify-center rounded-md hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                  className="text-muted hover:bg-surface-muted flex h-10 w-10 items-center justify-center rounded-md active:bg-zinc-200 lg:hidden dark:active:bg-zinc-700"
                   aria-label="Open navigation menu"
                 >
                   <MenuIcon className="h-5 w-5" />
@@ -122,7 +122,7 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
                   <div className="relative">
                     <button
                       onClick={() => setUserMenuOpen(!userMenuOpen)}
-                      className="ui-text-sm border-edge-strong bg-surface text-body hover:bg-surface-hover flex min-h-[40px] items-center gap-2 rounded-md border px-3 transition-colors active:bg-zinc-100 dark:active:bg-zinc-700"
+                      className="ui-text-sm border-edge-strong bg-surface text-body hover:bg-surface-muted flex min-h-[40px] items-center gap-2 rounded-md border px-3 transition-colors active:bg-zinc-100 dark:active:bg-zinc-700"
                       aria-expanded={userMenuOpen}
                       aria-haspopup="true"
                     >
@@ -148,14 +148,14 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
                           <ClientLink
                             href="/settings"
                             onNavigate={() => setUserMenuOpen(false)}
-                            className="ui-text-sm text-body flex min-h-[44px] items-center px-4 hover:bg-zinc-100 active:bg-zinc-200 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                            className="ui-text-sm text-body hover:bg-surface-muted flex min-h-[44px] items-center px-4 active:bg-zinc-200 dark:active:bg-zinc-700"
                           >
                             Settings
                           </ClientLink>
                           <ClientLink
                             href="/settings/sessions"
                             onNavigate={() => setUserMenuOpen(false)}
-                            className="ui-text-sm text-body flex min-h-[44px] items-center px-4 hover:bg-zinc-100 active:bg-zinc-200 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                            className="ui-text-sm text-body hover:bg-surface-muted flex min-h-[44px] items-center px-4 active:bg-zinc-200 dark:active:bg-zinc-700"
                           >
                             Sessions
                           </ClientLink>
@@ -166,7 +166,7 @@ export function AppLayoutContent({ initialCursors }: AppLayoutContentProps) {
                               handleLogout();
                             }}
                             disabled={logoutMutation.isPending}
-                            className="ui-text-sm text-body flex min-h-[44px] w-full items-center px-4 text-left hover:bg-zinc-100 active:bg-zinc-200 disabled:opacity-50 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                            className="ui-text-sm text-body hover:bg-surface-muted flex min-h-[44px] w-full items-center px-4 text-left active:bg-zinc-200 disabled:opacity-50 dark:active:bg-zinc-700"
                           >
                             {logoutMutation.isPending ? "Signing out..." : "Sign out"}
                           </button>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -166,7 +166,7 @@ function LoginForm() {
       {/* Divider */}
       <div className="relative my-6">
         <div className="absolute inset-0 flex items-center">
-          <div className="w-full border-t border-zinc-300 dark:border-zinc-700" />
+          <div className="border-edge-input w-full border-t" />
         </div>
         <div className="ui-text-sm relative flex justify-center">
           <span className="bg-surface text-subtle px-2">Or continue with email</span>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -169,7 +169,7 @@ function LoginForm() {
           <div className="border-edge-input w-full border-t" />
         </div>
         <div className="ui-text-sm relative flex justify-center">
-          <span className="bg-surface text-subtle px-2">Or continue with email</span>
+          <span className="bg-surface text-muted px-2">Or continue with email</span>
         </div>
       </div>
 

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -185,7 +185,7 @@ function RegisterForm() {
               <div className="border-edge-input w-full border-t" />
             </div>
             <div className="ui-text-sm relative flex justify-center">
-              <span className="bg-surface text-subtle px-2">Or continue with email</span>
+              <span className="bg-surface text-muted px-2">Or continue with email</span>
             </div>
           </div>
 
@@ -233,7 +233,7 @@ function RegisterForm() {
         </>
       )}
 
-      <p className="ui-text-xs text-subtle mt-4 text-center">
+      <p className="ui-text-xs text-muted mt-4 text-center">
         By creating an account, you agree to our{" "}
         <Link href="/terms" className="underline hover:text-zinc-700 dark:hover:text-zinc-300">
           Terms of Service

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -182,7 +182,7 @@ function RegisterForm() {
           {/* Divider */}
           <div className="relative my-6">
             <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-zinc-300 dark:border-zinc-700" />
+              <div className="border-edge-input w-full border-t" />
             </div>
             <div className="ui-text-sm relative flex justify-center">
               <span className="bg-surface text-subtle px-2">Or continue with email</span>

--- a/src/app/complete-signup/page.tsx
+++ b/src/app/complete-signup/page.tsx
@@ -78,7 +78,7 @@ export default function CompleteSignupPage() {
             type="checkbox"
             checked={acceptedTos}
             onChange={(e) => setAcceptedTos(e.target.checked)}
-            className="text-strong mt-0.5 h-5 w-5 shrink-0 rounded border-zinc-300 focus:ring-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:focus:ring-zinc-400"
+            className="text-strong border-edge-input focus:ring-focus mt-0.5 h-5 w-5 shrink-0 rounded dark:bg-zinc-800"
           />
           <span className="ui-text-sm text-body">
             I have read and agree to the{" "}
@@ -98,7 +98,7 @@ export default function CompleteSignupPage() {
             type="checkbox"
             checked={acceptedPrivacy}
             onChange={(e) => setAcceptedPrivacy(e.target.checked)}
-            className="text-strong mt-0.5 h-5 w-5 shrink-0 rounded border-zinc-300 focus:ring-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:focus:ring-zinc-400"
+            className="text-strong border-edge-input focus:ring-focus mt-0.5 h-5 w-5 shrink-0 rounded dark:bg-zinc-800"
           />
           <span className="ui-text-sm text-body">
             I have read and agree to the{" "}
@@ -118,7 +118,7 @@ export default function CompleteSignupPage() {
             type="checkbox"
             checked={confirmedNotInEu}
             onChange={(e) => setConfirmedNotInEu(e.target.checked)}
-            className="text-strong mt-0.5 h-5 w-5 shrink-0 rounded border-zinc-300 focus:ring-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:focus:ring-zinc-400"
+            className="text-strong border-edge-input focus:ring-focus mt-0.5 h-5 w-5 shrink-0 rounded dark:bg-zinc-800"
           />
           <span className="ui-text-sm text-body">
             I confirm that I am not located in the European Union

--- a/src/app/complete-signup/page.tsx
+++ b/src/app/complete-signup/page.tsx
@@ -139,7 +139,7 @@ export default function CompleteSignupPage() {
         {!showDeleteConfirm ? (
           <button
             onClick={() => setShowDeleteConfirm(true)}
-            className="ui-text-sm text-subtle w-full text-center underline hover:text-zinc-700 dark:hover:text-zinc-300"
+            className="ui-text-sm text-muted w-full text-center underline hover:text-zinc-700 dark:hover:text-zinc-300"
           >
             Delete my account instead
           </button>

--- a/src/app/demo/DemoEntryListSSR.tsx
+++ b/src/app/demo/DemoEntryListSSR.tsx
@@ -32,7 +32,7 @@ export function DemoEntryListSSR({ entries, backHref, title }: DemoEntryListSSRP
             <a
               key={entry.id}
               href={`${backHref}?entry=${entry.id}`}
-              className="group border-edge-input relative block cursor-pointer rounded-lg border bg-zinc-50 p-3 transition-colors hover:bg-zinc-100 active:bg-zinc-200 sm:p-4 dark:bg-zinc-800 dark:hover:bg-zinc-700/50 dark:active:bg-zinc-700"
+              className="group border-edge-input hover:bg-surface-muted relative block cursor-pointer rounded-lg border bg-zinc-50 p-3 transition-colors active:bg-zinc-200 sm:p-4 dark:bg-zinc-800 dark:active:bg-zinc-700"
             >
               <div className="flex items-start gap-3">
                 <div className="mt-1.5 shrink-0">
@@ -45,7 +45,7 @@ export function DemoEntryListSSR({ entries, backHref, title }: DemoEntryListSSRP
                   <h3 className="ui-text-sm text-strong line-clamp-2 font-medium">
                     {displayTitle}
                   </h3>
-                  <div className="ui-text-xs text-subtle mt-1 flex items-center gap-2">
+                  <div className="ui-text-xs text-muted mt-1 flex items-center gap-2">
                     <span className="truncate">{source}</span>
                     <span aria-hidden="true">&middot;</span>
                     <time dateTime={date.toISOString()} className="shrink-0">

--- a/src/app/demo/DemoEntryListSSR.tsx
+++ b/src/app/demo/DemoEntryListSSR.tsx
@@ -32,7 +32,7 @@ export function DemoEntryListSSR({ entries, backHref, title }: DemoEntryListSSRP
             <a
               key={entry.id}
               href={`${backHref}?entry=${entry.id}`}
-              className="group relative block cursor-pointer rounded-lg border border-zinc-300 bg-zinc-50 p-3 transition-colors hover:bg-zinc-100 active:bg-zinc-200 sm:p-4 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:bg-zinc-700/50 dark:active:bg-zinc-700"
+              className="group border-edge-input relative block cursor-pointer rounded-lg border bg-zinc-50 p-3 transition-colors hover:bg-zinc-100 active:bg-zinc-200 sm:p-4 dark:bg-zinc-800 dark:hover:bg-zinc-700/50 dark:active:bg-zinc-700"
             >
               <div className="flex items-start gap-3">
                 <div className="mt-1.5 shrink-0">

--- a/src/app/demo/DemoLayoutContent.tsx
+++ b/src/app/demo/DemoLayoutContent.tsx
@@ -81,7 +81,7 @@ export function DemoLayoutContent({ children }: DemoLayoutContentProps) {
                   </Link>
                   <Link
                     href="/login"
-                    className="ui-text-sm border-edge-strong bg-surface text-body inline-flex min-h-[40px] items-center gap-1.5 rounded-md border px-3 font-medium transition-colors hover:bg-zinc-50 active:bg-zinc-100 dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                    className="ui-text-sm border-edge-strong bg-surface text-body hover:bg-surface-hover inline-flex min-h-[40px] items-center gap-1.5 rounded-md border px-3 font-medium transition-colors active:bg-zinc-100 dark:active:bg-zinc-700"
                   >
                     Sign In
                   </Link>

--- a/src/app/demo/DemoLayoutContent.tsx
+++ b/src/app/demo/DemoLayoutContent.tsx
@@ -56,7 +56,7 @@ export function DemoLayoutContent({ children }: DemoLayoutContentProps) {
               sidebarCloseButton={
                 <button
                   onClick={() => setSidebarOpen(false)}
-                  className="text-subtle flex h-10 w-10 items-center justify-center rounded-md hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                  className="text-muted hover:bg-surface-muted flex h-10 w-10 items-center justify-center rounded-md active:bg-zinc-200 lg:hidden dark:active:bg-zinc-700"
                   aria-label="Close navigation menu"
                 >
                   <CloseIcon className="h-5 w-5" />
@@ -65,7 +65,7 @@ export function DemoLayoutContent({ children }: DemoLayoutContentProps) {
               mobileMenuButton={
                 <button
                   onClick={() => setSidebarOpen(true)}
-                  className="text-subtle flex h-10 w-10 items-center justify-center rounded-md hover:bg-zinc-100 active:bg-zinc-200 lg:hidden dark:hover:bg-zinc-800 dark:active:bg-zinc-700"
+                  className="text-muted hover:bg-surface-muted flex h-10 w-10 items-center justify-center rounded-md active:bg-zinc-200 lg:hidden dark:active:bg-zinc-700"
                   aria-label="Open navigation menu"
                 >
                   <MenuIcon className="h-5 w-5" />
@@ -81,7 +81,7 @@ export function DemoLayoutContent({ children }: DemoLayoutContentProps) {
                   </Link>
                   <Link
                     href="/login"
-                    className="ui-text-sm border-edge-strong bg-surface text-body hover:bg-surface-hover inline-flex min-h-[40px] items-center gap-1.5 rounded-md border px-3 font-medium transition-colors active:bg-zinc-100 dark:active:bg-zinc-700"
+                    className="ui-text-sm border-edge-strong bg-surface text-body hover:bg-surface-muted inline-flex min-h-[40px] items-center gap-1.5 rounded-md border px-3 font-medium transition-colors active:bg-zinc-100 dark:active:bg-zinc-700"
                   >
                     Sign In
                   </Link>

--- a/src/app/demo/DemoListSkeleton.tsx
+++ b/src/app/demo/DemoListSkeleton.tsx
@@ -9,7 +9,7 @@ export function DemoListSkeleton() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
       <div className="mb-4 sm:mb-6">
-        <div className="h-8 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+        <div className="bg-fill-muted h-8 w-48 animate-pulse rounded" />
       </div>
       <div className="space-y-4">
         {[1, 2, 3].map((i) => (

--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -329,7 +329,7 @@ function DemoRouterContent() {
                     </Link>
                     <Link
                       href="/login"
-                      className="ui-text-base bg-surface text-strong inline-flex h-12 w-full items-center justify-center rounded-md border border-zinc-300 px-6 font-medium transition-colors hover:bg-zinc-50 sm:w-auto dark:border-zinc-700 dark:hover:bg-zinc-800"
+                      className="ui-text-base bg-surface text-strong border-edge-input hover:bg-surface-hover inline-flex h-12 w-full items-center justify-center rounded-md border px-6 font-medium transition-colors sm:w-auto"
                     >
                       Sign in
                     </Link>

--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -239,7 +239,7 @@ function DemoRouterContent() {
           backButton={
             <ClientLink
               href={backHref}
-              className="ui-text-sm text-muted mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 transition-colors hover:bg-zinc-100 hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
+              className="ui-text-sm text-muted hover:bg-surface-muted mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 transition-colors hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
             >
               <ArrowLeftIcon className="h-4 w-4" />
               <span>Back to list</span>
@@ -329,7 +329,7 @@ function DemoRouterContent() {
                     </Link>
                     <Link
                       href="/login"
-                      className="ui-text-base bg-surface text-strong border-edge-input hover:bg-surface-hover inline-flex h-12 w-full items-center justify-center rounded-md border px-6 font-medium transition-colors sm:w-auto"
+                      className="ui-text-base bg-surface text-strong border-edge-input hover:bg-surface-muted inline-flex h-12 w-full items-center justify-center rounded-md border px-6 font-medium transition-colors sm:w-auto"
                     >
                       Sign in
                     </Link>

--- a/src/app/demo/DemoSidebar.tsx
+++ b/src/app/demo/DemoSidebar.tsx
@@ -68,7 +68,7 @@ export function DemoSidebar({ onClose }: DemoSidebarProps) {
           isActive={isAllActive}
           countElement={
             totalUnread > 0 ? (
-              <span className="ui-text-xs text-subtle ml-2 shrink-0">({totalUnread})</span>
+              <span className="ui-text-xs text-muted ml-2 shrink-0">({totalUnread})</span>
             ) : undefined
           }
           onClick={onClose}
@@ -81,7 +81,7 @@ export function DemoSidebar({ onClose }: DemoSidebarProps) {
           isActive={isHighlightsActive}
           countElement={
             highlightCount > 0 ? (
-              <span className="ui-text-xs text-subtle ml-2 shrink-0">({highlightCount})</span>
+              <span className="ui-text-xs text-muted ml-2 shrink-0">({highlightCount})</span>
             ) : undefined
           }
           onClick={onClose}
@@ -114,7 +114,7 @@ export function DemoSidebar({ onClose }: DemoSidebarProps) {
                       e.stopPropagation();
                       toggleTag(tag.id);
                     }}
-                    className="text-subtle flex h-6 w-6 shrink-0 items-center justify-center hover:text-zinc-700 dark:hover:text-zinc-300"
+                    className="text-muted flex h-6 w-6 shrink-0 items-center justify-center hover:text-zinc-700 dark:hover:text-zinc-300"
                     aria-label={expanded ? "Collapse" : "Expand"}
                   >
                     {expanded ? <ChevronDownIcon /> : <ChevronRightIcon />}

--- a/src/app/extension/save/client.tsx
+++ b/src/app/extension/save/client.tsx
@@ -33,9 +33,7 @@ export function ExtensionSaveClient({ status, error, url, canRetry }: Props) {
           <p className="text-muted mb-4">
             {error || "An error occurred while saving the article."}
           </p>
-          {url && (
-            <p className="ui-text-sm mb-4 break-all text-zinc-500 dark:text-zinc-500">{url}</p>
-          )}
+          {url && <p className="ui-text-sm text-subtle mb-4 break-all">{url}</p>}
           {canRetry && url && (
             <a
               href={`/extension/save?url=${encodeURIComponent(url)}`}

--- a/src/app/extension/save/client.tsx
+++ b/src/app/extension/save/client.tsx
@@ -33,7 +33,7 @@ export function ExtensionSaveClient({ status, error, url, canRetry }: Props) {
           <p className="text-muted mb-4">
             {error || "An error occurred while saving the article."}
           </p>
-          {url && <p className="ui-text-sm text-subtle mb-4 break-all">{url}</p>}
+          {url && <p className="ui-text-sm text-muted mb-4 break-all">{url}</p>}
           {canRetry && url && (
             <a
               href={`/extension/save?url=${encodeURIComponent(url)}`}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,11 +65,17 @@
   --surface: #ffffff; /* white - cards, inputs, controls */
   --surface-muted: #f4f4f5; /* zinc-100 - chips, skeletons */
   --surface-subtle: #fafafa; /* zinc-50 - note boxes, subtle fills */
+  --surface-hover: #fafafa; /* zinc-50 - hover fill on secondary/ghost controls, list rows */
+  --fill-muted: #e4e4e7; /* zinc-200 - skeleton pulses, toggle-off/progress/range tracks, thin dividers */
 
   /* Borders: `edge` for card outlines, `edge-strong` for dividers/note boxes
-     (more visible in dark mode) */
+     (more visible in dark mode), `edge-input` for input/control outlines */
   --edge: #e4e4e7; /* zinc-200 */
   --edge-strong: #e4e4e7; /* zinc-200 (dark mode differs: zinc-700 vs zinc-800) */
+  --edge-input: #d4d4d8; /* zinc-300 */
+
+  /* Focus ring / focused-border color (also drives control focus outlines) */
+  --focus: #18181b; /* zinc-900 */
 
   /* =================================
      UI Typography Scale (16px baseline)
@@ -109,8 +115,12 @@
   --color-surface: var(--surface);
   --color-surface-muted: var(--surface-muted);
   --color-surface-subtle: var(--surface-subtle);
+  --color-surface-hover: var(--surface-hover);
+  --color-fill-muted: var(--fill-muted);
   --color-edge: var(--edge);
   --color-edge-strong: var(--edge-strong);
+  --color-edge-input: var(--edge-input);
+  --color-focus: var(--focus);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -151,8 +161,12 @@
   --surface: #18181b; /* zinc-900 */
   --surface-muted: #27272a; /* zinc-800 */
   --surface-subtle: rgba(39, 39, 42, 0.5); /* zinc-800/50 */
+  --surface-hover: #27272a; /* zinc-800 */
+  --fill-muted: #3f3f46; /* zinc-700 */
   --edge: #27272a; /* zinc-800 */
   --edge-strong: #3f3f46; /* zinc-700 */
+  --edge-input: #3f3f46; /* zinc-700 */
+  --focus: #a1a1aa; /* zinc-400 */
 }
 
 /* =================================
@@ -267,8 +281,12 @@
     --surface: #18181b; /* zinc-900 */
     --surface-muted: #27272a; /* zinc-800 */
     --surface-subtle: rgba(39, 39, 42, 0.5); /* zinc-800/50 */
+    --surface-hover: #27272a; /* zinc-800 */
+    --fill-muted: #3f3f46; /* zinc-700 */
     --edge: #27272a; /* zinc-800 */
     --edge-strong: #3f3f46; /* zinc-700 */
+    --edge-input: #3f3f46; /* zinc-700 */
+    --focus: #a1a1aa; /* zinc-400 */
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,16 +56,14 @@
   --text-strong: #18181b; /* zinc-900 - headings, primary values */
   --text-emphasis: #18181b; /* zinc-900 - <strong> inside muted prose (dimmer than strong in dark) */
   --text-body: #3f3f46; /* zinc-700 - body copy, labels */
-  --text-muted: #52525b; /* zinc-600 - descriptions, secondary text */
-  --text-subtle: #71717a; /* zinc-500 - metadata, hints */
+  --text-muted: #52525b; /* zinc-600 - descriptions, secondary text, metadata, hints */
   --text-faint: #a1a1aa; /* zinc-400 - de-emphasized notes, placeholders */
 
   /* Surfaces */
   --canvas: #fafafa; /* zinc-50 - page background behind cards/app shell */
   --surface: #ffffff; /* white - cards, inputs, controls */
-  --surface-muted: #f4f4f5; /* zinc-100 - chips, skeletons */
+  --surface-muted: #f4f4f5; /* zinc-100 - chips, skeletons, hover fill (hover:bg-surface-muted) */
   --surface-subtle: #fafafa; /* zinc-50 - note boxes, subtle fills */
-  --surface-hover: #fafafa; /* zinc-50 - hover fill on secondary/ghost controls, list rows */
   --fill-muted: #e4e4e7; /* zinc-200 - skeleton pulses, toggle-off/progress/range tracks, thin dividers */
 
   /* Borders: `edge` for card outlines, `edge-strong` for dividers/note boxes
@@ -76,6 +74,9 @@
 
   /* Focus ring / focused-border color (also drives control focus outlines) */
   --focus: #18181b; /* zinc-900 */
+  /* Selected / "on" state for checkboxes, radios, selected cards, progress fills.
+     Shares --focus's value today but kept separate so the two roles can diverge. */
+  --control-selected: #18181b; /* zinc-900 */
 
   /* =================================
      UI Typography Scale (16px baseline)
@@ -109,18 +110,17 @@
   --color-emphasis: var(--text-emphasis);
   --color-body: var(--text-body);
   --color-muted: var(--text-muted);
-  --color-subtle: var(--text-subtle);
   --color-faint: var(--text-faint);
   --color-canvas: var(--canvas);
   --color-surface: var(--surface);
   --color-surface-muted: var(--surface-muted);
   --color-surface-subtle: var(--surface-subtle);
-  --color-surface-hover: var(--surface-hover);
   --color-fill-muted: var(--fill-muted);
   --color-edge: var(--edge);
   --color-edge-strong: var(--edge-strong);
   --color-edge-input: var(--edge-input);
   --color-focus: var(--focus);
+  --color-control-selected: var(--control-selected);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -155,18 +155,17 @@
   --text-emphasis: #e4e4e7; /* zinc-200 - dimmer than strong so bold prose doesn't glare */
   --text-body: #d4d4d8; /* zinc-300 */
   --text-muted: #a1a1aa; /* zinc-400 */
-  --text-subtle: #a1a1aa; /* zinc-400 */
   --text-faint: #71717a; /* zinc-500 */
   --canvas: #09090b; /* zinc-950 */
   --surface: #18181b; /* zinc-900 */
   --surface-muted: #27272a; /* zinc-800 */
   --surface-subtle: rgba(39, 39, 42, 0.5); /* zinc-800/50 */
-  --surface-hover: #27272a; /* zinc-800 */
   --fill-muted: #3f3f46; /* zinc-700 */
   --edge: #27272a; /* zinc-800 */
   --edge-strong: #3f3f46; /* zinc-700 */
   --edge-input: #3f3f46; /* zinc-700 */
   --focus: #a1a1aa; /* zinc-400 */
+  --control-selected: #a1a1aa; /* zinc-400 */
 }
 
 /* =================================
@@ -214,7 +213,6 @@
   --text-emphasis: #000000;
   --text-body: #18181b; /* zinc-900 */
   --text-muted: #3f3f46; /* zinc-700 */
-  --text-subtle: #52525b; /* zinc-600 */
   --text-faint: #71717a; /* zinc-500 */
 
   /* Pure white surfaces; separation comes from the darker borders below */
@@ -275,18 +273,17 @@
     --text-emphasis: #e4e4e7; /* zinc-200 - dimmer than strong so bold prose doesn't glare */
     --text-body: #d4d4d8; /* zinc-300 */
     --text-muted: #a1a1aa; /* zinc-400 */
-    --text-subtle: #a1a1aa; /* zinc-400 */
     --text-faint: #71717a; /* zinc-500 */
     --canvas: #09090b; /* zinc-950 */
     --surface: #18181b; /* zinc-900 */
     --surface-muted: #27272a; /* zinc-800 */
     --surface-subtle: rgba(39, 39, 42, 0.5); /* zinc-800/50 */
-    --surface-hover: #27272a; /* zinc-800 */
     --fill-muted: #3f3f46; /* zinc-700 */
     --edge: #27272a; /* zinc-800 */
     --edge-strong: #3f3f46; /* zinc-700 */
     --edge-input: #3f3f46; /* zinc-700 */
     --focus: #a1a1aa; /* zinc-400 */
+    --control-selected: #a1a1aa; /* zinc-400 */
   }
 }
 

--- a/src/app/oauth/consent/ConsentForm.tsx
+++ b/src/app/oauth/consent/ConsentForm.tsx
@@ -101,7 +101,7 @@ export function ConsentForm({
       </form>
 
       {/* Client ID info */}
-      <p className="ui-text-xs text-subtle mt-4 text-center">
+      <p className="ui-text-xs text-muted mt-4 text-center">
         Client ID: {clientId.length > 50 ? `${clientId.slice(0, 50)}...` : clientId}
       </p>
     </div>

--- a/src/app/oauth/consent/ConsentForm.tsx
+++ b/src/app/oauth/consent/ConsentForm.tsx
@@ -85,7 +85,7 @@ export function ConsentForm({
             type="submit"
             name="user_action"
             value="deny"
-            className="ui-text-sm text-body flex-1 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 font-medium transition-colors hover:bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:bg-zinc-700"
+            className="ui-text-sm text-body border-edge-input flex-1 rounded-lg border bg-white px-4 py-2.5 font-medium transition-colors hover:bg-zinc-50 dark:bg-zinc-800 dark:hover:bg-zinc-700"
           >
             Deny
           </button>
@@ -101,7 +101,7 @@ export function ConsentForm({
       </form>
 
       {/* Client ID info */}
-      <p className="ui-text-xs mt-4 text-center text-zinc-500 dark:text-zinc-500">
+      <p className="ui-text-xs text-subtle mt-4 text-center">
         Client ID: {clientId.length > 50 ? `${clientId.slice(0, 50)}...` : clientId}
       </p>
     </div>

--- a/src/app/save/page.tsx
+++ b/src/app/save/page.tsx
@@ -260,7 +260,7 @@ function SaveContent() {
               <p className="ui-text-sm text-muted mt-3">
                 {shareType === "file" ? "Uploading file..." : "Saving article..."}
               </p>
-              {urlToSave && <p className="ui-text-xs text-subtle mt-2 truncate">{urlToSave}</p>}
+              {urlToSave && <p className="ui-text-xs text-muted mt-2 truncate">{urlToSave}</p>}
             </div>
           )}
 
@@ -276,7 +276,7 @@ function SaveContent() {
               {articleTitle && (
                 <p className="ui-text-sm text-muted mt-2 line-clamp-2">{articleTitle}</p>
               )}
-              <p className="ui-text-xs text-subtle mt-4">Closing in {countdown}...</p>
+              <p className="ui-text-xs text-muted mt-4">Closing in {countdown}...</p>
               <Button variant="secondary" className="mt-3 w-full" onClick={handleClose}>
                 Close Now
               </Button>
@@ -295,7 +295,7 @@ function SaveContent() {
                   <Alert variant="warning" className="mt-4 text-left">
                     Your session has expired. Please sign in again to save this article.
                   </Alert>
-                  <p className="ui-text-xs text-subtle mt-2 truncate">{urlToSave}</p>
+                  <p className="ui-text-xs text-muted mt-2 truncate">{urlToSave}</p>
                   <div className="mt-4 flex gap-2">
                     <Button variant="secondary" className="flex-1" onClick={handleClose}>
                       Close
@@ -318,7 +318,7 @@ function SaveContent() {
                         ? "Your Google account session has expired. Please reconnect to access private Google Docs."
                         : "This is a private Google Doc. You need to sign in with Google to save it."}
                   </Alert>
-                  <p className="ui-text-xs text-subtle mt-2 truncate">{urlToSave}</p>
+                  <p className="ui-text-xs text-muted mt-2 truncate">{urlToSave}</p>
                   <div className="mt-4 flex gap-2">
                     <Button variant="secondary" className="flex-1" onClick={handleClose}>
                       Close
@@ -355,7 +355,7 @@ function SaveContent() {
                     {activeMutation.error?.message ||
                       (shareType === "file" ? "Failed to upload file" : "Failed to save article")}
                   </Alert>
-                  {urlToSave && <p className="ui-text-xs text-subtle mt-2 truncate">{urlToSave}</p>}
+                  {urlToSave && <p className="ui-text-xs text-muted mt-2 truncate">{urlToSave}</p>}
                   <div className="mt-4 flex gap-2">
                     <Button variant="secondary" className="flex-1" onClick={handleClose}>
                       Close

--- a/src/app/save/page.tsx
+++ b/src/app/save/page.tsx
@@ -260,11 +260,7 @@ function SaveContent() {
               <p className="ui-text-sm text-muted mt-3">
                 {shareType === "file" ? "Uploading file..." : "Saving article..."}
               </p>
-              {urlToSave && (
-                <p className="ui-text-xs mt-2 truncate text-zinc-500 dark:text-zinc-500">
-                  {urlToSave}
-                </p>
-              )}
+              {urlToSave && <p className="ui-text-xs text-subtle mt-2 truncate">{urlToSave}</p>}
             </div>
           )}
 
@@ -280,9 +276,7 @@ function SaveContent() {
               {articleTitle && (
                 <p className="ui-text-sm text-muted mt-2 line-clamp-2">{articleTitle}</p>
               )}
-              <p className="ui-text-xs mt-4 text-zinc-500 dark:text-zinc-500">
-                Closing in {countdown}...
-              </p>
+              <p className="ui-text-xs text-subtle mt-4">Closing in {countdown}...</p>
               <Button variant="secondary" className="mt-3 w-full" onClick={handleClose}>
                 Close Now
               </Button>
@@ -301,9 +295,7 @@ function SaveContent() {
                   <Alert variant="warning" className="mt-4 text-left">
                     Your session has expired. Please sign in again to save this article.
                   </Alert>
-                  <p className="ui-text-xs mt-2 truncate text-zinc-500 dark:text-zinc-500">
-                    {urlToSave}
-                  </p>
+                  <p className="ui-text-xs text-subtle mt-2 truncate">{urlToSave}</p>
                   <div className="mt-4 flex gap-2">
                     <Button variant="secondary" className="flex-1" onClick={handleClose}>
                       Close
@@ -326,9 +318,7 @@ function SaveContent() {
                         ? "Your Google account session has expired. Please reconnect to access private Google Docs."
                         : "This is a private Google Doc. You need to sign in with Google to save it."}
                   </Alert>
-                  <p className="ui-text-xs mt-2 truncate text-zinc-500 dark:text-zinc-500">
-                    {urlToSave}
-                  </p>
+                  <p className="ui-text-xs text-subtle mt-2 truncate">{urlToSave}</p>
                   <div className="mt-4 flex gap-2">
                     <Button variant="secondary" className="flex-1" onClick={handleClose}>
                       Close
@@ -365,11 +355,7 @@ function SaveContent() {
                     {activeMutation.error?.message ||
                       (shareType === "file" ? "Failed to upload file" : "Failed to save article")}
                   </Alert>
-                  {urlToSave && (
-                    <p className="ui-text-xs mt-2 truncate text-zinc-500 dark:text-zinc-500">
-                      {urlToSave}
-                    </p>
-                  )}
+                  {urlToSave && <p className="ui-text-xs text-subtle mt-2 truncate">{urlToSave}</p>}
                   <div className="mt-4 flex gap-2">
                     <Button variant="secondary" className="flex-1" onClick={handleClose}>
                       Close

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -64,21 +64,23 @@ The `ui-text-*` classes are defined in `src/app/globals.css` and provide respons
 | `text-strong`        | `text-zinc-900 dark:text-zinc-50`      | Headings, primary values                                                        |
 | `text-emphasis`      | `text-zinc-900 dark:text-zinc-200`     | `<strong>` inside muted prose                                                   |
 | `text-body`          | `text-zinc-700 dark:text-zinc-300`     | Body copy, labels                                                               |
-| `text-muted`         | `text-zinc-600 dark:text-zinc-400`     | Descriptions, secondary text                                                    |
-| `text-subtle`        | `text-zinc-500 dark:text-zinc-400`     | Metadata, hints                                                                 |
+| `text-muted`         | `text-zinc-600 dark:text-zinc-400`     | Descriptions, secondary text, metadata, hints                                   |
 | `text-faint`         | `text-zinc-400 dark:text-zinc-500`     | De-emphasized notes, placeholders                                               |
 | `bg-canvas`          | `bg-zinc-50 dark:bg-zinc-950`          | Page background behind the shell                                                |
 | `bg-surface`         | `bg-white dark:bg-zinc-900`            | Cards, inputs, controls                                                         |
-| `bg-surface-muted`   | `bg-zinc-100 dark:bg-zinc-800`         | Chips, skeletons                                                                |
+| `bg-surface-muted`   | `bg-zinc-100 dark:bg-zinc-800`         | Chips, skeletons, and hover fill (`hover:bg-surface-muted`) on controls/rows    |
 | `bg-surface-subtle`  | `bg-zinc-50 dark:bg-zinc-800/50`       | Note boxes, subtle fills                                                        |
-| `bg-surface-hover`   | `bg-zinc-50 dark:bg-zinc-800`          | Hover fill (as `hover:bg-surface-hover`) on secondary/ghost controls, list rows |
 | `bg-fill-muted`      | `bg-zinc-200 dark:bg-zinc-700`         | Skeleton pulses, toggle-off/progress/range tracks, thin dividers                |
 | `border-edge`        | `border-zinc-200 dark:border-zinc-800` | Card outlines (also `divide-edge`)                                              |
 | `border-edge-strong` | `border-zinc-200 dark:border-zinc-700` | Dividers, note-box borders                                                      |
 | `border-edge-input`  | `border-zinc-300 dark:border-zinc-700` | Input/control outlines                                                          |
 | `ring-focus`         | `ring-zinc-900 dark:ring-zinc-400`     | Focus rings (as `focus:ring-focus`); also `focus:border-focus`                  |
+| `control-selected`   | `zinc-900 dark:zinc-400`               | Selected/"on" outline: checkbox/radio/selected-card `border`/`ring`, radio dots |
 
-Tokens work under variants (`hover:bg-surface-hover`, `focus:ring-focus`), so interactive states use them too. Two remaining raw patterns are deliberately left un-tokenized because they're intentional variations, not drift: the ghost-button hover fill `hover:bg-zinc-100 dark:hover:bg-zinc-800` (one step stronger than `surface-hover` on purpose) and the `active:` press step `active:bg-zinc-100 dark:active:bg-zinc-700`.
+Tokens work under variants (`hover:bg-surface-muted`, `focus:ring-focus`), so interactive states use them too. Notes:
+
+- **Filled** "on"/selected controls (a solid pill/toggle, not an outline) use `bg-primary-solid text-primary-solid-foreground` — the same token as primary buttons. `control-selected` is only the neutral **outline/indicator** color; it shares `ring-focus`'s value today but is a separate token so the two roles can diverge.
+- The `active:` press step (`active:bg-zinc-100 dark:active:bg-zinc-700`) is deliberately left raw — it's the pressed state, one step darker than the `surface-muted` hover.
 
 ### Settings Sections
 

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -59,22 +59,26 @@ The `ui-text-*` classes are defined in `src/app/globals.css` and provide respons
 
 **Use the semantic color tokens instead of raw zinc light/dark pairs.** Each token is one utility class covering all themes; the palettes live in `src/app/globals.css` (`:root` for light, `.dark`, and `.epaper` for e-ink screens), so retheming means editing CSS variables, not call sites:
 
-| Token                | Replaces                               | Use for                            |
-| -------------------- | -------------------------------------- | ---------------------------------- |
-| `text-strong`        | `text-zinc-900 dark:text-zinc-50`      | Headings, primary values           |
-| `text-emphasis`      | `text-zinc-900 dark:text-zinc-200`     | `<strong>` inside muted prose      |
-| `text-body`          | `text-zinc-700 dark:text-zinc-300`     | Body copy, labels                  |
-| `text-muted`         | `text-zinc-600 dark:text-zinc-400`     | Descriptions, secondary text       |
-| `text-subtle`        | `text-zinc-500 dark:text-zinc-400`     | Metadata, hints                    |
-| `text-faint`         | `text-zinc-400 dark:text-zinc-500`     | De-emphasized notes, placeholders  |
-| `bg-canvas`          | `bg-zinc-50 dark:bg-zinc-950`          | Page background behind the shell   |
-| `bg-surface`         | `bg-white dark:bg-zinc-900`            | Cards, inputs, controls            |
-| `bg-surface-muted`   | `bg-zinc-100 dark:bg-zinc-800`         | Chips, skeletons                   |
-| `bg-surface-subtle`  | `bg-zinc-50 dark:bg-zinc-800/50`       | Note boxes, subtle fills           |
-| `border-edge`        | `border-zinc-200 dark:border-zinc-800` | Card outlines (also `divide-edge`) |
-| `border-edge-strong` | `border-zinc-200 dark:border-zinc-700` | Dividers, note-box borders         |
+| Token                | Replaces                               | Use for                                                                         |
+| -------------------- | -------------------------------------- | ------------------------------------------------------------------------------- |
+| `text-strong`        | `text-zinc-900 dark:text-zinc-50`      | Headings, primary values                                                        |
+| `text-emphasis`      | `text-zinc-900 dark:text-zinc-200`     | `<strong>` inside muted prose                                                   |
+| `text-body`          | `text-zinc-700 dark:text-zinc-300`     | Body copy, labels                                                               |
+| `text-muted`         | `text-zinc-600 dark:text-zinc-400`     | Descriptions, secondary text                                                    |
+| `text-subtle`        | `text-zinc-500 dark:text-zinc-400`     | Metadata, hints                                                                 |
+| `text-faint`         | `text-zinc-400 dark:text-zinc-500`     | De-emphasized notes, placeholders                                               |
+| `bg-canvas`          | `bg-zinc-50 dark:bg-zinc-950`          | Page background behind the shell                                                |
+| `bg-surface`         | `bg-white dark:bg-zinc-900`            | Cards, inputs, controls                                                         |
+| `bg-surface-muted`   | `bg-zinc-100 dark:bg-zinc-800`         | Chips, skeletons                                                                |
+| `bg-surface-subtle`  | `bg-zinc-50 dark:bg-zinc-800/50`       | Note boxes, subtle fills                                                        |
+| `bg-surface-hover`   | `bg-zinc-50 dark:bg-zinc-800`          | Hover fill (as `hover:bg-surface-hover`) on secondary/ghost controls, list rows |
+| `bg-fill-muted`      | `bg-zinc-200 dark:bg-zinc-700`         | Skeleton pulses, toggle-off/progress/range tracks, thin dividers                |
+| `border-edge`        | `border-zinc-200 dark:border-zinc-800` | Card outlines (also `divide-edge`)                                              |
+| `border-edge-strong` | `border-zinc-200 dark:border-zinc-700` | Dividers, note-box borders                                                      |
+| `border-edge-input`  | `border-zinc-300 dark:border-zinc-700` | Input/control outlines                                                          |
+| `ring-focus`         | `ring-zinc-900 dark:ring-zinc-400`     | Focus rings (as `focus:ring-focus`); also `focus:border-focus`                  |
 
-Interactive-state colors (`hover:bg-zinc-50`, focus rings, input borders) are not tokenized yet — keep using raw utilities with `dark:` variants for those.
+Tokens work under variants (`hover:bg-surface-hover`, `focus:ring-focus`), so interactive states use them too. Two remaining raw patterns are deliberately left un-tokenized because they're intentional variations, not drift: the ghost-button hover fill `hover:bg-zinc-100 dark:hover:bg-zinc-800` (one step stronger than `surface-hover` on purpose) and the `active:` press step `active:bg-zinc-100 dark:active:bg-zinc-700`.
 
 ### Settings Sections
 

--- a/src/components/admin/AdminApp.tsx
+++ b/src/components/admin/AdminApp.tsx
@@ -115,8 +115,8 @@ function AdminTabNav() {
               href={tab.href}
               className={`ui-text-sm block shrink-0 border-b-2 px-4 py-3 font-medium whitespace-nowrap transition-colors ${
                 isActive
-                  ? "text-strong border-zinc-900 dark:border-zinc-50"
-                  : "text-subtle border-transparent hover:border-zinc-300 hover:text-zinc-700 dark:hover:border-zinc-600 dark:hover:text-zinc-200"
+                  ? "text-strong border-control-selected"
+                  : "text-muted border-transparent hover:border-zinc-300 hover:text-zinc-700 dark:hover:border-zinc-600 dark:hover:text-zinc-200"
               }`}
             >
               {tab.label}
@@ -213,7 +213,7 @@ export function AdminApp({ children }: AdminAppProps) {
   if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <p className="ui-text-sm text-subtle">Verifying credentials...</p>
+        <p className="ui-text-sm text-muted">Verifying credentials...</p>
       </div>
     );
   }

--- a/src/components/admin/AdminFeedsContent.tsx
+++ b/src/components/admin/AdminFeedsContent.tsx
@@ -391,7 +391,7 @@ export default function AdminFeedsContent() {
               type="checkbox"
               checked={hasSubscribers}
               onChange={(e) => setHasSubscribers(e.target.checked)}
-              className="text-accent focus:ring-accent h-4 w-4 rounded border-zinc-300 dark:border-zinc-700 dark:bg-zinc-800"
+              className="text-accent focus:ring-accent border-edge-input h-4 w-4 rounded dark:bg-zinc-800"
             />
             Has subscribers
           </label>

--- a/src/components/admin/AdminFeedsContent.tsx
+++ b/src/components/admin/AdminFeedsContent.tsx
@@ -170,7 +170,7 @@ function FeedRow({ feed, onRetry, isRetrying }: FeedRowProps) {
               href={feed.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="ui-text-xs text-subtle mt-0.5 inline-flex items-center gap-1 hover:text-zinc-700 dark:hover:text-zinc-200"
+              className="ui-text-xs text-muted mt-0.5 inline-flex items-center gap-1 hover:text-zinc-700 dark:hover:text-zinc-200"
             >
               <span className="truncate">{truncateUrl(feed.url)}</span>
               <ExternalLinkIcon className="h-3 w-3 shrink-0" />
@@ -197,7 +197,7 @@ function FeedRow({ feed, onRetry, isRetrying }: FeedRowProps) {
       {feed.lastError && <ExpandableError error={feed.lastError} />}
 
       {/* Stats grid */}
-      <div className="ui-text-xs text-subtle mt-3 grid grid-cols-2 gap-x-6 gap-y-1.5 sm:grid-cols-3 lg:grid-cols-4">
+      <div className="ui-text-xs text-muted mt-3 grid grid-cols-2 gap-x-6 gap-y-1.5 sm:grid-cols-3 lg:grid-cols-4">
         <StatItem
           label="Last fetched"
           value={feed.lastFetchedAt ? formatRelativeTime(new Date(feed.lastFetchedAt)) : "Never"}
@@ -244,7 +244,7 @@ function EmptyState({ hasFilters }: { hasFilters: boolean }) {
       <h3 className="ui-text-sm text-strong mt-4 font-medium">
         {hasFilters ? "No matching feeds" : "No feeds"}
       </h3>
-      <p className="ui-text-sm text-subtle mt-1">
+      <p className="ui-text-sm text-muted mt-1">
         {hasFilters ? "Try adjusting your filters." : "No feeds have been added to the system yet."}
       </p>
     </div>
@@ -444,7 +444,7 @@ export default function AdminFeedsContent() {
           {feedsQuery.isFetchingNextPage && (
             <div className="flex items-center justify-center p-4">
               <SpinnerIcon className="mr-2 h-4 w-4 text-zinc-400" />
-              <span className="ui-text-sm text-subtle">Loading more...</span>
+              <span className="ui-text-sm text-muted">Loading more...</span>
             </div>
           )}
 

--- a/src/components/admin/AdminInvitesContent.tsx
+++ b/src/components/admin/AdminInvitesContent.tsx
@@ -54,7 +54,7 @@ function StatusBadge({ status }: StatusBadgeProps) {
   const styles = {
     pending: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
     used: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
-    expired: "bg-surface-muted text-subtle",
+    expired: "bg-surface-muted text-muted",
   };
 
   return (
@@ -104,7 +104,7 @@ function CreatedInviteDisplay({ inviteUrl, onDismiss }: CreatedInviteProps) {
         </div>
         <button
           onClick={onDismiss}
-          className="ui-text-sm text-subtle self-start underline hover:text-zinc-700 dark:hover:text-zinc-200"
+          className="ui-text-sm text-muted self-start underline hover:text-zinc-700 dark:hover:text-zinc-200"
         >
           Dismiss
         </button>
@@ -142,7 +142,7 @@ function InviteRow({ invite, onRevoke, isRevoking }: InviteRowProps) {
           <code className="ui-text-sm text-muted">{truncateToken(invite.token)}</code>
         </div>
 
-        <div className="ui-text-xs text-subtle mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5">
+        <div className="ui-text-xs text-muted mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5">
           <span>Created: {formatDate(invite.createdAt)}</span>
           <span>Expires: {formatDate(invite.expiresAt)}</span>
           {invite.usedAt && <span>Used: {formatDate(invite.usedAt)}</span>}
@@ -150,7 +150,7 @@ function InviteRow({ invite, onRevoke, isRevoking }: InviteRowProps) {
 
         {invite.status === "used" && invite.usedByEmail && (
           <p className="ui-text-sm mt-1">
-            <span className="text-subtle">Used by: </span>
+            <span className="text-muted">Used by: </span>
             <ClientLink
               href={`/admin/users?search=${encodeURIComponent(invite.usedByEmail)}`}
               className="text-blue-600 underline hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
@@ -188,7 +188,7 @@ function EmptyState({ hasSearch }: { hasSearch: boolean }) {
       <h3 className="ui-text-sm text-strong font-medium">
         {hasSearch ? "No matching invites" : "No invites yet"}
       </h3>
-      <p className="ui-text-sm text-subtle mt-1">
+      <p className="ui-text-sm text-muted mt-1">
         {hasSearch ? "Try a different search term." : "Generate an invite to get started."}
       </p>
     </div>
@@ -366,7 +366,7 @@ export default function AdminInvitesContent() {
           {invitesQuery.isFetchingNextPage && (
             <div className="flex items-center justify-center p-4">
               <SpinnerIcon className="mr-2 h-4 w-4 text-zinc-400" />
-              <span className="ui-text-sm text-subtle">Loading more...</span>
+              <span className="ui-text-sm text-muted">Loading more...</span>
             </div>
           )}
 

--- a/src/components/admin/AdminOverviewContent.tsx
+++ b/src/components/admin/AdminOverviewContent.tsx
@@ -26,7 +26,7 @@ function StatCard({
 }) {
   return (
     <div className="border-edge bg-surface rounded-lg border p-4">
-      <p className="ui-text-xs text-subtle">{label}</p>
+      <p className="ui-text-xs text-muted">{label}</p>
       <p className="ui-text-lg text-strong mt-1 font-semibold">
         {typeof value === "number" ? value.toLocaleString() : value}
       </p>

--- a/src/components/admin/AdminUsersContent.tsx
+++ b/src/components/admin/AdminUsersContent.tsx
@@ -248,7 +248,7 @@ export default function AdminUsersContent() {
             id="user-sort"
             value={sort}
             onChange={(e) => setSort(e.target.value as UserSort)}
-            className="ui-text-sm bg-surface text-strong block rounded-md border border-zinc-300 px-3 py-2 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none dark:border-zinc-700 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+            className="ui-text-sm bg-surface text-strong border-edge-input focus:border-focus focus:ring-focus block rounded-md border px-3 py-2 focus:ring-2 focus:ring-offset-2 focus:outline-none"
           >
             {SORT_OPTIONS.map((option) => (
               <option key={option.value} value={option.value}>

--- a/src/components/admin/AdminUsersContent.tsx
+++ b/src/components/admin/AdminUsersContent.tsx
@@ -116,7 +116,7 @@ function UserRow({ user }: { user: User }) {
       )}
 
       {/* Stats row */}
-      <div className="ui-text-xs text-subtle flex flex-wrap gap-x-4 gap-y-1">
+      <div className="ui-text-xs text-muted flex flex-wrap gap-x-4 gap-y-1">
         <span>Member since {formatDate(user.createdAt)}</span>
         <span>Last active: {user.lastActiveAt ? formatDate(user.lastActiveAt) : "Never"}</span>
         <span>
@@ -147,7 +147,7 @@ function EmptyState({ hasSearch }: { hasSearch: boolean }) {
       <h3 className="ui-text-sm text-strong font-medium">
         {hasSearch ? "No matching users" : "No users yet"}
       </h3>
-      <p className="ui-text-sm text-subtle mt-1">
+      <p className="ui-text-sm text-muted mt-1">
         {hasSearch ? "Try a different search term." : "No users have registered yet."}
       </p>
     </div>
@@ -293,7 +293,7 @@ export default function AdminUsersContent() {
           {usersQuery.isFetchingNextPage && (
             <div className="flex items-center justify-center p-4">
               <SpinnerIcon className="mr-2 h-4 w-4 text-zinc-400" />
-              <span className="ui-text-sm text-subtle">Loading more...</span>
+              <span className="ui-text-sm text-muted">Loading more...</span>
             </div>
           )}
 

--- a/src/components/app/AppRouter.tsx
+++ b/src/components/app/AppRouter.tsx
@@ -26,7 +26,7 @@ function PageSkeleton() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
       <div className="mb-4 sm:mb-6">
-        <div className="h-8 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+        <div className="bg-fill-muted h-8 w-48 animate-pulse rounded" />
       </div>
       <div className="space-y-4">
         {[1, 2, 3].map((i) => (

--- a/src/components/auth/AuthFooter.tsx
+++ b/src/components/auth/AuthFooter.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 export function AuthFooter() {
   return (
     <footer className="border-edge mt-8 border-t pt-6">
-      <p className="ui-text-xs text-subtle text-center">
+      <p className="ui-text-xs text-muted text-center">
         <Link
           href="/terms"
           className="hover:text-zinc-900 hover:underline dark:hover:text-zinc-300"
@@ -24,7 +24,7 @@ export function AuthFooter() {
           Privacy Policy
         </Link>
       </p>
-      <p className="ui-text-xs text-subtle mt-2 text-center">
+      <p className="ui-text-xs text-muted mt-2 text-center">
         Created by{" "}
         <a
           href="https://www.brendanlong.com"

--- a/src/components/auth/AuthFooter.tsx
+++ b/src/components/auth/AuthFooter.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 export function AuthFooter() {
   return (
     <footer className="border-edge mt-8 border-t pt-6">
-      <p className="ui-text-xs text-center text-zinc-500 dark:text-zinc-500">
+      <p className="ui-text-xs text-subtle text-center">
         <Link
           href="/terms"
           className="hover:text-zinc-900 hover:underline dark:hover:text-zinc-300"
@@ -24,7 +24,7 @@ export function AuthFooter() {
           Privacy Policy
         </Link>
       </p>
-      <p className="ui-text-xs mt-2 text-center text-zinc-500 dark:text-zinc-500">
+      <p className="ui-text-xs text-subtle mt-2 text-center">
         Created by{" "}
         <a
           href="https://www.brendanlong.com"

--- a/src/components/auth/OAuthSignInButton.tsx
+++ b/src/components/auth/OAuthSignInButton.tsx
@@ -24,10 +24,10 @@ interface OAuthSignInButtonProps {
 }
 
 const defaultButtonClassName =
-  "ui-text-sm flex min-h-[44px] w-full items-center justify-center gap-3 rounded-md border border-zinc-300 bg-surface px-4 font-medium text-strong transition-colors hover:bg-zinc-50 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400";
+  "ui-text-sm flex min-h-[44px] w-full items-center justify-center gap-3 rounded-md border border-edge-input bg-surface px-4 font-medium text-strong transition-colors hover:bg-surface-hover focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50";
 
 const appleButtonClassName =
-  "ui-text-sm flex min-h-[44px] w-full items-center justify-center gap-3 rounded-md bg-black px-4 font-medium text-white transition-colors hover:bg-zinc-800 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-black dark:hover:bg-zinc-200 dark:focus:ring-zinc-400";
+  "ui-text-sm flex min-h-[44px] w-full items-center justify-center gap-3 rounded-md bg-black px-4 font-medium text-white transition-colors hover:bg-zinc-800 focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-black dark:hover:bg-zinc-200";
 
 export function OAuthSignInButton({
   provider,

--- a/src/components/auth/OAuthSignInButton.tsx
+++ b/src/components/auth/OAuthSignInButton.tsx
@@ -24,7 +24,7 @@ interface OAuthSignInButtonProps {
 }
 
 const defaultButtonClassName =
-  "ui-text-sm flex min-h-[44px] w-full items-center justify-center gap-3 rounded-md border border-edge-input bg-surface px-4 font-medium text-strong transition-colors hover:bg-surface-hover focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+  "ui-text-sm flex min-h-[44px] w-full items-center justify-center gap-3 rounded-md border border-edge-input bg-surface px-4 font-medium text-strong transition-colors hover:bg-surface-muted focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50";
 
 const appleButtonClassName =
   "ui-text-sm flex min-h-[44px] w-full items-center justify-center gap-3 rounded-md bg-black px-4 font-medium text-white transition-colors hover:bg-zinc-800 focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-black dark:hover:bg-zinc-200";

--- a/src/components/entries/EntryArticle.tsx
+++ b/src/components/entries/EntryArticle.tsx
@@ -107,19 +107,19 @@ export function EntryArticle({
                 href={url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="ui-text-xl sm:ui-text-2xl hover:text-accent block leading-tight font-bold text-strong underline-offset-2 transition-colors hover:underline md:text-3xl"
+                className="ui-text-xl sm:ui-text-2xl hover:text-accent text-strong block leading-tight font-bold underline-offset-2 transition-colors hover:underline md:text-3xl"
               >
                 {title}
               </a>
             ) : (
-              <h1 className="ui-text-xl sm:ui-text-2xl leading-tight font-bold text-strong md:text-3xl">
+              <h1 className="ui-text-xl sm:ui-text-2xl text-strong leading-tight font-bold md:text-3xl">
                 {title}
               </h1>
             )}
           </div>
 
           {/* Meta row: Source, Author, Date */}
-          <div className="ui-text-xs sm:ui-text-sm flex flex-wrap items-center gap-x-3 gap-y-1 text-muted sm:gap-x-4 sm:gap-y-2">
+          <div className="ui-text-xs sm:ui-text-sm text-muted flex flex-wrap items-center gap-x-3 gap-y-1 sm:gap-x-4 sm:gap-y-2">
             <span className="font-medium">{source}</span>
             {author && author.toLowerCase().trim() !== source.toLowerCase().trim() && (
               <>
@@ -148,7 +148,7 @@ export function EntryArticle({
       </header>
 
       {/* Divider */}
-      <hr className="mb-6 border-edge-strong sm:mb-8" />
+      <hr className="border-edge-strong mb-6 sm:mb-8" />
 
       {/* Before content slot (summary card, narration highlight styles) */}
       {beforeContent}
@@ -171,7 +171,7 @@ export function EntryArticle({
 
       {/* Footer with original link and unsubscribe link */}
       {(url || unsubscribeUrl) && (
-        <footer className="mt-8 border-t border-edge-strong pt-6 sm:mt-12 sm:pt-8">
+        <footer className="border-edge-strong mt-8 border-t pt-6 sm:mt-12 sm:pt-8">
           <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
             {url && (
               <a
@@ -189,7 +189,7 @@ export function EntryArticle({
                 href={unsubscribeUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="ui-text-sm inline-flex min-h-[44px] items-center gap-2 font-medium text-subtle transition-colors hover:text-zinc-700 active:text-zinc-800 dark:hover:text-zinc-300 dark:active:text-zinc-200"
+                className="ui-text-sm text-muted inline-flex min-h-[44px] items-center gap-2 font-medium transition-colors hover:text-zinc-700 active:text-zinc-800 dark:hover:text-zinc-300 dark:active:text-zinc-200"
               >
                 <ExternalLinkIcon className="h-4 w-4" />
                 Unsubscribe

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -337,7 +337,7 @@ export function EntryContentBody({
         onBack ? (
           <button
             onClick={onBack}
-            className="ui-text-sm text-muted mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 transition-colors hover:bg-zinc-100 hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
+            className="ui-text-sm text-muted hover:bg-surface-muted mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 transition-colors hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
           >
             <ArrowLeftIcon className="h-4 w-4" />
             <span>Back to list</span>

--- a/src/components/entries/EntryContentFallback.tsx
+++ b/src/components/entries/EntryContentFallback.tsx
@@ -38,7 +38,7 @@ interface EntryContentFallbackProps {
  * Shimmer placeholder for a button.
  */
 function ButtonShimmer({ width = "w-24" }: { width?: string }) {
-  return <div className={`h-10 ${width} animate-pulse rounded bg-zinc-200 dark:bg-zinc-700`} />;
+  return <div className={`h-10 ${width} bg-fill-muted animate-pulse rounded`} />;
 }
 
 /**

--- a/src/components/entries/EntryContentFallback.tsx
+++ b/src/components/entries/EntryContentFallback.tsx
@@ -93,7 +93,7 @@ export function EntryContentFallback({ entryId, onBack }: EntryContentFallbackPr
         {onBack && (
           <button
             onClick={onBack}
-            className="ui-text-sm text-muted mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 transition-colors hover:bg-zinc-100 hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
+            className="ui-text-sm text-muted hover:bg-surface-muted mb-4 -ml-2 inline-flex min-h-[44px] items-center gap-2 rounded-md px-2 transition-colors hover:text-zinc-900 active:bg-zinc-200 sm:mb-6 dark:hover:text-zinc-100 dark:active:bg-zinc-700"
           >
             <ArrowLeftIcon className="h-4 w-4" />
             <span>Back to list</span>

--- a/src/components/entries/EntryContentRenderer.tsx
+++ b/src/components/entries/EntryContentRenderer.tsx
@@ -53,5 +53,5 @@ export const EntryContentRenderer = React.memo(function EntryContentRenderer({
     );
   }
 
-  return <p className="text-subtle italic">No content available.</p>;
+  return <p className="text-muted italic">No content available.</p>;
 });

--- a/src/components/entries/EntryContentStates.tsx
+++ b/src/components/entries/EntryContentStates.tsx
@@ -12,7 +12,7 @@ export function EntryContentSkeleton() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-6 sm:py-8">
       {/* Back button placeholder */}
-      <div className="mb-4 h-10 w-28 animate-pulse rounded bg-zinc-200 sm:mb-6 dark:bg-zinc-700" />
+      <div className="bg-fill-muted mb-4 h-10 w-28 animate-pulse rounded sm:mb-6" />
 
       {/* Header section */}
       <header className="mb-6 sm:mb-8">
@@ -20,28 +20,28 @@ export function EntryContentSkeleton() {
         <div className="mb-4 flex gap-4 sm:mb-6">
           <div className="min-w-0 flex-1">
             {/* Title placeholder */}
-            <div className="mb-2 h-8 w-3/4 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-            <div className="mb-4 h-8 w-1/2 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+            <div className="bg-fill-muted mb-2 h-8 w-3/4 animate-pulse rounded" />
+            <div className="bg-fill-muted mb-4 h-8 w-1/2 animate-pulse rounded" />
 
             {/* Meta row placeholder */}
             <div className="flex items-center gap-4">
-              <div className="h-4 w-24 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-              <div className="h-4 w-32 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+              <div className="bg-fill-muted h-4 w-24 animate-pulse rounded" />
+              <div className="bg-fill-muted h-4 w-32 animate-pulse rounded" />
             </div>
           </div>
 
           {/* Vote controls placeholder */}
           <div className="shrink-0">
-            <div className="flex h-24 w-10 animate-pulse flex-col items-center justify-center rounded bg-zinc-200 dark:bg-zinc-700" />
+            <div className="bg-fill-muted flex h-24 w-10 animate-pulse flex-col items-center justify-center rounded" />
           </div>
         </div>
 
         {/* Action buttons placeholder */}
         <div className="flex gap-2 sm:gap-3">
-          <div className="h-10 w-24 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-          <div className="h-10 w-24 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-          <div className="h-10 w-28 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-          <div className="h-10 w-20 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+          <div className="bg-fill-muted h-10 w-24 animate-pulse rounded" />
+          <div className="bg-fill-muted h-10 w-24 animate-pulse rounded" />
+          <div className="bg-fill-muted h-10 w-28 animate-pulse rounded" />
+          <div className="bg-fill-muted h-10 w-20 animate-pulse rounded" />
         </div>
       </header>
 
@@ -61,13 +61,13 @@ export function EntryContentSkeleton() {
 export function ContentSkeleton() {
   return (
     <div className="animate-pulse space-y-4">
-      <div className="h-4 w-full rounded bg-zinc-200 dark:bg-zinc-700" />
-      <div className="h-4 w-full rounded bg-zinc-200 dark:bg-zinc-700" />
-      <div className="h-4 w-5/6 rounded bg-zinc-200 dark:bg-zinc-700" />
-      <div className="h-4 w-full rounded bg-zinc-200 dark:bg-zinc-700" />
-      <div className="h-4 w-3/4 rounded bg-zinc-200 dark:bg-zinc-700" />
-      <div className="h-4 w-full rounded bg-zinc-200 dark:bg-zinc-700" />
-      <div className="h-4 w-4/5 rounded bg-zinc-200 dark:bg-zinc-700" />
+      <div className="bg-fill-muted h-4 w-full rounded" />
+      <div className="bg-fill-muted h-4 w-full rounded" />
+      <div className="bg-fill-muted h-4 w-5/6 rounded" />
+      <div className="bg-fill-muted h-4 w-full rounded" />
+      <div className="bg-fill-muted h-4 w-3/4 rounded" />
+      <div className="bg-fill-muted h-4 w-full rounded" />
+      <div className="bg-fill-muted h-4 w-4/5 rounded" />
     </div>
   );
 }

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -85,7 +85,7 @@ export function getItemClasses(read: boolean, selected: boolean): string {
   // Unread entries stand out as raised surface cards with a distinctly stronger
   // border (the only card/canvas separation available on e-paper, where every
   // fill is white).
-  return `${baseClasses} border-edge-input bg-surface hover:bg-surface-hover active:bg-zinc-100 dark:active:bg-zinc-700 epaper:border-zinc-500`;
+  return `${baseClasses} border-edge-input bg-surface hover:bg-surface-muted active:bg-zinc-100 dark:active:bg-zinc-700 epaper:border-zinc-500`;
 }
 
 /**
@@ -229,7 +229,7 @@ export const EntryListItem = memo(function EntryListItem({
           </div>
 
           {/* Meta Row: Source and Date */}
-          <div className="ui-text-xs text-subtle mt-1 flex items-center gap-2">
+          <div className="ui-text-xs text-muted mt-1 flex items-center gap-2">
             <span className="truncate">{source}</span>
             <span aria-hidden="true">·</span>
             <time dateTime={date.toISOString()} className="shrink-0">

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -85,7 +85,7 @@ export function getItemClasses(read: boolean, selected: boolean): string {
   // Unread entries stand out as raised surface cards with a distinctly stronger
   // border (the only card/canvas separation available on e-paper, where every
   // fill is white).
-  return `${baseClasses} border-zinc-300 bg-surface hover:bg-zinc-50 active:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-800 dark:active:bg-zinc-700 epaper:border-zinc-500`;
+  return `${baseClasses} border-edge-input bg-surface hover:bg-surface-hover active:bg-zinc-100 dark:active:bg-zinc-700 epaper:border-zinc-500`;
 }
 
 /**
@@ -172,7 +172,7 @@ export const EntryListItem = memo(function EntryListItem({
               <span
                 className={`block h-2.5 w-2.5 rounded-full transition-colors ${
                   read
-                    ? "group-hover/toggle:border-accent group-hover/toggle:bg-accent-subtle border border-zinc-300 bg-transparent dark:border-zinc-600"
+                    ? "group-hover/toggle:border-accent group-hover/toggle:bg-accent-subtle border-edge-input border bg-transparent"
                     : "bg-accent-muted group-hover/toggle:bg-accent dark:bg-accent dark:group-hover/toggle:bg-accent-hover"
                 }`}
               />
@@ -180,9 +180,7 @@ export const EntryListItem = memo(function EntryListItem({
           ) : (
             <span
               className={`block h-2.5 w-2.5 rounded-full ${
-                read
-                  ? "border border-zinc-300 bg-transparent dark:border-zinc-600"
-                  : "bg-accent-muted dark:bg-accent"
+                read ? "border-edge-input border bg-transparent" : "bg-accent-muted dark:bg-accent"
               }`}
               aria-hidden="true"
             />

--- a/src/components/entries/EntryListSkeleton.tsx
+++ b/src/components/entries/EntryListSkeleton.tsx
@@ -28,26 +28,26 @@ const EntryListItemSkeleton = memo(function EntryListItemSkeleton({
       <div className="flex items-start gap-3">
         {/* Read indicator skeleton */}
         <div className="mt-1.5 shrink-0">
-          <div className="h-2.5 w-2.5 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-700" />
+          <div className="bg-fill-muted h-2.5 w-2.5 animate-pulse rounded-full" />
         </div>
 
         <div className="min-w-0 flex-1">
           {/* Title skeleton */}
           <div className="flex items-start justify-between gap-2">
-            <div className="h-5 w-3/4 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+            <div className="bg-fill-muted h-5 w-3/4 animate-pulse rounded" />
           </div>
 
           {/* Meta row skeleton (feed name and date) */}
           <div className="mt-1 flex items-center gap-2">
-            <div className="h-3 w-24 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-            <div className="h-3 w-16 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+            <div className="bg-fill-muted h-3 w-24 animate-pulse rounded" />
+            <div className="bg-fill-muted h-3 w-16 animate-pulse rounded" />
           </div>
 
           {/* Summary skeleton */}
           <div className="mt-2 space-y-1.5">
-            <div className="h-4 w-full animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+            <div className="bg-fill-muted h-4 w-full animate-pulse rounded" />
             <div
-              className={`h-4 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700 ${
+              className={`bg-fill-muted h-4 animate-pulse rounded ${
                 hasLongSummary ? "w-4/5" : "w-1/2"
               }`}
             />

--- a/src/components/entries/EntryListStates.tsx
+++ b/src/components/entries/EntryListStates.tsx
@@ -28,7 +28,7 @@ export function EntryListEmpty({ message, icon }: EntryListEmptyProps) {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
       {icon ?? <DefaultEmptyIcon className="text-faint mb-4 h-12 w-12" />}
-      <p className="ui-text-sm text-subtle">{message}</p>
+      <p className="ui-text-sm text-muted">{message}</p>
     </div>
   );
 }
@@ -50,7 +50,7 @@ export function EntryListError({ message, onRetry }: EntryListErrorProps) {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
       <AlertIcon className="mb-4 h-12 w-12 text-red-400 dark:text-red-500" />
-      <p className="ui-text-sm text-subtle mb-4">{message}</p>
+      <p className="ui-text-sm text-muted mb-4">{message}</p>
       <Button onClick={onRetry}>Try again</Button>
     </div>
   );

--- a/src/components/entries/EntryPageLayout.tsx
+++ b/src/components/entries/EntryPageLayout.tsx
@@ -22,7 +22,7 @@ import { MarkAllReadButton } from "./MarkAllReadButton";
  * Loading skeleton for the page title.
  */
 export function TitleSkeleton() {
-  return <div className="h-8 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />;
+  return <div className="bg-fill-muted h-8 w-48 animate-pulse rounded" />;
 }
 
 /**

--- a/src/components/entries/MarkAllReadButton.tsx
+++ b/src/components/entries/MarkAllReadButton.tsx
@@ -32,7 +32,7 @@ export function MarkAllReadButton({
       <button
         type="button"
         onClick={() => setShowDialog(true)}
-        className="text-subtle inline-flex items-center justify-center rounded-md p-2 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400"
+        className="text-muted hover:bg-surface-muted focus:ring-focus inline-flex items-center justify-center rounded-md p-2 transition-colors hover:text-zinc-700 focus:ring-2 focus:ring-offset-2 focus:outline-none dark:hover:text-zinc-200"
         title="Mark all as read"
         aria-label="Mark all as read"
       >

--- a/src/components/entries/StickyEntryControls.tsx
+++ b/src/components/entries/StickyEntryControls.tsx
@@ -78,7 +78,7 @@ export function StickyEntryControls({
         </button>
 
         {/* Divider */}
-        <div className="h-5 w-px bg-zinc-200 dark:bg-zinc-700" />
+        <div className="bg-fill-muted h-5 w-px" />
 
         {/* Read/unread button */}
         <button

--- a/src/components/entries/StickyEntryControls.tsx
+++ b/src/components/entries/StickyEntryControls.tsx
@@ -70,7 +70,7 @@ export function StickyEntryControls({
           className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full transition-colors ${
             starred
               ? "text-amber-500 hover:bg-amber-50 dark:hover:bg-amber-950"
-              : "text-subtle hover:bg-zinc-100 dark:hover:bg-zinc-800"
+              : "text-muted hover:bg-surface-muted"
           }`}
           aria-label={starred ? "Remove from starred" : "Add to starred"}
         >
@@ -84,9 +84,7 @@ export function StickyEntryControls({
         <button
           onClick={onToggleRead}
           className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full transition-colors ${
-            !read
-              ? "text-accent hover:bg-accent-subtle"
-              : "text-subtle hover:bg-zinc-100 dark:hover:bg-zinc-800"
+            !read ? "text-accent hover:bg-accent-subtle" : "text-muted hover:bg-surface-muted"
           }`}
           aria-label={read ? "Mark as unread" : "Mark as read"}
           title="Keyboard shortcut: m"

--- a/src/components/feeds/EditSubscriptionDialog.tsx
+++ b/src/components/feeds/EditSubscriptionDialog.tsx
@@ -192,7 +192,7 @@ function EditSubscriptionForm({
                     className={`ui-text-sm flex items-center gap-1.5 rounded-full border px-3 py-1.5 transition-colors ${
                       isSelected
                         ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
-                        : "text-body border-zinc-300 bg-white hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:border-zinc-500 dark:hover:bg-zinc-700"
+                        : "text-body border-edge-input bg-white hover:border-zinc-400 hover:bg-zinc-50 dark:bg-zinc-800 dark:hover:border-zinc-500 dark:hover:bg-zinc-700"
                     }`}
                   >
                     <ColorDot color={tag.color} size="sm" />

--- a/src/components/feeds/EditSubscriptionDialog.tsx
+++ b/src/components/feeds/EditSubscriptionDialog.tsx
@@ -146,7 +146,7 @@ function EditSubscriptionForm({
       <DialogTitle id="edit-subscription-title">Edit Subscription</DialogTitle>
 
       <DialogBody>
-        <p className="ui-text-sm text-subtle mb-4">
+        <p className="ui-text-sm text-muted mb-4">
           Feed: <span className="text-body font-medium">{currentTitle}</span>
         </p>
 
@@ -172,7 +172,7 @@ function EditSubscriptionForm({
         <div className="mb-2">
           <label className="ui-text-sm text-body mb-2 block font-medium">Tags</label>
           {tags.length === 0 ? (
-            <p className="ui-text-sm text-subtle">
+            <p className="ui-text-sm text-muted">
               No tags created yet. Create tags in{" "}
               <ClientLink href="/settings" className="text-strong underline">
                 Settings
@@ -191,7 +191,7 @@ function EditSubscriptionForm({
                     disabled={isPending}
                     className={`ui-text-sm flex items-center gap-1.5 rounded-full border px-3 py-1.5 transition-colors ${
                       isSelected
-                        ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
+                        ? "border-primary-solid bg-primary-solid text-primary-solid-foreground"
                         : "text-body border-edge-input bg-white hover:border-zinc-400 hover:bg-zinc-50 dark:bg-zinc-800 dark:hover:border-zinc-500 dark:hover:bg-zinc-700"
                     }`}
                   >

--- a/src/components/keyboard/KeyboardShortcutsModal.tsx
+++ b/src/components/keyboard/KeyboardShortcutsModal.tsx
@@ -109,7 +109,7 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsMod
       <DialogBody className="space-y-6">
         {SHORTCUT_SECTIONS.map((section) => (
           <div key={section.title}>
-            <h3 className="ui-text-sm text-subtle mb-3 font-medium">{section.title}</h3>
+            <h3 className="ui-text-sm text-muted mb-3 font-medium">{section.title}</h3>
             <div className="space-y-2">
               {section.shortcuts.map((shortcut) => (
                 <div key={shortcut.description} className="flex items-center justify-between py-1">
@@ -131,7 +131,7 @@ export function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsMod
 
       {/* Footer */}
       <DialogFooter className="border-edge-strong flex-col items-stretch border-t pt-4">
-        <p className="ui-text-xs text-subtle mb-4">
+        <p className="ui-text-xs text-muted mb-4">
           Keyboard shortcuts can be disabled in Settings.
         </p>
         <div className="flex justify-end">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -119,7 +119,7 @@ export function Sidebar({ onClose }: SidebarProps) {
 
         {/* Divider with unread toggle */}
         <div className="border-edge-strong mx-3 flex items-center gap-2 border-t pt-2">
-          <span className="ui-text-xs text-subtle flex-1 font-medium">Feeds</span>
+          <span className="ui-text-xs text-muted flex-1 font-medium">Feeds</span>
           <SidebarUnreadToggle unreadOnly={sidebarUnreadOnly} onToggle={toggleSidebarUnreadOnly} />
         </div>
 

--- a/src/components/layout/SidebarNav.tsx
+++ b/src/components/layout/SidebarNav.tsx
@@ -25,7 +25,7 @@ interface SidebarNavProps {
  */
 function CountBadge({ count }: { count: number }) {
   if (count === 0) return null;
-  return <span className="ui-text-xs text-subtle ml-2 shrink-0">({count})</span>;
+  return <span className="ui-text-xs text-muted ml-2 shrink-0">({count})</span>;
 }
 
 /**

--- a/src/components/layout/SidebarUnreadToggle.tsx
+++ b/src/components/layout/SidebarUnreadToggle.tsx
@@ -71,7 +71,7 @@ export function SidebarUnreadToggle({ unreadOnly, onToggle }: SidebarUnreadToggl
     <button
       type="button"
       onClick={onToggle}
-      className="text-faint rounded p-1 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+      className="text-faint hover:bg-surface-muted rounded p-1 transition-colors hover:text-zinc-600 dark:hover:text-zinc-300"
       title={label}
       aria-label={label}
       aria-pressed={unreadOnly}

--- a/src/components/layout/SubscriptionItem.tsx
+++ b/src/components/layout/SubscriptionItem.tsx
@@ -54,14 +54,12 @@ export function SubscriptionItem({
         onNavigate={onClose}
         onPrefetch={onPrefetch}
         className={`ui-text-sm flex min-h-[44px] items-center justify-between rounded-md px-3 py-2 transition-colors ${
-          isActive
-            ? "bg-surface-muted text-strong"
-            : "text-body hover:bg-zinc-100 dark:hover:bg-zinc-800"
+          isActive ? "bg-surface-muted text-strong" : "text-body hover:bg-surface-muted"
         }`}
       >
         <span className="truncate pr-8">{displayTitle}</span>
         {subscription.unreadCount > 0 && (
-          <span className="ui-text-xs text-subtle shrink-0 group-hover:hidden">
+          <span className="ui-text-xs text-muted shrink-0 group-hover:hidden">
             ({subscription.unreadCount})
           </span>
         )}

--- a/src/components/layout/TagList.tsx
+++ b/src/components/layout/TagList.tsx
@@ -80,7 +80,7 @@ function TagListContent({
   };
 
   if (!hasTags) {
-    return <p className="ui-text-sm text-subtle px-3">No unread feeds</p>;
+    return <p className="ui-text-sm text-muted px-3">No unread feeds</p>;
   }
 
   return (
@@ -101,7 +101,7 @@ function TagListContent({
                   e.stopPropagation();
                   toggleExpanded(tag.id);
                 }}
-                className="text-subtle flex h-6 w-6 shrink-0 items-center justify-center hover:text-zinc-700 dark:hover:text-zinc-300"
+                className="text-muted flex h-6 w-6 shrink-0 items-center justify-center hover:text-zinc-700 dark:hover:text-zinc-300"
                 aria-label={expanded ? "Collapse" : "Expand"}
               >
                 {expanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
@@ -146,7 +146,7 @@ function TagListContent({
                 e.stopPropagation();
                 toggleExpanded("uncategorized");
               }}
-              className="text-subtle flex h-6 w-6 shrink-0 items-center justify-center hover:text-zinc-700 dark:hover:text-zinc-300"
+              className="text-muted flex h-6 w-6 shrink-0 items-center justify-center hover:text-zinc-700 dark:hover:text-zinc-300"
               aria-label={isExpanded("uncategorized") ? "Collapse" : "Expand"}
             >
               {isExpanded("uncategorized") ? <ChevronDownIcon /> : <ChevronRightIcon />}

--- a/src/components/layout/UserEmail.tsx
+++ b/src/components/layout/UserEmail.tsx
@@ -22,9 +22,7 @@ function UserEmailContent() {
  * Skeleton fallback while loading.
  */
 function UserEmailSkeleton() {
-  return (
-    <span className="inline-block h-4 w-20 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-  );
+  return <span className="bg-fill-muted inline-block h-4 w-20 animate-pulse rounded" />;
 }
 
 /**

--- a/src/components/legal/LegalProse.tsx
+++ b/src/components/legal/LegalProse.tsx
@@ -35,7 +35,7 @@ export function LegalPage({ title, lastUpdated, children }: LegalPageProps) {
             &larr; Back to Lion Reader
           </Link>
           <h1 className="text-strong mt-4 text-3xl font-bold tracking-tight">{title}</h1>
-          <p className="ui-text-sm text-subtle mt-2">Last updated: {lastUpdated}</p>
+          <p className="ui-text-sm text-muted mt-2">Last updated: {lastUpdated}</p>
         </div>
 
         <div className="prose prose-zinc dark:prose-invert max-w-none">{children}</div>

--- a/src/components/narration/EnhancedVoiceList.tsx
+++ b/src/components/narration/EnhancedVoiceList.tsx
@@ -64,7 +64,7 @@ function ProgressBar({ progress, size }: { progress: number; size: number }) {
 
   return (
     <div className="mt-2">
-      <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+      <div className="bg-fill-muted h-2 w-full overflow-hidden rounded-full">
         <div
           className="h-full rounded-full bg-zinc-900 transition-all duration-200 dark:bg-zinc-400"
           style={{ width: `${percent}%` }}
@@ -134,7 +134,7 @@ function VoiceItem({
         isSelected
           ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
           : isDownloaded
-            ? "border-edge-strong cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+            ? "border-edge-strong hover:bg-surface-hover cursor-pointer"
             : "border-edge-strong"
       }`}
       onClick={handleClick}
@@ -153,7 +153,7 @@ function VoiceItem({
                 ? "border-zinc-900 dark:border-zinc-400"
                 : isDownloaded
                   ? "border-zinc-400 dark:border-zinc-500"
-                  : "border-zinc-300 dark:border-zinc-600"
+                  : "border-edge-input"
             }`}
           >
             {isSelected && <div className="h-2 w-2 rounded-full bg-zinc-900 dark:bg-zinc-400" />}

--- a/src/components/narration/EnhancedVoiceList.tsx
+++ b/src/components/narration/EnhancedVoiceList.tsx
@@ -66,11 +66,11 @@ function ProgressBar({ progress, size }: { progress: number; size: number }) {
     <div className="mt-2">
       <div className="bg-fill-muted h-2 w-full overflow-hidden rounded-full">
         <div
-          className="h-full rounded-full bg-zinc-900 transition-all duration-200 dark:bg-zinc-400"
+          className="bg-control-selected h-full rounded-full transition-all duration-200"
           style={{ width: `${percent}%` }}
         />
       </div>
-      <p className="ui-text-xs text-subtle mt-1">
+      <p className="ui-text-xs text-muted mt-1">
         {percent}% ({downloadedMB} MB / {totalMB} MB)
       </p>
     </div>
@@ -132,9 +132,9 @@ function VoiceItem({
     <div
       className={`relative rounded-lg border p-4 transition-colors ${
         isSelected
-          ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
+          ? "border-control-selected bg-zinc-50 dark:bg-zinc-800"
           : isDownloaded
-            ? "border-edge-strong hover:bg-surface-hover cursor-pointer"
+            ? "border-edge-strong hover:bg-surface-muted cursor-pointer"
             : "border-edge-strong"
       }`}
       onClick={handleClick}
@@ -150,20 +150,20 @@ function VoiceItem({
           <div
             className={`mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border ${
               isSelected
-                ? "border-zinc-900 dark:border-zinc-400"
+                ? "border-control-selected"
                 : isDownloaded
                   ? "border-zinc-400 dark:border-zinc-500"
                   : "border-edge-input"
             }`}
           >
-            {isSelected && <div className="h-2 w-2 rounded-full bg-zinc-900 dark:bg-zinc-400" />}
+            {isSelected && <div className="bg-control-selected h-2 w-2 rounded-full" />}
           </div>
 
           {/* Voice info */}
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <span className="ui-text-sm text-strong font-medium">{voice.displayName}</span>
-              <span className="ui-text-xs text-subtle">- {voice.description}</span>
+              <span className="ui-text-xs text-muted">- {voice.description}</span>
             </div>
 
             {/* Status line */}
@@ -181,11 +181,11 @@ function VoiceItem({
                   {errorInfo.message}
                 </div>
                 {errorInfo.suggestion && (
-                  <p className="ui-text-xs text-subtle">{errorInfo.suggestion}</p>
+                  <p className="ui-text-xs text-muted">{errorInfo.suggestion}</p>
                 )}
               </div>
             ) : (
-              <p className="ui-text-xs text-subtle mt-1">{formatSize(voice.sizeBytes)}</p>
+              <p className="ui-text-xs text-muted mt-1">{formatSize(voice.sizeBytes)}</p>
             )}
           </div>
         </div>
@@ -194,7 +194,7 @@ function VoiceItem({
         <div className="flex flex-shrink-0 items-center gap-2">
           {isDownloading ? (
             // Cancel button during download (optional - just showing spinner for now)
-            <div className="ui-text-xs text-subtle flex items-center gap-2">
+            <div className="ui-text-xs text-muted flex items-center gap-2">
               <SpinnerIcon className="h-4 w-4" />
               Downloading...
             </div>
@@ -235,7 +235,7 @@ function VoiceItem({
                   e.stopPropagation();
                   onDelete();
                 }}
-                className="text-faint rounded-md p-2 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                className="text-faint hover:bg-surface-muted rounded-md p-2 transition-colors hover:text-zinc-600 dark:hover:text-zinc-300"
                 title="Delete voice"
               >
                 <TrashIcon className="h-4 w-4" />
@@ -353,7 +353,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
     return (
       <div className="flex items-center justify-center py-8">
         <SpinnerIcon className="h-6 w-6 text-zinc-400" />
-        <span className="ui-text-sm text-subtle ml-2">Loading voices...</span>
+        <span className="ui-text-sm text-muted ml-2">Loading voices...</span>
       </div>
     );
   }
@@ -431,7 +431,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
             <button
               type="button"
               onClick={handleDeleteAllVoices}
-              className="ui-text-xs text-subtle underline hover:text-zinc-700 dark:hover:text-zinc-200"
+              className="ui-text-xs text-muted underline hover:text-zinc-700 dark:hover:text-zinc-200"
             >
               Delete All
             </button>
@@ -440,7 +440,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
       )}
 
       {/* Info text */}
-      <p className="ui-text-xs text-subtle">
+      <p className="ui-text-xs text-muted">
         Enhanced voices run entirely in your browser. Once downloaded, they work offline.
       </p>
     </div>

--- a/src/components/narration/EnhancedVoicesHelp.tsx
+++ b/src/components/narration/EnhancedVoicesHelp.tsx
@@ -78,7 +78,7 @@ function FAQItemComponent({
       >
         <span className="ui-text-sm text-body font-medium">{item.question}</span>
         <ChevronDownIcon
-          className={`text-subtle h-4 w-4 flex-shrink-0 transition-transform duration-200 ${
+          className={`text-muted h-4 w-4 flex-shrink-0 transition-transform duration-200 ${
             isOpen ? "rotate-180" : ""
           }`}
         />
@@ -126,15 +126,15 @@ export function EnhancedVoicesHelp() {
       <button
         type="button"
         onClick={() => setIsExpanded(!isExpanded)}
-        className="hover:bg-surface-hover flex w-full items-center justify-between px-4 py-3 text-left"
+        className="hover:bg-surface-muted flex w-full items-center justify-between px-4 py-3 text-left"
         aria-expanded={isExpanded}
       >
         <div className="flex items-center gap-2">
-          <QuestionCircleIcon className="text-subtle h-4 w-4" />
+          <QuestionCircleIcon className="text-muted h-4 w-4" />
           <span className="ui-text-sm text-body font-medium">Help with enhanced voices</span>
         </div>
         <ChevronDownIcon
-          className={`text-subtle h-4 w-4 transition-transform duration-200 ${
+          className={`text-muted h-4 w-4 transition-transform duration-200 ${
             isExpanded ? "rotate-180" : ""
           }`}
         />

--- a/src/components/narration/EnhancedVoicesHelp.tsx
+++ b/src/components/narration/EnhancedVoicesHelp.tsx
@@ -126,7 +126,7 @@ export function EnhancedVoicesHelp() {
       <button
         type="button"
         onClick={() => setIsExpanded(!isExpanded)}
-        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+        className="hover:bg-surface-hover flex w-full items-center justify-between px-4 py-3 text-left"
         aria-expanded={isExpanded}
       >
         <div className="flex items-center gap-2">

--- a/src/components/narration/NarrationControls.tsx
+++ b/src/components/narration/NarrationControls.tsx
@@ -196,7 +196,7 @@ export function NarrationControlsImpl({
 
       {/* Paragraph indicator - only show when active */}
       {isActive && totalParagraphs > 0 && (
-        <span className="ui-text-xs text-subtle">
+        <span className="ui-text-xs text-muted">
           {currentParagraph + 1} of {totalParagraphs}
         </span>
       )}

--- a/src/components/narration/NarrationSettings.tsx
+++ b/src/components/narration/NarrationSettings.tsx
@@ -183,7 +183,7 @@ export function NarrationSettings() {
           <AlertIcon className="text-faint mt-0.5 h-5 w-5 flex-shrink-0" />
           <div>
             <p className="ui-text-sm text-strong font-medium">Narration Unavailable</p>
-            <p className="ui-text-sm text-subtle mt-1">{supportInfo.reason}</p>
+            <p className="ui-text-sm text-muted mt-1">{supportInfo.reason}</p>
             <p className="ui-text-xs text-faint mt-2">
               Try using Chrome, Safari, or Edge for the best narration experience.
             </p>
@@ -199,14 +199,14 @@ export function NarrationSettings() {
       <div className="flex items-center justify-between">
         <div>
           <h3 className="ui-text-sm text-strong font-medium">Enable narration</h3>
-          <p className="ui-text-sm text-subtle mt-1">Listen to articles using text-to-speech.</p>
+          <p className="ui-text-sm text-muted mt-1">Listen to articles using text-to-speech.</p>
         </div>
         <button
           type="button"
           role="switch"
           aria-checked={settings.enabled}
           onClick={() => setSettings((prev) => ({ ...prev, enabled: !prev.enabled }))}
-          className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
+          className={`focus:ring-focus relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
             settings.enabled ? "bg-primary-solid" : "bg-fill-muted"
           }`}
         >
@@ -230,8 +230,8 @@ export function NarrationSettings() {
               <label
                 className={`relative flex cursor-pointer rounded-lg border p-4 transition-colors ${
                   settings.provider === "browser"
-                    ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
-                    : "border-edge-strong hover:bg-surface-hover"
+                    ? "border-control-selected bg-zinc-50 dark:bg-zinc-800"
+                    : "border-edge-strong hover:bg-surface-muted"
                 }`}
               >
                 <input
@@ -246,17 +246,17 @@ export function NarrationSettings() {
                   <div
                     className={`mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border ${
                       settings.provider === "browser"
-                        ? "border-zinc-900 dark:border-zinc-400"
+                        ? "border-control-selected"
                         : "border-zinc-400 dark:border-zinc-500"
                     }`}
                   >
                     {settings.provider === "browser" && (
-                      <div className="h-2 w-2 rounded-full bg-zinc-900 dark:bg-zinc-400" />
+                      <div className="bg-control-selected h-2 w-2 rounded-full" />
                     )}
                   </div>
                   <div>
                     <span className="ui-text-sm text-strong block font-medium">Browser Voices</span>
-                    <span className="ui-text-xs text-subtle mt-0.5 block">
+                    <span className="ui-text-xs text-muted mt-0.5 block">
                       Uses your browser&apos;s built-in text-to-speech
                     </span>
                   </div>
@@ -267,8 +267,8 @@ export function NarrationSettings() {
               <label
                 className={`relative flex cursor-pointer rounded-lg border p-4 transition-colors ${
                   settings.provider === "piper"
-                    ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
-                    : "border-edge-strong hover:bg-surface-hover"
+                    ? "border-control-selected bg-zinc-50 dark:bg-zinc-800"
+                    : "border-edge-strong hover:bg-surface-muted"
                 }`}
               >
                 <input
@@ -283,19 +283,19 @@ export function NarrationSettings() {
                   <div
                     className={`mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border ${
                       settings.provider === "piper"
-                        ? "border-zinc-900 dark:border-zinc-400"
+                        ? "border-control-selected"
                         : "border-zinc-400 dark:border-zinc-500"
                     }`}
                   >
                     {settings.provider === "piper" && (
-                      <div className="h-2 w-2 rounded-full bg-zinc-900 dark:bg-zinc-400" />
+                      <div className="bg-control-selected h-2 w-2 rounded-full" />
                     )}
                   </div>
                   <div>
                     <span className="ui-text-sm text-strong block font-medium">
                       Enhanced Voices
                     </span>
-                    <span className="ui-text-xs text-subtle mt-0.5 block">
+                    <span className="ui-text-xs text-muted mt-0.5 block">
                       Higher quality voices (requires download)
                     </span>
                   </div>
@@ -346,7 +346,7 @@ export function NarrationSettings() {
                   {isPreviewing ? "Stop" : "Preview"}
                 </Button>
               </div>
-              <p className="ui-text-xs text-subtle mt-1.5">
+              <p className="ui-text-xs text-muted mt-1.5">
                 Voices are provided by your browser. Chrome and Safari typically offer higher
                 quality voices.
               </p>
@@ -427,7 +427,7 @@ export function NarrationSettings() {
               <div className="flex items-center justify-between">
                 <div>
                   <p className="ui-text-sm text-body">Use AI text processing</p>
-                  <p className="ui-text-xs text-subtle">
+                  <p className="ui-text-xs text-muted">
                     Improves narration quality by expanding abbreviations and formatting content
                   </p>
                 </div>
@@ -441,7 +441,7 @@ export function NarrationSettings() {
                       useLlmNormalization: !prev.useLlmNormalization,
                     }))
                   }
-                  className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
+                  className={`focus:ring-focus relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
                     settings.useLlmNormalization ? "bg-primary-solid" : "bg-fill-muted"
                   }`}
                 >
@@ -464,9 +464,7 @@ export function NarrationSettings() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="ui-text-sm text-body">Highlight current paragraph</p>
-                <p className="ui-text-xs text-subtle">
-                  Visually highlight the paragraph being read
-                </p>
+                <p className="ui-text-xs text-muted">Visually highlight the paragraph being read</p>
               </div>
               <button
                 type="button"
@@ -475,7 +473,7 @@ export function NarrationSettings() {
                 onClick={() =>
                   setSettings((prev) => ({ ...prev, highlightEnabled: !prev.highlightEnabled }))
                 }
-                className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
+                className={`focus:ring-focus relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
                   settings.highlightEnabled ? "bg-primary-solid" : "bg-fill-muted"
                 }`}
               >
@@ -492,7 +490,7 @@ export function NarrationSettings() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="ui-text-sm text-body">Auto-scroll to current paragraph</p>
-                <p className="ui-text-xs text-subtle">
+                <p className="ui-text-xs text-muted">
                   Automatically scroll the page to keep the current paragraph visible
                 </p>
               </div>
@@ -503,7 +501,7 @@ export function NarrationSettings() {
                 onClick={() =>
                   setSettings((prev) => ({ ...prev, autoScrollEnabled: !prev.autoScrollEnabled }))
                 }
-                className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
+                className={`focus:ring-focus relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
                   settings.autoScrollEnabled ? "bg-primary-solid" : "bg-fill-muted"
                 }`}
               >
@@ -533,7 +531,7 @@ export function NarrationSettings() {
       {/* Media Session Info */}
       {settings.enabled && supportInfo.mediaSession && (
         <CardSection>
-          <div className="ui-text-xs text-subtle flex items-start gap-2">
+          <div className="ui-text-xs text-muted flex items-start gap-2">
             <InfoCircleIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
             <span>
               Your browser supports media controls. You can control playback using your keyboard

--- a/src/components/narration/NarrationSettings.tsx
+++ b/src/components/narration/NarrationSettings.tsx
@@ -166,10 +166,10 @@ export function NarrationSettings() {
       <SettingsSection title="Narration">
         <div className="flex items-center justify-between">
           <div>
-            <div className="h-5 w-32 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
-            <div className="mt-2 h-4 w-48 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+            <div className="bg-fill-muted h-5 w-32 animate-pulse rounded" />
+            <div className="bg-fill-muted mt-2 h-4 w-48 animate-pulse rounded" />
           </div>
-          <div className="h-6 w-11 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-700" />
+          <div className="bg-fill-muted h-6 w-11 animate-pulse rounded-full" />
         </div>
       </SettingsSection>
     );
@@ -207,7 +207,7 @@ export function NarrationSettings() {
           aria-checked={settings.enabled}
           onClick={() => setSettings((prev) => ({ ...prev, enabled: !prev.enabled }))}
           className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
-            settings.enabled ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
+            settings.enabled ? "bg-primary-solid" : "bg-fill-muted"
           }`}
         >
           <span
@@ -231,7 +231,7 @@ export function NarrationSettings() {
                 className={`relative flex cursor-pointer rounded-lg border p-4 transition-colors ${
                   settings.provider === "browser"
                     ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
-                    : "border-edge-strong hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+                    : "border-edge-strong hover:bg-surface-hover"
                 }`}
               >
                 <input
@@ -268,7 +268,7 @@ export function NarrationSettings() {
                 className={`relative flex cursor-pointer rounded-lg border p-4 transition-colors ${
                   settings.provider === "piper"
                     ? "border-zinc-900 bg-zinc-50 dark:border-zinc-400 dark:bg-zinc-800"
-                    : "border-edge-strong hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+                    : "border-edge-strong hover:bg-surface-hover"
                 }`}
               >
                 <input
@@ -319,7 +319,7 @@ export function NarrationSettings() {
                   value={settings.voiceId || ""}
                   onChange={handleVoiceChange}
                   disabled={isLoadingVoices}
-                  className="ui-text-sm bg-surface text-strong block flex-1 rounded-md border border-zinc-300 px-3 py-2 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+                  className="ui-text-sm bg-surface text-strong border-edge-input focus:border-focus focus:ring-focus block flex-1 rounded-md border px-3 py-2 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {isLoadingVoices ? (
                     <option value="">Loading voices...</option>
@@ -380,7 +380,7 @@ export function NarrationSettings() {
               step="0.1"
               value={settings.rate}
               onChange={handleRateChange}
-              className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-zinc-200 accent-zinc-900 dark:bg-zinc-700 dark:accent-zinc-400"
+              className="bg-fill-muted h-2 w-full cursor-pointer appearance-none rounded-lg accent-zinc-900 dark:accent-zinc-400"
             />
             <div className="ui-text-xs text-faint mt-1 flex justify-between">
               <span>0.5x</span>
@@ -407,7 +407,7 @@ export function NarrationSettings() {
                 step="0.1"
                 value={settings.pitch}
                 onChange={handlePitchChange}
-                className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-zinc-200 accent-zinc-900 dark:bg-zinc-700 dark:accent-zinc-400"
+                className="bg-fill-muted h-2 w-full cursor-pointer appearance-none rounded-lg accent-zinc-900 dark:accent-zinc-400"
               />
               <div className="ui-text-xs text-faint mt-1 flex justify-between">
                 <span>0.5x</span>
@@ -442,9 +442,7 @@ export function NarrationSettings() {
                     }))
                   }
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
-                    settings.useLlmNormalization
-                      ? "bg-primary-solid"
-                      : "bg-zinc-200 dark:bg-zinc-700"
+                    settings.useLlmNormalization ? "bg-primary-solid" : "bg-fill-muted"
                   }`}
                 >
                   <span
@@ -478,7 +476,7 @@ export function NarrationSettings() {
                   setSettings((prev) => ({ ...prev, highlightEnabled: !prev.highlightEnabled }))
                 }
                 className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
-                  settings.highlightEnabled ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
+                  settings.highlightEnabled ? "bg-primary-solid" : "bg-fill-muted"
                 }`}
               >
                 <span
@@ -506,7 +504,7 @@ export function NarrationSettings() {
                   setSettings((prev) => ({ ...prev, autoScrollEnabled: !prev.autoScrollEnabled }))
                 }
                 className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
-                  settings.autoScrollEnabled ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
+                  settings.autoScrollEnabled ? "bg-primary-solid" : "bg-fill-muted"
                 }`}
               >
                 <span

--- a/src/components/saved/FileUploadButton.tsx
+++ b/src/components/saved/FileUploadButton.tsx
@@ -177,7 +177,7 @@ export function FileUploadButton({ className = "", onSuccess }: FileUploadButton
       <button
         type="button"
         onClick={handleOpen}
-        className={`ui-text-sm border-edge-strong bg-surface text-body inline-flex min-h-[40px] items-center gap-1.5 rounded-md border px-3 font-medium transition-colors hover:bg-zinc-50 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none active:bg-zinc-100 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400 dark:active:bg-zinc-700 ${className}`}
+        className={`ui-text-sm border-edge-strong bg-surface text-body hover:bg-surface-hover inline-flex min-h-[40px] items-center gap-1.5 rounded-md border px-3 font-medium transition-colors focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none active:bg-zinc-100 dark:focus:ring-zinc-400 dark:active:bg-zinc-700 ${className}`}
         title="Upload file"
         aria-label="Upload file"
       >
@@ -213,7 +213,7 @@ export function FileUploadButton({ className = "", onSuccess }: FileUploadButton
                 ? "bg-surface-muted border-zinc-500 dark:border-zinc-400"
                 : selectedFile
                   ? "border-green-500 bg-green-50 dark:border-green-600 dark:bg-green-900/20"
-                  : "border-zinc-300 hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-600 dark:hover:border-zinc-500 dark:hover:bg-zinc-800"
+                  : "border-edge-input hover:bg-surface-hover hover:border-zinc-400 dark:hover:border-zinc-500"
             }`}
           >
             <input

--- a/src/components/saved/FileUploadButton.tsx
+++ b/src/components/saved/FileUploadButton.tsx
@@ -177,7 +177,7 @@ export function FileUploadButton({ className = "", onSuccess }: FileUploadButton
       <button
         type="button"
         onClick={handleOpen}
-        className={`ui-text-sm border-edge-strong bg-surface text-body hover:bg-surface-hover inline-flex min-h-[40px] items-center gap-1.5 rounded-md border px-3 font-medium transition-colors focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none active:bg-zinc-100 dark:focus:ring-zinc-400 dark:active:bg-zinc-700 ${className}`}
+        className={`ui-text-sm border-edge-strong bg-surface text-body hover:bg-surface-muted focus:ring-focus inline-flex min-h-[40px] items-center gap-1.5 rounded-md border px-3 font-medium transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none active:bg-zinc-100 dark:active:bg-zinc-700 ${className}`}
         title="Upload file"
         aria-label="Upload file"
       >
@@ -213,7 +213,7 @@ export function FileUploadButton({ className = "", onSuccess }: FileUploadButton
                 ? "bg-surface-muted border-zinc-500 dark:border-zinc-400"
                 : selectedFile
                   ? "border-green-500 bg-green-50 dark:border-green-600 dark:bg-green-900/20"
-                  : "border-edge-input hover:bg-surface-hover hover:border-zinc-400 dark:hover:border-zinc-500"
+                  : "border-edge-input hover:bg-surface-muted hover:border-zinc-400 dark:hover:border-zinc-500"
             }`}
           >
             <input
@@ -228,7 +228,7 @@ export function FileUploadButton({ className = "", onSuccess }: FileUploadButton
               <div className="flex flex-col items-center">
                 <DocumentIcon className="h-10 w-10 text-green-600 dark:text-green-500" />
                 <p className="text-strong mt-2 font-medium">{selectedFile.name}</p>
-                <p className="ui-text-sm text-subtle">{formatFileSize(selectedFile.size)}</p>
+                <p className="ui-text-sm text-muted">{formatFileSize(selectedFile.size)}</p>
                 <p className="ui-text-xs text-faint mt-2">
                   Click or drop a different file to replace
                 </p>
@@ -237,7 +237,7 @@ export function FileUploadButton({ className = "", onSuccess }: FileUploadButton
               <div className="flex flex-col items-center">
                 <UploadIcon className="text-faint h-10 w-10" />
                 <p className="text-strong mt-2 font-medium">Drop file here or click to browse</p>
-                <p className="ui-text-sm text-subtle">.docx, .html, .md up to 10MB</p>
+                <p className="ui-text-sm text-muted">.docx, .html, .md up to 10MB</p>
               </div>
             )}
           </div>

--- a/src/components/settings/ApiKeySettings.tsx
+++ b/src/components/settings/ApiKeySettings.tsx
@@ -412,7 +412,7 @@ export function SummarizationApiKeySettings() {
                   <option value={currentModel}>{currentModel}</option>
                 )}
             </select>
-            <p className="ui-text-xs text-subtle mt-1.5">
+            <p className="ui-text-xs text-muted mt-1.5">
               Choose the Anthropic model used for generating article summaries. Sonnet models offer
               the best balance of quality and cost.
             </p>
@@ -485,7 +485,7 @@ export function SummarizationApiKeySettings() {
                 )}
               </div>
             )}
-            <p className="ui-text-xs text-subtle mt-1.5">
+            <p className="ui-text-xs text-muted mt-1.5">
               Maximum number of words for generated summaries.
             </p>
           </div>
@@ -509,7 +509,7 @@ export function SummarizationApiKeySettings() {
                   disabled={updatePreferences.isPending}
                   className="ui-text-sm bg-surface text-strong border-edge-input focus:border-focus focus:ring-focus block w-full rounded-md border px-3 py-2 font-mono focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
                 />
-                <p className="ui-text-xs text-subtle">
+                <p className="ui-text-xs text-muted">
                   Available template variables: <InlineCode>{"{{content}}"}</InlineCode>,{" "}
                   <InlineCode>{"{{title}}"}</InlineCode>, <InlineCode>{"{{maxWords}}"}</InlineCode>.
                   The response should be wrapped in <InlineCode>{"<summary>"}</InlineCode> tags.
@@ -561,7 +561,7 @@ export function SummarizationApiKeySettings() {
                 )}
               </div>
             )}
-            <p className="ui-text-xs text-subtle mt-1.5">
+            <p className="ui-text-xs text-muted mt-1.5">
               Override the default prompt sent to the AI model when generating summaries.
             </p>
           </div>

--- a/src/components/settings/ApiKeySettings.tsx
+++ b/src/components/settings/ApiKeySettings.tsx
@@ -390,7 +390,7 @@ export function SummarizationApiKeySettings() {
               value={currentModel ?? defaultModelId}
               onChange={handleModelChange}
               disabled={updatePreferences.isPending || modelsQuery.isLoading}
-              className="ui-text-sm bg-surface text-strong block w-full rounded-md border border-zinc-300 px-3 py-2 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+              className="ui-text-sm bg-surface text-strong border-edge-input focus:border-focus focus:ring-focus block w-full rounded-md border px-3 py-2 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             >
               {modelsQuery.isLoading ? (
                 <option value={currentModel ?? defaultModelId}>Loading models...</option>
@@ -507,7 +507,7 @@ export function SummarizationApiKeySettings() {
                   value={promptInput}
                   onChange={(e) => setPromptInput(e.target.value)}
                   disabled={updatePreferences.isPending}
-                  className="ui-text-sm bg-surface text-strong block w-full rounded-md border border-zinc-300 px-3 py-2 font-mono focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+                  className="ui-text-sm bg-surface text-strong border-edge-input focus:border-focus focus:ring-focus block w-full rounded-md border px-3 py-2 font-mono focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
                 />
                 <p className="ui-text-xs text-subtle">
                   Available template variables: <InlineCode>{"{{content}}"}</InlineCode>,{" "}

--- a/src/components/settings/AppearanceSettings.tsx
+++ b/src/components/settings/AppearanceSettings.tsx
@@ -69,7 +69,7 @@ function OptionGroup<T extends string>({
           </OptionButton>
         ))}
       </div>
-      {description && <p className="ui-text-sm text-subtle mt-1">{description}</p>}
+      {description && <p className="ui-text-sm text-muted mt-1">{description}</p>}
     </div>
   );
 }
@@ -111,7 +111,7 @@ function TextPreview() {
 
   return (
     <div className="border-edge-strong rounded-lg border bg-white p-4 dark:bg-zinc-800">
-      <p className="ui-text-xs text-subtle mb-2 font-medium tracking-wide uppercase">Preview</p>
+      <p className="ui-text-xs text-muted mb-2 font-medium tracking-wide uppercase">Preview</p>
       <p className="text-body" style={style}>
         The quick brown fox jumps over the lazy dog. This sample text demonstrates how your articles
         will appear with the current settings. Adjusting the text size, font, and justification can

--- a/src/components/settings/BookmarkletSettings.tsx
+++ b/src/components/settings/BookmarkletSettings.tsx
@@ -144,7 +144,7 @@ export function BookmarkletSettings() {
                 onClick={() => {
                   navigator.clipboard.writeText(bookmarkletHref);
                 }}
-                className="ui-text-xs absolute top-2 right-2 rounded border border-zinc-300 bg-white px-2 py-1 font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600 dark:hover:text-zinc-100"
+                className="ui-text-xs border-edge-input absolute top-2 right-2 rounded border bg-white px-2 py-1 font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600 dark:hover:text-zinc-100"
               >
                 Copy
               </button>

--- a/src/components/settings/BookmarkletSettings.tsx
+++ b/src/components/settings/BookmarkletSettings.tsx
@@ -132,7 +132,7 @@ export function BookmarkletSettings() {
 
         {showCode && (
           <div className="mt-4">
-            <p className="ui-text-sm text-subtle mb-2">
+            <p className="ui-text-sm text-muted mb-2">
               If you prefer, you can manually create a bookmark with this JavaScript code:
             </p>
             <div className="relative">

--- a/src/components/settings/DiscordBotSettings.tsx
+++ b/src/components/settings/DiscordBotSettings.tsx
@@ -85,7 +85,7 @@ export function DiscordBotSettings() {
           <button
             type="button"
             onClick={copyInviteUrl}
-            className="ui-text-sm text-body inline-flex items-center gap-2 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 font-medium shadow-sm transition-all hover:border-zinc-400 hover:bg-zinc-50 hover:shadow dark:border-zinc-600 dark:bg-zinc-800 dark:hover:border-zinc-500 dark:hover:bg-zinc-700"
+            className="ui-text-sm text-body border-edge-input inline-flex items-center gap-2 rounded-lg border bg-white px-4 py-2.5 font-medium shadow-sm transition-all hover:border-zinc-400 hover:bg-zinc-50 hover:shadow dark:bg-zinc-800 dark:hover:border-zinc-500 dark:hover:bg-zinc-700"
           >
             {copied ? "Copied!" : "Copy Link"}
           </button>

--- a/src/components/settings/KeyboardShortcutsSettings.tsx
+++ b/src/components/settings/KeyboardShortcutsSettings.tsx
@@ -32,7 +32,7 @@ export function KeyboardShortcutsSettings() {
           aria-checked={enabled}
           onClick={() => setEnabled(!enabled)}
           className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
-            enabled ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
+            enabled ? "bg-primary-solid" : "bg-fill-muted"
           }`}
         >
           <span

--- a/src/components/settings/KeyboardShortcutsSettings.tsx
+++ b/src/components/settings/KeyboardShortcutsSettings.tsx
@@ -22,7 +22,7 @@ export function KeyboardShortcutsSettings() {
       <div className="flex items-center justify-between">
         <div>
           <h3 className="ui-text-sm text-strong font-medium">Enable keyboard shortcuts</h3>
-          <p className="ui-text-sm text-subtle mt-1">
+          <p className="ui-text-sm text-muted mt-1">
             Use keyboard shortcuts to navigate entries and perform actions quickly.
           </p>
         </div>
@@ -31,7 +31,7 @@ export function KeyboardShortcutsSettings() {
           role="switch"
           aria-checked={enabled}
           onClick={() => setEnabled(!enabled)}
-          className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
+          className={`focus:ring-focus relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-zinc-900 ${
             enabled ? "bg-primary-solid" : "bg-fill-muted"
           }`}
         >

--- a/src/components/settings/LinkedAccounts.tsx
+++ b/src/components/settings/LinkedAccounts.tsx
@@ -260,12 +260,12 @@ function LinkableProviderItem({ provider, isLinking, onLink }: LinkableProviderI
   const name = providerNames[provider];
 
   return (
-    <div className="flex items-center justify-between rounded-md border border-dashed border-zinc-300 p-4 dark:border-zinc-600">
+    <div className="border-edge-input flex items-center justify-between rounded-md border border-dashed p-4">
       <div className="flex items-center gap-3">
         <ProviderIcon provider={provider} muted />
         <div>
           <p className="ui-text-sm text-muted font-medium">{name}</p>
-          <p className="ui-text-xs text-zinc-500 dark:text-zinc-500">Not connected</p>
+          <p className="ui-text-xs text-subtle">Not connected</p>
         </div>
       </div>
       <Button

--- a/src/components/settings/LinkedAccounts.tsx
+++ b/src/components/settings/LinkedAccounts.tsx
@@ -189,14 +189,12 @@ export function LinkedAccounts() {
 
         {/* Show message if no providers available */}
         {enabledProviders.length === 0 && linkedAccounts.length === 0 && (
-          <p className="ui-text-sm text-subtle">
-            No OAuth providers are configured on this server.
-          </p>
+          <p className="ui-text-sm text-muted">No OAuth providers are configured on this server.</p>
         )}
       </div>
 
       {!hasPassword && linkedAccounts.length > 0 && (
-        <p className="ui-text-xs text-subtle mt-4">
+        <p className="ui-text-xs text-muted mt-4">
           Tip: Add a password to your account so you can unlink OAuth providers if needed.
         </p>
       )}
@@ -229,7 +227,7 @@ function LinkedAccountItem({ account, canUnlink, isUnlinking, onUnlink }: Linked
         <ProviderIcon provider={account.provider} />
         <div>
           <p className="ui-text-sm text-strong font-medium">{name}</p>
-          <p className="ui-text-xs text-subtle">Linked on {linkedDate}</p>
+          <p className="ui-text-xs text-muted">Linked on {linkedDate}</p>
         </div>
       </div>
       <Button
@@ -265,7 +263,7 @@ function LinkableProviderItem({ provider, isLinking, onLink }: LinkableProviderI
         <ProviderIcon provider={provider} muted />
         <div>
           <p className="ui-text-sm text-muted font-medium">{name}</p>
-          <p className="ui-text-xs text-subtle">Not connected</p>
+          <p className="ui-text-xs text-muted">Not connected</p>
         </div>
       </div>
       <Button

--- a/src/components/settings/OpmlImportExport.tsx
+++ b/src/components/settings/OpmlImportExport.tsx
@@ -255,7 +255,7 @@ function ImportSection() {
   return (
     <Card>
       <h3 className="ui-text-sm text-strong mb-2 font-medium">Import from OPML</h3>
-      <p className="ui-text-sm text-subtle mb-4">
+      <p className="ui-text-sm text-muted mb-4">
         Import your feed subscriptions from another RSS reader by uploading an OPML file.
       </p>
 
@@ -287,7 +287,7 @@ function ImportSection() {
               Drag and drop your OPML file here, or{" "}
               <span className="text-accent font-medium">browse</span>
             </p>
-            <p className="ui-text-xs text-subtle mt-1">Supports .opml and .xml files up to 5MB</p>
+            <p className="ui-text-xs text-muted mt-1">Supports .opml and .xml files up to 5MB</p>
           </div>
         </div>
       )}
@@ -324,7 +324,7 @@ function ImportSection() {
                   }}
                 />
               </div>
-              <p className="ui-text-xs text-subtle mt-1">
+              <p className="ui-text-xs text-muted mt-1">
                 {importQuery.data.importedCount +
                   importQuery.data.skippedCount +
                   importQuery.data.failedCount}{" "}
@@ -332,7 +332,7 @@ function ImportSection() {
               </p>
             </div>
           )}
-          <p className="ui-text-xs text-subtle">
+          <p className="ui-text-xs text-muted">
             This may take a moment depending on the number of feeds.
           </p>
         </div>
@@ -380,7 +380,7 @@ function ImportPreview({ feeds, onImport, onCancel, isImporting }: ImportPreview
           {displayedFeeds.map((feed, index) => (
             <li key={`${feed.xmlUrl}-${index}`} className="px-4 py-3">
               <p className="ui-text-sm text-strong font-medium">{feed.title || "Untitled Feed"}</p>
-              <p className="ui-text-xs text-subtle mt-0.5 truncate">{feed.xmlUrl}</p>
+              <p className="ui-text-xs text-muted mt-0.5 truncate">{feed.xmlUrl}</p>
               {feed.category && feed.category.length > 0 && (
                 <p className="ui-text-xs text-faint mt-1">Folder: {feed.category.join(" / ")}</p>
               )}
@@ -467,7 +467,7 @@ function ImportResults({ imported, skipped, failed, results, onReset }: ImportRe
                         <p className="ui-text-sm text-strong truncate font-medium">
                           {result.title || "Untitled Feed"}
                         </p>
-                        <p className="ui-text-xs text-subtle truncate">{result.url}</p>
+                        <p className="ui-text-xs text-muted truncate">{result.url}</p>
                         {result.error && (
                           <p className="ui-text-xs mt-1 text-red-600 dark:text-red-400">
                             {result.error}
@@ -543,7 +543,7 @@ function ExportSection() {
   return (
     <Card>
       <h3 className="ui-text-sm text-strong mb-2 font-medium">Export to OPML</h3>
-      <p className="ui-text-sm text-subtle mb-4">
+      <p className="ui-text-sm text-muted mb-4">
         Download your subscriptions as an OPML file to import into another RSS reader.
       </p>
 

--- a/src/components/settings/OpmlImportExport.tsx
+++ b/src/components/settings/OpmlImportExport.tsx
@@ -268,7 +268,7 @@ function ImportSection() {
       {importState.type === "idle" && (
         <div
           className={`relative rounded-lg border-2 border-dashed p-8 text-center transition-colors ${
-            isDragOver ? "border-accent bg-accent-subtle" : "border-zinc-300 dark:border-zinc-700"
+            isDragOver ? "border-accent bg-accent-subtle" : "border-edge-input"
           }`}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
@@ -287,9 +287,7 @@ function ImportSection() {
               Drag and drop your OPML file here, or{" "}
               <span className="text-accent font-medium">browse</span>
             </p>
-            <p className="ui-text-xs mt-1 text-zinc-500 dark:text-zinc-500">
-              Supports .opml and .xml files up to 5MB
-            </p>
+            <p className="ui-text-xs text-subtle mt-1">Supports .opml and .xml files up to 5MB</p>
           </div>
         </div>
       )}
@@ -318,7 +316,7 @@ function ImportSection() {
           </div>
           {importState.type === "importing" && importQuery.data && (
             <div className="mb-2">
-              <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+              <div className="bg-fill-muted h-2 w-full overflow-hidden rounded-full">
                 <div
                   className="bg-accent h-full transition-all duration-300"
                   style={{

--- a/src/components/settings/SettingsListContainer.tsx
+++ b/src/components/settings/SettingsListContainer.tsx
@@ -43,7 +43,7 @@ export function SettingsListContainer<T>({
   skeletonHeight,
   footer,
 }: SettingsListContainerProps<T>) {
-  const defaultEmpty = <p className="ui-text-sm text-subtle text-center">{emptyMessage}</p>;
+  const defaultEmpty = <p className="ui-text-sm text-muted text-center">{emptyMessage}</p>;
 
   const resolvedEmptyState = emptyState ?? defaultEmpty;
 

--- a/src/components/settings/TagManagement.tsx
+++ b/src/components/settings/TagManagement.tsx
@@ -161,7 +161,7 @@ function CreateTagForm({ onSuccess, onError }: CreateTagFormProps) {
         <button
           type="button"
           onClick={() => setShowColorPicker(!showColorPicker)}
-          className="ui-text-sm bg-surface flex h-[38px] items-center gap-2 rounded-md border border-zinc-300 px-3 py-2 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          className="ui-text-sm bg-surface border-edge-input hover:bg-surface-hover flex h-[38px] items-center gap-2 rounded-md border px-3 py-2 transition-colors"
           disabled={createMutation.isPending}
         >
           <ColorDot color={color} size="md" />
@@ -311,7 +311,7 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
             <button
               type="button"
               onClick={() => setShowColorPicker(!showColorPicker)}
-              className="flex items-center justify-center rounded-md border border-zinc-300 p-2 transition-colors hover:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-700"
+              className="border-edge-input flex items-center justify-center rounded-md border p-2 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700"
               disabled={updateMutation.isPending}
             >
               <ColorDot color={editingValues.color} size="lg" />
@@ -331,7 +331,7 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
             type="text"
             value={editingValues.name}
             onChange={(e) => setEditingValues({ ...editingValues, name: e.target.value })}
-            className="ui-text-sm bg-surface text-strong flex-1 rounded-md border border-zinc-300 px-3 py-1.5 focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 focus:outline-none dark:border-zinc-600 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+            className="ui-text-sm bg-surface text-strong border-edge-input focus:border-focus focus:ring-focus flex-1 rounded-md border px-3 py-1.5 focus:ring-2 focus:ring-offset-2 focus:outline-none"
             disabled={updateMutation.isPending}
             autoFocus
           />

--- a/src/components/settings/TagManagement.tsx
+++ b/src/components/settings/TagManagement.tsx
@@ -61,9 +61,7 @@ function TagManagementContent() {
       {/* Tag list */}
       <CardSection>
         {tags.length === 0 ? (
-          <p className="ui-text-sm text-subtle">
-            No tags created yet. Create your first tag above.
-          </p>
+          <p className="ui-text-sm text-muted">No tags created yet. Create your first tag above.</p>
         ) : (
           <div className="space-y-3">
             {tags.map((tag) => (
@@ -161,7 +159,7 @@ function CreateTagForm({ onSuccess, onError }: CreateTagFormProps) {
         <button
           type="button"
           onClick={() => setShowColorPicker(!showColorPicker)}
-          className="ui-text-sm bg-surface border-edge-input hover:bg-surface-hover flex h-[38px] items-center gap-2 rounded-md border px-3 py-2 transition-colors"
+          className="ui-text-sm bg-surface border-edge-input hover:bg-surface-muted flex h-[38px] items-center gap-2 rounded-md border px-3 py-2 transition-colors"
           disabled={createMutation.isPending}
         >
           <ColorDot color={color} size="md" />
@@ -275,7 +273,7 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
           <ColorDot color={tag.color} size="lg" />
           <div>
             <p className="ui-text-sm text-strong font-medium">Delete &quot;{tag.name}&quot;?</p>
-            <p className="ui-text-xs text-subtle">
+            <p className="ui-text-xs text-muted">
               This will remove the tag from all {tag.feedCount} subscription
               {tag.feedCount !== 1 ? "s" : ""}.
             </p>
@@ -311,7 +309,7 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
             <button
               type="button"
               onClick={() => setShowColorPicker(!showColorPicker)}
-              className="border-edge-input flex items-center justify-center rounded-md border p-2 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700"
+              className="border-edge-input hover:bg-surface-muted flex items-center justify-center rounded-md border p-2 transition-colors"
               disabled={updateMutation.isPending}
             >
               <ColorDot color={editingValues.color} size="lg" />
@@ -359,7 +357,7 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
         <ColorDot color={tag.color} size="lg" />
         <div>
           <p className="ui-text-sm text-strong font-medium">{tag.name}</p>
-          <p className="ui-text-xs text-subtle">
+          <p className="ui-text-xs text-muted">
             {tag.feedCount} feed{tag.feedCount !== 1 ? "s" : ""}
           </p>
         </div>

--- a/src/components/settings/UnifiedSettingsContent.tsx
+++ b/src/components/settings/UnifiedSettingsContent.tsx
@@ -88,7 +88,7 @@ export function UnifiedSettingsContent() {
       <div className="mb-8">
         <ClientLink
           href="/all"
-          className="ui-text-sm text-subtle mb-4 inline-flex items-center hover:text-zinc-700 dark:hover:text-zinc-200"
+          className="ui-text-sm text-muted mb-4 inline-flex items-center hover:text-zinc-700 dark:hover:text-zinc-200"
         >
           <ChevronLeftIcon className="mr-1 h-4 w-4" />
           Back to feeds
@@ -109,7 +109,7 @@ export function UnifiedSettingsContent() {
                     className={`ui-text-sm block rounded-md px-3 py-2 font-medium whitespace-nowrap transition-colors ${
                       isActive
                         ? "bg-surface-muted text-strong"
-                        : "text-muted hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
+                        : "text-muted hover:bg-surface-muted hover:text-zinc-900 dark:hover:text-zinc-50"
                     }`}
                   >
                     {link.label}

--- a/src/components/settings/pages/AccountSettingsContent.tsx
+++ b/src/components/settings/pages/AccountSettingsContent.tsx
@@ -100,11 +100,11 @@ function AccountInfoSection() {
       ) : (
         <dl className="space-y-4">
           <div>
-            <dt className="ui-text-sm text-subtle font-medium">Email</dt>
+            <dt className="ui-text-sm text-muted font-medium">Email</dt>
             <dd className="ui-text-sm text-strong mt-1">{userQuery.data?.user.email}</dd>
           </div>
           <div>
-            <dt className="ui-text-sm text-subtle font-medium">Member since</dt>
+            <dt className="ui-text-sm text-muted font-medium">Member since</dt>
             <dd className="ui-text-sm text-strong mt-1">
               {userQuery.data?.user.createdAt
                 ? new Date(userQuery.data.user.createdAt).toLocaleDateString("en-US", {
@@ -116,7 +116,7 @@ function AccountInfoSection() {
             </dd>
           </div>
           <div>
-            <dt className="ui-text-sm text-subtle font-medium">Email verified</dt>
+            <dt className="ui-text-sm text-muted font-medium">Email verified</dt>
             <dd className="ui-text-sm text-strong mt-1">
               {userQuery.data?.user.emailVerifiedAt ? (
                 <span className="inline-flex items-center text-green-600 dark:text-green-400">
@@ -124,7 +124,7 @@ function AccountInfoSection() {
                   Verified
                 </span>
               ) : (
-                <span className="text-subtle">Not verified</span>
+                <span className="text-muted">Not verified</span>
               )}
             </dd>
           </div>

--- a/src/components/settings/pages/ApiTokensSettingsContent.tsx
+++ b/src/components/settings/pages/ApiTokensSettingsContent.tsx
@@ -183,7 +183,7 @@ export default function ApiTokensSettingsContent() {
                 placeholder="e.g., Claude Desktop, Browser Extension"
                 className="w-full"
               />
-              <p className="ui-text-xs text-subtle mt-1">
+              <p className="ui-text-xs text-muted mt-1">
                 A descriptive name to help you identify this token
               </p>
             </div>
@@ -195,7 +195,7 @@ export default function ApiTokensSettingsContent() {
                 {Object.entries(scopeLabels).map(([scope, { label, description }]) => (
                   <label
                     key={scope}
-                    className="border-edge hover:bg-surface-hover flex cursor-pointer items-start gap-3 rounded-lg border p-3"
+                    className="border-edge hover:bg-surface-muted flex cursor-pointer items-start gap-3 rounded-lg border p-3"
                   >
                     <input
                       type="checkbox"
@@ -205,7 +205,7 @@ export default function ApiTokensSettingsContent() {
                     />
                     <div className="flex-1">
                       <p className="text-strong font-medium">{label}</p>
-                      <p className="ui-text-xs text-subtle">{description}</p>
+                      <p className="ui-text-xs text-muted">{description}</p>
                     </div>
                   </label>
                 ))}
@@ -225,7 +225,7 @@ export default function ApiTokensSettingsContent() {
                 className="w-full"
                 min="1"
               />
-              <p className="ui-text-xs text-subtle mt-1">
+              <p className="ui-text-xs text-muted mt-1">
                 Leave empty for a token that never expires
               </p>
             </div>
@@ -300,7 +300,7 @@ export default function ApiTokensSettingsContent() {
                     <p className="font-medium text-zinc-700 dark:text-zinc-400">
                       {token.name || "Unnamed Token"}
                     </p>
-                    <p className="ui-text-xs text-subtle">
+                    <p className="ui-text-xs text-muted">
                       {token.revokedAt
                         ? `Revoked ${formatRelativeTime(new Date(token.revokedAt))}`
                         : `Expired ${formatRelativeTime(new Date(token.expiresAt!))}`}
@@ -359,7 +359,7 @@ function ActiveTokenCard({ token, onRevoke, isRevoking }: ActiveTokenCardProps) 
             </div>
           </div>
 
-          <div className="ui-text-xs text-subtle mt-2 flex flex-wrap gap-x-4 gap-y-1">
+          <div className="ui-text-xs text-muted mt-2 flex flex-wrap gap-x-4 gap-y-1">
             <span>
               Created:{" "}
               {new Date(token.createdAt).toLocaleDateString("en-US", {

--- a/src/components/settings/pages/ApiTokensSettingsContent.tsx
+++ b/src/components/settings/pages/ApiTokensSettingsContent.tsx
@@ -195,13 +195,13 @@ export default function ApiTokensSettingsContent() {
                 {Object.entries(scopeLabels).map(([scope, { label, description }]) => (
                   <label
                     key={scope}
-                    className="border-edge flex cursor-pointer items-start gap-3 rounded-lg border p-3 hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                    className="border-edge hover:bg-surface-hover flex cursor-pointer items-start gap-3 rounded-lg border p-3"
                   >
                     <input
                       type="checkbox"
                       checked={selectedScopes.includes(scope)}
                       onChange={() => toggleScope(scope)}
-                      className="text-accent focus:ring-accent mt-1 h-4 w-4 rounded border-zinc-300 dark:border-zinc-700 dark:bg-zinc-800"
+                      className="text-accent focus:ring-accent border-edge-input mt-1 h-4 w-4 rounded dark:bg-zinc-800"
                     />
                     <div className="flex-1">
                       <p className="text-strong font-medium">{label}</p>
@@ -300,7 +300,7 @@ export default function ApiTokensSettingsContent() {
                     <p className="font-medium text-zinc-700 dark:text-zinc-400">
                       {token.name || "Unnamed Token"}
                     </p>
-                    <p className="ui-text-xs text-zinc-500 dark:text-zinc-500">
+                    <p className="ui-text-xs text-subtle">
                       {token.revokedAt
                         ? `Revoked ${formatRelativeTime(new Date(token.revokedAt))}`
                         : `Expired ${formatRelativeTime(new Date(token.expiresAt!))}`}

--- a/src/components/settings/pages/BlockedSendersSettingsContent.tsx
+++ b/src/components/settings/pages/BlockedSendersSettingsContent.tsx
@@ -79,7 +79,7 @@ function EmptyState() {
         <ProhibitionIcon className="text-faint h-6 w-6" />
       </div>
       <h3 className="ui-text-sm text-strong mt-4 font-medium">No blocked senders</h3>
-      <p className="ui-text-sm text-subtle mt-1">
+      <p className="ui-text-sm text-muted mt-1">
         When you unsubscribe from a newsletter, the sender will be added here to prevent future
         emails.
       </p>
@@ -153,7 +153,7 @@ function BlockedSenderRow({ sender }: BlockedSenderRowProps) {
           <p className="text-strong font-medium">{sender.senderEmail}</p>
 
           {/* Metadata */}
-          <div className="ui-text-sm text-subtle mt-1 flex flex-wrap gap-x-4 gap-y-1">
+          <div className="ui-text-sm text-muted mt-1 flex flex-wrap gap-x-4 gap-y-1">
             <span>Blocked {formatRelativeTime(sender.blockedAt)}</span>
             {sender.unsubscribeSentAt && (
               <span className="flex items-center gap-1">

--- a/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
+++ b/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
@@ -126,9 +126,7 @@ function EmptyState() {
         <CheckIcon className="h-6 w-6 text-green-600 dark:text-green-400" />
       </div>
       <h3 className="ui-text-sm text-strong mt-4 font-medium">All feeds are working</h3>
-      <p className="ui-text-sm text-subtle mt-1">
-        None of your subscribed feeds have fetch errors.
-      </p>
+      <p className="ui-text-sm text-muted mt-1">None of your subscribed feeds have fetch errors.</p>
     </div>
   );
 }
@@ -179,7 +177,7 @@ function BrokenFeedRow({ feed, onUnsubscribe }: BrokenFeedRowProps) {
 
           {/* Feed URL */}
           {feed.url && feed.title && (
-            <p className="ui-text-sm text-subtle mt-0.5 truncate">{feed.url}</p>
+            <p className="ui-text-sm text-muted mt-0.5 truncate">{feed.url}</p>
           )}
 
           {/* Error Message */}
@@ -192,7 +190,7 @@ function BrokenFeedRow({ feed, onUnsubscribe }: BrokenFeedRowProps) {
           )}
 
           {/* Metadata */}
-          <div className="ui-text-sm text-subtle mt-2 flex flex-wrap gap-x-4 gap-y-1">
+          <div className="ui-text-sm text-muted mt-2 flex flex-wrap gap-x-4 gap-y-1">
             <span className="flex items-center gap-1">
               <AlertCircleIcon className="h-4 w-4 text-red-500" />
               {feed.consecutiveFailures} consecutive failure

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -109,7 +109,7 @@ function IngestAddressesSection() {
     <section>
       <div className="mb-4 flex items-center justify-between">
         <h3 className="ui-text-sm text-strong font-medium">Ingest Addresses</h3>
-        <span className="ui-text-sm text-subtle">{addresses.length} / 5</span>
+        <span className="ui-text-sm text-muted">{addresses.length} / 5</span>
       </div>
 
       <SettingsListContainer
@@ -124,7 +124,7 @@ function IngestAddressesSection() {
             <></>
           ) : (
             <div className="p-6 text-center">
-              <p className="ui-text-sm text-subtle">
+              <p className="ui-text-sm text-muted">
                 No ingest addresses yet. Create one to start receiving newsletter emails.
               </p>
             </div>
@@ -293,7 +293,7 @@ function IngestAddressRow({ address }: IngestAddressRowProps) {
             <button
               type="button"
               onClick={handleCopy}
-              className="text-subtle flex-shrink-0 rounded p-1 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+              className="text-muted hover:bg-surface-muted flex-shrink-0 rounded p-1 transition-colors hover:text-zinc-700 dark:hover:text-zinc-200"
               title="Copy email address"
             >
               {copied ? (
@@ -424,7 +424,7 @@ function SpamPreferenceSection() {
         <div className="flex items-center justify-between">
           <div>
             <h4 className="ui-text-sm text-strong font-medium">Show spam entries</h4>
-            <p className="ui-text-sm text-subtle mt-1">
+            <p className="ui-text-sm text-muted mt-1">
               Display entries that were flagged as spam by our email provider.
             </p>
           </div>
@@ -434,7 +434,7 @@ function SpamPreferenceSection() {
             aria-checked={showSpam}
             onClick={handleToggle}
             disabled={preferencesQuery.isLoading || updateMutation.isPending}
-            className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-zinc-900 ${
+            className={`focus:ring-focus relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-zinc-900 ${
               showSpam ? "bg-primary-solid" : "bg-fill-muted"
             }`}
           >

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -435,7 +435,7 @@ function SpamPreferenceSection() {
             onClick={handleToggle}
             disabled={preferencesQuery.isLoading || updateMutation.isPending}
             className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-zinc-900 ${
-              showSpam ? "bg-primary-solid" : "bg-zinc-200 dark:bg-zinc-700"
+              showSpam ? "bg-primary-solid" : "bg-fill-muted"
             }`}
           >
             <span

--- a/src/components/settings/pages/FeedStatsSettingsContent.tsx
+++ b/src/components/settings/pages/FeedStatsSettingsContent.tsx
@@ -184,7 +184,7 @@ export default function FeedStatsSettingsContent() {
             {statsQuery.isFetchingNextPage && (
               <div className="flex items-center justify-center p-4">
                 <SpinnerIcon className="mr-2 h-4 w-4 text-zinc-400" />
-                <span className="ui-text-sm text-subtle">Loading more...</span>
+                <span className="ui-text-sm text-muted">Loading more...</span>
               </div>
             )}
 
@@ -219,7 +219,7 @@ function SummaryCard({ label, value, variant = "default" }: SummaryCardProps) {
 
   return (
     <div className="border-edge-strong rounded-lg border bg-zinc-50 p-4 dark:bg-zinc-800">
-      <p className="ui-text-sm text-subtle">{label}</p>
+      <p className="ui-text-sm text-muted">{label}</p>
       <p className={`ui-text-2xl font-semibold ${variantClasses[variant]}`}>{value}</p>
     </div>
   );
@@ -236,7 +236,7 @@ function EmptyState() {
         <RssIcon className="text-faint h-6 w-6" />
       </div>
       <h3 className="ui-text-sm text-strong mt-4 font-medium">No feeds subscribed</h3>
-      <p className="ui-text-sm text-subtle mt-1">
+      <p className="ui-text-sm text-muted mt-1">
         Subscribe to some feeds to see their statistics here.
       </p>
     </div>
@@ -271,7 +271,7 @@ function FeedStatsRow({ feed }: FeedStatsRowProps) {
           </div>
 
           {/* Feed URL */}
-          {feed.url && <p className="ui-text-sm text-subtle mt-0.5 truncate">{feed.url}</p>}
+          {feed.url && <p className="ui-text-sm text-muted mt-0.5 truncate">{feed.url}</p>}
 
           {/* Error Message (if any) */}
           {feed.lastError && (
@@ -348,7 +348,7 @@ interface StatItemProps {
 
 function StatItem({ icon, label, value }: StatItemProps) {
   return (
-    <div className="text-subtle flex items-center gap-1.5">
+    <div className="text-muted flex items-center gap-1.5">
       <span className="h-4 w-4 shrink-0">{icon}</span>
       <span className="truncate">
         <span className="text-body font-medium">{label}:</span> {value}

--- a/src/components/settings/pages/SessionsSettingsContent.tsx
+++ b/src/components/settings/pages/SessionsSettingsContent.tsx
@@ -86,7 +86,7 @@ export default function SessionsSettingsContent() {
     <div>
       <div className="mb-4 flex items-center justify-between">
         <h2 className="ui-text-lg text-strong font-semibold">Active Sessions</h2>
-        <span className="ui-text-sm text-subtle">
+        <span className="ui-text-sm text-muted">
           {sessionsQuery.data?.sessions.length ?? 0} active
         </span>
       </div>
@@ -178,11 +178,11 @@ function SessionCard({ session, onRevoke, isRevoking }: SessionCardProps) {
                   Current session
                 </span>
               )}
-              <p className="ui-text-sm text-subtle">{session.ipAddress || "Unknown IP"}</p>
+              <p className="ui-text-sm text-muted">{session.ipAddress || "Unknown IP"}</p>
             </div>
           </div>
 
-          <div className="ui-text-xs text-subtle mt-2 flex flex-wrap gap-x-4 gap-y-1">
+          <div className="ui-text-xs text-muted mt-2 flex flex-wrap gap-x-4 gap-y-1">
             <span>Last active: {formatRelativeTime(lastActive)}</span>
             <span>
               Created:{" "}

--- a/src/components/subscribe/SubscribeContent.tsx
+++ b/src/components/subscribe/SubscribeContent.tsx
@@ -309,7 +309,7 @@ export function SubscribeContent() {
                   className={`w-full rounded-lg border p-4 text-left transition-colors ${
                     selectedFeedUrl === feed.url
                       ? "border-zinc-900 bg-zinc-50 dark:border-zinc-100 dark:bg-zinc-800"
-                      : "border-edge-strong bg-surface hover:border-zinc-300 hover:bg-zinc-50 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
+                      : "border-edge-strong bg-surface hover:bg-surface-hover hover:border-zinc-300 dark:hover:border-zinc-600"
                   } ${isLoading ? "cursor-not-allowed opacity-50" : ""}`}
                 >
                   <div className="flex items-start justify-between gap-3">

--- a/src/components/subscribe/SubscribeContent.tsx
+++ b/src/components/subscribe/SubscribeContent.tsx
@@ -308,8 +308,8 @@ export function SubscribeContent() {
                   disabled={isLoading}
                   className={`w-full rounded-lg border p-4 text-left transition-colors ${
                     selectedFeedUrl === feed.url
-                      ? "border-zinc-900 bg-zinc-50 dark:border-zinc-100 dark:bg-zinc-800"
-                      : "border-edge-strong bg-surface hover:bg-surface-hover hover:border-zinc-300 dark:hover:border-zinc-600"
+                      ? "border-control-selected bg-zinc-50 dark:bg-zinc-800"
+                      : "border-edge-strong bg-surface hover:bg-surface-muted hover:border-zinc-300 dark:hover:border-zinc-600"
                   } ${isLoading ? "cursor-not-allowed opacity-50" : ""}`}
                 >
                   <div className="flex items-start justify-between gap-3">
@@ -320,7 +320,7 @@ export function SubscribeContent() {
                           {getFeedTypeLabel(feed.type)}
                         </span>
                       </div>
-                      <p className="ui-text-xs text-subtle mt-1 truncate font-mono">{feed.url}</p>
+                      <p className="ui-text-xs text-muted mt-1 truncate font-mono">{feed.url}</p>
                     </div>
                     {selectedFeedUrl === feed.url && isLoading ? (
                       <SpinnerIcon className="h-5 w-5 text-zinc-500" />
@@ -372,7 +372,7 @@ export function SubscribeContent() {
                     href={previewQuery.data.feed.siteUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="ui-text-sm text-subtle hover:underline"
+                    className="ui-text-sm text-muted hover:underline"
                   >
                     {new URL(previewQuery.data.feed.siteUrl).hostname}
                   </a>
@@ -384,7 +384,7 @@ export function SubscribeContent() {
               <p className="ui-text-sm text-muted mb-4">{previewQuery.data.feed.description}</p>
             )}
 
-            <p className="ui-text-xs text-subtle">
+            <p className="ui-text-xs text-muted">
               Feed URL: <span className="font-mono">{previewQuery.data?.feed.url}</span>
             </p>
           </Card>
@@ -409,7 +409,7 @@ export function SubscribeContent() {
                           )}
                         </div>
                         {entry.pubDate && (
-                          <span className="ui-text-xs text-subtle shrink-0">
+                          <span className="ui-text-xs text-muted shrink-0">
                             {formatDate(entry.pubDate)}
                           </span>
                         )}

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -56,7 +56,7 @@ function DefaultErrorFallback({
     <div className="flex flex-col items-center justify-center py-12 text-center" role="alert">
       <AlertIcon className="mb-4 h-12 w-12 text-red-400 dark:text-red-500" />
       <h2 className="ui-text-lg text-strong mb-2 font-semibold">Something went wrong</h2>
-      <p className="ui-text-sm text-subtle mb-4 max-w-sm">
+      <p className="ui-text-sm text-muted mb-4 max-w-sm">
         {message ?? "An unexpected error occurred. Please try again."}
       </p>
       {error && process.env.NODE_ENV === "development" && (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -30,9 +30,8 @@ export function Button({
   const variantStyles = {
     primary: "btn-primary",
     secondary:
-      "border border-zinc-300 bg-surface text-strong hover:bg-zinc-50 focus:ring-zinc-900 dark:border-zinc-700 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400",
-    ghost:
-      "text-strong hover:bg-zinc-100 focus:ring-zinc-900 dark:hover:bg-zinc-800 dark:focus:ring-zinc-400",
+      "border border-edge-input bg-surface text-strong hover:bg-surface-hover focus:ring-focus",
+    ghost: "text-strong hover:bg-zinc-100 focus:ring-focus dark:hover:bg-zinc-800",
   };
 
   // Ensure minimum 44px height for touch targets on mobile (WCAG touch target guidelines)

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -30,8 +30,8 @@ export function Button({
   const variantStyles = {
     primary: "btn-primary",
     secondary:
-      "border border-edge-input bg-surface text-strong hover:bg-surface-hover focus:ring-focus",
-    ghost: "text-strong hover:bg-zinc-100 focus:ring-focus dark:hover:bg-zinc-800",
+      "border border-edge-input bg-surface text-strong hover:bg-surface-muted focus:ring-focus",
+    ghost: "text-strong hover:bg-surface-muted focus:ring-focus",
   };
 
   // Ensure minimum 44px height for touch targets on mobile (WCAG touch target guidelines)

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -77,7 +77,7 @@ export interface CardDescriptionProps {
 }
 
 export function CardDescription({ children, className = "" }: CardDescriptionProps) {
-  return <p className={`ui-text-sm text-subtle mt-1 ${className}`}>{children}</p>;
+  return <p className={`ui-text-sm text-muted mt-1 ${className}`}>{children}</p>;
 }
 
 /**

--- a/src/components/ui/color-picker.tsx
+++ b/src/components/ui/color-picker.tsx
@@ -83,7 +83,7 @@ export function ColorPicker({ selectedColor, onSelect, onClose }: ColorPickerPro
               key={colorOption.value}
               type="button"
               onClick={() => onSelect(colorOption.value)}
-              className={`flex h-7 w-7 items-center justify-center rounded-md transition-transform hover:scale-110 focus:ring-2 focus:ring-zinc-900 focus:ring-offset-1 focus:outline-none dark:focus:ring-zinc-400 ${
+              className={`focus:ring-focus flex h-7 w-7 items-center justify-center rounded-md transition-transform hover:scale-110 focus:ring-2 focus:ring-offset-1 focus:outline-none ${
                 selectedColor === colorOption.value
                   ? "ring-2 ring-zinc-900 ring-offset-1 dark:ring-zinc-400"
                   : ""

--- a/src/components/ui/color-picker.tsx
+++ b/src/components/ui/color-picker.tsx
@@ -85,7 +85,7 @@ export function ColorPicker({ selectedColor, onSelect, onClose }: ColorPickerPro
               onClick={() => onSelect(colorOption.value)}
               className={`focus:ring-focus flex h-7 w-7 items-center justify-center rounded-md transition-transform hover:scale-110 focus:ring-2 focus:ring-offset-1 focus:outline-none ${
                 selectedColor === colorOption.value
-                  ? "ring-2 ring-zinc-900 ring-offset-1 dark:ring-zinc-400"
+                  ? "ring-control-selected ring-2 ring-offset-1"
                   : ""
               }`}
               title={colorOption.name}

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -12,7 +12,7 @@
 import { useEffect, useRef, useState } from "react";
 
 const BUTTON_CLASSES =
-  "ui-text-xs rounded border border-zinc-300 bg-white font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600 dark:hover:text-zinc-100";
+  "ui-text-xs rounded border border-edge-input bg-white font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600 dark:hover:text-zinc-100";
 
 interface CopyButtonProps {
   /** Text to copy to the clipboard. */

--- a/src/components/ui/icon-button.tsx
+++ b/src/components/ui/icon-button.tsx
@@ -48,7 +48,7 @@ export function IconButton({
 
   const variantStyles = {
     ghost:
-      "text-subtle hover:bg-zinc-100 hover:text-zinc-700 active:bg-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-zinc-300 dark:active:bg-zinc-700",
+      "text-muted hover:bg-surface-muted hover:text-zinc-700 active:bg-zinc-200 dark:hover:text-zinc-300 dark:active:bg-zinc-700",
     subtle:
       "text-zinc-400 hover:bg-zinc-200 hover:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-300",
   };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -26,7 +26,7 @@ export function Input({ label, error, id, className = "", ref, ...props }: Input
         className={`ui-text-sm bg-surface text-strong block w-full rounded-md border px-3 py-2 placeholder:text-zinc-400 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-zinc-500 ${
           error
             ? "border-red-500 focus:border-red-500 focus:ring-red-500 dark:border-red-500"
-            : "border-zinc-300 focus:border-zinc-900 focus:ring-zinc-900 dark:border-zinc-700 dark:focus:border-zinc-400 dark:focus:ring-zinc-400"
+            : "border-edge-input focus:border-focus focus:ring-focus"
         } ${className}`}
         aria-invalid={error ? "true" : undefined}
         aria-describedby={error ? `${id}-error` : undefined}

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -14,7 +14,7 @@ export interface KbdProps {
 export function Kbd({ children, className = "" }: KbdProps) {
   return (
     <kbd
-      className={`ui-text-xs bg-surface-muted text-body inline-flex min-w-[24px] items-center justify-center rounded border border-zinc-300 px-1.5 py-0.5 font-mono font-medium dark:border-zinc-600 ${className}`}
+      className={`ui-text-xs bg-surface-muted text-body border-edge-input inline-flex min-w-[24px] items-center justify-center rounded border px-1.5 py-0.5 font-mono font-medium ${className}`}
     >
       {children}
     </kbd>

--- a/src/components/ui/nav-link.tsx
+++ b/src/components/ui/nav-link.tsx
@@ -57,9 +57,7 @@ export function NavLink({
       onNavigate={onClick}
       onPrefetch={onPrefetch}
       className={`ui-text-sm flex min-h-[44px] items-center justify-between rounded-md px-3 py-2 font-medium transition-colors ${
-        isActive
-          ? "bg-surface-muted text-strong"
-          : "text-body hover:bg-zinc-100 dark:hover:bg-zinc-800"
+        isActive ? "bg-surface-muted text-strong" : "text-body hover:bg-surface-muted"
       } ${className}`}
     >
       <span className="truncate">{children}</span>
@@ -111,15 +109,13 @@ export function NavLinkWithIcon({
       onNavigate={onClick}
       onPrefetch={onPrefetch}
       className={`ui-text-sm flex min-h-[44px] flex-1 items-center gap-2 rounded-md px-3 py-2 transition-colors ${
-        isActive
-          ? "bg-surface-muted text-strong"
-          : "text-body hover:bg-zinc-100 dark:hover:bg-zinc-800"
+        isActive ? "bg-surface-muted text-strong" : "text-body hover:bg-surface-muted"
       } ${className}`}
     >
       {icon && <span className="shrink-0">{icon}</span>}
       <span className="truncate">{label}</span>
       {count !== undefined && count > 0 && (
-        <span className="ui-text-xs text-subtle ml-auto shrink-0">({count})</span>
+        <span className="ui-text-xs text-muted ml-auto shrink-0">({count})</span>
       )}
     </ClientLink>
   );

--- a/src/components/ui/state-toggle-button.tsx
+++ b/src/components/ui/state-toggle-button.tsx
@@ -70,7 +70,7 @@ export function StateToggleButton({
     <button
       type="button"
       onClick={handleClick}
-      className={`text-subtle inline-flex items-center justify-center rounded-md p-2 transition-colors hover:bg-zinc-100 hover:text-zinc-700 focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:outline-none dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:focus:ring-zinc-400 ${className}`}
+      className={`text-muted hover:bg-surface-muted focus:ring-focus inline-flex items-center justify-center rounded-md p-2 transition-colors hover:text-zinc-700 focus:ring-2 focus:ring-offset-2 focus:outline-none dark:hover:text-zinc-200 ${className}`}
       title={ariaLabel}
       aria-label={ariaLabel}
       aria-pressed={isPressed}

--- a/tests/unit/frontend/components/Card.test.tsx
+++ b/tests/unit/frontend/components/Card.test.tsx
@@ -116,7 +116,7 @@ describe("CardDescription", () => {
   it("applies description styles", () => {
     render(<CardDescription>Styled description</CardDescription>);
     const description = screen.getByText("Styled description");
-    expect(description).toHaveClass("text-subtle", "mt-1");
+    expect(description).toHaveClass("text-muted", "mt-1");
   });
 
   it("applies custom className", () => {

--- a/tests/unit/frontend/components/Input.test.tsx
+++ b/tests/unit/frontend/components/Input.test.tsx
@@ -74,7 +74,7 @@ describe("Input", () => {
     it("applies normal border styles when no error", () => {
       render(<Input id="normal-field" />);
       const input = screen.getByRole("textbox");
-      expect(input).toHaveClass("border-zinc-300");
+      expect(input).toHaveClass("border-edge-input");
       expect(input).not.toHaveClass("border-red-500");
     });
 

--- a/tests/unit/frontend/entry-list-item.test.ts
+++ b/tests/unit/frontend/entry-list-item.test.ts
@@ -18,13 +18,12 @@ describe("getItemClasses", () => {
 
       expect(classes).toContain(baseClasses);
       // Unread stands out: raised surface card with a distinctly stronger border
-      expect(classes).toContain("border-zinc-300");
+      expect(classes).toContain("border-edge-input");
       expect(classes).toContain("bg-surface");
-      expect(classes).toContain("hover:bg-zinc-50");
+      expect(classes).toContain("hover:bg-surface-muted");
       expect(classes).toContain("active:bg-zinc-100");
-      // Dark mode variants
-      expect(classes).toContain("dark:border-zinc-600");
-      expect(classes).toContain("dark:hover:bg-zinc-800");
+      // Dark mode variants (active press step is still a raw pair)
+      expect(classes).toContain("dark:active:bg-zinc-700");
       // E-paper (all fills white) leans on a darker border for card separation
       expect(classes).toContain("epaper:border-zinc-500");
     });
@@ -88,7 +87,7 @@ describe("getItemClasses", () => {
       expect(selectedRead).toContain("ring-accent");
 
       // Neither should have hover states that conflict with selection
-      expect(selectedUnread).not.toContain("hover:bg-zinc-50");
+      expect(selectedUnread).not.toContain("hover:bg-surface-muted");
       expect(selectedRead).not.toContain("hover:bg-surface");
     });
   });


### PR DESCRIPTION
Follow-up to the #1016 style cleanup (closes #1144). Tokenizes the interactive-state, neutral-fill, and selected-state zinc pairs that were still raw at every call site, resolves the shade drift between them, and merges a redundant text tier. Two commits:

**Commit 1 — interactive-state tokens + drift**
- `bg-fill-muted` (zinc-200/700) — skeletons, toggle-off/progress/range tracks, thin dividers
- `border-edge-input` (zinc-300/700) — input/control outlines (resolved the zinc-700 vs zinc-600 drift)
- `ring-focus` (zinc-900/400) — `focus:ring-focus` + `focus:border-focus`

**Commit 2 — consolidation (per review discussion)**
Treated the remaining shade variations as unplanned drift and unified them:
- **`control-selected`** (zinc-900/400) — new token for the neutral selected/"on" *outline*: checkbox/radio/selected-card `border`/`ring` and radio dots. Folds in the drifted dark shades (zinc-100, zinc-50) other selected states used. Shares `ring-focus`'s value today but is a separate token so the roles can diverge.
- The one **filled** selected pill (EditSubscriptionDialog) now uses the existing `primary-solid` "on" tokens instead of a bespoke zinc-900 fill — that's exactly what `--primary-solid` documents itself for.
- **Focus rings unified** — the toggle/icon `focus:ring-zinc-500` shade folded into `ring-focus`, so every focus ring is one token.
- **Hover fills unified** — dropped the interim `surface-hover` token and routed all neutral hover fills (both the zinc-50 and zinc-100 shades) to `hover:bg-surface-muted`. One value, one token.
- **Text tiers merged** — removed the `subtle` tier (zinc-500/400), folded into `muted` (zinc-600/400); they only differed in light mode and were used interchangeably. Tiers are now strong/emphasis/body/muted/faint.
- Also folded the mode-invariant `text-zinc-500 dark:text-zinc-500` hint text into `muted`.

## Deliberately left raw (real variations, not drift)
- The `active:` press step (`active:bg-zinc-100 dark:active:bg-zinc-700`) — pressed state, one step past hover.
- Filled-control hovers whose dark hover is zinc-700 (copy button, etc.) — these lighten a filled bg, not the transparent→fill pattern.
- Unselected radio outlines (`border-zinc-400 dark:border-zinc-500`), the extension spinner, and the `bg-zinc-50 dark:bg-zinc-800` subtle fill behind selected cards (that last one is the issue's separate ambiguous group).

## E-paper safety
New tokens are defined in `:root`/`.dark`/system-preference media block only — **no `.epaper` overrides** — so they fall through to the light value on e-ink exactly as the raw classes did. The removed text tiers collapse into `muted`, which e-paper already themes.

## Verification
- `pnpm typecheck` passes both commits.
- Production build compiles the CSS; confirmed in the generated stylesheet that the new `bg-fill-muted`/`border-edge-input`/`ring-focus`/`control-selected` utilities exist and reference the correct `var(--…)`, and that the removed `text-subtle`/`bg-surface-hover` utilities are gone. (Build's only failure is the DB-dependent page-data step — no `DATABASE_URL` in the sandbox.)
- Global greps confirm no orphaned/redundant `dark:` partners remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)