### PR TITLE
Render UI chrome in loaded Geist font instead of Arial fallback (#1170)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -290,7 +290,11 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  /* Use the loaded UI typeface (Geist, wired to --font-sans in @theme above)
+     rather than falling back to Arial. Article reading fonts are applied as an
+     inline style on the prose element (see AppearanceProvider), so they still
+     win here; only UI chrome is affected. */
+  font-family: var(--font-sans), system-ui, sans-serif;
 }
 
 /* =================================


### PR DESCRIPTION
## Problem

`src/app/globals.css` hardcoded `font-family: Arial, Helvetica, sans-serif` on `body`. The app bundles Geist via `next/font/google` and maps `--font-sans: var(--font-geist-sans)` in `@theme inline`, but any UI element without an explicit `font-sans` utility fell back to Arial — so UI chrome silently rendered in a font we don't load.

Fixes #1170.

## Fix

Point the base `body` font at `var(--font-sans)` (Geist, already the `@theme` mapping) so the base UI font and the theme mapping agree:

```css
body {
  font-family: var(--font-sans), system-ui, sans-serif;
}
```

## Article fonts unaffected

`EntryContentRenderer` applies the selected article font as an **inline style** (`var(--entry-font-family, inherit)`) on the prose element, which wins over the body font. The `"system"` article-font option (which resolves to `inherit`) now correctly picks up Geist as the app default instead of Arial.

## Verification (in-browser, computed styles)

Ran a dev server against local services and checked `getComputedStyle` on `/demo`:

- `body` / UI chrome → `Geist, "Geist Fallback", system-ui, sans-serif` ✅
- Article prose in default (system) mode → inherits Geist ✅
- After simulating a Merriweather selection → prose computes to `Merriweather, "Merriweather Fallback", Georgia, serif` while body stays Geist ✅ (explicit article fonts still win and remain switchable)

`pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)