### PR TITLE
Tokenize status-color layer (danger/success/warning/star) and codemod raw utilities (#1169)

### DIFF
--- a/src/app/(auth)/auth/oauth/callback/page.tsx
+++ b/src/app/(auth)/auth/oauth/callback/page.tsx
@@ -299,7 +299,7 @@ function OAuthCallbackContent() {
 
       {errorMessage ? (
         <div className="text-center">
-          <p className="ui-text-sm mb-4 text-red-600 dark:text-red-400">{errorMessage}</p>
+          <p className="ui-text-sm text-danger mb-4">{errorMessage}</p>
           <p className="ui-text-sm text-muted">
             Redirecting to {isSaveMode ? "save" : isLinkMode ? "settings" : "login"} page...
           </p>

--- a/src/app/complete-signup/page.tsx
+++ b/src/app/complete-signup/page.tsx
@@ -144,8 +144,8 @@ export default function CompleteSignupPage() {
             Delete my account instead
           </button>
         ) : (
-          <div className="rounded-md border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950">
-            <p className="ui-text-sm mb-3 text-red-800 dark:text-red-200">
+          <div className="border-danger-border bg-danger-subtle rounded-md border p-4">
+            <p className="ui-text-sm text-danger-subtle-foreground mb-3">
               This will permanently delete your account and all associated data. Type{" "}
               <span className="font-semibold">delete</span> to confirm.
             </p>
@@ -176,7 +176,7 @@ export default function CompleteSignupPage() {
                 onClick={handleDelete}
                 loading={deleteMutation.isPending}
                 disabled={!isDeleteConfirmed || deleteMutation.isPending}
-                className="bg-red-600 text-white hover:bg-red-700 dark:bg-red-600 dark:text-white dark:hover:bg-red-700"
+                className="bg-danger-solid text-danger-solid-foreground hover:bg-danger-solid-hover"
               >
                 Delete account
               </Button>

--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -254,7 +254,7 @@ function DemoRouterContent() {
                 onClick={() => demoState.toggleStar(selectedEntry.id)}
                 className={
                   selectedEntry.starred
-                    ? "bg-amber-500 text-white hover:bg-amber-600 dark:bg-amber-500 dark:text-white dark:hover:bg-amber-600"
+                    ? "bg-warning-solid text-warning-solid-foreground hover:bg-warning-solid-hover"
                     : ""
                 }
                 aria-label={selectedEntry.starred ? "Remove from starred" : "Add to starred"}

--- a/src/app/extension/callback/page.tsx
+++ b/src/app/extension/callback/page.tsx
@@ -31,7 +31,7 @@ export default async function ExtensionCallbackPage({ searchParams }: PageProps)
       <div className="max-w-md p-8 text-center">
         {isSuccess ? (
           <>
-            <div className="mb-4 text-5xl text-green-500">✓</div>
+            <div className="text-success mb-4 text-5xl">✓</div>
             <h1 className="ui-text-xl text-strong mb-2 font-semibold">Article Saved!</h1>
             {title && <p className="text-muted mb-4">{title}</p>}
             <p className="ui-text-sm text-zinc-400 dark:text-zinc-600">
@@ -42,7 +42,7 @@ export default async function ExtensionCallbackPage({ searchParams }: PageProps)
           </>
         ) : (
           <>
-            <div className="mb-4 text-5xl text-red-500">!</div>
+            <div className="text-danger mb-4 text-5xl">!</div>
             <h1 className="ui-text-xl text-strong mb-2 font-semibold">Something Went Wrong</h1>
             <p className="text-muted mb-4">{error || "Failed to complete the save operation."}</p>
             <p className="ui-text-sm text-zinc-400 dark:text-zinc-600">

--- a/src/app/extension/save/client.tsx
+++ b/src/app/extension/save/client.tsx
@@ -28,7 +28,7 @@ export function ExtensionSaveClient({ status, error, url, canRetry }: Props) {
     return (
       <div className="bg-canvas flex min-h-screen items-center justify-center">
         <div className="max-w-md p-8 text-center">
-          <div className="mb-4 text-5xl text-red-500">!</div>
+          <div className="text-danger mb-4 text-5xl">!</div>
           <h1 className="ui-text-xl text-strong mb-2 font-semibold">Failed to Save</h1>
           <p className="text-muted mb-4">
             {error || "An error occurred while saving the article."}
@@ -54,7 +54,7 @@ export function ExtensionSaveClient({ status, error, url, canRetry }: Props) {
   return (
     <div className="bg-canvas flex min-h-screen items-center justify-center">
       <div className="p-8 text-center">
-        <div className="mb-4 text-5xl text-green-500">✓</div>
+        <div className="text-success mb-4 text-5xl">✓</div>
         <p className="text-muted">Article saved!</p>
       </div>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,6 +45,51 @@
   --info-border: #bfdbfe; /* blue-200 */
 
   /* =================================
+     Status Colors (danger / success / warning / star)
+
+     One token trio per status role, mirroring --info, so every
+     error/success/warning/star is a token instead of a hand-rolled raw
+     Tailwind pair. Each role has: base on-surface text/icon (AA on --surface),
+     a text -hover, a -subtle background + -subtle-foreground text (AA on the
+     subtle fill), a -border, and a -solid fill (buttons/dots/banners) with its
+     -solid-foreground and -solid-hover. Retheme every consumer by editing here.
+     ================================= */
+
+  /* Danger / error (red) */
+  --danger: #dc2626; /* red-600 - AA on white (4.8:1) */
+  --danger-hover: #b91c1c; /* red-700 */
+  --danger-subtle: #fef2f2; /* red-50 */
+  --danger-subtle-foreground: #991b1b; /* red-800 */
+  --danger-border: #fecaca; /* red-200 */
+  --danger-solid: #dc2626; /* red-600 */
+  --danger-solid-foreground: #ffffff;
+  --danger-solid-hover: #b91c1c; /* red-700 */
+
+  /* Success (green) */
+  --success: #15803d; /* green-700 - AA on white (5.0:1); green-600 fails AA */
+  --success-hover: #166534; /* green-800 */
+  --success-subtle: #f0fdf4; /* green-50 */
+  --success-subtle-foreground: #166534; /* green-800 */
+  --success-border: #bbf7d0; /* green-200 */
+  --success-solid: #16a34a; /* green-600 */
+  --success-solid-foreground: #ffffff;
+  --success-solid-hover: #15803d; /* green-700 */
+
+  /* Warning (amber - the single warning hue; replaces the amber/yellow drift) */
+  --warning: #b45309; /* amber-700 - AA on white (5.0:1); amber-600 fails AA */
+  --warning-hover: #92400e; /* amber-800 */
+  --warning-subtle: #fffbeb; /* amber-50 */
+  --warning-subtle-foreground: #92400e; /* amber-800 */
+  --warning-border: #fde68a; /* amber-200 */
+  --warning-solid: #f59e0b; /* amber-500 */
+  --warning-solid-foreground: #ffffff;
+  --warning-solid-hover: #d97706; /* amber-600 */
+
+  /* Star (formalized amber star) */
+  --star: #f59e0b; /* amber-500 */
+  --star-hover: #d97706; /* amber-600 */
+
+  /* =================================
      Neutral Semantic Colors
 
      One utility class per role (e.g. `text-muted`) instead of a light/dark
@@ -106,6 +151,32 @@
   --color-info-subtle-foreground: var(--info-subtle-foreground);
   --color-info-foreground: var(--info-foreground);
   --color-info-border: var(--info-border);
+  --color-danger: var(--danger);
+  --color-danger-hover: var(--danger-hover);
+  --color-danger-subtle: var(--danger-subtle);
+  --color-danger-subtle-foreground: var(--danger-subtle-foreground);
+  --color-danger-border: var(--danger-border);
+  --color-danger-solid: var(--danger-solid);
+  --color-danger-solid-foreground: var(--danger-solid-foreground);
+  --color-danger-solid-hover: var(--danger-solid-hover);
+  --color-success: var(--success);
+  --color-success-hover: var(--success-hover);
+  --color-success-subtle: var(--success-subtle);
+  --color-success-subtle-foreground: var(--success-subtle-foreground);
+  --color-success-border: var(--success-border);
+  --color-success-solid: var(--success-solid);
+  --color-success-solid-foreground: var(--success-solid-foreground);
+  --color-success-solid-hover: var(--success-solid-hover);
+  --color-warning: var(--warning);
+  --color-warning-hover: var(--warning-hover);
+  --color-warning-subtle: var(--warning-subtle);
+  --color-warning-subtle-foreground: var(--warning-subtle-foreground);
+  --color-warning-border: var(--warning-border);
+  --color-warning-solid: var(--warning-solid);
+  --color-warning-solid-foreground: var(--warning-solid-foreground);
+  --color-warning-solid-hover: var(--warning-solid-hover);
+  --color-star: var(--star);
+  --color-star-hover: var(--star-hover);
   --color-strong: var(--text-strong);
   --color-emphasis: var(--text-emphasis);
   --color-body: var(--text-body);
@@ -149,6 +220,39 @@
   --info-subtle-foreground: #e4e4e7; /* zinc-200 */
   --info-foreground: #d4d4d8; /* zinc-300 */
   --info-border: #3f3f46; /* zinc-700 */
+
+  /* Dark mode: status colors keep their conventional hues (a red error is still
+     red) — the low-blue-light rule governs dominant surfaces and the accent,
+     not semantic status. */
+  --danger: #f87171; /* red-400 */
+  --danger-hover: #fca5a5; /* red-300 */
+  --danger-subtle: rgba(127, 29, 29, 0.2); /* red-900/20 */
+  --danger-subtle-foreground: #fecaca; /* red-200 */
+  --danger-border: #991b1b; /* red-800 */
+  --danger-solid: #dc2626; /* red-600 */
+  --danger-solid-foreground: #ffffff;
+  --danger-solid-hover: #b91c1c; /* red-700 */
+
+  --success: #4ade80; /* green-400 */
+  --success-hover: #86efac; /* green-300 */
+  --success-subtle: rgba(20, 83, 45, 0.2); /* green-900/20 */
+  --success-subtle-foreground: #bbf7d0; /* green-200 */
+  --success-border: #166534; /* green-800 */
+  --success-solid: #16a34a; /* green-600 */
+  --success-solid-foreground: #ffffff;
+  --success-solid-hover: #15803d; /* green-700 */
+
+  --warning: #fbbf24; /* amber-400 */
+  --warning-hover: #fcd34d; /* amber-300 */
+  --warning-subtle: rgba(120, 53, 15, 0.2); /* amber-900/20 */
+  --warning-subtle-foreground: #fde68a; /* amber-200 */
+  --warning-border: #92400e; /* amber-800 */
+  --warning-solid: #f59e0b; /* amber-500 */
+  --warning-solid-foreground: #ffffff;
+  --warning-solid-hover: #d97706; /* amber-600 */
+
+  --star: #fbbf24; /* amber-400 */
+  --star-hover: #fcd34d; /* amber-300 */
 
   /* Dark mode: neutral semantic colors */
   --text-strong: #fafafa; /* zinc-50 */
@@ -207,6 +311,39 @@
   --info-subtle-foreground: #1e3a8a; /* blue-900 */
   --info-foreground: #1e3a8a; /* blue-900 */
   --info-border: #60a5fa; /* blue-400 */
+
+  /* Status colors: base/solid tones sit dark so they gray to clearly-darker-than-
+     mid-gray on e-ink; subtle fills are one step darker (100, not 50) to survive
+     dithering; borders use the 400 step to stay visible. Never hue alone. */
+  --danger: #991b1b; /* red-800 */
+  --danger-hover: #7f1d1d; /* red-900 */
+  --danger-subtle: #fee2e2; /* red-100 */
+  --danger-subtle-foreground: #7f1d1d; /* red-900 */
+  --danger-border: #f87171; /* red-400 */
+  --danger-solid: #b91c1c; /* red-700 */
+  --danger-solid-foreground: #ffffff;
+  --danger-solid-hover: #991b1b; /* red-800 */
+
+  --success: #166534; /* green-800 */
+  --success-hover: #14532d; /* green-900 */
+  --success-subtle: #dcfce7; /* green-100 */
+  --success-subtle-foreground: #14532d; /* green-900 */
+  --success-border: #4ade80; /* green-400 */
+  --success-solid: #15803d; /* green-700 */
+  --success-solid-foreground: #ffffff;
+  --success-solid-hover: #166534; /* green-800 */
+
+  --warning: #92400e; /* amber-800 */
+  --warning-hover: #78350f; /* amber-900 */
+  --warning-subtle: #fef3c7; /* amber-100 */
+  --warning-subtle-foreground: #78350f; /* amber-900 */
+  --warning-border: #fbbf24; /* amber-400 */
+  --warning-solid: #b45309; /* amber-700 - darker so it grays dark and white text stays readable */
+  --warning-solid-foreground: #ffffff;
+  --warning-solid-hover: #92400e; /* amber-800 */
+
+  --star: #b45309; /* amber-700 - a filled star grays to a dark-mid tone, distinct from an unstarred outline */
+  --star-hover: #92400e; /* amber-800 */
 
   /* Text tones shifted darker than light mode: e-ink can't render faint grays */
   --text-strong: #000000;
@@ -267,6 +404,37 @@
     --info-subtle-foreground: #e4e4e7; /* zinc-200 */
     --info-foreground: #d4d4d8; /* zinc-300 */
     --info-border: #3f3f46; /* zinc-700 */
+
+    /* Dark mode: status colors keep their conventional hues (see .dark above) */
+    --danger: #f87171; /* red-400 */
+    --danger-hover: #fca5a5; /* red-300 */
+    --danger-subtle: rgba(127, 29, 29, 0.2); /* red-900/20 */
+    --danger-subtle-foreground: #fecaca; /* red-200 */
+    --danger-border: #991b1b; /* red-800 */
+    --danger-solid: #dc2626; /* red-600 */
+    --danger-solid-foreground: #ffffff;
+    --danger-solid-hover: #b91c1c; /* red-700 */
+
+    --success: #4ade80; /* green-400 */
+    --success-hover: #86efac; /* green-300 */
+    --success-subtle: rgba(20, 83, 45, 0.2); /* green-900/20 */
+    --success-subtle-foreground: #bbf7d0; /* green-200 */
+    --success-border: #166534; /* green-800 */
+    --success-solid: #16a34a; /* green-600 */
+    --success-solid-foreground: #ffffff;
+    --success-solid-hover: #15803d; /* green-700 */
+
+    --warning: #fbbf24; /* amber-400 */
+    --warning-hover: #fcd34d; /* amber-300 */
+    --warning-subtle: rgba(120, 53, 15, 0.2); /* amber-900/20 */
+    --warning-subtle-foreground: #fde68a; /* amber-200 */
+    --warning-border: #92400e; /* amber-800 */
+    --warning-solid: #f59e0b; /* amber-500 */
+    --warning-solid-foreground: #ffffff;
+    --warning-solid-hover: #d97706; /* amber-600 */
+
+    --star: #fbbf24; /* amber-400 */
+    --star-hover: #fcd34d; /* amber-300 */
 
     /* Dark mode: neutral semantic colors */
     --text-strong: #fafafa; /* zinc-50 */

--- a/src/app/oauth/consent/ConsentForm.tsx
+++ b/src/app/oauth/consent/ConsentForm.tsx
@@ -56,7 +56,7 @@ export function ConsentForm({
         <ul className="space-y-2">
           {scopes.map((scope) => (
             <li key={scope.name} className="flex items-start gap-2">
-              <CheckIcon className="mt-0.5 h-4 w-4 shrink-0 text-green-600 dark:text-green-400" />
+              <CheckIcon className="text-success mt-0.5 h-4 w-4 shrink-0" />
               <span className="ui-text-sm text-body">{scope.description}</span>
             </li>
           ))}
@@ -64,9 +64,9 @@ export function ConsentForm({
       </div>
 
       {/* Warning */}
-      <div className="mb-6 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-900/50 dark:bg-amber-900/20">
-        <WarningTriangleIcon className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
-        <p className="ui-text-sm text-amber-800 dark:text-amber-200">
+      <div className="border-warning-border bg-warning-subtle mb-6 flex items-start gap-2 rounded-lg border p-3">
+        <WarningTriangleIcon className="text-warning mt-0.5 h-4 w-4 shrink-0" />
+        <p className="ui-text-sm text-warning-subtle-foreground">
           Only authorize applications you trust. You can revoke access at any time in Settings.
         </p>
       </div>

--- a/src/app/oauth/consent/page.tsx
+++ b/src/app/oauth/consent/page.tsx
@@ -135,8 +135,8 @@ function ConsentLayout({ children }: { children: React.ReactNode }) {
 function ErrorMessage({ title, message }: { title: string; message: string }) {
   return (
     <div className="text-center">
-      <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/20">
-        <WarningTriangleIcon className="h-6 w-6 text-red-600 dark:text-red-400" />
+      <div className="bg-danger-subtle mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+        <WarningTriangleIcon className="text-danger h-6 w-6" />
       </div>
       <h2 className="ui-text-lg text-strong font-semibold">{title}</h2>
       <p className="ui-text-sm text-muted mt-2">{message}</p>

--- a/src/app/save/page.tsx
+++ b/src/app/save/page.tsx
@@ -268,11 +268,9 @@ function SaveContent() {
           {activeMutation.isSuccess && (
             <div className="mt-6">
               <div className="flex justify-center">
-                <CheckIcon className="h-8 w-8 text-green-600 dark:text-green-500" />
+                <CheckIcon className="text-success h-8 w-8" />
               </div>
-              <p className="ui-text-sm mt-3 font-medium text-green-700 dark:text-green-400">
-                Saved successfully!
-              </p>
+              <p className="ui-text-sm text-success mt-3 font-medium">Saved successfully!</p>
               {articleTitle && (
                 <p className="ui-text-sm text-muted mt-2 line-clamp-2">{articleTitle}</p>
               )}
@@ -290,7 +288,7 @@ function SaveContent() {
               {isAuthError ? (
                 <>
                   <div className="flex justify-center">
-                    <LockIcon className="h-8 w-8 text-amber-600 dark:text-amber-500" />
+                    <LockIcon className="text-warning h-8 w-8" />
                   </div>
                   <Alert variant="warning" className="mt-4 text-left">
                     Your session has expired. Please sign in again to save this article.
@@ -349,7 +347,7 @@ function SaveContent() {
                 <>
                   {/* General Error */}
                   <div className="flex justify-center">
-                    <CloseIcon className="h-8 w-8 text-red-600 dark:text-red-500" />
+                    <CloseIcon className="text-danger h-8 w-8" />
                   </div>
                   <Alert variant="error" className="mt-4 text-left">
                     {activeMutation.error?.message ||

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -77,6 +77,25 @@ The `ui-text-*` classes are defined in `src/app/globals.css` and provide respons
 | `ring-focus`         | `ring-zinc-900 dark:ring-zinc-400`     | Focus rings (as `focus:ring-focus`); also `focus:border-focus`                  |
 | `control-selected`   | `zinc-900 dark:zinc-400`               | Selected/"on" outline: checkbox/radio/selected-card `border`/`ring`, radio dots |
 
+#### Status colors (danger / success / warning / info / star)
+
+**Never hand-roll a raw `red/green/amber/yellow` pair for a status.** Each status role is tokenized the same way as the neutrals — one utility class per role, covering light, dark, and e-paper — themed in `globals.css` and exposed via `@theme inline`. Dark mode keeps status hues conventional (a red error stays red); e-paper darkens each so it survives grayscale. The base on-surface text and `-subtle-foreground` tokens meet WCAG AA on their backgrounds in all three themes (this is why success text is `green-700`, not the AA-failing `green-600`).
+
+| Token role                      | Danger (red)                    | Success (green)                   | Warning (amber)                   | Use for                                                   |
+| ------------------------------- | ------------------------------- | --------------------------------- | --------------------------------- | --------------------------------------------------------- |
+| `text-{role}`                   | `text-danger`                   | `text-success`                    | `text-warning`                    | Status text/icon on a normal surface (AA)                 |
+| `text-{role}-hover`             | `text-danger-hover`             | `text-success-hover`              | `text-warning-hover`              | `hover:`/link hover for status text                       |
+| `bg-{role}-subtle`              | `bg-danger-subtle`              | `bg-success-subtle`               | `bg-warning-subtle`               | Subtle status card/alert/badge fill (also `hover:` fills) |
+| `text-{role}-subtle-foreground` | `text-danger-subtle-foreground` | `text-success-subtle-foreground`  | `text-warning-subtle-foreground`  | Text on a `-subtle` fill (AA)                             |
+| `border-{role}-border`          | `border-danger-border`          | `border-success-border`           | `border-warning-border`           | Border of a subtle status card/alert                      |
+| `bg-{role}-solid` (+ `-hover`)  | `bg-danger-solid`               | `bg-success-solid`                | `bg-warning-solid`                | Solid status button/dot/banner; hover via `-solid-hover`  |
+| `text-{role}-solid-foreground`  | `text-danger-solid-foreground`  | `text-success-solid-foreground`   | `text-warning-solid-foreground`   | Text/icon on a `-solid` fill                              |
+| `border-{role}` / `ring-{role}` | `border-danger` / `ring-danger` | `border-success` / `ring-success` | `border-warning` / `ring-warning` | Input-error border + focus ring                           |
+
+- **`info`** is the pre-existing blue trio (`text-info-foreground`, `bg-info-subtle`, `border-info-border`, `text-info-subtle-foreground`, …) — unchanged.
+- **`star`**: `text-star` (+ `hover:text-star-hover`, `bg-star`) is the formalized amber favorite/star color. Use it only for the star/favorite icon; amber used for alerts/offline/"unsaved changes" is `warning`, not `star`.
+- `StatusCard`, `Alert`, and the `Input` error state are already token-driven — reuse them instead of rebuilding a colored box.
+
 Tokens work under variants (`hover:bg-surface-muted`, `focus:ring-focus`), so interactive states use them too. Notes:
 
 - **Filled** "on"/selected controls (a solid pill/toggle, not an outline) use `bg-primary-solid text-primary-solid-foreground` — the same token as primary buttons. `control-selected` is only the neutral **outline/indicator** color; it shares `ring-focus`'s value today but is a separate token so the two roles can diverge.

--- a/src/components/admin/AdminFeedsContent.tsx
+++ b/src/components/admin/AdminFeedsContent.tsx
@@ -81,13 +81,13 @@ function getFeedDisplayTitle(feed: FeedItem): string {
 function FeedStatusBadge({ feed }: { feed: FeedItem }) {
   if (feed.consecutiveFailures > 0) {
     return (
-      <span className="ui-text-xs inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 font-medium text-red-700 dark:bg-red-900/30 dark:text-red-300">
+      <span className="ui-text-xs bg-danger-subtle text-danger inline-flex items-center rounded-full px-2 py-0.5 font-medium">
         {feed.consecutiveFailures} failure{feed.consecutiveFailures === 1 ? "" : "s"}
       </span>
     );
   }
   return (
-    <span className="ui-text-xs inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 font-medium text-green-700 dark:bg-green-900/30 dark:text-green-300">
+    <span className="ui-text-xs bg-success-subtle text-success inline-flex items-center rounded-full px-2 py-0.5 font-medium">
       Healthy
     </span>
   );
@@ -114,15 +114,15 @@ function ExpandableError({ error }: { error: string }) {
   const isLong = error.length > 120;
 
   return (
-    <div className="mt-2 rounded-md bg-red-50 px-3 py-2 dark:bg-red-900/20">
-      <p className="ui-text-sm text-red-700 dark:text-red-300">
+    <div className="bg-danger-subtle mt-2 rounded-md px-3 py-2">
+      <p className="ui-text-sm text-danger">
         <span className="font-medium">Error: </span>
         {expanded || !isLong ? error : error.slice(0, 120) + "..."}
       </p>
       {isLong && (
         <button
           onClick={() => setExpanded(!expanded)}
-          className="ui-text-xs mt-1 inline-flex items-center gap-0.5 text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-200"
+          className="ui-text-xs text-danger hover:text-danger-hover mt-1 inline-flex items-center gap-0.5"
         >
           {expanded ? (
             <>
@@ -412,9 +412,7 @@ export default function AdminFeedsContent() {
         </div>
       ) : feedsQuery.isError ? (
         <div className="p-8 text-center">
-          <p className="ui-text-sm text-red-600 dark:text-red-400">
-            Failed to load feeds. Please try again.
-          </p>
+          <p className="ui-text-sm text-danger">Failed to load feeds. Please try again.</p>
           <Button
             variant="secondary"
             size="sm"

--- a/src/components/admin/AdminInvitesContent.tsx
+++ b/src/components/admin/AdminInvitesContent.tsx
@@ -53,7 +53,7 @@ interface StatusBadgeProps {
 function StatusBadge({ status }: StatusBadgeProps) {
   const styles = {
     pending: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
-    used: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+    used: "bg-success-subtle text-success",
     expired: "bg-surface-muted text-muted",
   };
 
@@ -168,7 +168,7 @@ function InviteRow({ invite, onRevoke, isRevoking }: InviteRowProps) {
             size="sm"
             onClick={() => onRevoke(invite.id)}
             loading={isRevoking}
-            className="text-red-600 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-900/20 dark:hover:text-red-300"
+            className="text-danger hover:bg-danger-subtle hover:text-danger-hover"
           >
             Revoke
           </Button>
@@ -334,9 +334,7 @@ export default function AdminInvitesContent() {
         </div>
       ) : invitesQuery.isError ? (
         <div className="p-8 text-center">
-          <p className="ui-text-sm text-red-600 dark:text-red-400">
-            Failed to load invites. Please try again.
-          </p>
+          <p className="ui-text-sm text-danger">Failed to load invites. Please try again.</p>
           <Button
             variant="secondary"
             size="sm"

--- a/src/components/admin/AdminOverviewContent.tsx
+++ b/src/components/admin/AdminOverviewContent.tsx
@@ -53,9 +53,7 @@ export default function AdminOverviewContent() {
   if (overviewQuery.isError) {
     return (
       <div className="p-8 text-center">
-        <p className="ui-text-sm text-red-600 dark:text-red-400">
-          Failed to load overview. Please try again.
-        </p>
+        <p className="ui-text-sm text-danger">Failed to load overview. Please try again.</p>
         <Button
           variant="secondary"
           size="sm"

--- a/src/components/admin/AdminUsersContent.tsx
+++ b/src/components/admin/AdminUsersContent.tsx
@@ -266,9 +266,7 @@ export default function AdminUsersContent() {
         </div>
       ) : usersQuery.isError ? (
         <div className="p-8 text-center">
-          <p className="ui-text-sm text-red-600 dark:text-red-400">
-            Failed to load users. Please try again.
-          </p>
+          <p className="ui-text-sm text-danger">Failed to load users. Please try again.</p>
           <Button
             variant="secondary"
             size="sm"

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -353,7 +353,7 @@ export function EntryContentBody({
             onClick={onToggleStar}
             className={
               starred
-                ? "bg-amber-500 text-white hover:bg-amber-600 dark:bg-amber-500 dark:text-white dark:hover:bg-amber-600"
+                ? "bg-warning-solid text-warning-solid-foreground hover:bg-warning-solid-hover"
                 : ""
             }
             aria-label={starred ? "Remove from starred" : "Add to starred"}
@@ -395,7 +395,7 @@ export function EntryContentBody({
               disabled={isFullContentFetching}
               className={
                 fullContentError
-                  ? "border-red-300 text-red-600 hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950"
+                  ? "border-danger-border text-danger hover:bg-danger-subtle"
                   : fetchFullContent
                     ? "bg-accent-muted hover:bg-accent dark:bg-accent dark:hover:bg-accent-hover text-white dark:text-zinc-900"
                     : ""

--- a/src/components/entries/EntryContentFallback.tsx
+++ b/src/components/entries/EntryContentFallback.tsx
@@ -162,7 +162,7 @@ export function EntryContentFallback({ entryId, onBack }: EntryContentFallbackPr
               onClick={handleStarToggle}
               className={
                 cachedEntry.starred
-                  ? "bg-amber-500 text-white hover:bg-amber-600 dark:bg-amber-500 dark:text-white dark:hover:bg-amber-600"
+                  ? "bg-warning-solid text-warning-solid-foreground hover:bg-warning-solid-hover"
                   : ""
               }
               aria-label={cachedEntry.starred ? "Remove from starred" : "Add to starred"}

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -207,8 +207,8 @@ export const EntryListItem = memo(function EntryListItem({
                 // the padding with an equal negative margin so layout is unchanged.
                 className={`-m-[14px] flex shrink-0 items-center justify-center rounded-full p-[14px] transition-colors ${
                   starred
-                    ? "text-amber-500 hover:text-amber-600 dark:text-amber-400 dark:hover:text-amber-300"
-                    : "text-zinc-300 opacity-0 group-hover:opacity-100 hover:text-amber-400 dark:text-zinc-600 dark:hover:text-amber-400"
+                    ? "text-star hover:text-star-hover"
+                    : "hover:text-star text-zinc-300 opacity-0 group-hover:opacity-100 dark:text-zinc-600"
                 }`}
                 aria-label={starred ? "Remove from starred" : "Add to starred"}
                 title={starred ? "Remove from starred" : "Add to starred"}
@@ -221,7 +221,7 @@ export const EntryListItem = memo(function EntryListItem({
               </button>
             ) : (
               starred && (
-                <span className="shrink-0 text-amber-500 dark:text-amber-400" aria-label="Starred">
+                <span className="text-star shrink-0" aria-label="Starred">
                   <StarFilledIcon className="h-4 w-4" />
                 </span>
               )

--- a/src/components/entries/EntryListStates.tsx
+++ b/src/components/entries/EntryListStates.tsx
@@ -49,7 +49,7 @@ export interface EntryListErrorProps {
 export function EntryListError({ message, onRetry }: EntryListErrorProps) {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
-      <AlertIcon className="mb-4 h-12 w-12 text-red-400 dark:text-red-500" />
+      <AlertIcon className="text-danger mb-4 h-12 w-12" />
       <p className="ui-text-sm text-muted mb-4">{message}</p>
       <Button onClick={onRetry}>Try again</Button>
     </div>

--- a/src/components/entries/StickyEntryControls.tsx
+++ b/src/components/entries/StickyEntryControls.tsx
@@ -68,9 +68,7 @@ export function StickyEntryControls({
         <button
           onClick={onToggleStar}
           className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full transition-colors ${
-            starred
-              ? "text-amber-500 hover:bg-amber-50 dark:hover:bg-amber-950"
-              : "text-muted hover:bg-surface-muted"
+            starred ? "text-star hover:bg-warning-subtle" : "text-muted hover:bg-surface-muted"
           }`}
           aria-label={starred ? "Remove from starred" : "Add to starred"}
         >

--- a/src/components/feeds/UnsubscribeDialog.tsx
+++ b/src/components/feeds/UnsubscribeDialog.tsx
@@ -58,7 +58,7 @@ export function UnsubscribeDialog({
           variant="primary"
           onClick={onConfirm}
           loading={isLoading}
-          className="bg-red-600 hover:bg-red-700 focus:ring-red-600 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-600"
+          className="bg-danger-solid hover:bg-danger-solid-hover focus:ring-danger"
         >
           Unsubscribe
         </Button>

--- a/src/components/layout/ConnectionStatusIndicator.tsx
+++ b/src/components/layout/ConnectionStatusIndicator.tsx
@@ -43,8 +43,8 @@ export function ConnectionStatusIndicator({ status, onReconnect }: ConnectionSta
       {status === "connecting" && (
         <>
           <span className="relative flex h-2 w-2">
-            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-yellow-400 opacity-75" />
-            <span className="relative inline-flex h-2 w-2 rounded-full bg-yellow-500" />
+            <span className="bg-warning-solid absolute inline-flex h-full w-full animate-ping rounded-full opacity-75" />
+            <span className="bg-warning-solid relative inline-flex h-2 w-2 rounded-full" />
           </span>
           <span className="text-muted">Connecting...</span>
         </>
@@ -53,7 +53,7 @@ export function ConnectionStatusIndicator({ status, onReconnect }: ConnectionSta
       {(status === "disconnected" || status === "error") && (
         <>
           <span className="relative flex h-2 w-2">
-            <span className="relative inline-flex h-2 w-2 rounded-full bg-red-500" />
+            <span className="bg-danger-solid relative inline-flex h-2 w-2 rounded-full" />
           </span>
           <span className="text-muted">
             {status === "error" ? "Connection error" : "Disconnected"}

--- a/src/components/layout/OfflineBanner.tsx
+++ b/src/components/layout/OfflineBanner.tsx
@@ -148,7 +148,7 @@ export const OfflineBanner = memo(function OfflineBanner({ className = "" }: Off
     return (
       <div
         role="alert"
-        className={`ui-text-sm flex items-center justify-center gap-2 bg-amber-500 px-4 py-2 font-medium text-white ${className}`}
+        className={`ui-text-sm bg-warning-solid text-warning-solid-foreground flex items-center justify-center gap-2 px-4 py-2 font-medium ${className}`}
       >
         <WifiOffIcon className="h-4 w-4" />
         <span>You are offline. Some features may not be available.</span>
@@ -160,7 +160,7 @@ export const OfflineBanner = memo(function OfflineBanner({ className = "" }: Off
   return (
     <div
       role="status"
-      className={`ui-text-sm flex items-center justify-center gap-2 bg-green-500 px-4 py-2 font-medium text-white ${className}`}
+      className={`ui-text-sm bg-success-solid text-success-solid-foreground flex items-center justify-center gap-2 px-4 py-2 font-medium ${className}`}
     >
       <WifiOnIcon className="h-4 w-4" />
       <span>You are back online.</span>

--- a/src/components/layout/TagList.tsx
+++ b/src/components/layout/TagList.tsx
@@ -199,7 +199,7 @@ function TagListSkeleton() {
  * Error fallback for TagList.
  */
 function TagListError() {
-  return <p className="ui-text-sm px-3 text-red-600 dark:text-red-400">Failed to load feeds</p>;
+  return <p className="ui-text-sm text-danger px-3">Failed to load feeds</p>;
 }
 
 /**

--- a/src/components/narration/EnhancedVoiceList.tsx
+++ b/src/components/narration/EnhancedVoiceList.tsx
@@ -170,13 +170,13 @@ function VoiceItem({
             {isDownloading ? (
               <ProgressBar progress={progress} size={voice.sizeBytes} />
             ) : isDownloaded ? (
-              <div className="ui-text-xs mt-1 flex items-center gap-1 text-green-600 dark:text-green-400">
+              <div className="ui-text-xs text-success mt-1 flex items-center gap-1">
                 <CheckIcon className="h-3.5 w-3.5" />
                 Downloaded
               </div>
             ) : hasError ? (
               <div className="mt-1 space-y-1">
-                <div className="ui-text-xs flex items-center gap-1 text-red-600 dark:text-red-400">
+                <div className="ui-text-xs text-danger flex items-center gap-1">
                   <AlertCircleIcon className="h-3.5 w-3.5" />
                   {errorInfo.message}
                 </div>
@@ -362,13 +362,13 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
     <div className="space-y-3">
       {/* Error message */}
       {error && (
-        <div className="rounded-md bg-red-50 p-3 dark:bg-red-900/20">
-          <div className="ui-text-xs flex items-start gap-2 text-red-800 dark:text-red-200">
+        <div className="bg-danger-subtle rounded-md p-3">
+          <div className="ui-text-xs text-danger-subtle-foreground flex items-start gap-2">
             <AlertCircleIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
             <div className="flex-1 space-y-1">
               <p>{error}</p>
               {lastErrorInfo?.suggestion && (
-                <p className="text-red-600 dark:text-red-300">{lastErrorInfo.suggestion}</p>
+                <p className="text-danger">{lastErrorInfo.suggestion}</p>
               )}
             </div>
             <div className="flex items-center gap-2">
@@ -376,7 +376,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
                 <button
                   type="button"
                   onClick={retryDownload}
-                  className="text-red-600 underline hover:text-red-800 dark:text-red-300 dark:hover:text-red-100"
+                  className="text-danger hover:text-danger-hover underline"
                 >
                   Retry
                 </button>
@@ -384,7 +384,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
               <button
                 type="button"
                 onClick={clearError}
-                className="text-red-600 hover:text-red-800 dark:text-red-300 dark:hover:text-red-100"
+                className="text-danger hover:text-danger-hover"
               >
                 <CloseIcon className="h-4 w-4" />
               </button>
@@ -395,7 +395,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
 
       {/* Storage limit warning */}
       {isStorageLimitExceeded && (
-        <div className="ui-text-xs flex items-start gap-2 rounded-md bg-amber-50 p-3 text-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+        <div className="ui-text-xs bg-warning-subtle text-warning-subtle-foreground flex items-start gap-2 rounded-md p-3">
           <AlertIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
           <span className="flex-1">
             Voice storage exceeds 200 MB. Consider removing unused voices to free up space.

--- a/src/components/narration/NarrationSettings.tsx
+++ b/src/components/narration/NarrationSettings.tsx
@@ -517,7 +517,7 @@ export function NarrationSettings() {
 
           {/* Firefox Warning */}
           {isFirefoxBrowser && (
-            <div className="ui-text-xs flex items-start gap-2 rounded-md bg-amber-50 p-3 text-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+            <div className="ui-text-xs bg-warning-subtle text-warning-subtle-foreground flex items-start gap-2 rounded-md p-3">
               <AlertIcon className="mt-0.5 h-4 w-4 flex-shrink-0" />
               <span>
                 Firefox has limited support for pausing narration. When you pause and resume,

--- a/src/components/saved/FileUploadButton.tsx
+++ b/src/components/saved/FileUploadButton.tsx
@@ -212,7 +212,7 @@ export function FileUploadButton({ className = "", onSuccess }: FileUploadButton
               isDragging
                 ? "bg-surface-muted border-zinc-500 dark:border-zinc-400"
                 : selectedFile
-                  ? "border-green-500 bg-green-50 dark:border-green-600 dark:bg-green-900/20"
+                  ? "border-success bg-success-subtle"
                   : "border-edge-input hover:bg-surface-muted hover:border-zinc-400 dark:hover:border-zinc-500"
             }`}
           >
@@ -226,7 +226,7 @@ export function FileUploadButton({ className = "", onSuccess }: FileUploadButton
 
             {selectedFile ? (
               <div className="flex flex-col items-center">
-                <DocumentIcon className="h-10 w-10 text-green-600 dark:text-green-500" />
+                <DocumentIcon className="text-success h-10 w-10" />
                 <p className="text-strong mt-2 font-medium">{selectedFile.name}</p>
                 <p className="ui-text-sm text-muted">{formatFileSize(selectedFile.size)}</p>
                 <p className="ui-text-xs text-faint mt-2">

--- a/src/components/settings/ApiKeySettings.tsx
+++ b/src/components/settings/ApiKeySettings.tsx
@@ -121,7 +121,7 @@ export function GroqApiKeySettings() {
         <div className="flex items-center gap-3">
           {hasKey ? (
             <>
-              <span className="ui-text-sm inline-flex items-center text-green-600 dark:text-green-400">
+              <span className="ui-text-sm text-success inline-flex items-center">
                 <CheckIcon className="mr-1 h-4 w-4" />
                 API key configured
               </span>
@@ -353,7 +353,7 @@ export function SummarizationApiKeySettings() {
             <div className="flex items-center gap-3">
               {hasKey ? (
                 <>
-                  <span className="ui-text-sm inline-flex items-center text-green-600 dark:text-green-400">
+                  <span className="ui-text-sm text-success inline-flex items-center">
                     <CheckIcon className="mr-1 h-4 w-4" />
                     API key configured
                   </span>

--- a/src/components/settings/BookmarkletSettings.tsx
+++ b/src/components/settings/BookmarkletSettings.tsx
@@ -70,7 +70,7 @@ export function BookmarkletSettings() {
             href="https://addons.mozilla.org/en-US/firefox/addon/lion-reader/"
             target="_blank"
             rel="noopener noreferrer"
-            className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-orange-300 bg-orange-50 px-4 py-2.5 font-medium text-orange-800 shadow-sm transition-all hover:border-orange-400 hover:bg-orange-100 hover:shadow dark:border-orange-700 dark:bg-orange-950 dark:text-orange-200 dark:hover:border-orange-600 dark:hover:bg-orange-900"
+            className="ui-text-sm border-warning-border bg-warning-subtle text-warning-subtle-foreground hover:border-warning hover:bg-warning-subtle inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 font-medium shadow-sm transition-all hover:shadow"
           >
             <FirefoxIcon className="h-4 w-4" />
             Install Firefox Extension
@@ -94,7 +94,7 @@ export function BookmarkletSettings() {
           href="#"
           onClick={(e) => e.preventDefault()}
           draggable
-          className="ui-text-sm inline-flex items-center gap-2 rounded-lg border border-amber-300 bg-amber-50 px-4 py-2.5 font-medium text-amber-800 shadow-sm transition-all hover:border-amber-400 hover:bg-amber-100 hover:shadow active:scale-95 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200 dark:hover:border-amber-600 dark:hover:bg-amber-900"
+          className="ui-text-sm border-warning-border bg-warning-subtle text-warning-subtle-foreground hover:border-warning hover:bg-warning-subtle inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 font-medium shadow-sm transition-all hover:shadow active:scale-95"
         >
           <BookmarkIcon className="h-4 w-4" />
           Save to Lion Reader

--- a/src/components/settings/OpmlImportExport.tsx
+++ b/src/components/settings/OpmlImportExport.tsx
@@ -433,17 +433,17 @@ function ImportResults({ imported, skipped, failed, results, onReset }: ImportRe
       </Alert>
 
       <div className="mb-4 grid grid-cols-3 gap-4">
-        <div className="rounded-md bg-green-50 p-3 dark:bg-green-950/20">
-          <p className="ui-text-2xl font-bold text-green-600 dark:text-green-400">{imported}</p>
-          <p className="ui-text-xs text-green-600 dark:text-green-400">Imported</p>
+        <div className="bg-success-subtle rounded-md p-3">
+          <p className="ui-text-2xl text-success font-bold">{imported}</p>
+          <p className="ui-text-xs text-success">Imported</p>
         </div>
-        <div className="rounded-md bg-yellow-50 p-3 dark:bg-yellow-950/20">
-          <p className="ui-text-2xl font-bold text-yellow-600 dark:text-yellow-400">{skipped}</p>
-          <p className="ui-text-xs text-yellow-600 dark:text-yellow-400">Skipped</p>
+        <div className="bg-warning-subtle rounded-md p-3">
+          <p className="ui-text-2xl text-warning font-bold">{skipped}</p>
+          <p className="ui-text-xs text-warning">Skipped</p>
         </div>
-        <div className="rounded-md bg-red-50 p-3 dark:bg-red-950/20">
-          <p className="ui-text-2xl font-bold text-red-600 dark:text-red-400">{failed}</p>
-          <p className="ui-text-xs text-red-600 dark:text-red-400">Failed</p>
+        <div className="bg-danger-subtle rounded-md p-3">
+          <p className="ui-text-2xl text-danger font-bold">{failed}</p>
+          <p className="ui-text-xs text-danger">Failed</p>
         </div>
       </div>
 
@@ -469,18 +469,16 @@ function ImportResults({ imported, skipped, failed, results, onReset }: ImportRe
                         </p>
                         <p className="ui-text-xs text-muted truncate">{result.url}</p>
                         {result.error && (
-                          <p className="ui-text-xs mt-1 text-red-600 dark:text-red-400">
-                            {result.error}
-                          </p>
+                          <p className="ui-text-xs text-danger mt-1">{result.error}</p>
                         )}
                       </div>
                       <span
                         className={`ui-text-xs ml-2 shrink-0 rounded-full px-2 py-0.5 font-medium ${
                           result.status === "imported"
-                            ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                            ? "bg-success-subtle text-success"
                             : result.status === "skipped"
-                              ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400"
-                              : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                              ? "bg-warning-subtle text-warning"
+                              : "bg-danger-subtle text-danger"
                         }`}
                       >
                         {result.status}

--- a/src/components/settings/TagManagement.tsx
+++ b/src/components/settings/TagManagement.tsx
@@ -268,7 +268,7 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
 
   if (showDeleteConfirm) {
     return (
-      <div className="flex items-center justify-between rounded-md border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950/30">
+      <div className="border-danger-border bg-danger-subtle flex items-center justify-between rounded-md border p-4">
         <div className="flex items-center gap-3">
           <ColorDot color={tag.color} size="lg" />
           <div>
@@ -292,7 +292,7 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
             size="sm"
             onClick={handleDelete}
             loading={deleteMutation.isPending}
-            className="bg-red-600 text-white hover:bg-red-700 focus:ring-red-600 dark:bg-red-600 dark:hover:bg-red-700"
+            className="bg-danger-solid text-danger-solid-foreground hover:bg-danger-solid-hover focus:ring-danger"
           >
             Delete
           </Button>
@@ -371,7 +371,7 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
           size="sm"
           onClick={() => setShowDeleteConfirm(true)}
           title="Delete tag"
-          className="px-2 text-red-600 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-950/20 dark:hover:text-red-300"
+          className="text-danger hover:bg-danger-subtle hover:text-danger-hover px-2"
         >
           <TrashIcon className="h-4 w-4" />
         </Button>

--- a/src/components/settings/pages/AccountSettingsContent.tsx
+++ b/src/components/settings/pages/AccountSettingsContent.tsx
@@ -94,9 +94,7 @@ function AccountInfoSection() {
           <div className="bg-surface-muted h-5 w-32 animate-pulse rounded" />
         </div>
       ) : userQuery.error ? (
-        <p className="ui-text-sm text-red-600 dark:text-red-400">
-          Failed to load account information
-        </p>
+        <p className="ui-text-sm text-danger">Failed to load account information</p>
       ) : (
         <dl className="space-y-4">
           <div>
@@ -119,7 +117,7 @@ function AccountInfoSection() {
             <dt className="ui-text-sm text-muted font-medium">Email verified</dt>
             <dd className="ui-text-sm text-strong mt-1">
               {userQuery.data?.user.emailVerifiedAt ? (
-                <span className="inline-flex items-center text-green-600 dark:text-green-400">
+                <span className="text-success inline-flex items-center">
                   <CheckIcon className="mr-1 h-4 w-4" />
                   Verified
                 </span>

--- a/src/components/settings/pages/ApiTokensSettingsContent.tsx
+++ b/src/components/settings/pages/ApiTokensSettingsContent.tsx
@@ -381,9 +381,7 @@ function ActiveTokenCard({ token, onRevoke, isRevoking }: ActiveTokenCardProps) 
                 })}
               </span>
             )}
-            {!token.lastUsedAt && (
-              <span className="text-amber-600 dark:text-amber-400">Never used</span>
-            )}
+            {!token.lastUsedAt && <span className="text-warning">Never used</span>}
           </div>
         </div>
 
@@ -392,7 +390,7 @@ function ActiveTokenCard({ token, onRevoke, isRevoking }: ActiveTokenCardProps) 
           size="sm"
           onClick={() => onRevoke(token.id)}
           disabled={isRevoking}
-          className="w-full text-red-600 hover:bg-red-50 hover:text-red-700 sm:w-auto dark:text-red-400 dark:hover:bg-red-950 dark:hover:text-red-300"
+          className="text-danger hover:bg-danger-subtle hover:text-danger-hover w-full sm:w-auto"
         >
           Revoke
         </Button>

--- a/src/components/settings/pages/BlockedSendersSettingsContent.tsx
+++ b/src/components/settings/pages/BlockedSendersSettingsContent.tsx
@@ -157,7 +157,7 @@ function BlockedSenderRow({ sender }: BlockedSenderRowProps) {
             <span>Blocked {formatRelativeTime(sender.blockedAt)}</span>
             {sender.unsubscribeSentAt && (
               <span className="flex items-center gap-1">
-                <CheckIcon className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+                <CheckIcon className="text-success h-3.5 w-3.5" />
                 Unsubscribe sent
               </span>
             )}

--- a/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
+++ b/src/components/settings/pages/BrokenFeedsSettingsContent.tsx
@@ -122,8 +122,8 @@ export default function BrokenFeedsSettingsContent() {
 function EmptyState() {
   return (
     <div className="p-8 text-center">
-      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
-        <CheckIcon className="h-6 w-6 text-green-600 dark:text-green-400" />
+      <div className="bg-success-subtle mx-auto flex h-12 w-12 items-center justify-center rounded-full">
+        <CheckIcon className="text-success h-6 w-6" />
       </div>
       <h3 className="ui-text-sm text-strong mt-4 font-medium">All feeds are working</h3>
       <p className="ui-text-sm text-muted mt-1">None of your subscribed feeds have fetch errors.</p>
@@ -182,8 +182,8 @@ function BrokenFeedRow({ feed, onUnsubscribe }: BrokenFeedRowProps) {
 
           {/* Error Message */}
           {feed.lastError && (
-            <div className="mt-2 rounded-md bg-red-50 px-3 py-2 dark:bg-red-900/20">
-              <p className="ui-text-sm text-red-700 dark:text-red-300">
+            <div className="bg-danger-subtle mt-2 rounded-md px-3 py-2">
+              <p className="ui-text-sm text-danger">
                 <span className="font-medium">Error:</span> {feed.lastError}
               </p>
             </div>
@@ -192,7 +192,7 @@ function BrokenFeedRow({ feed, onUnsubscribe }: BrokenFeedRowProps) {
           {/* Metadata */}
           <div className="ui-text-sm text-muted mt-2 flex flex-wrap gap-x-4 gap-y-1">
             <span className="flex items-center gap-1">
-              <AlertCircleIcon className="h-4 w-4 text-red-500" />
+              <AlertCircleIcon className="text-danger h-4 w-4" />
               {feed.consecutiveFailures} consecutive failure
               {feed.consecutiveFailures === 1 ? "" : "s"}
             </span>
@@ -213,7 +213,7 @@ function BrokenFeedRow({ feed, onUnsubscribe }: BrokenFeedRowProps) {
             variant="secondary"
             size="sm"
             onClick={() => onUnsubscribe(feed.subscriptionId, displayName)}
-            className="text-red-600 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-900/20 dark:hover:text-red-300"
+            className="text-danger hover:bg-danger-subtle hover:text-danger-hover"
           >
             Unsubscribe
           </Button>

--- a/src/components/settings/pages/DeleteAccountSettingsContent.tsx
+++ b/src/components/settings/pages/DeleteAccountSettingsContent.tsx
@@ -72,10 +72,8 @@ export default function DeleteAccountSettingsContent() {
   return (
     <div className="space-y-8">
       <section>
-        <h2 className="ui-text-lg mb-4 font-semibold text-red-600 dark:text-red-400">
-          Delete Account
-        </h2>
-        <div className="bg-surface rounded-lg border border-red-200 p-6 dark:border-red-900/50">
+        <h2 className="ui-text-lg text-danger mb-4 font-semibold">Delete Account</h2>
+        <div className="bg-surface border-danger-border rounded-lg border p-6">
           <p className="ui-text-sm text-muted">
             Permanently delete your account and all associated data. This action cannot be undone.
           </p>
@@ -87,7 +85,7 @@ export default function DeleteAccountSettingsContent() {
           <div className="mt-4">
             <Button
               onClick={handleOpenDialog}
-              className="bg-red-600 text-white hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700"
+              className="bg-danger-solid text-danger-solid-foreground hover:bg-danger-solid-hover"
             >
               Delete account
             </Button>
@@ -141,7 +139,7 @@ export default function DeleteAccountSettingsContent() {
             onClick={handleDelete}
             loading={deleteAccountMutation.isPending}
             disabled={!isConfirmed}
-            className="bg-red-600 text-white hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700"
+            className="bg-danger-solid text-danger-solid-foreground hover:bg-danger-solid-hover"
           >
             Delete my account
           </Button>

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -275,7 +275,7 @@ function IngestAddressRow({ address }: IngestAddressRowProps) {
           <Button
             onClick={handleDelete}
             loading={deleteMutation.isPending}
-            className="bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700"
+            className="bg-danger-solid hover:bg-danger-solid-hover"
           >
             Delete
           </Button>
@@ -297,7 +297,7 @@ function IngestAddressRow({ address }: IngestAddressRowProps) {
               title="Copy email address"
             >
               {copied ? (
-                <CheckIcon className="h-4 w-4 text-green-600 dark:text-green-400" />
+                <CheckIcon className="text-success h-4 w-4" />
               ) : (
                 <CopyIcon className="h-4 w-4" />
               )}
@@ -361,7 +361,7 @@ function IngestAddressRow({ address }: IngestAddressRowProps) {
           variant="ghost"
           size="sm"
           onClick={() => setShowDeleteConfirm(true)}
-          className="text-red-600 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-950 dark:hover:text-red-300"
+          className="text-danger hover:bg-danger-subtle hover:text-danger-hover"
         >
           Delete
         </Button>

--- a/src/components/settings/pages/FeedStatsSettingsContent.tsx
+++ b/src/components/settings/pages/FeedStatsSettingsContent.tsx
@@ -69,7 +69,7 @@ function getStatusBadge(feed: FeedStats): { text: string; className: string } {
   if (feed.consecutiveFailures > 0) {
     return {
       text: `${feed.consecutiveFailures} failure${feed.consecutiveFailures === 1 ? "" : "s"}`,
-      className: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+      className: "bg-danger-subtle text-danger",
     };
   }
   if (feed.websubActive) {
@@ -80,7 +80,7 @@ function getStatusBadge(feed: FeedStats): { text: string; className: string } {
   }
   return {
     text: "OK",
-    className: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+    className: "bg-success-subtle text-success",
   };
 }
 
@@ -212,8 +212,8 @@ interface SummaryCardProps {
 function SummaryCard({ label, value, variant = "default" }: SummaryCardProps) {
   const variantClasses = {
     default: "text-strong",
-    success: "text-green-600 dark:text-green-400",
-    error: "text-red-600 dark:text-red-400",
+    success: "text-success",
+    error: "text-danger",
     info: "text-purple-600 dark:text-purple-400",
   };
 
@@ -275,8 +275,8 @@ function FeedStatsRow({ feed }: FeedStatsRowProps) {
 
           {/* Error Message (if any) */}
           {feed.lastError && (
-            <div className="mt-2 rounded-md bg-red-50 px-3 py-2 dark:bg-red-900/20">
-              <p className="ui-text-sm text-red-700 dark:text-red-300">
+            <div className="bg-danger-subtle mt-2 rounded-md px-3 py-2">
+              <p className="ui-text-sm text-danger">
                 <span className="font-medium">Error:</span> {feed.lastError}
               </p>
             </div>

--- a/src/components/settings/pages/SessionsSettingsContent.tsx
+++ b/src/components/settings/pages/SessionsSettingsContent.tsx
@@ -152,9 +152,7 @@ function SessionCard({ session, onRevoke, isRevoking }: SessionCardProps) {
   return (
     <div
       className={`rounded-lg border p-3 sm:p-4 ${
-        session.isCurrent
-          ? "border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950"
-          : "border-edge bg-surface"
+        session.isCurrent ? "border-success-border bg-success-subtle" : "border-edge bg-surface"
       }`}
     >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -174,7 +172,7 @@ function SessionCard({ session, onRevoke, isRevoking }: SessionCardProps) {
                 {browser} on {platform}
               </p>
               {session.isCurrent && (
-                <span className="ui-text-xs mt-0.5 inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 font-medium text-green-800 dark:bg-green-900 dark:text-green-200">
+                <span className="ui-text-xs bg-success-subtle text-success-subtle-foreground mt-0.5 inline-flex items-center rounded-full px-2 py-0.5 font-medium">
                   Current session
                 </span>
               )}
@@ -201,7 +199,7 @@ function SessionCard({ session, onRevoke, isRevoking }: SessionCardProps) {
             size="sm"
             onClick={() => onRevoke(session.id)}
             disabled={isRevoking}
-            className="w-full text-red-600 hover:bg-red-50 hover:text-red-700 sm:w-auto dark:text-red-400 dark:hover:bg-red-950 dark:hover:text-red-300"
+            className="text-danger hover:bg-danger-subtle hover:text-danger-hover w-full sm:w-auto"
           >
             Revoke
           </Button>

--- a/src/components/subscribe/SubscribeContent.tsx
+++ b/src/components/subscribe/SubscribeContent.tsx
@@ -282,7 +282,7 @@ export function SubscribeContent() {
           {/* Discovery Results Card */}
           <Card>
             <div className="mb-4 flex items-center gap-2">
-              <CheckCircleIcon className="h-5 w-5 text-green-600 dark:text-green-400" />
+              <CheckCircleIcon className="text-success h-5 w-5" />
               <h2 className="ui-text-lg text-strong font-semibold">
                 We found {discoveredFeeds.length} feed{discoveredFeeds.length !== 1 ? "s" : ""} on
                 this site

--- a/src/components/summarization/SummaryCard.tsx
+++ b/src/components/summarization/SummaryCard.tsx
@@ -73,29 +73,29 @@ export function SummaryCard({
   // Show error state
   if (error) {
     return (
-      <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+      <div className="border-danger-border bg-danger-subtle mb-6 rounded-lg border p-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <SparklesIcon className="h-5 w-5 text-red-600 dark:text-red-400" />
-            <span className="ui-text-sm font-medium text-red-900 dark:text-red-100">
+            <SparklesIcon className="text-danger h-5 w-5" />
+            <span className="ui-text-sm text-danger-subtle-foreground font-medium">
               Summary generation failed
             </span>
           </div>
           {onClose && (
             <button
               onClick={onClose}
-              className="rounded p-1 text-red-600 hover:bg-red-100 dark:text-red-400 dark:hover:bg-red-800/50"
+              className="text-danger hover:bg-danger-subtle rounded p-1"
               aria-label="Close"
             >
               <CloseIcon className="h-4 w-4" />
             </button>
           )}
         </div>
-        <p className="ui-text-sm mt-2 text-red-700 dark:text-red-300">{error}</p>
+        <p className="ui-text-sm text-danger mt-2">{error}</p>
         {onRegenerate && (
           <button
             onClick={onRegenerate}
-            className="ui-text-sm mt-3 font-medium text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+            className="ui-text-sm text-danger hover:text-danger-hover mt-3 font-medium"
           >
             Try again
           </button>

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -54,7 +54,7 @@ function DefaultErrorFallback({
 }) {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center" role="alert">
-      <AlertIcon className="mb-4 h-12 w-12 text-red-400 dark:text-red-500" />
+      <AlertIcon className="text-danger mb-4 h-12 w-12" />
       <h2 className="ui-text-lg text-strong mb-2 font-semibold">Something went wrong</h2>
       <p className="ui-text-sm text-muted mb-4 max-w-sm">
         {message ?? "An unexpected error occurred. Please try again."}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -14,9 +14,9 @@ export interface AlertProps {
 
 export function Alert({ variant = "info", children, className = "" }: AlertProps) {
   const variantStyles = {
-    error: "bg-red-50 text-red-800 dark:bg-red-950 dark:text-red-200",
-    success: "bg-green-50 text-green-800 dark:bg-green-950 dark:text-green-200",
-    warning: "bg-yellow-50 text-yellow-800 dark:bg-yellow-950 dark:text-yellow-200",
+    error: "bg-danger-subtle text-danger-subtle-foreground",
+    success: "bg-success-subtle text-success-subtle-foreground",
+    warning: "bg-warning-subtle text-warning-subtle-foreground",
     info: "bg-info-subtle text-info-foreground",
   };
 

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -136,9 +136,9 @@ export function StatusCard({ children, variant, padding = "md", className = "" }
 
   const variantStyles = {
     info: "border-info-border bg-info-subtle",
-    success: "border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/20",
-    warning: "border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-900/20",
-    error: "border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20",
+    success: "border-success-border bg-success-subtle",
+    warning: "border-warning-border bg-warning-subtle",
+    error: "border-danger-border bg-danger-subtle",
   };
 
   return (

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -23,9 +23,9 @@ export function Input({ label, error, id, className = "", ref, ...props }: Input
       <input
         ref={ref}
         id={id}
-        className={`ui-text-sm bg-surface text-strong block w-full rounded-md border px-3 py-2 placeholder:text-zinc-400 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-zinc-500 ${
+        className={`ui-text-sm bg-surface text-strong placeholder:text-faint block w-full rounded-md border px-3 py-2 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 ${
           error
-            ? "border-red-500 focus:border-red-500 focus:ring-red-500 dark:border-red-500"
+            ? "border-danger focus:border-danger focus:ring-danger"
             : "border-edge-input focus:border-focus focus:ring-focus"
         } ${className}`}
         aria-invalid={error ? "true" : undefined}
@@ -33,7 +33,7 @@ export function Input({ label, error, id, className = "", ref, ...props }: Input
         {...props}
       />
       {error && (
-        <p id={`${id}-error`} className="ui-text-sm mt-1.5 text-red-600 dark:text-red-400">
+        <p id={`${id}-error`} className="ui-text-sm text-danger mt-1.5">
           {error}
         </p>
       )}

--- a/src/components/ui/not-found-card.tsx
+++ b/src/components/ui/not-found-card.tsx
@@ -18,8 +18,8 @@ export function NotFoundCard({ title, message }: NotFoundCardProps) {
   return (
     <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
       <div className="border-edge bg-surface rounded-lg border p-6 text-center sm:p-8">
-        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/20">
-          <AlertIcon className="h-6 w-6 text-red-500 dark:text-red-400" />
+        <div className="bg-danger-subtle mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+          <AlertIcon className="text-danger h-6 w-6" />
         </div>
         <h2 className="ui-text-lg text-strong mb-2 font-medium">{title}</h2>
         <p className="ui-text-sm text-muted">{message}</p>

--- a/tests/unit/frontend/components/Alert.test.tsx
+++ b/tests/unit/frontend/components/Alert.test.tsx
@@ -35,19 +35,19 @@ describe("Alert", () => {
     it("applies error variant styles", () => {
       render(<Alert variant="error">Error message</Alert>);
       const alert = screen.getByRole("alert");
-      expect(alert).toHaveClass("bg-red-50", "text-red-800");
+      expect(alert).toHaveClass("bg-danger-subtle", "text-danger-subtle-foreground");
     });
 
     it("applies success variant styles", () => {
       render(<Alert variant="success">Success message</Alert>);
       const alert = screen.getByRole("alert");
-      expect(alert).toHaveClass("bg-green-50", "text-green-800");
+      expect(alert).toHaveClass("bg-success-subtle", "text-success-subtle-foreground");
     });
 
     it("applies warning variant styles", () => {
       render(<Alert variant="warning">Warning message</Alert>);
       const alert = screen.getByRole("alert");
-      expect(alert).toHaveClass("bg-yellow-50", "text-yellow-800");
+      expect(alert).toHaveClass("bg-warning-subtle", "text-warning-subtle-foreground");
     });
 
     it("applies info variant styles", () => {
@@ -77,7 +77,7 @@ describe("Alert", () => {
         </Alert>
       );
       const alert = screen.getByRole("alert");
-      expect(alert).toHaveClass("bg-red-50", "mt-4");
+      expect(alert).toHaveClass("bg-danger-subtle", "mt-4");
     });
   });
 

--- a/tests/unit/frontend/components/Card.test.tsx
+++ b/tests/unit/frontend/components/Card.test.tsx
@@ -168,19 +168,19 @@ describe("StatusCard", () => {
     it("applies success variant styles", () => {
       render(<StatusCard variant="success">Success</StatusCard>);
       const card = screen.getByText("Success").closest("div");
-      expect(card).toHaveClass("border-green-200", "bg-green-50");
+      expect(card).toHaveClass("border-success-border", "bg-success-subtle");
     });
 
     it("applies warning variant styles", () => {
       render(<StatusCard variant="warning">Warning</StatusCard>);
       const card = screen.getByText("Warning").closest("div");
-      expect(card).toHaveClass("border-yellow-200", "bg-yellow-50");
+      expect(card).toHaveClass("border-warning-border", "bg-warning-subtle");
     });
 
     it("applies error variant styles", () => {
       render(<StatusCard variant="error">Error</StatusCard>);
       const card = screen.getByText("Error").closest("div");
-      expect(card).toHaveClass("border-red-200", "bg-red-50");
+      expect(card).toHaveClass("border-danger-border", "bg-danger-subtle");
     });
   });
 

--- a/tests/unit/frontend/components/Input.test.tsx
+++ b/tests/unit/frontend/components/Input.test.tsx
@@ -68,14 +68,14 @@ describe("Input", () => {
     it("applies error border styles", () => {
       render(<Input error="Error" id="error-field" />);
       const input = screen.getByRole("textbox");
-      expect(input).toHaveClass("border-red-500");
+      expect(input).toHaveClass("border-danger");
     });
 
     it("applies normal border styles when no error", () => {
       render(<Input id="normal-field" />);
       const input = screen.getByRole("textbox");
       expect(input).toHaveClass("border-edge-input");
-      expect(input).not.toHaveClass("border-red-500");
+      expect(input).not.toHaveClass("border-danger");
     });
 
     it("sets aria-invalid when error is present", () => {
@@ -105,7 +105,7 @@ describe("Input", () => {
     it("applies error text styles", () => {
       render(<Input error="Error text" id="field" />);
       const errorMessage = screen.getByText("Error text");
-      expect(errorMessage).toHaveClass("text-red-600");
+      expect(errorMessage).toHaveClass("text-danger");
     });
   });
 


### PR DESCRIPTION
Fixes #1169.

## What

The neutral/accent/`--info` layer was already tokenized, but the **status-color layer never was** — every success/warning/error/star was a hand-rolled raw Tailwind pair, copy-pasted and drifted (9 red text shades, 16 green combos, warning split across `amber-*` **and** `yellow-*`, un-tokenized amber star). This adds token trios per status role and codemods every raw utility onto them.

## Tokens

Defined in `src/app/globals.css` for `:root` / `.dark` / `.epaper` (+ the `prefers-color-scheme` fallback) and exposed via `@theme inline`, mirroring the existing `--info` pattern. Per role (`danger` / `success` / `warning`):

- base on-surface text/icon (AA), `-hover`, `-subtle` + `-subtle-foreground`, `-border`, `-solid` + `-solid-foreground` + `-solid-hover`, and `border-`/`ring-` for the input-error state.
- Dark mode keeps status hues conventional (a red error stays red — the low-blue-light rule governs dominant surfaces/accent, not semantic status). E-paper darkens each tone so it survives grayscale, with subtle fills one step darker and visible borders.
- The amber star is formalized as `--star` / `--star-hover` / `bg-star`.

## Codemod

- `StatusCard`, `Alert`, and the `Input` error state unified to symmetric token-driven variants.
- Every `bg-red-50 dark:bg-red-950 text-red-800 …` etc. across `src/components` + `src/app` collapses to the tokens.
- **Fixes the `text-green-600` WCAG AA bug** (~3.3:1 on white) → success text is now `green-700` (~5:1). Base and `-subtle-foreground` text meets AA in all three themes.
- The two drifted bookmarklet chips (orange + amber) collapse onto the warning tokens.
- `grep` shows **zero** remaining raw red/green/amber/yellow/orange utilities in components/app.

## Acceptance

- [x] `--success/--warning/--danger/--star` tokens defined for all three themes + `@theme inline`.
- [x] `StatusCard`/`Alert`/`Input`-error unified to symmetric token-driven variants.
- [x] grep shows zero raw red/green/amber/yellow/orange utilities in components/app.
- [x] Status text meets WCAG AA on its background in all three themes.
- [x] `src/components/CLAUDE.md` semantic-color table updated with the new tokens.

## Out of scope / follow-up

- **zinc → neutral tokens** (~274 call sites): the neutral tokens already exist; converting them is a separate mechanical sweep and was left out to keep this PR focused on the *new* status layer. Also left untouched: a few raw `blue-*`/`purple-*` classes (not in the status palette).

## Testing

- `pnpm typecheck`, `pnpm lint` clean.
- Updated the `Alert` / `Card` / `Input` unit tests to assert the token classes; full unit suite passes (2218 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)