### PR TITLE
Remove dead session cache field and duplicate HTML text extractor

### DIFF
--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -86,7 +86,6 @@ interface CachedSession {
   userCreatedAt: string;
   userUpdatedAt: string;
   userEmailVerifiedAt: string | null;
-  userPasswordHash?: string | null; // deprecated: no longer cached but kept for compat with old cache entries
   userInviteId: string | null;
   userShowSpam: boolean;
   userHasGroqApiKey: boolean;

--- a/src/server/http/html.ts
+++ b/src/server/http/html.ts
@@ -2,42 +2,10 @@
  * HTML Utilities
  *
  * Common HTML processing utilities used across the server.
- */
-
-import { parseHTML } from "linkedom";
-
-/**
- * Extracts plain text from HTML content.
  *
- * Uses linkedom for proper parsing rather than regex, which correctly
- * handles nested tags, script/style content, and entity decoding.
- *
- * @param html - The HTML content to extract text from
- * @returns The plain text content
+ * For extracting plain text from HTML, use `stripHtml` from
+ * `@/server/html/strip-html` (streaming SAX parse).
  */
-export function extractTextFromHtml(html: string): string {
-  if (!html || !html.trim()) {
-    return "";
-  }
-
-  // Wrap fragments in a full HTML document structure for proper parsing
-  // linkedom requires a proper document structure
-  const trimmedHtml = html.trim().toLowerCase();
-  const isFullDocument = trimmedHtml.startsWith("<!doctype") || trimmedHtml.startsWith("<html");
-  const htmlToParse = isFullDocument ? html : `<!DOCTYPE html><html><body>${html}</body></html>`;
-
-  const { document } = parseHTML(htmlToParse);
-
-  // Remove script and style elements
-  for (const el of document.querySelectorAll("script, style")) {
-    el.remove();
-  }
-
-  // Get text content, collapse whitespace
-  return (document.body?.textContent || document.documentElement?.textContent || "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
 
 /**
  * Escapes HTML special characters for safe embedding in HTML.

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -16,11 +16,10 @@ import { normalizeUrl } from "@/lib/url";
 import { fetchHtmlPage, HttpFetchError, ContentTooLargeError } from "@/server/http/fetch";
 import { processMarkdown } from "@/server/markdown";
 import { usageLimitsConfig } from "@/server/config/env";
-import { extractTextFromHtml } from "@/server/http/html";
 import { absolutizeUrls } from "@/server/feed/content-cleaner";
 import { cleanContentInWorker, sanitizeEntryHtmlInWorker } from "@/server/worker-thread/pool";
 import { getOrCreateSavedFeed, getSavedFeedId, SAVED_FEED_TITLE } from "@/server/feed/saved-feed";
-import { generateSummary } from "@/server/html/strip-html";
+import { generateSummary, stripHtml } from "@/server/html/strip-html";
 import { withSanitizedEntryContentAsync } from "@/server/html/sanitize-entry";
 import { logger } from "@/lib/logger";
 import { publishNewEntry, publishEntryUpdatedFromEntry } from "@/server/redis/pubsub";
@@ -863,15 +862,13 @@ export async function saveArticle(
     // Compare content quality to avoid overwriting good content with bad
     // (e.g., private Google Doc fetched with auth, refetched without)
     if (!params.force) {
-      const oldTextLength = oldEntry.contentCleaned
-        ? extractTextFromHtml(oldEntry.contentCleaned).length
-        : 0;
+      const oldTextLength = oldEntry.contentCleaned ? stripHtml(oldEntry.contentCleaned).length : 0;
 
       const newTextLength = pluginContent
-        ? extractTextFromHtml(pluginContent.html).length
+        ? stripHtml(pluginContent.html).length
         : cleaned
           ? cleaned.textContent.length
-          : extractTextFromHtml(html).length;
+          : stripHtml(html).length;
 
       // Reject if new content is significantly shorter AND short in absolute terms
       // This catches error pages and access-denied pages while allowing legitimate edits

--- a/tests/unit/html-utils.test.ts
+++ b/tests/unit/html-utils.test.ts
@@ -3,7 +3,8 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { escapeHtml, extractTextFromHtml } from "@/server/http/html";
+import { escapeHtml } from "@/server/http/html";
+import { stripHtml } from "@/server/html/strip-html";
 
 describe("escapeHtml", () => {
   it("should escape ampersands", () => {
@@ -30,10 +31,10 @@ describe("escapeHtml", () => {
   });
 });
 
-describe("extractTextFromHtml", () => {
+describe("stripHtml", () => {
   it("should extract text from simple HTML", () => {
     const html = "<p>Hello <strong>world</strong>!</p>";
-    expect(extractTextFromHtml(html)).toBe("Hello world!");
+    expect(stripHtml(html)).toBe("Hello world!");
   });
 
   it("should remove script tags and their content", () => {
@@ -43,7 +44,7 @@ describe("extractTextFromHtml", () => {
         <p>Visible content</p>
       </div>
     `;
-    expect(extractTextFromHtml(html)).toBe("Visible content");
+    expect(stripHtml(html)).toBe("Visible content");
   });
 
   it("should remove style tags and their content", () => {
@@ -53,12 +54,12 @@ describe("extractTextFromHtml", () => {
         <p>Visible text</p>
       </div>
     `;
-    expect(extractTextFromHtml(html)).toBe("Visible text");
+    expect(stripHtml(html)).toBe("Visible text");
   });
 
   it("should collapse whitespace", () => {
     const html = "<p>Multiple    spaces\n\nand\nnewlines</p>";
-    expect(extractTextFromHtml(html)).toBe("Multiple spaces and newlines");
+    expect(stripHtml(html)).toBe("Multiple spaces and newlines");
   });
 
   it("should handle nested elements", () => {
@@ -69,17 +70,17 @@ describe("extractTextFromHtml", () => {
         <p>Second paragraph.</p>
       </article>
     `;
-    expect(extractTextFromHtml(html)).toBe("Title First paragraph here. Second paragraph.");
+    expect(stripHtml(html)).toBe("Title First paragraph here. Second paragraph.");
   });
 
   it("should handle empty HTML", () => {
-    expect(extractTextFromHtml("")).toBe("");
-    expect(extractTextFromHtml("<div></div>")).toBe("");
+    expect(stripHtml("")).toBe("");
+    expect(stripHtml("<div></div>")).toBe("");
   });
 
   it("should decode HTML entities", () => {
     const html = "<p>&lt;Hello&gt; &amp; &quot;world&quot;</p>";
-    expect(extractTextFromHtml(html)).toBe('<Hello> & "world"');
+    expect(stripHtml(html)).toBe('<Hello> & "world"');
   });
 
   it("should handle full HTML document", () => {
@@ -94,7 +95,7 @@ describe("extractTextFromHtml", () => {
         </body>
       </html>
     `;
-    const result = extractTextFromHtml(html);
+    const result = stripHtml(html);
     expect(result).toContain("Main content here");
     expect(result).toContain("Navigation");
     expect(result).toContain("Footer");


### PR DESCRIPTION
Two low-risk cleanups from a repo-wide simplification pass.

## 1. Remove dead `userPasswordHash` cache field

`CachedSession.userPasswordHash` was marked *"no longer cached but kept for compat with old cache entries,"* but nothing reads or writes it anywhere. Session cache entries expire within the 5-minute TTL, so there are never old-format entries around long enough to need a compat field. Removed.

## 2. Consolidate two HTML→text extractors

The repo had two functions extracting plain text from HTML:

- `extractTextFromHtml` (`src/server/http/html.ts`) — linkedom, builds a full DOM, wraps fragments in a whole document.
- `stripHtml` (`src/server/html/strip-html.ts`) — htmlparser2, streaming SAX.

The only caller of `extractTextFromHtml` was `saved.ts`, measuring extracted-text `.length` for refetch quality checks. It now uses `stripHtml`, which skips `script`/`style`/`head` and decodes entities identically. Verified equivalence by migrating the existing `extractTextFromHtml` unit tests onto `stripHtml` (all pass unchanged). This:

- aligns with the repo's *"prefer SAX parsing unless the algorithm requires a DOM"* guideline (CLAUDE.md),
- removes a linkedom DOM parse from the saved-article refetch path,
- deletes ~35 lines of duplicate extraction logic.

`escapeHtml` stays in `http/html.ts`.

## Verification

- `pnpm typecheck` ✅
- `pnpm test:unit` — 2209 passed ✅

Part of a two-PR cleanup; the AbortSignal.timeout sweep follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)