### PR TITLE
Drop the deprecated voiceUri → voiceId narration migration

### DIFF
--- a/src/lib/narration/settings.ts
+++ b/src/lib/narration/settings.ts
@@ -37,12 +37,6 @@ export interface NarrationSettings {
   voiceId: string | null;
 
   /**
-   * @deprecated Use voiceId instead. Kept for backwards compatibility.
-   * Will be migrated to voiceId on load.
-   */
-  voiceUri?: string | null;
-
-  /**
    * Playback rate multiplier (0.5 - 2.0, default 1.0).
    */
   rate: number;
@@ -129,17 +123,9 @@ export function loadNarrationSettings(): NarrationSettings {
       return DEFAULT_NARRATION_SETTINGS;
     }
 
-    const parsed = JSON.parse(stored) as Partial<NarrationSettings> & { voiceUri?: string | null };
+    const parsed = JSON.parse(stored) as Partial<NarrationSettings>;
 
-    // Handle migration from voiceUri to voiceId
-    // If voiceId is not present but voiceUri is, use voiceUri as voiceId
-    let voiceId: string | null = null;
-    if (typeof parsed.voiceId === "string") {
-      voiceId = parsed.voiceId;
-    } else if (typeof parsed.voiceUri === "string") {
-      // Migration: use old voiceUri as voiceId
-      voiceId = parsed.voiceUri;
-    }
+    const voiceId = typeof parsed.voiceId === "string" ? parsed.voiceId : null;
 
     // Validate provider value
     const validProviders = ["browser", "piper"] as const;
@@ -197,7 +183,7 @@ export function loadNarrationSettings(): NarrationSettings {
  * ```ts
  * saveNarrationSettings({
  *   enabled: true,
- *   voiceUri: "com.apple.voice.compact.en-US.Samantha",
+ *   voiceId: "com.apple.voice.compact.en-US.Samantha",
  *   rate: 1.25,
  *   pitch: 1.0,
  * });

--- a/tests/unit/narration-settings.test.ts
+++ b/tests/unit/narration-settings.test.ts
@@ -1,8 +1,7 @@
 /**
- * Unit tests for narration settings loading and migration.
+ * Unit tests for narration settings loading.
  *
- * Tests the pure logic of settings parsing and migration from
- * old formats (voiceUri) to new formats (voiceId, provider).
+ * Tests the pure logic of settings parsing, validation, and merging with defaults.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
@@ -107,41 +106,6 @@ describe("loadNarrationSettings", () => {
 
       const settings = loadNarrationSettings();
       expect(settings.pitch).toBe(0.8);
-    });
-  });
-
-  describe("migration from voiceUri to voiceId", () => {
-    it("migrates voiceUri to voiceId when voiceId is not present", () => {
-      localStorageMock.setItem(
-        "lion-reader-narration-settings",
-        JSON.stringify({ voiceUri: "old-voice-uri" })
-      );
-
-      const settings = loadNarrationSettings();
-      expect(settings.voiceId).toBe("old-voice-uri");
-    });
-
-    it("prefers voiceId over voiceUri when both are present", () => {
-      localStorageMock.setItem(
-        "lion-reader-narration-settings",
-        JSON.stringify({
-          voiceUri: "old-voice-uri",
-          voiceId: "new-voice-id",
-        })
-      );
-
-      const settings = loadNarrationSettings();
-      expect(settings.voiceId).toBe("new-voice-id");
-    });
-
-    it("handles null voiceUri gracefully", () => {
-      localStorageMock.setItem(
-        "lion-reader-narration-settings",
-        JSON.stringify({ voiceUri: null })
-      );
-
-      const settings = loadNarrationSettings();
-      expect(settings.voiceId).toBeNull();
     });
   });
 


### PR DESCRIPTION
Removes the last remaining `voiceUri` backwards-compat code in narration settings.

## Background

The narration voice field was renamed `voiceUri` → `voiceId` when the TTS provider abstraction landed (~6 months ago, Jan 2026). Since then:

- `loadNarrationSettings` returns a settings object with **no** `voiceUri` key.
- `saveNarrationSettings` writes that object straight back.

So the migration is **self-healing on first save**: any user who has changed a narration setting since the rename has already had the old `voiceUri` key dropped from their localStorage and `voiceId` written. Until then it re-migrates in memory on every load.

## Change

- Remove the `@deprecated voiceUri?` field from `NarrationSettings`.
- Remove the load-time `voiceUri` → `voiceId` fallback (the load logic is now a plain `voiceId` read).
- Remove the three migration unit tests and fix a stale docstring example.

Net −49 lines.

## Risk

The only cohort affected: users who picked a voice under the old `voiceUri` name **and have never re-saved** narration settings in the 6 months since the rename. On next load their voice falls back to the provider default — fully recoverable by re-picking a voice. No server data, no other surface (grep confirms `voiceUri` appears nowhere else in the repo).

## Verification

- `pnpm typecheck` ✅
- `pnpm test:unit` — 2206 passed ✅ (3 removed migration tests)

Follow-up to the cleanup pass (#1162, #1163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)