### PR TITLE
Synthesize embed + description when saving YouTube videos

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -659,13 +659,13 @@ The registry indexes plugins by hostname for O(1) lookup, then calls the plugin'
 
 ### Available Plugins
 
-| Plugin          | Capabilities           | Description                                                                                                                         |
-| --------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| **LessWrong**   | `feed`, `savedArticle` | GraphQL API for posts/comments, user profile feeds                                                                                  |
-| **Google Docs** | `savedArticle`         | Fetch Google Docs content via API                                                                                                   |
-| **ArXiv**       | `savedArticle`         | Fetch ArXiv paper content                                                                                                           |
-| **GitHub**      | `savedArticle`         | Fetch GitHub content                                                                                                                |
-| **YouTube**     | `feed`                 | Polling floor (1h) to avoid per-IP rate limiting; synthesizes entry content (embedded player + description) from Media RSS metadata |
+| Plugin          | Capabilities           | Description                                                                                                                                                                                                                                                                                                                      |
+| --------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **LessWrong**   | `feed`, `savedArticle` | GraphQL API for posts/comments, user profile feeds                                                                                                                                                                                                                                                                               |
+| **Google Docs** | `savedArticle`         | Fetch Google Docs content via API                                                                                                                                                                                                                                                                                                |
+| **ArXiv**       | `savedArticle`         | Fetch ArXiv paper content                                                                                                                                                                                                                                                                                                        |
+| **GitHub**      | `savedArticle`         | Fetch GitHub content                                                                                                                                                                                                                                                                                                             |
+| **YouTube**     | `feed`, `savedArticle` | Feed: polling floor (1h) to avoid per-IP rate limiting; synthesizes entry content (embedded player + description) from Media RSS metadata. SavedArticle: saving a watch/`youtu.be`/shorts/live URL synthesizes the same embed-plus-description body from the watch page's metadata (Readability would fail on the JS watch page) |
 
 ---
 

--- a/src/server/plugins/youtube.ts
+++ b/src/server/plugins/youtube.ts
@@ -143,8 +143,11 @@ export function synthesizeYouTubeSavedArticle(
     html: iframe + description,
     title: metadata.title,
     author: metadata.author,
-    // Canonical watch URL so youtu.be / shorts / live / embed forms all resolve
-    // to the same saved article (guid = normalized URL).
+    // The canonical watch URL for this video, used as the base for resolving
+    // relative URLs in the content. Note this does NOT change the saved
+    // article's guid/url: saveArticle keys those off the caller's original URL
+    // (normalizeSavedUrl(params.url)), so saving the same video via youtu.be vs.
+    // watch?v=... still produces distinct saved articles.
     canonicalUrl: `https://www.youtube.com/watch?v=${videoId}`,
   };
 }

--- a/src/server/plugins/youtube.ts
+++ b/src/server/plugins/youtube.ts
@@ -1,6 +1,9 @@
-import type { UrlPlugin } from "./types";
+import type { UrlPlugin, SavedArticleContent } from "./types";
 import type { ParsedEntry } from "@/server/feed/types";
+import { Parser } from "htmlparser2";
 import { escapeHtml } from "@/server/http/html";
+import { fetchHtmlPage } from "@/server/http/fetch";
+import { logger } from "@/lib/logger";
 import {
   extractYouTubeVideoId,
   YOUTUBE_IFRAME_ALLOW,
@@ -34,6 +37,119 @@ export function youtubeDescriptionToHtml(description: string): string {
 }
 
 /**
+ * Builds the privacy-enhanced YouTube embed iframe for a video id. Shared by
+ * the feed capability (synthesizing content from Media RSS metadata) and the
+ * savedArticle capability (synthesizing content from a watch-page save).
+ *
+ * The sanitizer re-validates the src and re-forces sandbox/allow on the read
+ * path (see transformTags.iframe in sanitize.ts); setting them here just keeps
+ * the stored raw content self-contained.
+ */
+export function buildYouTubeEmbedIframe(videoId: string, title?: string | null): string {
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  return (
+    `<iframe src="https://www.youtube-nocookie.com/embed/${videoId}"` +
+    ` width="560" height="315"${titleAttr}` +
+    ` sandbox="${YOUTUBE_IFRAME_SANDBOX}" allow="${YOUTUBE_IFRAME_ALLOW}"` +
+    ` allowfullscreen loading="lazy"></iframe>`
+  );
+}
+
+/**
+ * Pulls a JSON string field's value out of a page's inline scripts by regex
+ * (e.g. `"shortDescription":"..."` / `"author":"..."` from YouTube's embedded
+ * `ytInitialPlayerResponse`). Matches a JSON string literal and JSON-parses it
+ * so escapes (`\n`, `\uXXXX`, `\"`) decode correctly. Best-effort: returns null
+ * if the field is absent or doesn't parse.
+ */
+function extractInlineJsonString(html: string, field: string): string | null {
+  const match = new RegExp(`"${field}":("(?:[^"\\\\]|\\\\.)*")`).exec(html);
+  if (!match) return null;
+  try {
+    const value = JSON.parse(match[1]);
+    return typeof value === "string" && value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+interface YouTubeVideoMetadata {
+  title: string | null;
+  author: string | null;
+  description: string | null;
+}
+
+/**
+ * Extracts video metadata from a fetched YouTube watch page. Title comes from
+ * the stable Open Graph tag; the description prefers the full
+ * `videoDetails.shortDescription` from the embedded player JSON and falls back
+ * to the (truncated) `og:description`; the author (channel name) prefers the
+ * player JSON and falls back to the `<link itemprop="name">` microdata. All
+ * fields are best-effort — a valid embed can still be built without them.
+ */
+function extractYouTubeVideoMetadata(html: string): YouTubeVideoMetadata {
+  let ogTitle: string | null = null;
+  let ogDescription: string | null = null;
+  let itempropName: string | null = null;
+
+  const parser = new Parser({
+    onopentag(name, attribs) {
+      const tag = name.toLowerCase();
+      if (tag === "meta") {
+        const property = attribs.property?.toLowerCase();
+        const content = attribs.content;
+        if (property === "og:title" && content && !ogTitle) {
+          ogTitle = content;
+        } else if (property === "og:description" && content && !ogDescription) {
+          ogDescription = content;
+        }
+      } else if (
+        tag === "link" &&
+        attribs.itemprop?.toLowerCase() === "name" &&
+        attribs.content &&
+        !itempropName
+      ) {
+        itempropName = attribs.content;
+      }
+    },
+  });
+  parser.write(html);
+  parser.end();
+
+  return {
+    title: ogTitle,
+    author: extractInlineJsonString(html, "author") ?? itempropName,
+    description: extractInlineJsonString(html, "shortDescription") ?? ogDescription,
+  };
+}
+
+/**
+ * Synthesizes the saved-article body for a YouTube video: the embed player plus
+ * the description, matching the feed path's `buildEntryContent`. Pure so the
+ * synthesis is unit-testable without network mocking — `fetchContent` just
+ * supplies the fetched watch-page HTML (or null when it couldn't be fetched, in
+ * which case a titleless embed is still produced).
+ */
+export function synthesizeYouTubeSavedArticle(
+  videoId: string,
+  watchPageHtml: string | null
+): SavedArticleContent {
+  const metadata = watchPageHtml
+    ? extractYouTubeVideoMetadata(watchPageHtml)
+    : { title: null, author: null, description: null };
+  const iframe = buildYouTubeEmbedIframe(videoId, metadata.title);
+  const description = metadata.description ? youtubeDescriptionToHtml(metadata.description) : "";
+  return {
+    html: iframe + description,
+    title: metadata.title,
+    author: metadata.author,
+    // Canonical watch URL so youtu.be / shorts / live / embed forms all resolve
+    // to the same saved article (guid = normalized URL).
+    canonicalUrl: `https://www.youtube.com/watch?v=${videoId}`,
+  };
+}
+
+/**
  * Wraps bare http(s) URLs in already-HTML-escaped text with <a> tags. Escaped
  * text contains no raw `<`/`"`, so a match is safe to place in an href
  * attribute as-is (entities like `&amp;` decode back to the original URL).
@@ -54,13 +170,20 @@ function linkifyEscapedText(escapedText: string): string {
 /**
  * YouTube plugin.
  *
- * Provides feed capability for YouTube's RSS feeds
- * (`/feeds/videos.xml?channel_id=...`, `?playlist_id=...`, `?user=...`):
- * a polling floor so we don't hammer YouTube's aggressively rate-limited feed
- * endpoint (see YOUTUBE_MIN_FETCH_INTERVAL_SECONDS), and entry-content
- * synthesis — the feed entries carry no HTML body, only Media RSS metadata,
- * so `buildEntryContent` builds one from the embedded player plus the
- * `media:description` (issue #1115).
+ * Provides two capabilities:
+ *
+ * - `feed` for YouTube's RSS feeds (`/feeds/videos.xml?channel_id=...`,
+ *   `?playlist_id=...`, `?user=...`): a polling floor so we don't hammer
+ *   YouTube's aggressively rate-limited feed endpoint (see
+ *   YOUTUBE_MIN_FETCH_INTERVAL_SECONDS), and entry-content synthesis — the feed
+ *   entries carry no HTML body, only Media RSS metadata, so `buildEntryContent`
+ *   builds one from the embedded player plus the `media:description` (#1115).
+ *
+ * - `savedArticle` for video-page URLs (watch / youtu.be / shorts / live /
+ *   embed): saving a YouTube video otherwise runs Readability over the watch
+ *   page, which fails (it's a JS app) and stores an unwatchable footer scrape.
+ *   Instead we synthesize the same embed-player-plus-description body from the
+ *   watch page's metadata, mirroring the feed path.
  *
  * Note: YouTube supports WebSub push for channel feeds via Google's hub
  * (https://developers.google.com/youtube/v3/guides/push_notifications), but
@@ -71,16 +194,24 @@ function linkifyEscapedText(escapedText: string): string {
  */
 export const youtubePlugin: UrlPlugin = {
   name: "youtube",
-  hosts: ["www.youtube.com", "youtube.com", "m.youtube.com"],
+  hosts: ["www.youtube.com", "youtube.com", "m.youtube.com", "youtu.be"],
 
   matchUrl(url: URL): boolean {
-    // Only feed URLs; watch/channel/etc. pages are handled generically.
-    return (
+    // Feed URLs (handled by the `feed` capability).
+    if (
       url.pathname === "/feeds/videos.xml" &&
       (url.searchParams.has("channel_id") ||
         url.searchParams.has("playlist_id") ||
         url.searchParams.has("user"))
-    );
+    ) {
+      return true;
+    }
+    // Video-page URLs (watch / youtu.be / shorts / live / embed), handled by
+    // the `savedArticle` capability. Channel/search/other pages return false so
+    // they're handled generically. `getFeedPlugin` may resolve the plugin for
+    // these, but the feed sub-capabilities it uses (transformToFeedUrl,
+    // cleanEntryContent) are undefined here, so it's a no-op there.
+    return extractYouTubeVideoId(url.href) !== null;
   },
 
   capabilities: {
@@ -99,20 +230,43 @@ export const youtubePlugin: UrlPlugin = {
             : null);
         if (!videoId) return null;
 
-        // The sanitizer re-validates the src and re-forces sandbox/allow on
-        // the read path (see transformTags.iframe in sanitize.ts); setting
-        // them here just keeps the stored raw content self-contained.
-        const title = entry.title ? ` title="${escapeHtml(entry.title)}"` : "";
-        const iframe =
-          `<iframe src="https://www.youtube-nocookie.com/embed/${videoId}"` +
-          ` width="560" height="315"${title}` +
-          ` sandbox="${YOUTUBE_IFRAME_SANDBOX}" allow="${YOUTUBE_IFRAME_ALLOW}"` +
-          ` allowfullscreen loading="lazy"></iframe>`;
-
+        const iframe = buildYouTubeEmbedIframe(videoId, entry.title);
         const description = entry.mediaDescription
           ? youtubeDescriptionToHtml(entry.mediaDescription)
           : "";
         return iframe + description;
+      },
+    },
+
+    savedArticle: {
+      // The synthesized body (embed iframe + description) is clean HTML we
+      // build ourselves — Readability would strip the iframe and fail on it.
+      skipReadability: true,
+      siteName: "YouTube",
+
+      async fetchContent(url: URL): Promise<SavedArticleContent | null> {
+        const videoId = extractYouTubeVideoId(url.href);
+        // Not a video-page URL (e.g. a channel page that slipped through) —
+        // fall back to normal fetching.
+        if (!videoId) return null;
+
+        // Fetch the watch page for metadata. Best-effort: a blocked/failed
+        // fetch still yields a working embed (just without a title/description),
+        // which beats falling back to the unwatchable generic scrape.
+        let watchPageHtml: string | null = null;
+        try {
+          const result = await fetchHtmlPage(`https://www.youtube.com/watch?v=${videoId}`);
+          if (result.content && !result.isMarkdown) {
+            watchPageHtml = result.content;
+          }
+        } catch (error) {
+          logger.warn("Failed to fetch YouTube watch page for saved-article metadata", {
+            videoId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+
+        return synthesizeYouTubeSavedArticle(videoId, watchPageHtml);
       },
     },
   },

--- a/tests/unit/youtube-plugin.test.ts
+++ b/tests/unit/youtube-plugin.test.ts
@@ -11,10 +11,16 @@ import { describe, it, expect } from "vitest";
 import {
   youtubePlugin,
   youtubeDescriptionToHtml,
+  synthesizeYouTubeSavedArticle,
   YOUTUBE_MIN_FETCH_INTERVAL_SECONDS,
 } from "@/server/plugins/youtube";
 import { getFeedPlugin } from "@/server/plugins";
-import { extractYouTubeVideoId, normalizeYouTubeEmbedUrl } from "@/server/html/youtube-embed";
+import {
+  extractYouTubeVideoId,
+  normalizeYouTubeEmbedUrl,
+  YOUTUBE_IFRAME_ALLOW,
+  YOUTUBE_IFRAME_SANDBOX,
+} from "@/server/html/youtube-embed";
 import type { ParsedEntry } from "@/server/feed/types";
 
 describe("youtubePlugin.matchUrl", () => {
@@ -34,10 +40,20 @@ describe("youtubePlugin.matchUrl", () => {
     ).toBe(true);
   });
 
-  it("does not match non-feed YouTube URLs", () => {
-    expect(youtubePlugin.matchUrl(new URL("https://www.youtube.com/watch?v=abc123"))).toBe(false);
+  it("matches video-page URLs (handled by the savedArticle capability)", () => {
+    expect(youtubePlugin.matchUrl(new URL("https://www.youtube.com/watch?v=dQw4w9WgXcQ"))).toBe(
+      true
+    );
+    expect(youtubePlugin.matchUrl(new URL("https://youtu.be/dQw4w9WgXcQ"))).toBe(true);
+    expect(youtubePlugin.matchUrl(new URL("https://www.youtube.com/shorts/dQw4w9WgXcQ"))).toBe(
+      true
+    );
+  });
+
+  it("does not match channel/other non-video pages or a bare feed URL", () => {
     expect(youtubePlugin.matchUrl(new URL("https://www.youtube.com/@somechannel"))).toBe(false);
     expect(youtubePlugin.matchUrl(new URL("https://www.youtube.com/feeds/videos.xml"))).toBe(false);
+    expect(youtubePlugin.matchUrl(new URL("https://www.youtube.com/watch?v=notanid!"))).toBe(false);
   });
 });
 
@@ -61,8 +77,19 @@ describe("getFeedPlugin resolution for YouTube", () => {
     );
   });
 
-  it("does not resolve non-feed YouTube URLs", () => {
-    expect(getFeedPlugin("https://www.youtube.com/watch?v=abc123")).toBeNull();
+  it("resolves video-page URLs but exposes no page→feed transform for them", () => {
+    // matchUrl now also matches video pages (for the savedArticle capability),
+    // so getFeedPlugin resolves the plugin — but the feed sub-capabilities used
+    // on page URLs (transformToFeedUrl, cleanEntryContent) are undefined, so
+    // treating a watch URL as a feed source is a no-op.
+    const plugin = getFeedPlugin("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+    expect(plugin?.name).toBe("youtube");
+    expect(plugin?.capabilities.feed.transformToFeedUrl).toBeUndefined();
+    expect(plugin?.capabilities.feed.cleanEntryContent).toBeUndefined();
+  });
+
+  it("does not resolve non-video YouTube pages", () => {
+    expect(getFeedPlugin("https://www.youtube.com/@somechannel")).toBeNull();
   });
 });
 
@@ -194,5 +221,89 @@ describe("youtubePlugin buildEntryContent", () => {
       "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     );
     expect(html).not.toContain("<script>");
+  });
+});
+
+describe("synthesizeYouTubeSavedArticle", () => {
+  // A minimal watch-page stand-in with the metadata the extractor reads: the
+  // Open Graph title/description, the microdata author, and the full
+  // player-JSON description (whose newlines survive JSON-parsing).
+  const watchPageHtml = (opts: {
+    title?: string;
+    author?: string;
+    ogDescription?: string;
+    shortDescription?: string;
+  }) => {
+    const parts: string[] = ["<html><head>"];
+    if (opts.title) parts.push(`<meta property="og:title" content="${opts.title}">`);
+    if (opts.ogDescription)
+      parts.push(`<meta property="og:description" content="${opts.ogDescription}">`);
+    parts.push('<span itemprop="author">');
+    if (opts.author) parts.push(`<link itemprop="name" content="${opts.author}">`);
+    parts.push("</span></head><body>");
+    if (opts.shortDescription !== undefined) {
+      parts.push(
+        `<script>var x = {"shortDescription":${JSON.stringify(opts.shortDescription)}};</script>`
+      );
+    }
+    parts.push("</body></html>");
+    return parts.join("");
+  };
+
+  it("synthesizes an embed plus title, author, and full description", () => {
+    const result = synthesizeYouTubeSavedArticle(
+      "dQw4w9WgXcQ",
+      watchPageHtml({
+        title: "Rick Astley - Never Gonna Give You Up",
+        author: "Rick Astley",
+        ogDescription: "Truncated…",
+        shortDescription: "The official video.\n\nSecond paragraph with https://example.com/link",
+      })
+    );
+
+    expect(result.html).toContain('src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"');
+    expect(result.html).toContain('title="Rick Astley - Never Gonna Give You Up"');
+    // Prefers the full shortDescription over the truncated og:description.
+    expect(result.html).toContain("<p>The official video.</p>");
+    expect(result.html).toContain('<a href="https://example.com/link">');
+    expect(result.html).not.toContain("Truncated");
+    expect(result.title).toBe("Rick Astley - Never Gonna Give You Up");
+    expect(result.author).toBe("Rick Astley");
+    expect(result.canonicalUrl).toBe("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+  });
+
+  it("falls back to og:description when no player JSON is present", () => {
+    const result = synthesizeYouTubeSavedArticle(
+      "dQw4w9WgXcQ",
+      watchPageHtml({ title: "Title", ogDescription: "A short description." })
+    );
+    expect(result.html).toContain("<p>A short description.</p>");
+  });
+
+  it("escapes an XSS attempt in the title attribute", () => {
+    const result = synthesizeYouTubeSavedArticle(
+      "dQw4w9WgXcQ",
+      watchPageHtml({ title: '"><script>alert(1)</script>' })
+    );
+    expect(result.html).not.toContain("<script>");
+  });
+
+  it("produces a working embed with no description when metadata is missing", () => {
+    const result = synthesizeYouTubeSavedArticle("dQw4w9WgXcQ", "<html></html>");
+    expect(result.html).toContain("/embed/dQw4w9WgXcQ");
+    expect(result.html).not.toContain("<p>");
+    expect(result.title).toBeNull();
+    expect(result.author).toBeNull();
+  });
+
+  it("produces a titleless embed when the watch page couldn't be fetched", () => {
+    const result = synthesizeYouTubeSavedArticle("dQw4w9WgXcQ", null);
+    expect(result.html).toBe(
+      '<iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"' +
+        ' width="560" height="315"' +
+        ` sandbox="${YOUTUBE_IFRAME_SANDBOX}" allow="${YOUTUBE_IFRAME_ALLOW}"` +
+        ' allowfullscreen loading="lazy"></iframe>'
+    );
+    expect(result.title).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

Saving a YouTube video (read-it-later) didn't work right. The YouTube plugin only declared the `feed` capability, and its `matchUrl` only matched `/feeds/videos.xml` URLs — so saving a `watch?v=…` URL fell through to the generic Readability path.

Readability **fails outright** on a YouTube watch page (it's a JS app, no article body), so the save stored `contentCleaned = null` and the reader fell back to the sanitized raw page HTML — which after sanitization is ~247 chars of boilerplate footer:

> *"… - YouTube About Press Copyright Contact us Creators Advertise Developers Terms Privacy Policy & Safety … © 2026 Google LLC"*

Result: a correctly-titled entry (from `og:title`) with a junk body and **no player**.

## Fix

Give the YouTube plugin a `savedArticle` capability that synthesizes the same embed-player-plus-description body the `feed` path already produces:

- Broaden `matchUrl` to also match video-page URLs (watch / `youtu.be` / shorts / live / embed) and add `youtu.be` to the plugin hosts. Feed URLs still match for the `feed` capability. `getFeedPlugin` may now resolve the plugin for a watch URL, but the feed sub-capabilities it uses there (`transformToFeedUrl`, `cleanEntryContent`) are undefined, so it's a no-op. This mirrors the LessWrong plugin (one `matchUrl`, both capabilities).
- Extract a shared `buildYouTubeEmbedIframe` helper (used by both capabilities) and a **pure** `synthesizeYouTubeSavedArticle(videoId, watchPageHtml)` that builds the embed + description from the watch page's metadata: `og:title`, full `videoDetails.shortDescription` (falling back to the truncated `og:description`), and channel author. `skipReadability` since the body is clean HTML we build ourselves.
- A blocked/failed watch-page fetch still yields a working (titleless) embed rather than the unwatchable generic scrape.

## Verification

- New unit tests cover the pure synthesis (no network mocking) and the broadened `matchUrl` / `getFeedPlugin` behavior.
- Verified end-to-end against a real YouTube watch page: correct title + author, the full 14-paragraph description extracted, and the embed iframe survives the read-path sanitizer normalized to `youtube-nocookie.com/embed/…`.
- `pnpm typecheck`, `pnpm test:unit` (2216 passed), `pnpm lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)