### PR TITLE
Use AbortSignal.timeout() for fetch timeouts

### DIFF
--- a/src/server/email/unsubscribe.ts
+++ b/src/server/email/unsubscribe.ts
@@ -167,9 +167,6 @@ async function sendUnsubscribeEmail(mailtoUrl: string): Promise<void> {
  * @throws Error if the request fails
  */
 async function sendUnsubscribePost(url: string): Promise<void> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), HTTPS_TIMEOUT_MS);
-
   try {
     logger.info("Sending RFC 8058 one-click unsubscribe POST", { url });
 
@@ -182,7 +179,7 @@ async function sendUnsubscribePost(url: string): Promise<void> {
         "User-Agent": USER_AGENT,
       },
       body: "List-Unsubscribe=One-Click",
-      signal: controller.signal,
+      signal: AbortSignal.timeout(HTTPS_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -197,7 +194,7 @@ async function sendUnsubscribePost(url: string): Promise<void> {
       logger.info("One-click unsubscribe POST successful", { url, status: response.status });
     }
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       logger.warn("One-click unsubscribe POST timed out", { url });
       throw new Error("Unsubscribe request timed out");
     }
@@ -207,8 +204,6 @@ async function sendUnsubscribePost(url: string): Promise<void> {
       error: error instanceof Error ? error.message : String(error),
     });
     throw error;
-  } finally {
-    clearTimeout(timeoutId);
   }
 }
 

--- a/src/server/feed/arxiv.ts
+++ b/src/server/feed/arxiv.ts
@@ -118,9 +118,6 @@ async function checkArxivHtmlExists(url: string): Promise<ArxivHtmlCheckResult |
   const htmlUrl = buildArxivHtmlUrl(paperId);
   const fallbackUrl = buildArxivAbsUrl(paperId);
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FEED_FETCH_TIMEOUT_MS);
-
   try {
     // Use HEAD request to check if HTML version exists without downloading it
     const response = await fetch(htmlUrl, {
@@ -128,7 +125,7 @@ async function checkArxivHtmlExists(url: string): Promise<ArxivHtmlCheckResult |
       headers: {
         "User-Agent": USER_AGENT,
       },
-      signal: controller.signal,
+      signal: AbortSignal.timeout(FEED_FETCH_TIMEOUT_MS),
       redirect: "follow",
     });
 
@@ -142,7 +139,7 @@ async function checkArxivHtmlExists(url: string): Promise<ArxivHtmlCheckResult |
 
     return { exists, htmlUrl, fallbackUrl };
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       logger.warn("ArXiv HTML check timed out", { paperId, htmlUrl });
     } else {
       logger.warn("ArXiv HTML check failed", {
@@ -153,8 +150,6 @@ async function checkArxivHtmlExists(url: string): Promise<ArxivHtmlCheckResult |
     }
     // On error, assume HTML doesn't exist and fall back
     return { exists: false, htmlUrl, fallbackUrl };
-  } finally {
-    clearTimeout(timeout);
   }
 }
 

--- a/src/server/feed/fetcher.ts
+++ b/src/server/feed/fetcher.ts
@@ -353,19 +353,13 @@ export async function fetchFeed(
   let currentUrl = url;
 
   for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount++) {
-    // Create abort controller for timeout
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeout);
-
     try {
       const response = await fetchWithSsrfProtection(currentUrl, {
         method: "GET",
         headers,
-        signal: controller.signal,
+        signal: AbortSignal.timeout(timeout),
         redirect: "manual", // Handle redirects manually to track permanent ones
       });
-
-      clearTimeout(timeoutId);
 
       // Handle redirects
       if (isRedirect(response.status)) {
@@ -489,10 +483,11 @@ export async function fetchFeed(
         permanent: false,
       };
     } catch (error) {
-      clearTimeout(timeoutId);
-
       // Handle abort (timeout)
-      if (error instanceof Error && error.name === "AbortError") {
+      if (
+        error instanceof Error &&
+        (error.name === "TimeoutError" || error.name === "AbortError")
+      ) {
         return {
           status: "network_error",
           message: `Request timed out after ${timeout}ms`,

--- a/src/server/feed/lesswrong.ts
+++ b/src/server/feed/lesswrong.ts
@@ -306,9 +306,6 @@ const POST_QUERY = `
  * @returns Post content including HTML, or null if fetch fails
  */
 async function fetchLessWrongPost(postId: string): Promise<LessWrongPostContent | null> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), GRAPHQL_TIMEOUT_MS);
-
   try {
     const response = await fetch(LESSWRONG_GRAPHQL_ENDPOINT, {
       method: "POST",
@@ -321,7 +318,7 @@ async function fetchLessWrongPost(postId: string): Promise<LessWrongPostContent 
         query: POST_QUERY,
         variables: { postId },
       }),
-      signal: controller.signal,
+      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -400,7 +397,7 @@ async function fetchLessWrongPost(postId: string): Promise<LessWrongPostContent 
     if (error instanceof HttpFetchError) {
       throw error;
     }
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       logger.warn("LessWrong GraphQL request timed out", { postId });
     } else {
       logger.warn("LessWrong GraphQL request error", {
@@ -409,8 +406,6 @@ async function fetchLessWrongPost(postId: string): Promise<LessWrongPostContent 
       });
     }
     return null;
-  } finally {
-    clearTimeout(timeout);
   }
 }
 
@@ -448,9 +443,6 @@ const COMMENT_QUERY = `
  * @returns Comment content including HTML, or null if fetch fails
  */
 async function fetchLessWrongComment(commentId: string): Promise<LessWrongCommentContent | null> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), GRAPHQL_TIMEOUT_MS);
-
   try {
     const response = await fetch(LESSWRONG_GRAPHQL_ENDPOINT, {
       method: "POST",
@@ -463,7 +455,7 @@ async function fetchLessWrongComment(commentId: string): Promise<LessWrongCommen
         query: COMMENT_QUERY,
         variables: { commentId },
       }),
-      signal: controller.signal,
+      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -526,7 +518,7 @@ async function fetchLessWrongComment(commentId: string): Promise<LessWrongCommen
     if (error instanceof HttpFetchError) {
       throw error;
     }
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       logger.warn("LessWrong GraphQL comment request timed out", { commentId });
     } else {
       logger.warn("LessWrong GraphQL comment request error", {
@@ -535,8 +527,6 @@ async function fetchLessWrongComment(commentId: string): Promise<LessWrongCommen
       });
     }
     return null;
-  } finally {
-    clearTimeout(timeout);
   }
 }
 
@@ -652,9 +642,6 @@ const USER_BY_SLUG_QUERY = `
  * @returns User info including ID, or null if not found
  */
 export async function fetchLessWrongUserBySlug(slug: string): Promise<LessWrongUser | null> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), GRAPHQL_TIMEOUT_MS);
-
   try {
     const response = await fetch(LESSWRONG_GRAPHQL_ENDPOINT, {
       method: "POST",
@@ -667,7 +654,7 @@ export async function fetchLessWrongUserBySlug(slug: string): Promise<LessWrongU
         query: USER_BY_SLUG_QUERY,
         variables: { slug },
       }),
-      signal: controller.signal,
+      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -711,7 +698,7 @@ export async function fetchLessWrongUserBySlug(slug: string): Promise<LessWrongU
       slug: user.slug,
     };
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       logger.warn("LessWrong GraphQL user request timed out", { slug });
     } else {
       logger.warn("LessWrong GraphQL user request error", {
@@ -720,8 +707,6 @@ export async function fetchLessWrongUserBySlug(slug: string): Promise<LessWrongU
       });
     }
     return null;
-  } finally {
-    clearTimeout(timeout);
   }
 }
 
@@ -820,9 +805,6 @@ const USER_BY_ID_QUERY = `
  * @returns User info, or null if not found
  */
 export async function fetchLessWrongUserById(userId: string): Promise<LessWrongUser | null> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), GRAPHQL_TIMEOUT_MS);
-
   try {
     const response = await fetch(LESSWRONG_GRAPHQL_ENDPOINT, {
       method: "POST",
@@ -835,7 +817,7 @@ export async function fetchLessWrongUserById(userId: string): Promise<LessWrongU
         query: USER_BY_ID_QUERY,
         variables: { userId },
       }),
-      signal: controller.signal,
+      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -879,7 +861,7 @@ export async function fetchLessWrongUserById(userId: string): Promise<LessWrongU
       slug: user.slug,
     };
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       logger.warn("LessWrong GraphQL user-by-id request timed out", { userId });
     } else {
       logger.warn("LessWrong GraphQL user-by-id request error", {
@@ -888,8 +870,6 @@ export async function fetchLessWrongUserById(userId: string): Promise<LessWrongU
       });
     }
     return null;
-  } finally {
-    clearTimeout(timeout);
   }
 }
 
@@ -961,9 +941,6 @@ const POST_METADATA_QUERY = `
 export async function fetchLessWrongPostMetadata(
   postId: string
 ): Promise<LessWrongPostMetadata | null> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), GRAPHQL_TIMEOUT_MS);
-
   try {
     const response = await fetch(LESSWRONG_GRAPHQL_ENDPOINT, {
       method: "POST",
@@ -976,7 +953,7 @@ export async function fetchLessWrongPostMetadata(
         query: POST_METADATA_QUERY,
         variables: { postId },
       }),
-      signal: controller.signal,
+      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -1019,7 +996,7 @@ export async function fetchLessWrongPostMetadata(
       userId: post.userId,
     };
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       logger.warn("LessWrong GraphQL post metadata request timed out", { postId });
     } else {
       logger.warn("LessWrong GraphQL post metadata request error", {
@@ -1028,7 +1005,5 @@ export async function fetchLessWrongPostMetadata(
       });
     }
     return null;
-  } finally {
-    clearTimeout(timeout);
   }
 }

--- a/src/server/feed/websub.ts
+++ b/src/server/feed/websub.ts
@@ -437,8 +437,6 @@ export async function subscribeToHub(feed: Feed): Promise<SubscribeToHubResult> 
   }
 
   // POST subscription request to hub
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), HUB_REQUEST_TIMEOUT_MS);
   try {
     const response = await fetchWithSsrfProtection(feed.hubUrl, {
       method: "POST",
@@ -452,7 +450,7 @@ export async function subscribeToHub(feed: Feed): Promise<SubscribeToHubResult> 
         "hub.secret": secret,
         "hub.verify": "async",
       }).toString(),
-      signal: controller.signal,
+      signal: AbortSignal.timeout(HUB_REQUEST_TIMEOUT_MS),
     });
 
     // Hub should return 202 Accepted for async verification
@@ -510,8 +508,6 @@ export async function subscribeToHub(feed: Feed): Promise<SubscribeToHubResult> 
     });
 
     return { success: false, subscriptionId, error: errorMessage };
-  } finally {
-    clearTimeout(timeoutId);
   }
 }
 

--- a/src/server/google/docs.ts
+++ b/src/server/google/docs.ts
@@ -1288,9 +1288,6 @@ async function fetchPublicGoogleDoc(
     return null;
   }
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
-
   // Track if we should try Drive API fallback
   let shouldTryDriveFallback = false;
 
@@ -1307,7 +1304,7 @@ async function fetchPublicGoogleDoc(
         Authorization: `Bearer ${accessToken}`,
         "User-Agent": USER_AGENT,
       },
-      signal: controller.signal,
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -1381,7 +1378,7 @@ async function fetchPublicGoogleDoc(
       }
     }
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       logger.warn("Google Docs API request timed out, trying Drive API fallback", { docId });
       shouldTryDriveFallback = true;
     } else {
@@ -1391,8 +1388,6 @@ async function fetchPublicGoogleDoc(
       });
       shouldTryDriveFallback = true;
     }
-  } finally {
-    clearTimeout(timeout);
   }
 
   // Try Drive API fallback for .docx files
@@ -1431,9 +1426,6 @@ export async function fetchPrivateGoogleDoc(
   accessToken: string,
   tabId: string | null = null
 ): Promise<GoogleDocsContent | null> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
-
   // Track if we should try Drive API fallback and why
   let shouldTryDriveFallback = false;
   let docsApiError: Error | null = null;
@@ -1451,7 +1443,7 @@ export async function fetchPrivateGoogleDoc(
         Authorization: `Bearer ${accessToken}`,
         "User-Agent": USER_AGENT,
       },
-      signal: controller.signal,
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -1522,7 +1514,7 @@ export async function fetchPrivateGoogleDoc(
       }
     }
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       logger.warn("Google Docs API request timed out, trying Drive API fallback", { docId });
       shouldTryDriveFallback = true;
     } else if (error instanceof Error && error.message === "GOOGLE_TOKEN_INVALID") {
@@ -1535,8 +1527,6 @@ export async function fetchPrivateGoogleDoc(
       });
       shouldTryDriveFallback = true;
     }
-  } finally {
-    clearTimeout(timeout);
   }
 
   // Try Drive API fallback for .docx files

--- a/src/server/google/drive.ts
+++ b/src/server/google/drive.ts
@@ -153,9 +153,6 @@ async function getFileMetadata(
   fileId: string,
   accessToken: string
 ): Promise<DriveFileMetadata | null> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
-
   try {
     const url = `${GOOGLE_DRIVE_API_ENDPOINT}/${fileId}?fields=id,name,mimeType`;
 
@@ -166,7 +163,7 @@ async function getFileMetadata(
         Authorization: `Bearer ${accessToken}`,
         "User-Agent": USER_AGENT,
       },
-      signal: controller.signal,
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -186,7 +183,7 @@ async function getFileMetadata(
     const data = (await response.json()) as DriveFileMetadata;
     return data;
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       logger.warn("Drive API request timed out", { fileId });
     } else {
       logger.warn("Drive API request error", {
@@ -195,8 +192,6 @@ async function getFileMetadata(
       });
     }
     return null;
-  } finally {
-    clearTimeout(timeout);
   }
 }
 
@@ -204,9 +199,6 @@ async function getFileMetadata(
  * Downloads a file from Google Drive as raw bytes.
  */
 async function downloadFile(fileId: string, accessToken: string): Promise<ArrayBuffer | null> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
-
   try {
     const url = `${GOOGLE_DRIVE_API_ENDPOINT}/${fileId}?alt=media`;
 
@@ -216,7 +208,7 @@ async function downloadFile(fileId: string, accessToken: string): Promise<ArrayB
         Authorization: `Bearer ${accessToken}`,
         "User-Agent": USER_AGENT,
       },
-      signal: controller.signal,
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -229,7 +221,7 @@ async function downloadFile(fileId: string, accessToken: string): Promise<ArrayB
 
     return await response.arrayBuffer();
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       logger.warn("Download request timed out", { fileId });
     } else {
       logger.warn("Download request error", {
@@ -238,8 +230,6 @@ async function downloadFile(fileId: string, accessToken: string): Promise<ArrayB
       });
     }
     return null;
-  } finally {
-    clearTimeout(timeout);
   }
 }
 

--- a/src/server/http/fetch.ts
+++ b/src/server/http/fetch.ts
@@ -239,9 +239,6 @@ export async function fetchUrl(url: string, options?: FetchUrlOptions): Promise<
   const userAgent = options?.userAgent ?? USER_AGENT;
   const maxSizeBytes = options?.maxSizeBytes ?? usageLimitsConfig.maxFeedSizeBytes;
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
   try {
     const response = await fetchWithSsrfProtection(url, {
       headers: {
@@ -249,7 +246,7 @@ export async function fetchUrl(url: string, options?: FetchUrlOptions): Promise<
         Accept: accept,
         "Accept-Encoding": ACCEPT_ENCODING,
       },
-      signal: controller.signal,
+      signal: AbortSignal.timeout(timeoutMs),
       redirect: "follow",
     });
 
@@ -266,7 +263,7 @@ export async function fetchUrl(url: string, options?: FetchUrlOptions): Promise<
     if (error instanceof ContentTooLargeError) {
       throw errors.contentTooLarge("Feed", maxSizeBytes);
     }
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       throw errors.feedFetchError(url, "Request timed out");
     }
     if (error instanceof Error && "code" in error) {
@@ -274,8 +271,6 @@ export async function fetchUrl(url: string, options?: FetchUrlOptions): Promise<
       throw error;
     }
     throw errors.feedFetchError(url, error instanceof Error ? error.message : "Unknown error");
-  } finally {
-    clearTimeout(timeoutId);
   }
 }
 
@@ -306,41 +301,35 @@ export async function fetchHtmlPage(
   options?: { maxSizeBytes?: number }
 ): Promise<FetchHtmlPageResult> {
   const maxSizeBytes = options?.maxSizeBytes ?? usageLimitsConfig.maxSavedArticleSizeBytes;
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), PAGE_FETCH_TIMEOUT_MS);
 
-  try {
-    const response = await fetchWithSsrfProtection(url, {
-      signal: controller.signal,
-      headers: {
-        "User-Agent": USER_AGENT,
-        Accept: HTML_ACCEPT_HEADER,
-        "Accept-Encoding": ACCEPT_ENCODING,
-      },
-      redirect: "follow",
-    });
+  const response = await fetchWithSsrfProtection(url, {
+    signal: AbortSignal.timeout(PAGE_FETCH_TIMEOUT_MS),
+    headers: {
+      "User-Agent": USER_AGENT,
+      Accept: HTML_ACCEPT_HEADER,
+      "Accept-Encoding": ACCEPT_ENCODING,
+    },
+    redirect: "follow",
+  });
 
-    if (!response.ok) {
-      throw new HttpFetchError(response.status, response.statusText, url);
-    }
-
-    const contentType = response.headers.get("content-type") || "";
-    const isMarkdown = contentType.includes("text/markdown");
-
-    // Accept markdown, HTML, or XHTML
-    if (
-      !isMarkdown &&
-      !contentType.includes("text/html") &&
-      !contentType.includes("application/xhtml+xml")
-    ) {
-      throw new Error(`Invalid content type: ${contentType}`);
-    }
-
-    const content = await readResponseWithSizeLimit(response, maxSizeBytes, url);
-    return { content, isMarkdown, finalUrl: response.url };
-  } finally {
-    clearTimeout(timeout);
+  if (!response.ok) {
+    throw new HttpFetchError(response.status, response.statusText, url);
   }
+
+  const contentType = response.headers.get("content-type") || "";
+  const isMarkdown = contentType.includes("text/markdown");
+
+  // Accept markdown, HTML, or XHTML
+  if (
+    !isMarkdown &&
+    !contentType.includes("text/html") &&
+    !contentType.includes("application/xhtml+xml")
+  ) {
+    throw new Error(`Invalid content type: ${contentType}`);
+  }
+
+  const content = await readResponseWithSizeLimit(response, maxSizeBytes, url);
+  return { content, isMarkdown, finalUrl: response.url };
 }
 
 // ============================================================================

--- a/src/server/oauth/service.ts
+++ b/src/server/oauth/service.ts
@@ -159,16 +159,13 @@ const CLIENT_METADATA_MAX_BYTES = 256 * 1024;
  * and size-limited.
  */
 async function fetchClientMetadata(url: string): Promise<ClientMetadata | null> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), CLIENT_METADATA_TIMEOUT_MS);
-
   try {
     const response = await fetchWithSsrfProtection(url, {
       headers: {
         Accept: "application/json",
         "User-Agent": USER_AGENT,
       },
-      signal: controller.signal,
+      signal: AbortSignal.timeout(CLIENT_METADATA_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -191,8 +188,6 @@ async function fetchClientMetadata(url: string): Promise<ClientMetadata | null> 
     return metadata;
   } catch {
     return null;
-  } finally {
-    clearTimeout(timeoutId);
   }
 }
 

--- a/src/server/plugins/github.ts
+++ b/src/server/plugins/github.ts
@@ -242,15 +242,12 @@ const RAW_FETCH_TIMEOUT_MS = 30000;
  * so the read is size-limited and time-limited to avoid OOM/hangs on large files.
  */
 async function fetchRawContent(rawUrl: string): Promise<string | null> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), RAW_FETCH_TIMEOUT_MS);
-
   try {
     const response = await fetch(rawUrl, {
       headers: {
         "User-Agent": USER_AGENT,
       },
-      signal: controller.signal,
+      signal: AbortSignal.timeout(RAW_FETCH_TIMEOUT_MS),
     });
 
     if (!response.ok) {
@@ -269,8 +266,6 @@ async function fetchRawContent(rawUrl: string): Promise<string | null> {
       error: error instanceof Error ? error.message : String(error),
     });
     return null;
-  } finally {
-    clearTimeout(timeoutId);
   }
 }
 

--- a/src/server/services/full-content.ts
+++ b/src/server/services/full-content.ts
@@ -383,7 +383,7 @@ function getErrorMessage(error: unknown): string {
   }
 
   if (error instanceof Error) {
-    if (error.name === "AbortError") {
+    if (error.name === "TimeoutError" || error.name === "AbortError") {
       return "Request timed out";
     }
     return error.message;

--- a/src/server/storage/s3.ts
+++ b/src/server/storage/s3.ts
@@ -288,8 +288,6 @@ export async function fetchAndUploadImage(
   }
 
   const timeout = options.timeout || 30000;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
 
   try {
     const headers: Record<string, string> = {
@@ -305,7 +303,7 @@ export async function fetchAndUploadImage(
     const response = await fetchWithSsrfProtection(imageUrl, {
       method: "GET",
       headers,
-      signal: controller.signal,
+      signal: AbortSignal.timeout(timeout),
     });
 
     if (!response.ok) {
@@ -333,7 +331,7 @@ export async function fetchAndUploadImage(
       prefix: options.prefix,
     });
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       logger.warn("Image fetch timed out", { url: imageUrl });
     } else if (error instanceof ContentTooLargeError) {
       logger.warn("Image too large, skipping", {
@@ -347,7 +345,5 @@ export async function fetchAndUploadImage(
       });
     }
     return null;
-  } finally {
-    clearTimeout(timeoutId);
   }
 }

--- a/src/server/trpc/routers/feeds.ts
+++ b/src/server/trpc/routers/feeds.ts
@@ -147,9 +147,6 @@ async function tryFetchAsFeed(
   url: string,
   timeoutMs: number = DISCOVERY_PATH_TIMEOUT_MS
 ): Promise<DiscoveredFeed | null> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
   try {
     const response = await fetchWithSsrfProtection(url, {
       headers: {
@@ -158,7 +155,7 @@ async function tryFetchAsFeed(
           "application/rss+xml, application/atom+xml, application/feed+json, application/json, application/xml, text/xml, */*",
         "Accept-Encoding": ACCEPT_ENCODING,
       },
-      signal: controller.signal,
+      signal: AbortSignal.timeout(timeoutMs),
       redirect: "follow",
     });
 
@@ -191,8 +188,6 @@ async function tryFetchAsFeed(
     }
   } catch {
     return null;
-  } finally {
-    clearTimeout(timeoutId);
   }
 }
 


### PR DESCRIPTION
Replaces the manual `AbortController` + `setTimeout` + `finally { clearTimeout }` timeout boilerplate at every server-side fetch site with the native `AbortSignal.timeout(ms)` (already used in `notifications/healthchecks.ts`; supported on our Node target). **13 files, −97 net lines, no behavior change on success paths.**

## What changed

Each site went from:

```ts
const controller = new AbortController();
const timeoutId = setTimeout(() => controller.abort(), MS);
try {
  const res = await fetch(url, { signal: controller.signal, ... });
  ...
} finally {
  clearTimeout(timeoutId);
}
```

to:

```ts
const res = await fetch(url, { signal: AbortSignal.timeout(MS), ... });
```

Sites: `http/fetch.ts` (fetchUrl, fetchHtmlPage), `feed/fetcher.ts` (redirect loop), `feed/lesswrong.ts` (×5), `feed/arxiv.ts`, `feed/websub.ts`, `google/docs.ts` (×2), `google/drive.ts` (×2), `plugins/github.ts`, `oauth/service.ts`, `email/unsubscribe.ts`, `trpc/routers/feeds.ts`, `storage/s3.ts`.

## The one behavioral subtlety (handled)

`AbortSignal.timeout()` rejects with a **`TimeoutError`**, not the generic **`AbortError`** a manually-aborted controller throws. So every catch block that special-cased `error.name === "AbortError"` to detect a timeout now matches `"TimeoutError" || "AbortError"`:

- Kept the `AbortError` arm so any *externally* propagated abort still counts, and so test doubles that abort a controller keep working.
- Includes `services/full-content.ts`'s `getErrorMessage`, which formats errors thrown by the now-`TimeoutError`-throwing `fetchHtmlPage`/`fetchUrl` — without this a full-content-fetch timeout would lose its friendly "Request timed out" message.

## Timeout semantics preserved

- **`redirect: "manual"`** callers (the feed fetcher's own redirect loop) still get a fresh per-hop timeout budget — the signal is created inside each fetch call, as the per-iteration controller was before.
- **`redirect: "follow"`** callers still share one timeout across the whole redirect chain — `fetchWithSsrfProtection` spreads the caller's `signal` into every hop, so one `AbortSignal.timeout` covers all hops exactly as one controller did.

## Verification

- `pnpm typecheck` ✅
- `pnpm test:unit` — 2209 passed ✅
- Integration suite ✅ — exercises the feed redirect loop, SSRF fetch, saved-article refetch (via `fetchHtmlPage`), and websub subscribe.

Second of a two-PR cleanup pass (companion: #1162).

🤖 Generated with [Claude Code](https://claude.com/claude-code)