### PR TITLE
Support saving private Google Docs via Wallabag/MCP compat APIs (#1165)

### DIFF
--- a/src/app/api/wallabag/api/entries/route.ts
+++ b/src/app/api/wallabag/api/entries/route.ts
@@ -118,6 +118,10 @@ export async function POST(request: Request): Promise<Response> {
     const article = await savedService.saveArticle(db, auth.userId, {
       url: articleUrl,
       title: body.title || undefined,
+      // Use the user's stored Google credentials for private Google Docs when
+      // already linked/granted (no interactive consent possible from an API
+      // client). Falls back to a clean 4xx pointing at the web app otherwise.
+      googleDocsAuth: "non-interactive",
     });
 
     // Handle archive/starred flags if provided

--- a/src/server/discord/bot.ts
+++ b/src/server/discord/bot.ts
@@ -484,7 +484,13 @@ async function handleSaveReaction(
 
   for (const url of urls) {
     try {
-      const saved = await saveArticle(db, resolved.userId, { url });
+      // Discord is a non-interactive surface like Wallabag/MCP: use the user's
+      // stored Google credentials for private Google Docs when already
+      // linked/granted (the failure just surfaces as the error reaction below).
+      const saved = await saveArticle(db, resolved.userId, {
+        url,
+        googleDocsAuth: "non-interactive",
+      });
       logger.info("Saved article via Discord", {
         userId: resolved.userId,
         discordUser: user.tag,

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -310,13 +310,18 @@ function buildTools(): Tool[] {
     {
       name: "save_article",
       description:
-        "Save a URL for later reading. Fetches the page, extracts clean content using Readability, and stores it. Returns the saved article if already saved.",
+        "Save a URL for later reading. Fetches the page, extracts clean content using Readability, and stores it. Returns the saved article if already saved. Private Google Docs are supported when the user has linked their Google account and granted Google Docs access in the web app; otherwise a clear error explains how to authorize.",
       inputSchema: toInputSchema(saveArticleArgs),
       handler: async (db, userId, args) => {
         const params = parseArgs(saveArticleArgs, args);
         return savedService.saveArticle(db, userId, {
           url: params.url,
           title: params.title,
+          // Use the user's stored Google credentials for private Google Docs
+          // when already linked/granted; otherwise throw a clear error telling
+          // them to authorize Google Docs access in the web app (an MCP client
+          // can't run the interactive consent flow).
+          googleDocsAuth: "non-interactive",
         });
       },
     },

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -65,14 +65,24 @@ export interface SaveArticleParams {
   /** With refetch, update even if the new content appears lower quality. */
   force?: boolean;
   /**
-   * Enable the interactive private-Google-Docs auth flow: when a Google Docs
-   * URL can't be fetched publicly, throw NEEDS_GOOGLE_SIGNIN /
-   * NEEDS_DOCS_PERMISSION / NEEDS_GOOGLE_REAUTH errors that the web UI turns
-   * into consent prompts (or fetch with the user's OAuth token when already
-   * granted). Leave off for non-interactive callers (MCP), which fall back to
-   * a plain HTML fetch.
+   * Enable the private-Google-Docs auth flow: when a Google Docs URL can't be
+   * fetched publicly, fetch it with the user's stored Google OAuth token
+   * (requires a linked Google account with the Docs/Drive scopes granted). Both
+   * modes attempt exactly the same token fetch; they differ only in how they
+   * report "auth isn't set up yet":
+   *
+   * - `"interactive"` (web UI): throw the machine-readable NEEDS_GOOGLE_SIGNIN /
+   *   NEEDS_DOCS_PERMISSION / NEEDS_GOOGLE_REAUTH errors the UI matches to drive
+   *   an in-page consent prompt.
+   * - `"non-interactive"` (Wallabag, MCP, and other API surfaces that can't run
+   *   an interactive consent dance): throw the same 4xx classification but with a
+   *   human-readable message pointing the user at the web app to complete the
+   *   one-time Google authorization.
+   *
+   * Leave undefined for callers that shouldn't attempt private docs at all; they
+   * fall back to a plain HTML fetch.
    */
-  googleDocsAuth?: boolean;
+  googleDocsAuth?: "interactive" | "non-interactive";
 }
 
 /** How a saveArticle call resolved. */
@@ -361,17 +371,40 @@ async function insertSavedEntry(
 // ============================================================================
 
 /**
- * Fetch a private Google Doc with the user's OAuth credentials (the
- * interactive `googleDocsAuth` flow).
+ * Human-readable messages for the `"non-interactive"` auth flow (Wallabag, MCP,
+ * and other API surfaces that can't run an in-page consent dance). The
+ * `"interactive"` flow instead throws the machine-readable NEEDS_* codes the web
+ * UI matches — both share the same 4xx classification, so Wallabag's
+ * `clientErrorResponse` and MCP surface either one cleanly.
+ */
+const NON_INTERACTIVE_GOOGLE_DOCS_MESSAGES = {
+  signin:
+    "This is a private Google Doc. To save private Google Docs from the API, first link your Google account and authorize Google Docs access in the Lion Reader web app (by saving a Google Doc there once).",
+  permission:
+    "This is a private Google Doc. To save it from the API, grant Google Docs access in the Lion Reader web app first (by saving a Google Doc there once).",
+  reauth:
+    "Your Google authorization has expired. Please reconnect your Google account in the Lion Reader web app, then try saving again.",
+} as const;
+
+/**
+ * Fetch a private Google Doc with the user's stored OAuth credentials.
  *
- * Throws NEEDS_GOOGLE_SIGNIN when no Google account is linked and
- * NEEDS_DOCS_PERMISSION when the required scopes haven't been granted — the
- * web UI turns these into consent prompts. Returns null (caller falls back to
- * a plain HTML fetch) when the doc can't be fetched for other reasons.
+ * When no Google account is linked or the required scopes aren't granted, throws
+ * a 4xx error. The `mode` only controls the *message*:
+ * - `"interactive"` throws the machine-readable NEEDS_GOOGLE_SIGNIN /
+ *   NEEDS_DOCS_PERMISSION / NEEDS_GOOGLE_REAUTH codes the web UI turns into
+ *   consent prompts.
+ * - `"non-interactive"` throws the same UNAUTHORIZED/FORBIDDEN classification
+ *   with a human-readable message telling API clients to complete the one-time
+ *   authorization in the web app.
+ *
+ * Returns null (caller falls back to a plain HTML fetch) when the doc can't be
+ * fetched for other reasons.
  */
 async function fetchPrivateGoogleDocWithAuth(
   userId: string,
-  normalizedUrl: string
+  normalizedUrl: string,
+  mode: "interactive" | "non-interactive"
 ): Promise<GoogleDocsContent | null> {
   const docId = extractDocId(normalizedUrl);
   if (!docId) {
@@ -384,10 +417,14 @@ async function fetchPrivateGoogleDocWithAuth(
     logger.debug("User needs to sign in with Google for private docs", {
       userId,
       url: normalizedUrl,
+      mode,
     });
     throw new TRPCError({
       code: "UNAUTHORIZED",
-      message: "NEEDS_GOOGLE_SIGNIN",
+      message:
+        mode === "interactive"
+          ? "NEEDS_GOOGLE_SIGNIN"
+          : NON_INTERACTIVE_GOOGLE_DOCS_MESSAGES.signin,
       cause: {
         code: "NEEDS_GOOGLE_SIGNIN",
         details: {
@@ -411,10 +448,14 @@ async function fetchPrivateGoogleDocWithAuth(
       url: normalizedUrl,
       hasDocsApiScope,
       hasDriveScope,
+      mode,
     });
     throw new TRPCError({
       code: "FORBIDDEN",
-      message: "NEEDS_DOCS_PERMISSION",
+      message:
+        mode === "interactive"
+          ? "NEEDS_DOCS_PERMISSION"
+          : NON_INTERACTIVE_GOOGLE_DOCS_MESSAGES.permission,
       cause: {
         code: "NEEDS_DOCS_PERMISSION",
         details: {
@@ -433,7 +474,10 @@ async function fetchPrivateGoogleDocWithAuth(
     if (error instanceof Error && error.message === "GOOGLE_TOKEN_INVALID") {
       throw new TRPCError({
         code: "UNAUTHORIZED",
-        message: "Google authentication expired. Please reconnect your Google account.",
+        message:
+          mode === "interactive"
+            ? "Google authentication expired. Please reconnect your Google account."
+            : NON_INTERACTIVE_GOOGLE_DOCS_MESSAGES.reauth,
       });
     } else if (error instanceof Error && error.message === "GOOGLE_PERMISSION_DENIED") {
       throw new TRPCError({
@@ -443,7 +487,10 @@ async function fetchPrivateGoogleDocWithAuth(
     } else if (error instanceof Error && error.message === "GOOGLE_NEEDS_REAUTH") {
       throw new TRPCError({
         code: "UNAUTHORIZED",
-        message: "NEEDS_GOOGLE_REAUTH",
+        message:
+          mode === "interactive"
+            ? "NEEDS_GOOGLE_REAUTH"
+            : NON_INTERACTIVE_GOOGLE_DOCS_MESSAGES.reauth,
         cause: {
           code: "NEEDS_GOOGLE_REAUTH",
           details: {
@@ -499,9 +546,9 @@ interface AcquiredArticleContent {
 
 /**
  * Acquire the article HTML for a save. Precedence: provided HTML > plugin
- * (incl. public Google Docs) > private Google Docs OAuth (interactive
- * callers) > plain HTML fetch. Enforces maxSavedArticleSizeBytes on every
- * path.
+ * (incl. public Google Docs) > private Google Docs OAuth (when the caller
+ * opts in via `googleDocsAuth`) > plain HTML fetch. Enforces
+ * maxSavedArticleSizeBytes on every path.
  */
 async function acquireArticleContent(
   userId: string,
@@ -587,11 +634,17 @@ async function acquireArticleContent(
     }
   }
 
-  // Private Google Docs: the plugin only fetches public docs. For
-  // interactive callers, try the user's OAuth credentials (throws NEEDS_*
-  // errors the web UI converts into consent prompts).
+  // Private Google Docs: the plugin only fetches public docs. When the caller
+  // opts in, try the user's stored OAuth credentials. This needs no
+  // interactivity once the account is linked and the scopes are granted, so
+  // the compat surfaces (Wallabag/MCP) use "non-interactive" mode — the only
+  // difference is the message thrown when auth isn't set up yet.
   if (params.googleDocsAuth && isGoogleDocsUrl(params.url)) {
-    const googleDocsContent = await fetchPrivateGoogleDocWithAuth(userId, normalizedUrl);
+    const googleDocsContent = await fetchPrivateGoogleDocWithAuth(
+      userId,
+      normalizedUrl,
+      params.googleDocsAuth
+    );
     if (googleDocsContent) {
       if (googleDocsContent.html.length > maxSize) {
         throw errors.contentTooLarge("Article", maxSize);
@@ -685,8 +738,9 @@ async function acquireArticleContent(
  * it in place (guarded by a content-quality comparison unless `force`).
  *
  * Uses the plugin system for special URL handling (LessWrong, ArXiv, public
- * Google Docs, etc.); private Google Docs are supported via the interactive
- * `googleDocsAuth` option.
+ * Google Docs, etc.); private Google Docs are supported via the
+ * `googleDocsAuth` option (interactive for the web UI, non-interactive for the
+ * Wallabag/MCP compat surfaces).
  */
 /**
  * Normalizes a URL exactly the way {@link saveArticle} does before storing it as

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -147,8 +147,9 @@ export const savedRouter = createTRPCRouter({
         title: input.title,
         refetch: input.refetch,
         force: input.force,
-        // The web UI can walk the user through Google sign-in / consent.
-        googleDocsAuth: true,
+        // The web UI can walk the user through Google sign-in / consent, so it
+        // wants the machine-readable NEEDS_* codes it matches to drive prompts.
+        googleDocsAuth: "interactive",
       });
 
       const counts =

--- a/tests/integration/saved-google-docs-auth.test.ts
+++ b/tests/integration/saved-google-docs-auth.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration tests for saving PRIVATE Google Docs via the compat surfaces
+ * (Wallabag / MCP), which use `googleDocsAuth: "non-interactive"`.
+ *
+ * The behavioral change (issue #1165): the non-interactive surfaces attempt the
+ * user's stored Google OAuth credentials for a private doc, and — when auth
+ * isn't set up — surface a clean, correctly-classified 4xx error with a
+ * human-readable message pointing at the web app, instead of the machine-readable
+ * NEEDS_* codes the web UI matches (interactive mode) or a generic fetch failure.
+ *
+ * These tests exercise the auth *gate*, which is reached without any network:
+ * the public Google Docs plugin fetch no-ops when no service account is
+ * configured (the test env), so `saveArticle` falls straight through to the
+ * private-docs OAuth path. The authorized-success path (a real private-doc
+ * fetch) needs a live Google token + network, so it isn't covered here.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { getHTTPStatusCodeFromError } from "@trpc/server/http";
+import { db } from "../../src/server/db";
+import { users, oauthAccounts } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { saveArticle } from "../../src/server/services/saved";
+
+// A syntactically-valid but non-public Google Docs URL. The plugin's public
+// fetch no-ops (no service account), so this always reaches the private path.
+const PRIVATE_DOC_URL = "https://docs.google.com/document/d/1PrIvAtEdOcIdAbCdEfGhIjKlMnOpQr/edit";
+
+const createdUserIds: string[] = [];
+
+async function createTestUser(): Promise<string> {
+  const userId = generateUuidv7();
+  await db.insert(users).values({
+    id: userId,
+    email: `gdocs-${userId}@test.com`,
+    passwordHash: "test-hash",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  createdUserIds.push(userId);
+  return userId;
+}
+
+async function linkGoogleAccount(userId: string, scopes: string[]): Promise<void> {
+  await db.insert(oauthAccounts).values({
+    id: generateUuidv7(),
+    userId,
+    provider: "google",
+    providerAccountId: `google-${userId}`,
+    accessToken: "test-access-token",
+    refreshToken: "test-refresh-token",
+    expiresAt: new Date(Date.now() + 3600_000),
+    scopes,
+  });
+}
+
+afterAll(async () => {
+  // oauth_accounts cascade-deletes with the user.
+  for (const userId of createdUserIds) {
+    await db.delete(users).where(eq(users.id, userId));
+  }
+});
+
+describe("Saving private Google Docs via compat surfaces (issue #1165)", () => {
+  it("returns a 401 with a web-app-pointing message when Google is not linked", async () => {
+    const userId = await createTestUser();
+
+    let thrown: unknown;
+    try {
+      await saveArticle(db, userId, {
+        url: PRIVATE_DOC_URL,
+        googleDocsAuth: "non-interactive",
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(TRPCError);
+    const error = thrown as TRPCError;
+    // Correctly classified as a client (4xx) error, not a 500.
+    expect(getHTTPStatusCodeFromError(error)).toBe(401);
+    // Human-readable, not the machine-readable code the web UI matches.
+    expect(error.message).not.toBe("NEEDS_GOOGLE_SIGNIN");
+    expect(error.message.toLowerCase()).toContain("web app");
+    expect(error.message.toLowerCase()).toContain("google");
+    // The underlying cause code is preserved for any programmatic consumer.
+    expect((error.cause as { code?: string })?.code).toBe("NEEDS_GOOGLE_SIGNIN");
+  });
+
+  it("returns a 403 with a web-app-pointing message when Docs scopes are missing", async () => {
+    const userId = await createTestUser();
+    // Linked, but only the base sign-in scopes — no Docs/Drive access.
+    await linkGoogleAccount(userId, ["openid", "email", "profile"]);
+
+    let thrown: unknown;
+    try {
+      await saveArticle(db, userId, {
+        url: PRIVATE_DOC_URL,
+        googleDocsAuth: "non-interactive",
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(TRPCError);
+    const error = thrown as TRPCError;
+    expect(getHTTPStatusCodeFromError(error)).toBe(403);
+    expect(error.message).not.toBe("NEEDS_DOCS_PERMISSION");
+    expect(error.message.toLowerCase()).toContain("web app");
+    expect((error.cause as { code?: string })?.code).toBe("NEEDS_DOCS_PERMISSION");
+  });
+
+  it("still throws the machine-readable NEEDS_* codes in interactive mode (web UI contract)", async () => {
+    const userId = await createTestUser();
+
+    // No Google account linked → interactive mode surfaces the code verbatim.
+    await expect(
+      saveArticle(db, userId, {
+        url: PRIVATE_DOC_URL,
+        googleDocsAuth: "interactive",
+      })
+    ).rejects.toMatchObject({ message: "NEEDS_GOOGLE_SIGNIN" });
+
+    // Missing scopes → NEEDS_DOCS_PERMISSION verbatim.
+    await linkGoogleAccount(userId, ["openid", "email", "profile"]);
+    await expect(
+      saveArticle(db, userId, {
+        url: PRIVATE_DOC_URL,
+        googleDocsAuth: "interactive",
+      })
+    ).rejects.toMatchObject({ message: "NEEDS_DOCS_PERMISSION" });
+  });
+});


### PR DESCRIPTION
Fixes #1165.

## Problem

Saving a **private** Google Doc only worked from the web UI. The non-interactive save surfaces — the Wallabag API (`POST /api/wallabag/api/entries`) and MCP `save_article` — never attempted the private-docs path even when the user had **already linked their Google account with the Docs/Drive scopes**, so those saves fell through to a plain HTML fetch that failed (and, before #1161, could 500).

`saveArticle`'s private-docs path (`fetchPrivateGoogleDocWithAuth`) already uses the user's **stored** OAuth token, so it needs no interactivity once the account is linked and the scopes are granted. The single `googleDocsAuth` boolean gate was the only thing blocking it.

## Change

Turn `SaveArticleParams.googleDocsAuth` from a boolean into a mode:

- **`"interactive"`** (web UI, via `saved.save`): throws the machine-readable `NEEDS_GOOGLE_SIGNIN` / `NEEDS_DOCS_PERMISSION` / `NEEDS_GOOGLE_REAUTH` codes the UI matches to drive in-page consent prompts — **unchanged behavior**.
- **`"non-interactive"`** (Wallabag + MCP): attempts the same stored-credential fetch, but when auth isn't set up throws the **same** `UNAUTHORIZED`/`FORBIDDEN` (4xx) classification with a **human-readable message** pointing the user at the web app to complete the one-time Google authorization.

Both modes attempt exactly the same token fetch; they differ only in the message thrown when auth isn't configured. Wallabag's existing `clientErrorResponse` already turns those 4xx TRPCErrors into clean 401/403 envelopes, so a user without auth now gets a correctly-classified 4xx instead of a generic fetch failure or a 500.

## Acceptance criteria

- [x] A user with Docs/Drive scopes can save a private Google Doc via Wallabag/MCP (no interactive step) — same stored-credential fetch the web UI uses, just decoupled from the interactive gate.
- [x] A user without that auth gets a clear, correctly-classified 4xx (401 not-linked / 403 missing-scopes) telling them to grant Google Docs access in the web app.
- [x] Public Google Docs continue to work unchanged on all surfaces (plugin path is untouched).
- [x] Tests cover the unauthorized-error paths for the save service (not-linked → 401, missing-scopes → 403) plus the interactive-mode web-UI contract.

## Tests

`tests/integration/saved-google-docs-auth.test.ts` — exercises the auth gate deterministically without network (the public-docs plugin fetch no-ops when no service account is configured, so `saveArticle` falls straight through to the private-docs path). The authorized-success path (a live private-doc fetch) needs a real Google token + network, so it isn't covered by an automated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)