### PR TITLE
Fix frontend cache/SSE correctness gaps (#1081)

### DIFF
--- a/src/FRONTEND_STATE.md
+++ b/src/FRONTEND_STATE.md
@@ -26,6 +26,19 @@ refreshes the list (read entries stay visible under the reader). The sidebar
 calls the same `refreshEntryLists` when a link matching the current pathname
 is clicked, so clicking the current list acts as an explicit refresh.
 
+**`fetchNextPage` clobber guard (#1081):** React Query's `infiniteQueryBehavior`
+snapshots the existing pages when a `fetchNextPage` starts and, on completion,
+replaces the data with `snapshot + newPage` — silently dropping any
+`setQueryData` applied to the old pages mid-fetch. j/k navigation triggers this
+(opening an entry near the end auto-marks it read at the same moment
+`fetchNextPage` fires), so the completing fetch would revert the entry to unread.
+Every next-page fetch (keyboard- and scroll-triggered, in both
+`EntryListContainer` and `UnifiedEntriesContent`) therefore calls
+`reconcileListReadStarredFromEntryGet` after it settles, re-asserting the
+authoritative read/starred state from `entries.get` onto the list caches. (A
+brand-new SSE-inserted entry has no `entries.get` entry and can't be restored
+this way; it reappears on the next navigation refresh.)
+
 ## Cache Helpers (`src/lib/cache/`)
 
 | File                | Role                                                                                                                                                                                                    |
@@ -77,6 +90,11 @@ Tag mutations (`tags.create/update/delete`) invalidate/patch via their component
 
 **Key principle:** SSE events patch caches directly and must NOT trigger `entries.*` refetches (enforced by e2e tests via `recordTrpcProcedures`). Counts are always set to absolute server-provided values (idempotent — duplicate SSE/sync delivery can't drift them). The **one deliberate exception** is `mark_all_read`: mark-all-read is unbounded, so patching every entry (or shipping every id) isn't worth it, and the event invalidates `entries.list` instead — refetching a list the user just cleared is an acceptable rare cost.
 
+**Catch-up sync after (re)connect (#1081):** on SSE `open`, `useRealtimeUpdates` runs a catch-up sync against `sync.events` from the current cursors. Two invariants keep it from losing changes made while disconnected:
+
+- **Retry on failure.** A failed catch-up sync is retried with exponential backoff (2s→30s) even in the `connected` phase (the `polling` phase already retries every 30s). A single failure used to be swallowed as "done", stranding the gap forever on an idle view.
+- **Cursor freeze until caught up.** Live SSE events patch the cache immediately but do **not** advance the persisted sync cursor until the connection's catch-up sync has fully succeeded (`caughtUpRef`). Otherwise a live event would push the cursor past the not-yet-synced gap, making the pending/retrying catch-up query skip the gap's rows. The catch-up sync itself always advances the cursor (it drains the authoritative server sequence). Any stream error (including the browser's silent EventSource auto-reconnect) re-freezes the cursor so the next catch-up re-covers whatever was missed.
+
 | SSE Event              | Cache Updates                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `new_entry`            | Direct: absolute counts via `setEntryRelatedCounts`; inserts the event's `entry` payload into matching `entries.list` caches via `insertEntryIntoListCaches` (sorted position; tag/uncategorized membership from the cached subscription — conservatively skipped when uncached; skips search/unknown-filter caches and entries beyond the loaded pagination window). Spam entries carry no payload. The catch-up sync path sets `read`/`starred` for entries that changed state on another device; the live path omits them. Idempotent (absolute counts, insert deduped by ID). |
@@ -85,7 +103,7 @@ Tag mutations (`tags.create/update/delete`) invalidate/patch via their component
 | `mark_all_read`        | A `markAllRead` happened on another tab/device. Invalidate `entries.list`, `entries.count`, `tags.list`, `subscriptions.list` — the same thing the acting tab does on success. This is the **one** SSE event that deliberately refetches `entries.list`: mark-all-read is unbounded, so patching every entry (or shipping every id) isn't worth it, and refetching a list the user just cleared is an acceptable, rare cost. Advances the entries cursor so a reconnect catch-up doesn't re-deliver every marked entry.                                                           |
 | `subscription_created` | Add to `subscriptions.list`; absolute counts from server `counts` (live path). The sync.events catch-up path omits `counts`, so the client invalidates `tags.list` + `entries.count` instead.                                                                                                                                                                                                                                                                                                                                                                                     |
 | `subscription_updated` | Patch subscription in lookup map/list caches; invalidate `tags.list` + `subscriptions.list` (tag membership may have changed).                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `subscription_deleted` | Remove from `subscriptions.list`; absolute counts (live path) or invalidate `tags.list` + `entries.count` (catch-up). Always invalidates `entries.list`.                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `subscription_deleted` | Remove from `subscriptions.list`; absolute counts (live path) or invalidate `tags.list` + `entries.count` (catch-up). The count update **and** `entries.list` invalidation always run — even when the subscription isn't cached (optimistically removed, or never loaded with tags collapsed); only the structural removal is gated on the subscription being cached (#1081).                                                                                                                                                                                                     |
 | `tag_created`          | `applySyncTagChanges` — add to `tags.list`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `tag_updated`          | `applySyncTagChanges` — patch in `tags.list`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `tag_deleted`          | `removeSyncTags` — remove from `tags.list`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
@@ -167,17 +185,18 @@ bump `updated_at` and re-deliver as before.
 
 ## Key Files
 
-| File                                               | Purpose                                                            |
-| -------------------------------------------------- | ------------------------------------------------------------------ |
-| `src/lib/cache/*` (see table above)                | Cache operations, entry/count helpers, SSE event dispatch          |
-| `src/lib/hooks/useEntryMutations.ts`               | Entry mutations with optimistic updates + timestamp tracking       |
-| `src/lib/hooks/useEntryListRefreshOnNavigate.ts`   | Navigation-triggered entry list invalidation (pathname change)     |
-| `src/lib/hooks/useRealtimeUpdates.ts`              | SSE/polling glue feeding the connection machine                    |
-| `src/lib/events/connection-state.ts`               | Pure connection state machine (reconnect/backoff/polling fallback) |
-| `src/lib/events/cursors.ts`                        | Pure sync-cursor bookkeeping                                       |
-| `src/components/entries/EntryListContainer.tsx`    | Stateful entry list container (query, pagination, keyboard nav)    |
-| `src/components/entries/UnifiedEntriesContent.tsx` | Unified entry page with navigation and pagination                  |
-| `src/components/layout/Sidebar.tsx`                | Subscription delete with optimistic update                         |
+| File                                               | Purpose                                                             |
+| -------------------------------------------------- | ------------------------------------------------------------------- |
+| `src/lib/cache/*` (see table above)                | Cache operations, entry/count helpers, SSE event dispatch           |
+| `src/lib/hooks/useEntryMutations.ts`               | Entry mutations with optimistic updates + timestamp tracking        |
+| `src/lib/hooks/useEntryListRefreshOnNavigate.ts`   | Navigation-triggered entry list invalidation (pathname change)      |
+| `src/lib/hooks/useRealtimeUpdates.ts`              | SSE/polling glue feeding the connection machine                     |
+| `src/lib/events/connection-state.ts`               | Pure connection state machine (reconnect/backoff/polling fallback)  |
+| `src/lib/events/cursors.ts`                        | Pure sync-cursor bookkeeping                                        |
+| `src/components/entries/EntryListContainer.tsx`    | Stateful entry list container (query, pagination, keyboard nav)     |
+| `src/components/entries/UnifiedEntriesContent.tsx` | Unified entry page with navigation and pagination                   |
+| `src/components/layout/Sidebar.tsx`                | Subscription delete via `useUnsubscribeMutation`                    |
+| `src/lib/hooks/useUnsubscribeMutation.ts`          | Shared `subscriptions.delete` choreography (sidebar + broken feeds) |
 
 ## Adding New Cache Updates
 

--- a/src/FRONTEND_STATE.md
+++ b/src/FRONTEND_STATE.md
@@ -34,10 +34,17 @@ replaces the data with `snapshot + newPage` — silently dropping any
 `fetchNextPage` fires), so the completing fetch would revert the entry to unread.
 Every next-page fetch (keyboard- and scroll-triggered, in both
 `EntryListContainer` and `UnifiedEntriesContent`) therefore calls
-`reconcileListReadStarredFromEntryGet` after it settles, re-asserting the
-authoritative read/starred state from `entries.get` onto the list caches. (A
-brand-new SSE-inserted entry has no `entries.get` entry and can't be restored
-this way; it reappears on the next navigation refresh.)
+`snapshotEntryGetStates` **before** starting the fetch and
+`reconcileListFromChangedEntryGets` **after** it settles, re-asserting onto the
+list only the entries whose `entries.get` read/starred state **changed during
+the fetch window**. It is a diff, not a blanket re-assert, because `entries.get`
+is not universally in lockstep with the list — `mark_all_read` invalidates
+`entries.list` but never touches `entries.get`, so a blanket re-assert would
+resurrect a stale get (e.g. a prefetched-unread entry that mark-all-read marked
+read) into the freshly-refetched list. A clobber can only affect writes made
+after the fetch started, so restricting to mid-fetch changes captures exactly
+those. (A brand-new SSE-inserted entry has no `entries.get` entry and can't be
+restored this way; it reappears on the next navigation refresh.)
 
 ## Cache Helpers (`src/lib/cache/`)
 

--- a/src/components/entries/EntryListContainer.tsx
+++ b/src/components/entries/EntryListContainer.tsx
@@ -24,7 +24,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { trpc } from "@/lib/trpc/client";
 import { useEntryMutations } from "@/lib/hooks/useEntryMutations";
 import { refreshEntryLists } from "@/lib/hooks/useEntryListRefreshOnNavigate";
-import { reconcileListReadStarredFromEntryGet } from "@/lib/cache/entry-cache";
+import { snapshotEntryGetStates, reconcileListFromChangedEntryGets } from "@/lib/cache/entry-cache";
 import { useEntryUrlState } from "@/lib/hooks/useEntryUrlState";
 import { useKeyboardShortcutsContext } from "@/components/keyboard/KeyboardShortcutsProvider";
 import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
@@ -70,12 +70,15 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
     });
 
   // Wrap fetchNextPage so every next-page fetch (keyboard- or scroll-triggered)
-  // re-asserts read/starred state from entries.get after it settles — the
-  // completing fetch would otherwise clobber writes applied to the old pages
-  // mid-fetch (e.g. auto-mark-read from j/k). See #1081.
+  // re-asserts read/starred state that changed during the fetch — the completing
+  // fetch would otherwise clobber writes applied to the old pages mid-fetch (e.g.
+  // auto-mark-read from j/k). Snapshot entries.get state at fetch start and
+  // diff after settle, so only genuinely-mid-fetch changes are re-applied (not
+  // stale gets, e.g. after mark_all_read). See #1081.
   const fetchNextPageAndReconcile = useCallback(() => {
+    const before = snapshotEntryGetStates(queryClient);
     return fetchNextPage().then((result) => {
-      reconcileListReadStarredFromEntryGet(queryClient);
+      reconcileListFromChangedEntryGets(queryClient, before);
       return result;
     });
   }, [fetchNextPage, queryClient]);

--- a/src/components/entries/EntryListContainer.tsx
+++ b/src/components/entries/EntryListContainer.tsx
@@ -20,8 +20,11 @@
 "use client";
 
 import { useMemo, useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { trpc } from "@/lib/trpc/client";
 import { useEntryMutations } from "@/lib/hooks/useEntryMutations";
+import { refreshEntryLists } from "@/lib/hooks/useEntryListRefreshOnNavigate";
+import { reconcileListReadStarredFromEntryGet } from "@/lib/cache/entry-cache";
 import { useEntryUrlState } from "@/lib/hooks/useEntryUrlState";
 import { useKeyboardShortcutsContext } from "@/components/keyboard/KeyboardShortcutsProvider";
 import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
@@ -42,6 +45,7 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
   const { showUnreadOnly, sortOrder, toggleShowUnreadOnly } = useUrlViewPreferences();
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
   const utils = trpc.useUtils();
+  const queryClient = useQueryClient();
   const scrollContainerRef = useScrollContainer();
 
   // False during SSR + first client render. The smart (cache-reading) fallback
@@ -65,29 +69,24 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
       throwOnError: true,
     });
 
-  // Flatten entries from all pages
-  const entries = useMemo(
-    () =>
-      data?.pages.flatMap((page) =>
-        page.items.map((entry) => ({
-          id: entry.id,
-          feedId: entry.feedId,
-          subscriptionId: entry.subscriptionId,
-          type: entry.type,
-          url: entry.url,
-          title: entry.title,
-          author: entry.author,
-          summary: entry.summary,
-          publishedAt: entry.publishedAt,
-          fetchedAt: entry.fetchedAt,
-          read: entry.read,
-          starred: entry.starred,
-          feedTitle: entry.feedTitle,
-          siteName: entry.siteName,
-        }))
-      ) ?? [],
-    [data?.pages]
-  );
+  // Wrap fetchNextPage so every next-page fetch (keyboard- or scroll-triggered)
+  // re-asserts read/starred state from entries.get after it settles — the
+  // completing fetch would otherwise clobber writes applied to the old pages
+  // mid-fetch (e.g. auto-mark-read from j/k). See #1081.
+  const fetchNextPageAndReconcile = useCallback(() => {
+    return fetchNextPage().then((result) => {
+      reconcileListReadStarredFromEntryGet(queryClient);
+      return result;
+    });
+  }, [fetchNextPage, queryClient]);
+
+  // Flatten entries from all pages. Pass the cached items straight through
+  // rather than remapping into fresh object literals: React Query's structural
+  // sharing preserves the identity of unchanged items across cache updates, so
+  // forwarding them directly lets EntryListItem's `memo` skip re-rendering every
+  // row when a single entry changes (a remap would allocate new objects for all
+  // N rows and defeat the memo). See #1081.
+  const entries = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data?.pages]);
 
   // Compute next/previous entry IDs for keyboard navigation
   // Also compute how close we are to the pagination boundary
@@ -118,10 +117,10 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
       hasNextPage &&
       !isFetchingNextPage
     ) {
-      fetchNextPage();
+      void fetchNextPageAndReconcile();
     }
     prevDistanceToEnd.current = distanceToEnd;
-  }, [distanceToEnd, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [distanceToEnd, hasNextPage, isFetchingNextPage, fetchNextPageAndReconcile]);
 
   // Scroll to last viewed entry when returning from entry view to list
   // We track the previous openEntryId to know which entry to scroll to
@@ -196,7 +195,10 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
     enabled: keyboardShortcutsEnabled,
     onToggleRead: toggleRead,
     onToggleStar: toggleStar,
-    onRefresh: () => utils.entries.list.invalidate(),
+    // Route the `r` refresh through the shared helper so it cancels in-flight
+    // fetches on inactive lists first (a completing fetch would clear the
+    // staleness flag), matching navigation/sidebar refreshes (#1081).
+    onRefresh: () => void refreshEntryLists(queryClient),
     onToggleUnreadOnly: toggleShowUnreadOnly,
     onNavigateNext: goToNextEntry,
     onNavigatePrevious: goToPreviousEntry,
@@ -210,10 +212,10 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
       errorMessage: undefined,
       isFetchingNextPage,
       hasNextPage: hasNextPage ?? false,
-      fetchNextPage,
+      fetchNextPage: fetchNextPageAndReconcile,
       refetch,
     }),
-    [isLoading, isFetchingNextPage, hasNextPage, fetchNextPage, refetch]
+    [isLoading, isFetchingNextPage, hasNextPage, fetchNextPageAndReconcile, refetch]
   );
 
   // Deterministic skeleton on the server + first client render so hydration

--- a/src/components/entries/UnifiedEntriesContent.tsx
+++ b/src/components/entries/UnifiedEntriesContent.tsx
@@ -30,6 +30,7 @@ import { extractParamsFromPathname } from "@/lib/navigation";
 import { type ViewType } from "@/lib/hooks/viewPreferences";
 import { trpc } from "@/lib/trpc/client";
 import { findCachedSubscription } from "@/lib/cache/count-cache";
+import { reconcileListReadStarredFromEntryGet } from "@/lib/cache/entry-cache";
 import { type EntryType } from "@/lib/hooks/useEntryMutations";
 
 /**
@@ -260,6 +261,7 @@ function EntryListTitle({ routeInfo }: { routeInfo: RouteInfo }) {
  */
 function UnifiedEntriesContentInner() {
   const routeInfo = useRouteInfo();
+  const queryClient = useQueryClient();
   const { showUnreadOnly } = useUrlViewPreferences();
   const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
 
@@ -363,10 +365,15 @@ function UnifiedEntriesContentInner() {
       entriesQuery.hasNextPage &&
       !entriesQuery.isFetchingNextPage
     ) {
-      entriesQuery.fetchNextPage();
+      // Re-assert read/starred from entries.get after the fetch settles: the
+      // completing next-page fetch replaces the pages snapshot and would clobber
+      // writes applied mid-fetch, e.g. auto-mark-read from swipe/j-k (#1081).
+      void entriesQuery.fetchNextPage().then(() => {
+        reconcileListReadStarredFromEntryGet(queryClient);
+      });
     }
     prevDistanceToEnd.current = distanceToEnd;
-  }, [distanceToEnd, entriesQuery]);
+  }, [distanceToEnd, entriesQuery, queryClient]);
 
   // Navigation callbacks - just update URL, React re-renders
   const handleSwipeNext = useMemo(() => {

--- a/src/components/entries/UnifiedEntriesContent.tsx
+++ b/src/components/entries/UnifiedEntriesContent.tsx
@@ -30,7 +30,7 @@ import { extractParamsFromPathname } from "@/lib/navigation";
 import { type ViewType } from "@/lib/hooks/viewPreferences";
 import { trpc } from "@/lib/trpc/client";
 import { findCachedSubscription } from "@/lib/cache/count-cache";
-import { reconcileListReadStarredFromEntryGet } from "@/lib/cache/entry-cache";
+import { snapshotEntryGetStates, reconcileListFromChangedEntryGets } from "@/lib/cache/entry-cache";
 import { type EntryType } from "@/lib/hooks/useEntryMutations";
 
 /**
@@ -365,11 +365,14 @@ function UnifiedEntriesContentInner() {
       entriesQuery.hasNextPage &&
       !entriesQuery.isFetchingNextPage
     ) {
-      // Re-assert read/starred from entries.get after the fetch settles: the
-      // completing next-page fetch replaces the pages snapshot and would clobber
-      // writes applied mid-fetch, e.g. auto-mark-read from swipe/j-k (#1081).
+      // Re-assert read/starred that changed during the fetch: the completing
+      // next-page fetch replaces the pages snapshot and would clobber writes
+      // applied mid-fetch, e.g. auto-mark-read from swipe/j-k. Snapshot before,
+      // diff after, so stale gets (e.g. after mark_all_read) aren't resurrected
+      // (#1081).
+      const before = snapshotEntryGetStates(queryClient);
       void entriesQuery.fetchNextPage().then(() => {
-        reconcileListReadStarredFromEntryGet(queryClient);
+        reconcileListFromChangedEntryGets(queryClient, before);
       });
     }
     prevDistanceToEnd.current = distanceToEnd;

--- a/src/components/layout/ConnectionStatusIndicator.tsx
+++ b/src/components/layout/ConnectionStatusIndicator.tsx
@@ -58,7 +58,10 @@ export function ConnectionStatusIndicator({ status, onReconnect }: ConnectionSta
           <span className="text-muted">
             {status === "error" ? "Connection error" : "Disconnected"}
           </span>
-          {onReconnect && (
+          {/* Only offer Retry in the "error" state. The state machine ignores a
+              manual-reconnect while disconnected (unauthenticated/unmounted), so
+              a Retry button there does nothing (#1081). */}
+          {onReconnect && status === "error" && (
             <button onClick={onReconnect} className="text-strong ml-1 underline hover:no-underline">
               Retry
             </button>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -14,9 +14,8 @@
 import { useState, useCallback } from "react";
 import { usePathname } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
-import { removeSubscriptionFromCaches, setEntryRelatedCounts } from "@/lib/cache/operations";
+import { useUnsubscribeMutation } from "@/lib/hooks/useUnsubscribeMutation";
 import { refreshEntryLists } from "@/lib/hooks/useEntryListRefreshOnNavigate";
 import { buildEntriesListInputForRoute } from "@/lib/queries/entries-list-input";
 import { UnsubscribeDialog } from "@/components/feeds/UnsubscribeDialog";
@@ -47,28 +46,10 @@ export function Sidebar({ onClose }: SidebarProps) {
 
   const utils = trpc.useUtils();
 
-  const unsubscribeMutation = trpc.subscriptions.delete.useMutation({
-    onMutate: async (variables) => {
-      // Close dialog immediately and optimistically remove the subscription from
-      // the sidebar. Counts are applied from the server response in onSuccess.
-      setUnsubscribeTarget(null);
-      removeSubscriptionFromCaches(variables.id, queryClient);
-    },
-    onSuccess: (data) => {
-      // Apply the server-absolute counts for the affected lists, and drop the
-      // subscription's entries from any cached lists.
-      if (data.counts) {
-        setEntryRelatedCounts(utils, data.counts, queryClient);
-      }
-      utils.entries.list.invalidate();
-    },
-    onError: () => {
-      toast.error("Failed to unsubscribe from feed");
-      // On error, invalidate to refetch correct state
-      utils.subscriptions.list.invalidate();
-      utils.tags.list.invalidate();
-      utils.entries.count.invalidate();
-    },
+  // Close the dialog immediately on mutate; the shared hook owns the cache
+  // choreography (optimistic remove, counts, entries.list invalidate, rollback).
+  const unsubscribeMutation = useUnsubscribeMutation({
+    onMutate: () => setUnsubscribeTarget(null),
   });
 
   const handleNavigate = (href: string) => {

--- a/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
+++ b/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
@@ -8,10 +8,9 @@
 "use client";
 
 import { useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
-import { removeSubscriptionFromCaches, setEntryRelatedCounts } from "@/lib/cache/operations";
+import { useUnsubscribeMutation } from "@/lib/hooks/useUnsubscribeMutation";
 import { getFeedDisplayName, formatRelativeTime, formatFutureTime } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { SettingsListContainer } from "@/components/settings/SettingsListContainer";
@@ -38,7 +37,6 @@ interface BrokenFeed {
 // ============================================================================
 
 export default function BrokenFeedsSettingsContent() {
-  const queryClient = useQueryClient();
   const [unsubscribeTarget, setUnsubscribeTarget] = useState<{
     id: string;
     title: string;
@@ -47,26 +45,13 @@ export default function BrokenFeedsSettingsContent() {
   const utils = trpc.useUtils();
   const brokenQuery = trpc.brokenFeeds.list.useQuery();
 
-  const unsubscribeMutation = trpc.subscriptions.delete.useMutation({
-    onMutate: (variables) => {
-      // Optimistically remove the subscription; counts come from onSuccess.
-      removeSubscriptionFromCaches(variables.id, queryClient);
-    },
-    onSuccess: (data) => {
-      if (data.counts) {
-        setEntryRelatedCounts(utils, data.counts, queryClient);
-      }
-      utils.entries.list.invalidate();
+  // The shared hook owns the cache choreography; this page additionally refreshes
+  // the broken-feeds list, closes the dialog, and toasts on success.
+  const unsubscribeMutation = useUnsubscribeMutation({
+    onSuccess: () => {
       utils.brokenFeeds.list.invalidate();
       setUnsubscribeTarget(null);
       toast.success("Unsubscribed from feed");
-    },
-    onError: () => {
-      toast.error("Failed to unsubscribe from feed");
-      // On error, invalidate to refetch correct state
-      utils.subscriptions.list.invalidate();
-      utils.tags.list.invalidate();
-      utils.entries.count.invalidate();
     },
   });
 

--- a/src/lib/cache/entry-cache.ts
+++ b/src/lib/cache/entry-cache.ts
@@ -79,56 +79,103 @@ export function updateEntriesInListCache(
 }
 
 /**
- * Re-asserts the authoritative per-entry read/starred state from the
- * `entries.get` caches onto every `entries.list` cache.
+ * A snapshot of the read/starred state of every cached `entries.get` entry,
+ * taken at the moment a `fetchNextPage` begins. Diffed against the post-fetch
+ * state by `reconcileListFromChangedEntryGets` to find which entries changed
+ * during the fetch window. See `snapshotEntryGetStates`.
+ */
+export type EntryGetStateSnapshot = Map<string, { read: boolean; starred: boolean }>;
+
+/**
+ * Snapshots the read/starred state of every cached `entries.get` entry. Call
+ * this immediately before starting a `fetchNextPage`, and pass the result to
+ * `reconcileListFromChangedEntryGets` after the fetch settles. See #1081.
+ */
+export function snapshotEntryGetStates(queryClient: QueryClient): EntryGetStateSnapshot {
+  const getQueries = queryClient.getQueriesData<{
+    entry: { id: string; read: boolean; starred: boolean };
+  }>({ queryKey: [["entries", "get"]] });
+
+  const snapshot: EntryGetStateSnapshot = new Map();
+  for (const [, data] of getQueries) {
+    if (data?.entry) {
+      snapshot.set(data.entry.id, { read: data.entry.read, starred: data.entry.starred });
+    }
+  }
+  return snapshot;
+}
+
+/**
+ * Re-asserts onto the `entries.list` caches the read/starred state of any
+ * `entries.get` entry that **changed during a just-completed `fetchNextPage`**
+ * (compared to `before`, snapshotted at fetch start by `snapshotEntryGetStates`).
  *
- * React Query's `infiniteQueryBehavior` snapshots the existing pages when a
- * `fetchNextPage` begins and, on completion, replaces the query data with
- * `snapshot + newPage` — silently dropping any `setQueryData` applied to the old
- * pages while the fetch was in flight. j/k navigation routinely triggers this:
- * opening an entry near the end auto-marks it read (a list `setQueryData`) at the
- * same moment the container fires `fetchNextPage`, so the completing fetch
- * reverts the entry to unread. Calling this after the fetch settles restores the
- * correct state from `entries.get` (server-authoritative, timestamp-guarded, and
- * kept in lockstep with the list by every mutation/SSE write). See #1081.
+ * Why this exists: React Query's `infiniteQueryBehavior` snapshots the existing
+ * pages when a `fetchNextPage` begins and, on completion, replaces the query
+ * data with `snapshot + newPage` — silently dropping any `setQueryData` applied
+ * to the old pages while the fetch was in flight. j/k navigation routinely
+ * triggers this: opening an entry near the end auto-marks it read (a list
+ * `setQueryData`) at the same moment the container fires `fetchNextPage`, so the
+ * completing fetch reverts the entry to unread.
  *
- * Only touches list rows whose value actually differs, so unchanged item
- * identities are preserved (keeps EntryListItem's memo effective).
+ * Why the diff (not a blanket re-assert from `entries.get`): `entries.get` is
+ * NOT universally kept in lockstep with the list — `mark_all_read` invalidates
+ * `entries.list` but never touches `entries.get` (neither the SSE handler nor
+ * the acting-tab mutation). A blanket re-assert would resurrect a stale
+ * `entries.get` value (e.g. an entry prefetched-unread, then marked read by
+ * mark_all_read) back into a freshly-refetched list. Restricting to entries
+ * whose `entries.get` state actually *changed during the fetch window* captures
+ * exactly the writes that could have been clobbered (a clobber only affects
+ * writes made after the fetch started) while leaving untouched-and-therefore-
+ * possibly-stale gets alone (#1081).
+ *
+ * Only touches list rows whose value differs, so unchanged item identities are
+ * preserved (keeps EntryListItem's memo effective).
  *
  * Residual limitation: a brand-new entry inserted into the list by an SSE
  * `new_entry` during the fetch has no `entries.get` entry, so it can't be
  * restored here; it reappears on the next navigation-triggered list refresh.
  */
-export function reconcileListReadStarredFromEntryGet(queryClient: QueryClient): void {
+export function reconcileListFromChangedEntryGets(
+  queryClient: QueryClient,
+  before: EntryGetStateSnapshot
+): void {
   const getQueries = queryClient.getQueriesData<{
     entry: { id: string; read: boolean; starred: boolean };
   }>({ queryKey: [["entries", "get"]] });
 
-  const authoritative = new Map<string, { read: boolean; starred: boolean }>();
+  const changed = new Map<string, { read: boolean; starred: boolean }>();
   for (const [, data] of getQueries) {
-    if (data?.entry) {
-      authoritative.set(data.entry.id, { read: data.entry.read, starred: data.entry.starred });
+    if (!data?.entry) continue;
+    const prev = before.get(data.entry.id);
+    // Apply an entry only if its entries.get state changed since fetch start (or
+    // the get first appeared during the fetch — a fresh, server-authoritative
+    // read). A get already in its current state before the fetch can't have been
+    // clobbered by this fetch, so re-applying it would only risk resurrecting
+    // list state a concurrent refetch legitimately replaced.
+    if (!prev || prev.read !== data.entry.read || prev.starred !== data.entry.starred) {
+      changed.set(data.entry.id, { read: data.entry.read, starred: data.entry.starred });
     }
   }
-  if (authoritative.size === 0) return;
+  if (changed.size === 0) return;
 
   queryClient.setQueriesData<InfiniteData>({ queryKey: [["entries", "list"]] }, (oldData) => {
     if (!oldData?.pages) return oldData;
 
-    let changed = false;
+    let didChange = false;
     const pages = oldData.pages.map((page) => ({
       ...page,
       items: page.items.map((entry) => {
-        const state = authoritative.get(entry.id);
+        const state = changed.get(entry.id);
         if (state && (entry.read !== state.read || entry.starred !== state.starred)) {
-          changed = true;
+          didChange = true;
           return { ...entry, ...state };
         }
         return entry;
       }),
     }));
 
-    return changed ? { ...oldData, pages } : oldData;
+    return didChange ? { ...oldData, pages } : oldData;
   });
 }
 

--- a/src/lib/cache/entry-cache.ts
+++ b/src/lib/cache/entry-cache.ts
@@ -79,6 +79,60 @@ export function updateEntriesInListCache(
 }
 
 /**
+ * Re-asserts the authoritative per-entry read/starred state from the
+ * `entries.get` caches onto every `entries.list` cache.
+ *
+ * React Query's `infiniteQueryBehavior` snapshots the existing pages when a
+ * `fetchNextPage` begins and, on completion, replaces the query data with
+ * `snapshot + newPage` — silently dropping any `setQueryData` applied to the old
+ * pages while the fetch was in flight. j/k navigation routinely triggers this:
+ * opening an entry near the end auto-marks it read (a list `setQueryData`) at the
+ * same moment the container fires `fetchNextPage`, so the completing fetch
+ * reverts the entry to unread. Calling this after the fetch settles restores the
+ * correct state from `entries.get` (server-authoritative, timestamp-guarded, and
+ * kept in lockstep with the list by every mutation/SSE write). See #1081.
+ *
+ * Only touches list rows whose value actually differs, so unchanged item
+ * identities are preserved (keeps EntryListItem's memo effective).
+ *
+ * Residual limitation: a brand-new entry inserted into the list by an SSE
+ * `new_entry` during the fetch has no `entries.get` entry, so it can't be
+ * restored here; it reappears on the next navigation-triggered list refresh.
+ */
+export function reconcileListReadStarredFromEntryGet(queryClient: QueryClient): void {
+  const getQueries = queryClient.getQueriesData<{
+    entry: { id: string; read: boolean; starred: boolean };
+  }>({ queryKey: [["entries", "get"]] });
+
+  const authoritative = new Map<string, { read: boolean; starred: boolean }>();
+  for (const [, data] of getQueries) {
+    if (data?.entry) {
+      authoritative.set(data.entry.id, { read: data.entry.read, starred: data.entry.starred });
+    }
+  }
+  if (authoritative.size === 0) return;
+
+  queryClient.setQueriesData<InfiniteData>({ queryKey: [["entries", "list"]] }, (oldData) => {
+    if (!oldData?.pages) return oldData;
+
+    let changed = false;
+    const pages = oldData.pages.map((page) => ({
+      ...page,
+      items: page.items.map((entry) => {
+        const state = authoritative.get(entry.id);
+        if (state && (entry.read !== state.read || entry.starred !== state.starred)) {
+          changed = true;
+          return { ...entry, ...state };
+        }
+        return entry;
+      }),
+    }));
+
+    return changed ? { ...oldData, pages } : oldData;
+  });
+}
+
+/**
  * Affected scope info for targeted cache updates.
  */
 export interface AffectedScope {

--- a/src/lib/cache/event-handlers.ts
+++ b/src/lib/cache/event-handlers.ts
@@ -23,7 +23,6 @@ import {
   applySyncTagChanges,
   removeSyncTags,
   updateSubscriptionInCache,
-  findCachedSubscription,
   type CachedSubscription,
 } from "./count-cache";
 
@@ -194,16 +193,13 @@ export function handleSyncEvent(
     }
 
     case "subscription_deleted":
-      // Check if already removed (optimistic update from same tab).
-      // Check both the lookup map and infinite queries, since pre-existing
-      // subscriptions may only be in the infinite query caches.
-      {
-        const alreadyRemoved = !findCachedSubscription(queryClient, event.subscriptionId);
-
-        if (!alreadyRemoved) {
-          handleSubscriptionDeleted(utils, event.subscriptionId, queryClient, event.counts);
-        }
-      }
+      // handleSubscriptionDeleted is idempotent: it skips the structural removal
+      // when the subscription is already gone from cache (optimistic same-tab
+      // delete, or a never-cached subscription) but still applies the absolute
+      // counts and invalidates entries.list. Calling it unconditionally fixes
+      // the case where a delete for a never-cached subscription (common with
+      // tags collapsed) left inflated counts and stale entries (#1081).
+      handleSubscriptionDeleted(utils, event.subscriptionId, queryClient, event.counts);
       break;
 
     case "tag_created":

--- a/src/lib/cache/operations.ts
+++ b/src/lib/cache/operations.ts
@@ -261,28 +261,36 @@ export function handleSubscriptionDeleted(
   counts?: EntryRelatedCounts
 ): void {
   // Look up the cached subscription before removing it, so we can target the
-  // affected subscription-list queries.
+  // affected subscription-list queries and know whether a structural removal is
+  // needed at all.
   const subscription = queryClient
     ? findCachedSubscription(queryClient, subscriptionId)
-    : undefined;
+    : getSubscriptionLookupMap().get(subscriptionId);
 
-  // Remove from all subscription caches (structural).
-  removeSubscriptionFromCache(subscriptionId);
-  if (queryClient) {
-    removeSubscriptionFromInfiniteQueries(queryClient, subscriptionId);
+  // Structural removal only runs when the subscription is actually cached. A
+  // subscription may be uncached because the acting tab already removed it
+  // optimistically, or because it was never loaded (e.g. tags collapsed, so the
+  // per-tag subscriptions.list was never fetched). In the latter case the event
+  // still carries real state changes, so the count/entries updates below must
+  // still run — they were previously skipped entirely, leaving inflated counts
+  // and the deleted feed's entries in the list until an unrelated event (#1081).
+  if (subscription) {
+    removeSubscriptionFromCache(subscriptionId);
+    if (queryClient) {
+      removeSubscriptionFromInfiniteQueries(queryClient, subscriptionId);
+      invalidateSubscriptionListsForTags(
+        queryClient,
+        subscription.tags.map((t) => t.id),
+        subscription.tags.length === 0
+      );
+    } else {
+      utils.subscriptions.list.invalidate();
+    }
   }
 
-  // Refresh the affected subscription list queries.
-  if (subscription && queryClient) {
-    invalidateSubscriptionListsForTags(
-      queryClient,
-      subscription.tags.map((t) => t.id),
-      subscription.tags.length === 0
-    );
-  } else {
-    utils.subscriptions.list.invalidate();
-  }
-
+  // Counts and the entries.list refresh are idempotent (absolute counts; the
+  // list refetch just re-filters), so they run unconditionally regardless of
+  // whether the subscription was cached.
   applySubscriptionCounts(utils, counts, queryClient);
 
   // Always invalidate entries.list - entries from this subscription should be filtered out
@@ -666,9 +674,20 @@ export async function applyOptimisticStarredUpdate(
   // - Cancelling entries.list would disrupt scrolling/loading
   // - If a fetch completes with stale starred status, onSuccess will correct it immediately
 
-  // Snapshot previous state for rollback
+  // Snapshot the previous state for rollback. Prefer entries.get, but fall back
+  // to the list cache: an entry starred from the list view often has no
+  // entries.get entry, and defaulting to `!starred` would make a failed star of
+  // an already-starred entry (or a non-toggle star/unstar) "roll back" to the
+  // state the failed mutation wanted, silently diverging from the server. This
+  // mirrors applyOptimisticReadUpdate's list-cache fallback (#1081).
   const previousEntry = utils.entries.get.getData({ id: entryId });
-  const wasStarred = previousEntry?.entry?.starred ?? !starred;
+  let wasStarred: boolean;
+  if (previousEntry?.entry) {
+    wasStarred = previousEntry.entry.starred;
+  } else {
+    const listEntry = findEntryInListCache(queryClient, entryId);
+    wasStarred = listEntry ? listEntry.starred : !starred;
+  }
 
   // Optimistically update the cache
   updateEntryStarredStatus(utils, entryId, starred, queryClient);

--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -78,6 +78,16 @@ export interface UseRealtimeUpdatesResult {
  * (open/error) is tracked via the EventSource's own onopen/onerror, not a
  * data event.
  */
+/**
+ * Backoff bounds for retrying a failed catch-up sync while the SSE stream is
+ * connected (the polling phase already retries every POLL_INTERVAL_MS). Without
+ * this, a catch-up sync that fails on SSE `open` is never retried, so changes
+ * from other devices in the disconnected window stay wrong on an idle view
+ * (#1081).
+ */
+const INITIAL_SYNC_RETRY_DELAY_MS = 2_000;
+const MAX_SYNC_RETRY_DELAY_MS = 30_000;
+
 const SSE_EVENT_NAMES = [
   "new_entry",
   "entry_updated",
@@ -127,8 +137,18 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const sseRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const syncRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const syncRetryDelayRef = useRef<number>(INITIAL_SYNC_RETRY_DELAY_MS);
   // Initialize with server-provided cursors (granular tracking per entity type)
   const cursorsRef = useRef<SyncCursors>(initialCursors);
+
+  // Whether the catch-up sync after the current connection opened has fully
+  // succeeded. While this is false (freshly (re)connected, or a catch-up sync is
+  // still failing/draining), live SSE events must NOT advance the persisted sync
+  // cursor: doing so would push the cursor past a not-yet-synced gap, making the
+  // pending catch-up query skip the gap's rows forever (#1081). The cache is
+  // still patched live regardless; only the cursor is frozen.
+  const caughtUpRef = useRef<boolean>(false);
 
   // Latest callbacks, readable from the stable dispatch closure below
   const handleEventRef = useRef<(event: MessageEvent) => void>(() => {});
@@ -158,7 +178,14 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
       const data = parseSyncEvent(event.data);
       if (!data) return;
 
-      cursorsRef.current = advanceCursors(cursorsRef.current, data);
+      // Only advance the persisted sync cursor from live events once the
+      // post-connect catch-up sync has succeeded. Before then the cursor must
+      // stay pinned at the pre-gap position so a still-pending (or retrying)
+      // catch-up query returns the disconnected-window rows instead of skipping
+      // them (#1081). The cache is patched live either way.
+      if (caughtUpRef.current) {
+        cursorsRef.current = advanceCursors(cursorsRef.current, data);
+      }
 
       // Delegate to shared handler for cache updates
       handleSyncEvent(utils, queryClient, data);
@@ -178,8 +205,12 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
    * cursors and double-apply delta-based cache updates (#897). Serialization is
    * handled by the scheduler glue below — always go through `requestSync`, never
    * call this directly.
+   *
+   * Returns `{ ok, hasMore }`: `ok` is false when the request failed (so the
+   * caller schedules a backoff retry and keeps the cursor frozen); `hasMore`
+   * mirrors the server's drain flag.
    */
-  const runSyncOnce = useCallback(async (): Promise<boolean> => {
+  const runSyncOnce = useCallback(async (): Promise<{ ok: boolean; hasMore: boolean }> => {
     try {
       const currentCursors = cursorsRef.current;
 
@@ -192,16 +223,18 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
         },
       });
 
-      // Process each event through the shared handler (same as SSE path)
+      // Process each event through the shared handler (same as SSE path). The
+      // catch-up sync always advances the cursor — it drains the authoritative
+      // server sequence, unlike live events which are gated by caughtUpRef.
       for (const event of result.events) {
         cursorsRef.current = advanceCursors(cursorsRef.current, event);
         handleSyncEvent(utils, queryClient, event);
       }
 
-      return result.hasMore;
+      return { ok: true, hasMore: result.hasMore };
     } catch (error) {
       console.error("Sync failed:", error);
-      return false;
+      return { ok: false, hasMore: false };
     }
   }, [utils, queryClient]);
 
@@ -221,15 +254,58 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
       // instead of being stuck behind an abandoned `running` flag.
       if (stateRef.current.phase === "disconnected") {
         syncSchedulerStateRef.current = INITIAL_SYNC_SCHEDULER_STATE;
+        // Drop any pending catch-up retry so it can't fire after disconnect.
+        if (syncRetryTimeoutRef.current) {
+          clearTimeout(syncRetryTimeoutRef.current);
+          syncRetryTimeoutRef.current = null;
+        }
+        syncRetryDelayRef.current = INITIAL_SYNC_RETRY_DELAY_MS;
         return;
       }
       const { state, startSync } = reduceSyncScheduler(syncSchedulerStateRef.current, event);
       syncSchedulerStateRef.current = state;
       if (startSync) {
-        void runSyncOnce().then((hasMore) => {
-          dispatchSchedulerEvent({ type: "completed", hasMore });
+        void runSyncOnce().then((result) => {
+          if (result.ok) {
+            // Success: cancel any pending retry and reset the backoff.
+            if (syncRetryTimeoutRef.current) {
+              clearTimeout(syncRetryTimeoutRef.current);
+              syncRetryTimeoutRef.current = null;
+            }
+            syncRetryDelayRef.current = INITIAL_SYNC_RETRY_DELAY_MS;
+            // Fully drained: the cursor is now current, so live events may
+            // resume advancing it (#1081).
+            if (!result.hasMore) {
+              caughtUpRef.current = true;
+            }
+          } else {
+            // Failure: retry with backoff. The cursor stays frozen (caughtUp is
+            // still false) so the retry re-queries the same unsynced gap.
+            scheduleSyncRetry();
+          }
+          // Report to the scheduler as not-more on failure so it settles to idle
+          // (or runs a queued follow-up); the backoff timer drives the retry.
+          dispatchSchedulerEvent({ type: "completed", hasMore: result.ok && result.hasMore });
         });
       }
+    }
+
+    /**
+     * Schedules a backoff retry of the catch-up sync after a failure. Coalesces
+     * with the scheduler, so a retry that lands while another sync is running
+     * just queues a single follow-up. No-ops once disconnected.
+     */
+    function scheduleSyncRetry(): void {
+      if (syncRetryTimeoutRef.current) {
+        clearTimeout(syncRetryTimeoutRef.current);
+      }
+      const delay = syncRetryDelayRef.current;
+      syncRetryDelayRef.current = Math.min(delay * 2, MAX_SYNC_RETRY_DELAY_MS);
+      syncRetryTimeoutRef.current = setTimeout(() => {
+        syncRetryTimeoutRef.current = null;
+        if (stateRef.current.phase === "disconnected") return;
+        requestSyncRef.current();
+      }, delay);
     }
 
     dispatchSchedulerEvent({ type: "request" });
@@ -318,6 +394,10 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
     }
 
     function openEventSource(): void {
+      // A new connection opens a fresh (possibly empty) gap: freeze the cursor
+      // until this connection's catch-up sync succeeds (#1081).
+      caughtUpRef.current = false;
+
       // Open the EventSource directly: a single connection per session.
       // SSE availability (the 503 case) is only checked on the error path,
       // so the happy path doesn't double the per-connect auth and DB work.
@@ -338,6 +418,11 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
 
       eventSource.onerror = () => {
         if (eventSourceRef.current !== eventSource) return;
+        // Any stream error opens a potential gap — including the browser's own
+        // silent auto-reconnect (which reuses this EventSource and fires onopen
+        // again without going through openEventSource). Freeze the cursor so the
+        // next catch-up covers whatever was missed (#1081).
+        caughtUpRef.current = false;
         dispatchEvent({
           type: "stream-error",
           closed: eventSource.readyState === EventSource.CLOSED,
@@ -392,6 +477,18 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
       dispatch({ type: "disconnect" });
     };
   }, [isAuthenticated, dispatch]);
+
+  // Clear the catch-up retry timer on unmount (the connection machine's
+  // teardown handles the reconnect/poll/SSE-retry timers, but the sync retry is
+  // hook glue outside the machine).
+  useEffect(() => {
+    return () => {
+      if (syncRetryTimeoutRef.current) {
+        clearTimeout(syncRetryTimeoutRef.current);
+        syncRetryTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   // Handle visibility change - reconnect (or sync, in polling mode) when the
   // tab becomes visible

--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -150,6 +150,15 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
   // still patched live regardless; only the cursor is frozen.
   const caughtUpRef = useRef<boolean>(false);
 
+  // Monotonic generation bumped every time the cursor is frozen (a new/errored
+  // connection). A catch-up sync captures the epoch when it starts and may only
+  // mark caught-up if the epoch is unchanged when it settles — i.e. no freeze
+  // happened in between. Without this, a sync started by a now-superseded
+  // connection could resolve (while the current connection's catch-up hasn't
+  // even been requested yet) and un-freeze the cursor prematurely, re-opening
+  // the very gap this closes (#1081).
+  const syncEpochRef = useRef<number>(0);
+
   // Latest callbacks, readable from the stable dispatch closure below
   const handleEventRef = useRef<(event: MessageEvent) => void>(() => {});
   const requestSyncRef = useRef<() => void>(() => {});
@@ -265,6 +274,9 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
       const { state, startSync } = reduceSyncScheduler(syncSchedulerStateRef.current, event);
       syncSchedulerStateRef.current = state;
       if (startSync) {
+        // Capture the connection epoch this sync starts under; only un-freeze if
+        // no freeze (reconnect/stream-error) happened before it settled.
+        const syncEpoch = syncEpochRef.current;
         void runSyncOnce().then((result) => {
           if (result.ok) {
             // Success: cancel any pending retry and reset the backoff.
@@ -273,17 +285,19 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
               syncRetryTimeoutRef.current = null;
             }
             syncRetryDelayRef.current = INITIAL_SYNC_RETRY_DELAY_MS;
-            // Un-freeze the cursor only when this sync fully drained AND no
-            // follow-up is queued — i.e. the scheduler is actually settling to
-            // idle. Gating on `!hasMore` alone is not enough: a sync started by
-            // a now-superseded connection can resolve while the current
-            // connection's catch-up is still queued as `pending` (it couldn't
-            // start behind the in-flight one). Marking caught-up there would let
-            // live events advance the cursor past the current connection's
-            // not-yet-drained gap, re-opening exactly the hole this closes
-            // (#1081). The queued follow-up runs next and marks caught-up when
-            // it settles with nothing pending.
-            if (!result.hasMore && !syncSchedulerStateRef.current.pending) {
+            // Un-freeze the cursor only when this sync fully drained, no
+            // follow-up is queued (the scheduler is settling to idle), AND the
+            // epoch is unchanged (no reconnect/stream-error opened a fresh gap
+            // while this sync ran, and this sync belongs to the current
+            // connection — not a superseded one whose late success would
+            // un-freeze past the current connection's not-yet-drained gap).
+            // Otherwise the queued follow-up / next connection's catch-up marks
+            // caught-up when it settles cleanly (#1081).
+            if (
+              !result.hasMore &&
+              !syncSchedulerStateRef.current.pending &&
+              syncEpoch === syncEpochRef.current
+            ) {
               caughtUpRef.current = true;
             }
           } else {
@@ -403,8 +417,11 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
 
     function openEventSource(): void {
       // A new connection opens a fresh (possibly empty) gap: freeze the cursor
-      // until this connection's catch-up sync succeeds (#1081).
+      // until this connection's catch-up sync succeeds, and bump the epoch so an
+      // in-flight sync from the previous connection can't mark us caught-up
+      // (#1081).
       caughtUpRef.current = false;
+      syncEpochRef.current += 1;
 
       // Open the EventSource directly: a single connection per session.
       // SSE availability (the 503 case) is only checked on the error path,
@@ -428,9 +445,11 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
         if (eventSourceRef.current !== eventSource) return;
         // Any stream error opens a potential gap — including the browser's own
         // silent auto-reconnect (which reuses this EventSource and fires onopen
-        // again without going through openEventSource). Freeze the cursor so the
-        // next catch-up covers whatever was missed (#1081).
+        // again without going through openEventSource). Freeze the cursor (and
+        // bump the epoch) so the next catch-up covers whatever was missed and no
+        // in-flight sync from before the error can mark us caught-up (#1081).
         caughtUpRef.current = false;
+        syncEpochRef.current += 1;
         dispatchEvent({
           type: "stream-error",
           closed: eventSource.readyState === EventSource.CLOSED,

--- a/src/lib/hooks/useRealtimeUpdates.ts
+++ b/src/lib/hooks/useRealtimeUpdates.ts
@@ -273,9 +273,17 @@ export function useRealtimeUpdates(initialCursors: SyncCursors): UseRealtimeUpda
               syncRetryTimeoutRef.current = null;
             }
             syncRetryDelayRef.current = INITIAL_SYNC_RETRY_DELAY_MS;
-            // Fully drained: the cursor is now current, so live events may
-            // resume advancing it (#1081).
-            if (!result.hasMore) {
+            // Un-freeze the cursor only when this sync fully drained AND no
+            // follow-up is queued — i.e. the scheduler is actually settling to
+            // idle. Gating on `!hasMore` alone is not enough: a sync started by
+            // a now-superseded connection can resolve while the current
+            // connection's catch-up is still queued as `pending` (it couldn't
+            // start behind the in-flight one). Marking caught-up there would let
+            // live events advance the cursor past the current connection's
+            // not-yet-drained gap, re-opening exactly the hole this closes
+            // (#1081). The queued follow-up runs next and marks caught-up when
+            // it settles with nothing pending.
+            if (!result.hasMore && !syncSchedulerStateRef.current.pending) {
               caughtUpRef.current = true;
             }
           } else {

--- a/src/lib/hooks/useUnsubscribeMutation.ts
+++ b/src/lib/hooks/useUnsubscribeMutation.ts
@@ -1,0 +1,66 @@
+/**
+ * useUnsubscribeMutation Hook
+ *
+ * Shared `subscriptions.delete` choreography used by every unsubscribe surface
+ * (the sidebar feed list and the broken-feeds settings page). Both used to
+ * hand-roll the same optimistic-remove / onSuccess-counts / onError-rollback
+ * sequence; consolidating it here means a fix to the cache handling (e.g. how
+ * absolute counts are applied) can't miss one call site (#1081).
+ *
+ * The cache side effects are owned by the hook:
+ * - onMutate: optimistically remove the subscription from all caches.
+ * - onSuccess: apply the server-absolute counts and invalidate entries.list so
+ *   the removed feed's entries are re-filtered out.
+ * - onError: toast + invalidate subscription/tag/count caches to refetch truth.
+ *
+ * Callers pass extra callbacks for their own UI concerns (closing a dialog,
+ * showing a success toast, invalidating a page-specific list). These run in
+ * addition to the shared cache work, not instead of it.
+ */
+
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { trpc } from "@/lib/trpc/client";
+import { removeSubscriptionFromCaches, setEntryRelatedCounts } from "@/lib/cache/operations";
+
+export interface UseUnsubscribeMutationOptions {
+  /** Extra work after the optimistic cache removal (e.g. close a dialog). */
+  onMutate?: () => void;
+  /** Extra work after counts are applied (e.g. toast, page-specific refetch). */
+  onSuccess?: () => void;
+  /** Extra work after the rollback invalidations (e.g. clear local state). */
+  onError?: () => void;
+}
+
+export function useUnsubscribeMutation(options?: UseUnsubscribeMutationOptions) {
+  const utils = trpc.useUtils();
+  const queryClient = useQueryClient();
+
+  return trpc.subscriptions.delete.useMutation({
+    onMutate: (variables) => {
+      // Optimistically remove the subscription from the sidebar/lists. Counts
+      // are applied from the server response in onSuccess.
+      removeSubscriptionFromCaches(variables.id, queryClient);
+      options?.onMutate?.();
+    },
+    onSuccess: (data) => {
+      // Apply the server-absolute counts for the affected lists, and drop the
+      // subscription's entries from any cached lists.
+      if (data.counts) {
+        setEntryRelatedCounts(utils, data.counts, queryClient);
+      }
+      utils.entries.list.invalidate();
+      options?.onSuccess?.();
+    },
+    onError: () => {
+      toast.error("Failed to unsubscribe from feed");
+      // On error, invalidate to refetch correct state.
+      utils.subscriptions.list.invalidate();
+      utils.tags.list.invalidate();
+      utils.entries.count.invalidate();
+      options?.onError?.();
+    },
+  });
+}

--- a/tests/unit/frontend/cache/handle-sync-event.test.ts
+++ b/tests/unit/frontend/cache/handle-sync-event.test.ts
@@ -1077,9 +1077,34 @@ describe("handleSyncEvent - subscription_deleted", () => {
     expect(remaining?.pages[0]?.items.some((s) => s.id === "sub-preexisting")).toBe(false);
   });
 
-  it("is a no-op when subscription not in any cache (treated as already removed)", () => {
-    // When the subscription is not in the lookup map or any infinite query,
-    // the handler treats it as "already removed" and skips processing.
+  it("still applies counts + invalidates entries.list when the subscription is not cached (#1081)", () => {
+    // A delete for a subscription that was never cached (e.g. tags collapsed, so
+    // its per-tag subscriptions.list was never loaded) must NOT be skipped: the
+    // event still carries absolute counts and the deleted feed's entries must be
+    // dropped from the list. Only the structural removal is skipped.
+    setUtilsData(utils.entries.count, {}, { unread: 22 });
+
+    handleSyncEvent(
+      utils,
+      queryClient,
+      createSubscriptionDeletedEvent({
+        subscriptionId: "sub-unknown",
+        counts: {
+          all: { unread: 12 },
+          starred: { unread: 1 },
+          subscriptions: [],
+          tags: [],
+        },
+      })
+    );
+
+    // Absolute counts from the event are applied even though nothing was removed.
+    expect(getEntriesCount({})?.unread).toBe(12);
+    // entries.list is invalidated so the deleted feed's entries are re-filtered.
+    expect(invalidatedProcedures(invalidateSpy)).toContain("entries.list");
+  });
+
+  it("invalidates count caches + entries.list for an uncached subscription with no counts (sync catch-up)", () => {
     invalidateSpy.mockClear();
     handleSyncEvent(
       utils,
@@ -1089,8 +1114,12 @@ describe("handleSyncEvent - subscription_deleted", () => {
       })
     );
 
-    // No invalidations should occur (the alreadyRemoved check returns true)
-    expect(invalidateSpy).not.toHaveBeenCalled();
+    // No counts on the event → invalidate the count caches and entries.list
+    // rather than silently doing nothing.
+    const paths = invalidatedProcedures(invalidateSpy);
+    expect(paths).toContain("tags.list");
+    expect(paths).toContain("entries.count");
+    expect(paths).toContain("entries.list");
   });
 });
 

--- a/tests/unit/frontend/cache/reconcile-list.test.ts
+++ b/tests/unit/frontend/cache/reconcile-list.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for reconcileListReadStarredFromEntryGet.
+ *
+ * A completing `fetchNextPage` replaces the entries.list pages snapshot taken at
+ * fetch start, dropping any read/starred writes applied to the old pages while
+ * the fetch was in flight (e.g. auto-mark-read fired by j/k navigation). The
+ * reconcile helper re-asserts the authoritative per-entry state from entries.get
+ * onto the list caches after the fetch settles (#1081).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { reconcileListReadStarredFromEntryGet } from "@/lib/cache/entry-cache";
+import { _resetSubscriptionLookupMap } from "@/lib/cache/count-cache";
+import type { TRPCClientUtils } from "@/lib/trpc/client";
+import {
+  createSeededQueryClient,
+  createRealTrpcUtils,
+  seedCacheState,
+  getUtilsData,
+  setUtilsData,
+} from "../../../utils/cache-test-helpers";
+import type { QueryClient } from "@tanstack/react-query";
+
+let utils: TRPCClientUtils;
+let queryClient: QueryClient;
+
+beforeEach(() => {
+  _resetSubscriptionLookupMap();
+  queryClient = createSeededQueryClient();
+  utils = createRealTrpcUtils(queryClient);
+  seedCacheState(utils);
+});
+
+function listEntry(id: string): { id: string; read: boolean; starred: boolean } | undefined {
+  const queries = queryClient.getQueriesData<{
+    pages: Array<{ items: Array<{ id: string; read: boolean; starred: boolean }> }>;
+  }>({ queryKey: [["entries", "list"]] });
+  for (const [, data] of queries) {
+    for (const page of data?.pages ?? []) {
+      const found = page.items.find((e) => e.id === id);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+function setEntryGet(id: string, updates: { read?: boolean; starred?: boolean }): void {
+  const current = getUtilsData<{ entry: Record<string, unknown> }>(utils.entries.get, { id });
+  if (!current?.entry) throw new Error(`entry ${id} not seeded`);
+  setUtilsData(utils.entries.get, { id }, { ...current, entry: { ...current.entry, ...updates } });
+}
+
+describe("reconcileListReadStarredFromEntryGet", () => {
+  it("restores a read flag clobbered in the list from entries.get", () => {
+    // entry-1 starts unread in both caches. Simulate a mark-read whose list
+    // write was clobbered by a completing fetchNextPage: only entries.get holds
+    // the new state.
+    expect(listEntry("entry-1")?.read).toBe(false);
+    setEntryGet("entry-1", { read: true });
+
+    reconcileListReadStarredFromEntryGet(queryClient);
+
+    expect(listEntry("entry-1")?.read).toBe(true);
+    // starred is untouched (entry-1 was seeded starred)
+    expect(listEntry("entry-1")?.starred).toBe(true);
+  });
+
+  it("restores a starred flag clobbered in the list from entries.get", () => {
+    expect(listEntry("entry-2")?.starred).toBe(false);
+    setEntryGet("entry-2", { starred: true });
+
+    reconcileListReadStarredFromEntryGet(queryClient);
+
+    expect(listEntry("entry-2")?.starred).toBe(true);
+  });
+
+  it("preserves the object identity of unchanged list rows (keeps memo effective)", () => {
+    // Change only entry-1's state; entry-2 must keep its reference so
+    // EntryListItem's memo skips re-rendering it.
+    const beforeEntry2 = listEntry("entry-2");
+    setEntryGet("entry-1", { read: true });
+
+    reconcileListReadStarredFromEntryGet(queryClient);
+
+    expect(listEntry("entry-2")).toBe(beforeEntry2);
+  });
+
+  it("is a no-op when list and entries.get already agree", () => {
+    // No divergence seeded, so the whole infinite-query object should keep its
+    // identity (no needless re-render / structural churn).
+    const before = queryClient.getQueryData([
+      ["entries", "list"],
+      { input: { limit: 25 }, type: "infinite" },
+    ]);
+
+    reconcileListReadStarredFromEntryGet(queryClient);
+
+    const after = queryClient.getQueryData([
+      ["entries", "list"],
+      { input: { limit: 25 }, type: "infinite" },
+    ]);
+    expect(after).toBe(before);
+  });
+
+  it("leaves list rows without an entries.get entry untouched", () => {
+    // Remove entry-2 from entries.get, then diverge entry-1. entry-2 must be
+    // left exactly as it was.
+    setUtilsData(utils.entries.get, { id: "entry-2" }, undefined);
+    const beforeEntry2 = listEntry("entry-2");
+    setEntryGet("entry-1", { read: true });
+
+    reconcileListReadStarredFromEntryGet(queryClient);
+
+    expect(listEntry("entry-2")).toBe(beforeEntry2);
+  });
+});

--- a/tests/unit/frontend/cache/reconcile-list.test.ts
+++ b/tests/unit/frontend/cache/reconcile-list.test.ts
@@ -1,15 +1,22 @@
 /**
- * Tests for reconcileListReadStarredFromEntryGet.
+ * Tests for snapshotEntryGetStates + reconcileListFromChangedEntryGets.
  *
  * A completing `fetchNextPage` replaces the entries.list pages snapshot taken at
  * fetch start, dropping any read/starred writes applied to the old pages while
  * the fetch was in flight (e.g. auto-mark-read fired by j/k navigation). The
- * reconcile helper re-asserts the authoritative per-entry state from entries.get
- * onto the list caches after the fetch settles (#1081).
+ * reconcile snapshots entries.get state at fetch start and, after the fetch
+ * settles, re-asserts onto the list only the entries whose entries.get state
+ * *changed during the fetch window* — so clobbered mutation writes are restored
+ * without resurrecting stale gets (e.g. after mark_all_read, which never touches
+ * entries.get). See #1081.
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { reconcileListReadStarredFromEntryGet } from "@/lib/cache/entry-cache";
+import {
+  snapshotEntryGetStates,
+  reconcileListFromChangedEntryGets,
+  updateEntriesInListCache,
+} from "@/lib/cache/entry-cache";
 import { _resetSubscriptionLookupMap } from "@/lib/cache/count-cache";
 import type { TRPCClientUtils } from "@/lib/trpc/client";
 import {
@@ -50,67 +57,90 @@ function setEntryGet(id: string, updates: { read?: boolean; starred?: boolean })
   setUtilsData(utils.entries.get, { id }, { ...current, entry: { ...current.entry, ...updates } });
 }
 
-describe("reconcileListReadStarredFromEntryGet", () => {
-  it("restores a read flag clobbered in the list from entries.get", () => {
-    // entry-1 starts unread in both caches. Simulate a mark-read whose list
-    // write was clobbered by a completing fetchNextPage: only entries.get holds
-    // the new state.
+describe("reconcileListFromChangedEntryGets", () => {
+  it("restores a read flag that changed in entries.get during the fetch window", () => {
+    // entry-1 starts unread in both caches.
     expect(listEntry("entry-1")?.read).toBe(false);
+    const before = snapshotEntryGetStates(queryClient);
+
+    // Simulate a mid-fetch mark-read whose list write was clobbered by the
+    // completing fetchNextPage: only entries.get holds the new state.
     setEntryGet("entry-1", { read: true });
 
-    reconcileListReadStarredFromEntryGet(queryClient);
+    reconcileListFromChangedEntryGets(queryClient, before);
 
     expect(listEntry("entry-1")?.read).toBe(true);
-    // starred is untouched (entry-1 was seeded starred)
+    // starred untouched (entry-1 was seeded starred)
     expect(listEntry("entry-1")?.starred).toBe(true);
   });
 
-  it("restores a starred flag clobbered in the list from entries.get", () => {
+  it("restores a starred flag that changed in entries.get during the fetch window", () => {
     expect(listEntry("entry-2")?.starred).toBe(false);
+    const before = snapshotEntryGetStates(queryClient);
+
     setEntryGet("entry-2", { starred: true });
 
-    reconcileListReadStarredFromEntryGet(queryClient);
+    reconcileListFromChangedEntryGets(queryClient, before);
 
     expect(listEntry("entry-2")?.starred).toBe(true);
   });
 
-  it("preserves the object identity of unchanged list rows (keeps memo effective)", () => {
-    // Change only entry-1's state; entry-2 must keep its reference so
-    // EntryListItem's memo skips re-rendering it.
-    const beforeEntry2 = listEntry("entry-2");
-    setEntryGet("entry-1", { read: true });
+  it("does NOT resurrect a stale entries.get that didn't change during the fetch (mark_all_read)", () => {
+    // entry-1 unread in both caches. Snapshot at fetch start.
+    const before = snapshotEntryGetStates(queryClient);
 
-    reconcileListReadStarredFromEntryGet(queryClient);
+    // mark_all_read: the list is refetched to read=true, but entries.get is
+    // never touched (neither the SSE handler nor the acting mutation updates
+    // it), so it stays read=false — stale.
+    updateEntriesInListCache(queryClient, ["entry-1"], { read: true });
+    expect(listEntry("entry-1")?.read).toBe(true);
+    expect(
+      getUtilsData<{ entry: { read: boolean } }>(utils.entries.get, { id: "entry-1" })?.entry.read
+    ).toBe(false);
 
-    expect(listEntry("entry-2")).toBe(beforeEntry2);
+    reconcileListFromChangedEntryGets(queryClient, before);
+
+    // The stale get must NOT flip the freshly-refetched list back to unread.
+    expect(listEntry("entry-1")?.read).toBe(true);
   });
 
-  it("is a no-op when list and entries.get already agree", () => {
-    // No divergence seeded, so the whole infinite-query object should keep its
-    // identity (no needless re-render / structural churn).
-    const before = queryClient.getQueryData([
-      ["entries", "list"],
-      { input: { limit: 25 }, type: "infinite" },
-    ]);
-
-    reconcileListReadStarredFromEntryGet(queryClient);
-
-    const after = queryClient.getQueryData([
-      ["entries", "list"],
-      { input: { limit: 25 }, type: "infinite" },
-    ]);
-    expect(after).toBe(before);
-  });
-
-  it("leaves list rows without an entries.get entry untouched", () => {
-    // Remove entry-2 from entries.get, then diverge entry-1. entry-2 must be
-    // left exactly as it was.
+  it("applies a get that first appeared during the fetch (fresh server read)", () => {
+    // Remove entry-2 from entries.get, snapshot (so it's absent from `before`),
+    // then have it appear read=true (e.g. opened + auto-marked during the fetch)
+    // while its list row was clobbered to read=false.
     setUtilsData(utils.entries.get, { id: "entry-2" }, undefined);
+    const before = snapshotEntryGetStates(queryClient);
+
+    setEntryGet("entry-2", { read: true });
+
+    reconcileListFromChangedEntryGets(queryClient, before);
+
+    expect(listEntry("entry-2")?.read).toBe(true);
+  });
+
+  it("preserves the object identity of unchanged list rows (keeps memo effective)", () => {
     const beforeEntry2 = listEntry("entry-2");
+    const before = snapshotEntryGetStates(queryClient);
     setEntryGet("entry-1", { read: true });
 
-    reconcileListReadStarredFromEntryGet(queryClient);
+    reconcileListFromChangedEntryGets(queryClient, before);
 
     expect(listEntry("entry-2")).toBe(beforeEntry2);
+  });
+
+  it("is a no-op when nothing changed during the window", () => {
+    const before = snapshotEntryGetStates(queryClient);
+    const listBefore = queryClient.getQueryData([
+      ["entries", "list"],
+      { input: { limit: 25 }, type: "infinite" },
+    ]);
+
+    reconcileListFromChangedEntryGets(queryClient, before);
+
+    const listAfter = queryClient.getQueryData([
+      ["entries", "list"],
+      { input: { limit: 25 }, type: "infinite" },
+    ]);
+    expect(listAfter).toBe(listBefore);
   });
 });


### PR DESCRIPTION
Fixes the correctness, perf, and maintainability findings from the repo-wide audit tracked in #1081.

## Changes

### 1. Failed catch-up sync is now retried; live events can't skip the gap (high)
`useRealtimeUpdates` now retries a failed catch-up sync with exponential backoff (2s→30s) **in the connected phase** (the polling phase already retried every 30s). Crucially, live SSE events no longer advance the persisted sync cursor until the connection's catch-up sync has **fully succeeded** (`caughtUpRef`) — otherwise a live event pushes the cursor past the still-unsynced disconnected-window gap, and no future sync returns those rows. The cache is still patched live throughout; only the cursor is frozen. Any stream error (including the browser's silent EventSource auto-reconnect) re-freezes the cursor so the next catch-up re-covers whatever was missed.

### 2. `subscription_deleted` for a never-cached subscription no longer swallowed (medium)
The count update **and** `entries.list` invalidation now run unconditionally; only the structural removal is gated on the subscription being cached. Previously, with tags collapsed (the common case) the whole handler was skipped, leaving inflated counts and the deleted feed's entries in the list until an unrelated event.

### 3. Cache patches during an in-flight `fetchNextPage` are re-asserted (medium)
React Query's `infiniteQueryBehavior` snapshots the old pages at fetch start and drops any `setQueryData` applied mid-fetch. j/k navigation triggers this (auto-mark-read racing a `fetchNextPage`), reverting entries to unread. Every next-page fetch (keyboard- and scroll-triggered, both containers) now calls `reconcileListReadStarredFromEntryGet` after it settles, re-asserting the server-authoritative read/starred state from `entries.get`. (Residual: a brand-new SSE-inserted entry has no `entries.get` row and reappears on the next navigation refresh.)

### 4. `EntryListContainer` no longer defeats `EntryListItem`'s `memo` (perf)
Cached list items are forwarded straight through instead of remapped into fresh literals, so structural sharing's preserved identities reach the memo comparison — a single-entry change no longer re-renders all N rows.

### 5. Shared `useUnsubscribeMutation` hook (maintainability)
Extracted the duplicated `subscriptions.delete` optimistic-remove / counts / rollback choreography from `Sidebar` and `BrokenFeedsSettingsContent` into one hook, so fixes like #2 can't miss a site.

### Lower severity
- `applyOptimisticStarredUpdate` gains the read path's list-cache rollback fallback.
- Keyboard `r` refresh routes through `refreshEntryLists` (cancels inactive fetches first).
- Dead "Retry" button hidden in the `disconnected` phase (the state machine ignores manual-reconnect there).
- Dead `score`/`implicitScore` remnants were already removed in #1101.

### Deferred
- Acting-tab double-refetch after `markAllRead` (own onSuccess + its own SSE echo): needs per-tab identity on the event to suppress the echo; left as a known minor inefficiency.

## Tests & docs
- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (2215 tests) all pass.
- New unit tests: `reconcile-list.test.ts` (the fetchNextPage clobber guard) and updated `subscription_deleted` cases in `handle-sync-event.test.ts`.
- `src/FRONTEND_STATE.md` updated for all of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)