### PR TITLE
docs: main agent owns local services; subagents shouldn't start their own

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,22 @@ it stops both servers and deletes its temp dir + env files:
 pnpm services            # run in the BACKGROUND; leave it running
 ```
 
+**Ownership when using subagents:** the persistent **main agent** owns `pnpm
+services` — it starts it and keeps it running (restarting if it dies).
+**Subagents must not run `pnpm services` themselves**: a subagent's background
+tasks are torn down when the subagent finishes, which kills the DB out from under
+later work (and can orphan the Postgres/Redis processes). A subagent should assume
+the services are already up and just use the `*:local` scripts below — they read
+the `.env.local-services*` files the main agent's `pnpm services` wrote. So before
+delegating DB-dependent work to a subagent, the main agent must have `pnpm
+services` running; if it dies mid-run, the subagent should report back rather than
+start its own, and the main agent restarts it.
+
+> Background tasks are also periodically SIGTERM'd by the harness — even for the
+> main agent (see [clawed-abode#424](https://github.com/brendanlong/clawed-abode/issues/424)) —
+> so treat a mid-run DB-connection error as "restart `pnpm services` and retry",
+> not a code failure.
+
 Then, in the foreground, use the `*:local` variants (they layer the generated env
 file over `.env.test` so it wins, via `dotenv -o`):
 


### PR DESCRIPTION
Adds an **Ownership** note to CLAUDE.md's "Local Services (no Docker)" section.

**Why:** a subagent's background tasks are torn down when the subagent finishes, so a subagent that runs `pnpm services` itself loses the throwaway Postgres/Redis out from under any later work (and can orphan the DB processes). The lifecycle belongs to the persistent main agent.

**Rule documented:** the main agent starts and keeps `pnpm services` running (restarting if it dies); subagents assume services are already up and use the `*:local` scripts, which read the `.env.local-services*` files the main agent wrote. If services drop mid-run, the subagent reports back rather than starting its own, and the main agent restarts.

Also cross-references clawed-abode#424 (the harness periodically SIGTERMs background tasks even for the main agent), so a mid-run DB-connection error should be treated as "restart and retry", not a code failure.

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)