### PR TITLE
Add compact/comfortable list density option (#1171)

### DIFF
--- a/src/components/entries/EntryList.tsx
+++ b/src/components/entries/EntryList.tsx
@@ -12,6 +12,7 @@
 import { useEffect, useRef, useCallback } from "react";
 import type { EntryListData } from "@/lib/hooks/types";
 import { useScrollContainer } from "@/components/layout/ScrollContainerContext";
+import { useAppearance } from "@/lib/appearance/AppearanceProvider";
 import { EntryListItem } from "./EntryListItem";
 import { EntryListSkeleton } from "./EntryListSkeleton";
 import {
@@ -128,6 +129,9 @@ export function EntryList({
 }: EntryListProps) {
   const loadMoreRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useScrollContainer();
+  const {
+    settings: { listDensity },
+  } = useAppearance();
 
   const {
     isLoading,
@@ -175,7 +179,7 @@ export function EntryList({
   // Initial loading state - only show skeleton if we have no entries to display
   // (placeholder data from parent lists provides entries even while loading)
   if (isLoading && allEntries.length === 0) {
-    return <EntryListSkeleton count={5} />;
+    return <EntryListSkeleton count={5} density={listDensity} />;
   }
 
   // Error state
@@ -193,19 +197,26 @@ export function EntryList({
     return <EntryListEmpty message={emptyMessage} />;
   }
 
+  // Compact density: a single divided list (dividers survive e-paper via the
+  // darker `--edge`). Comfortable: gapped bordered cards.
+  const listClassName = listDensity === "compact" ? "divide-edge divide-y" : "space-y-3";
+
   return (
-    <div className="space-y-3">
-      {allEntries.map((entry) => (
-        <EntryListItem
-          key={entry.id}
-          entry={entry}
-          onClick={onEntryClick}
-          onMouseDown={onEntryMouseDown}
-          selected={selectedEntryId === entry.id}
-          onToggleRead={onToggleRead}
-          onToggleStar={onToggleStar}
-        />
-      ))}
+    <div>
+      <div className={listClassName}>
+        {allEntries.map((entry) => (
+          <EntryListItem
+            key={entry.id}
+            entry={entry}
+            onClick={onEntryClick}
+            onMouseDown={onEntryMouseDown}
+            selected={selectedEntryId === entry.id}
+            onToggleRead={onToggleRead}
+            onToggleStar={onToggleStar}
+            density={listDensity}
+          />
+        ))}
+      </div>
 
       {/* Load more trigger element */}
       <div ref={loadMoreRef} className="h-1" />

--- a/src/components/entries/EntryListFallback.tsx
+++ b/src/components/entries/EntryListFallback.tsx
@@ -10,6 +10,7 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { findParentListPlaceholderData } from "@/lib/cache/entry-cache";
+import { useAppearance } from "@/lib/appearance/AppearanceProvider";
 import { EntryListItem } from "./EntryListItem";
 import { EntryListSkeleton } from "./EntryListSkeleton";
 import { EntryListLoadingMore } from "./EntryListStates";
@@ -54,6 +55,9 @@ export function EntryListFallback({
   onEntryClick,
 }: EntryListFallbackProps) {
   const queryClient = useQueryClient();
+  const {
+    settings: { listDensity },
+  } = useAppearance();
 
   // Try to find placeholder data from cached parent lists
   // Subscriptions are automatically looked up from cache for tag/uncategorized filtering
@@ -61,25 +65,29 @@ export function EntryListFallback({
 
   // No cached data - show skeleton
   if (!placeholderData || placeholderData.pages[0]?.items.length === 0) {
-    return <EntryListSkeleton count={skeletonCount} />;
+    return <EntryListSkeleton count={skeletonCount} density={listDensity} />;
   }
 
   // Show cached entries with a subtle loading indicator
   const entries = placeholderData.pages.flatMap((page) => page.items);
+  const listClassName = listDensity === "compact" ? "divide-edge divide-y" : "space-y-3";
 
   return (
-    <div className="space-y-3">
-      {entries.map((entry) => (
-        <EntryListItem
-          key={entry.id}
-          entry={entry}
-          onClick={onEntryClick}
-          selected={selectedEntryId === entry.id}
-          // Disable mutations during fallback - they'd update stale data
-          onToggleRead={undefined}
-          onToggleStar={undefined}
-        />
-      ))}
+    <div>
+      <div className={listClassName}>
+        {entries.map((entry) => (
+          <EntryListItem
+            key={entry.id}
+            entry={entry}
+            onClick={onEntryClick}
+            selected={selectedEntryId === entry.id}
+            // Disable mutations during fallback - they'd update stale data
+            onToggleRead={undefined}
+            onToggleStar={undefined}
+            density={listDensity}
+          />
+        ))}
+      </div>
 
       {/* Show loading indicator at the bottom */}
       <EntryListLoadingMore label="Loading entries..." />

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -10,6 +10,7 @@
 import { memo } from "react";
 import { formatRelativeTime } from "@/lib/format";
 import type { EntryType } from "@/lib/hooks/useEntryMutations";
+import type { ListDensity } from "@/lib/appearance/settings";
 import { StarIcon, StarFilledIcon } from "@/components/ui/icon-button";
 
 /**
@@ -58,18 +59,39 @@ interface EntryListItemProps {
    * Callback when the star indicator is clicked.
    */
   onToggleStar?: (entryId: string, currentlyStarred: boolean) => void;
+
+  /**
+   * List density. In "compact" mode the item drops its per-card border/rounding
+   * and roomy padding in favor of a tighter row (the surrounding list supplies
+   * `divide-edge` separators). Defaults to "comfortable".
+   */
+  density?: ListDensity;
 }
 
 /**
- * Get the appropriate CSS classes for the entry item based on read and selected state.
+ * Get the appropriate CSS classes for the entry item based on read, selected,
+ * and density state.
+ *
+ * The unread/read/selected *color* language is identical across densities — only
+ * the padding and border treatment change. In "compact" mode items are borderless
+ * rows in a single `divide-edge` list (see EntryList), so the per-card borders
+ * (including the e-paper `border-zinc-500` fallback) are dropped; the darker
+ * e-paper divider handles row separation instead.
  */
-export function getItemClasses(read: boolean, selected: boolean): string {
-  const baseClasses =
-    "group relative cursor-pointer rounded-lg border p-3 transition-colors sm:p-4";
+export function getItemClasses(
+  read: boolean,
+  selected: boolean,
+  density: ListDensity = "comfortable"
+): string {
+  const compact = density === "compact";
+  const baseClasses = compact
+    ? "group relative cursor-pointer px-3 py-2.5 transition-colors sm:px-4"
+    : "group relative cursor-pointer rounded-lg border p-3 transition-colors sm:p-4";
 
   if (selected) {
-    // Selected state takes priority - accent ring indicator
-    return `${baseClasses} border-accent ring-2 ring-accent ring-offset-1 dark:ring-offset-zinc-900 ${
+    // Selected state takes priority - accent ring indicator. In compact mode the
+    // ring stands in for the border the cards would otherwise carry.
+    return `${baseClasses} ${compact ? "" : "border-accent "}ring-2 ring-accent ring-offset-1 dark:ring-offset-zinc-900 ${
       read ? "bg-canvas" : "bg-surface"
     }`;
   }
@@ -79,13 +101,15 @@ export function getItemClasses(read: boolean, selected: boolean): string {
     // faint hairline border, so they read as "already handled". They lift to a
     // surface fill on hover to signal they're still clickable (the surface
     // tokens already carry their own dark-mode values).
-    return `${baseClasses} border-edge bg-canvas hover:bg-surface active:bg-surface-muted`;
+    const readClasses = `${baseClasses} bg-canvas hover:bg-surface active:bg-surface-muted`;
+    return compact ? readClasses : `${readClasses} border-edge`;
   }
 
   // Unread entries stand out as raised surface cards with a distinctly stronger
   // border (the only card/canvas separation available on e-paper, where every
   // fill is white).
-  return `${baseClasses} border-edge-input bg-surface hover:bg-surface-muted active:bg-zinc-100 dark:active:bg-zinc-700 epaper:border-zinc-500`;
+  const unreadClasses = `${baseClasses} bg-surface hover:bg-surface-muted active:bg-zinc-100 dark:active:bg-zinc-700`;
+  return compact ? unreadClasses : `${unreadClasses} border-edge-input epaper:border-zinc-500`;
 }
 
 /**
@@ -99,6 +123,7 @@ export const EntryListItem = memo(function EntryListItem({
   selected = false,
   onToggleRead,
   onToggleStar,
+  density = "comfortable",
 }: EntryListItemProps) {
   const {
     id,
@@ -153,7 +178,7 @@ export const EntryListItem = memo(function EntryListItem({
       onMouseDown={handleMouseDown}
       onKeyDown={handleKeyDown}
       data-entry-id={id}
-      className={getItemClasses(read, selected)}
+      className={getItemClasses(read, selected, density)}
       aria-label={`${read ? "Read" : "Unread"}${selected ? ", selected" : ""} article: ${displayTitle} from ${source}`}
     >
       <div className="flex items-start gap-3">
@@ -237,8 +262,10 @@ export const EntryListItem = memo(function EntryListItem({
             </time>
           </div>
 
-          {/* Preview */}
-          {summary && <p className="ui-text-sm text-muted mt-2 line-clamp-2">{summary}</p>}
+          {/* Preview (hidden in compact density to pack more items per screen) */}
+          {summary && density !== "compact" && (
+            <p className="ui-text-sm text-muted mt-2 line-clamp-2">{summary}</p>
+          )}
         </div>
       </div>
     </article>

--- a/src/components/entries/EntryListSkeleton.tsx
+++ b/src/components/entries/EntryListSkeleton.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { memo } from "react";
+import type { ListDensity } from "@/lib/appearance/settings";
 
 interface EntryListItemSkeletonProps {
   /**
@@ -15,6 +16,12 @@ interface EntryListItemSkeletonProps {
    * Varies to create more natural looking skeletons.
    */
   hasLongSummary?: boolean;
+
+  /**
+   * List density (matches EntryListItem so the skeleton doesn't reflow when the
+   * real list renders).
+   */
+  density?: ListDensity;
 }
 
 /**
@@ -22,9 +29,17 @@ interface EntryListItemSkeletonProps {
  */
 const EntryListItemSkeleton = memo(function EntryListItemSkeleton({
   hasLongSummary = true,
+  density = "comfortable",
 }: EntryListItemSkeletonProps) {
+  const compact = density === "compact";
+  // Compact rows are borderless (the list supplies `divide-edge` separators);
+  // comfortable items are bordered cards.
+  const containerClasses = compact
+    ? "px-3 py-2.5 sm:px-4"
+    : "border-edge bg-surface rounded-lg border p-4";
+
   return (
-    <div className="border-edge bg-surface rounded-lg border p-4">
+    <div className={containerClasses}>
       <div className="flex items-start gap-3">
         {/* Read indicator skeleton */}
         <div className="mt-1.5 shrink-0">
@@ -43,15 +58,17 @@ const EntryListItemSkeleton = memo(function EntryListItemSkeleton({
             <div className="bg-fill-muted h-3 w-16 animate-pulse rounded" />
           </div>
 
-          {/* Summary skeleton */}
-          <div className="mt-2 space-y-1.5">
-            <div className="bg-fill-muted h-4 w-full animate-pulse rounded" />
-            <div
-              className={`bg-fill-muted h-4 animate-pulse rounded ${
-                hasLongSummary ? "w-4/5" : "w-1/2"
-              }`}
-            />
-          </div>
+          {/* Summary skeleton (hidden in compact density, matching EntryListItem) */}
+          {!compact && (
+            <div className="mt-2 space-y-1.5">
+              <div className="bg-fill-muted h-4 w-full animate-pulse rounded" />
+              <div
+                className={`bg-fill-muted h-4 animate-pulse rounded ${
+                  hasLongSummary ? "w-4/5" : "w-1/2"
+                }`}
+              />
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -64,6 +81,13 @@ interface EntryListSkeletonProps {
    * @default 5
    */
   count?: number;
+
+  /**
+   * List density (matches the entry list so the skeleton doesn't reflow when the
+   * real list renders).
+   * @default "comfortable"
+   */
+  density?: ListDensity;
 }
 
 /**
@@ -72,11 +96,14 @@ interface EntryListSkeletonProps {
  */
 export const EntryListSkeleton = memo(function EntryListSkeleton({
   count = 5,
+  density = "comfortable",
 }: EntryListSkeletonProps) {
+  const listClassName = density === "compact" ? "divide-edge divide-y" : "space-y-3";
+
   return (
-    <div className="space-y-3" role="status" aria-label="Loading entries">
+    <div className={listClassName} role="status" aria-label="Loading entries">
       {Array.from({ length: count }, (_, i) => (
-        <EntryListItemSkeleton key={i} hasLongSummary={i % 2 === 0} />
+        <EntryListItemSkeleton key={i} hasLongSummary={i % 2 === 0} density={density} />
       ))}
       <span className="sr-only">Loading entries...</span>
     </div>

--- a/src/components/settings/AppearanceSettings.tsx
+++ b/src/components/settings/AppearanceSettings.tsx
@@ -14,7 +14,12 @@ import { useTheme } from "next-themes";
 import { SettingsSection } from "@/components/settings/SettingsSection";
 import { useIsEInkDisplay } from "@/lib/theme/eink";
 import { useAppearance, useEntryTextStyles } from "@/lib/appearance/AppearanceProvider";
-import type { TextSize, TextJustification, FontFamily } from "@/lib/appearance/settings";
+import type {
+  TextSize,
+  TextJustification,
+  FontFamily,
+  ListDensity,
+} from "@/lib/appearance/settings";
 
 interface OptionButtonProps<T extends string> {
   value: T;
@@ -102,6 +107,11 @@ const FONT_OPTIONS: { value: FontFamily; label: string }[] = [
   { value: "source-sans", label: "Source Sans" },
 ];
 
+const LIST_DENSITY_OPTIONS: { value: ListDensity; label: string }[] = [
+  { value: "comfortable", label: "Comfortable" },
+  { value: "compact", label: "Compact" },
+];
+
 /**
  * Preview text for demonstrating text appearance settings.
  * Uses the same styling as actual article content.
@@ -177,6 +187,24 @@ export function AppearanceSettings() {
 
           <TextPreview />
         </div>
+      </SettingsSection>
+
+      {/* Entry List Section */}
+      <SettingsSection
+        title="Entry List"
+        description="Controls how densely entries are packed in the article list."
+      >
+        <OptionGroup
+          label="List Density"
+          description={
+            settings.listDensity === "compact"
+              ? "A single divided list with tighter spacing and no preview — best for scanning many entries."
+              : "Roomy bordered cards with a preview snippet — best for relaxed reading."
+          }
+          value={settings.listDensity}
+          options={LIST_DENSITY_OPTIONS}
+          onChange={(listDensity) => updateSettings({ listDensity })}
+        />
       </SettingsSection>
     </div>
   );

--- a/src/lib/appearance/settings.ts
+++ b/src/lib/appearance/settings.ts
@@ -27,6 +27,15 @@ export type TextJustification = "left" | "justify";
 export type FontFamily = "system" | "merriweather" | "literata" | "inter" | "source-sans";
 
 /**
+ * List density options for the entry list.
+ *
+ * - "comfortable": roomy bordered cards (the default reading view).
+ * - "compact": a single divided list with tighter padding and no excerpt, for
+ *   scanning/triaging many items at once.
+ */
+export type ListDensity = "comfortable" | "compact";
+
+/**
  * User preferences for text appearance.
  *
  * Note: Theme (dark/light mode) is managed by next-themes, not here.
@@ -46,6 +55,11 @@ export interface AppearanceSettings {
    * Font family for entry content.
    */
   fontFamily: FontFamily;
+
+  /**
+   * Vertical density of the entry list.
+   */
+  listDensity: ListDensity;
 }
 
 /**
@@ -55,6 +69,7 @@ const DEFAULT_APPEARANCE_SETTINGS: AppearanceSettings = {
   textSize: "medium",
   textJustification: "left",
   fontFamily: "system",
+  listDensity: "comfortable",
 };
 
 /**
@@ -94,6 +109,7 @@ function loadAppearanceSettings(): AppearanceSettings {
       "inter",
       "source-sans",
     ];
+    const validListDensities: ListDensity[] = ["comfortable", "compact"];
 
     return {
       textSize: validTextSizes.includes(parsed.textSize as TextSize)
@@ -105,6 +121,9 @@ function loadAppearanceSettings(): AppearanceSettings {
       fontFamily: validFontFamilies.includes(parsed.fontFamily as FontFamily)
         ? (parsed.fontFamily as FontFamily)
         : DEFAULT_APPEARANCE_SETTINGS.fontFamily,
+      listDensity: validListDensities.includes(parsed.listDensity as ListDensity)
+        ? (parsed.listDensity as ListDensity)
+        : DEFAULT_APPEARANCE_SETTINGS.listDensity,
     };
   } catch {
     // If parsing fails, return defaults

--- a/tests/unit/frontend/components/EntryListItem.test.tsx
+++ b/tests/unit/frontend/components/EntryListItem.test.tsx
@@ -129,6 +129,16 @@ describe("EntryListItem", () => {
       expect(article.querySelectorAll("p")).toHaveLength(0);
     });
 
+    it("renders the summary in comfortable density but hides it in compact", () => {
+      const entry = createMockEntry({ summary: "Article summary text" });
+
+      const { rerender } = render(<EntryListItem entry={entry} density="comfortable" />);
+      expect(screen.getByText("Article summary text")).toBeInTheDocument();
+
+      rerender(<EntryListItem entry={entry} density="compact" />);
+      expect(screen.queryByText("Article summary text")).not.toBeInTheDocument();
+    });
+
     it("renders relative time for publishedAt", () => {
       const entry = createMockEntry({
         publishedAt: new Date("2024-06-15T10:00:00Z"), // 2 hours ago

--- a/tests/unit/frontend/entry-list-item.test.ts
+++ b/tests/unit/frontend/entry-list-item.test.ts
@@ -91,4 +91,44 @@ describe("getItemClasses", () => {
       expect(selectedRead).not.toContain("hover:bg-surface");
     });
   });
+
+  describe("compact density", () => {
+    it("defaults to comfortable when density is omitted", () => {
+      // The explicit "comfortable" and the default must produce identical output.
+      expect(getItemClasses(false, false)).toBe(getItemClasses(false, false, "comfortable"));
+      expect(getItemClasses(true, true)).toBe(getItemClasses(true, true, "comfortable"));
+    });
+
+    it("drops the per-card border and rounding but keeps the color language", () => {
+      const unread = getItemClasses(false, false, "compact");
+      const read = getItemClasses(true, false, "compact");
+
+      // Borderless rows: the surrounding list supplies divide-edge separators.
+      expect(unread).not.toContain("rounded-lg");
+      expect(unread).not.toContain(" border ");
+      expect(unread).not.toContain("border-edge-input");
+      // The e-paper per-card border fallback is dropped (dividers separate rows).
+      expect(unread).not.toContain("epaper:border-zinc-500");
+      expect(read).not.toContain("border-edge");
+
+      // Tighter vertical padding for more items per screen.
+      expect(unread).toContain("py-2.5");
+      expect(unread).not.toContain("p-3");
+
+      // Unread/read background language is unchanged.
+      expect(unread).toContain("bg-surface");
+      expect(unread).toContain("hover:bg-surface-muted");
+      expect(read).toContain("bg-canvas");
+      expect(read).toContain("hover:bg-surface");
+    });
+
+    it("keeps the selection ring but no border in compact", () => {
+      const selected = getItemClasses(false, true, "compact");
+
+      expect(selected).toContain("ring-2");
+      expect(selected).toContain("ring-accent");
+      expect(selected).not.toContain("border-accent");
+      expect(selected).toContain("bg-surface");
+    });
+  });
 });


### PR DESCRIPTION
Closes #1171

## What

Adds a **List Density** appearance preference so users can switch the entry list between the roomy card view and a tight scanning view.

- **Comfortable** (default): the existing bordered-card view with a preview excerpt — unchanged.
- **Compact**: a single divided list (`divide-edge`) with no per-card borders, tighter vertical padding, and the excerpt hidden. Roughly 2× the items per screen for triaging.

It's driven off the same localStorage-backed `AppearanceSettings` mechanism as text size / font / alignment, so it persists per browser like the other appearance settings. The toggle lives in **Settings → Appearance** under a new "Entry List" section.

## Design notes

- The unread-dot / star / read **color language is identical** across densities — only padding and border treatment change, so muscle memory carries over.
- Compact drops the per-card border (including the e-paper `border-zinc-500` fallback) and relies on `divide-edge` separators instead. Those stay visible on e-ink because `--edge` is darker (zinc-400) in the e-paper theme — verified in **light, dark, and e-paper**.
- `EntryListItem` takes an optional `density` prop (default `"comfortable"`) rather than reading appearance context directly, keeping it presentational and its existing prop-only unit tests valid. `EntryList` / `EntryListFallback` / `EntryListSkeleton` read `useAppearance()` and thread density down. The skeleton stays comfortable on the deterministic pre-hydration path in `EntryListContainer` to avoid a hydration mismatch.

## Testing

- `pnpm typecheck` ✅
- `pnpm test:unit` ✅ (added compact-density cases to `getItemClasses` and an excerpt-hidden case to the `EntryListItem` component test)
- Manual verification via the `/demo` route across all three themes in both densities (screenshots taken locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)