### PR TITLE
Use tabular figures for UI numbers (unread counts, stats, narration)

### DIFF
--- a/src/app/demo/DemoSidebar.tsx
+++ b/src/app/demo/DemoSidebar.tsx
@@ -68,7 +68,9 @@ export function DemoSidebar({ onClose }: DemoSidebarProps) {
           isActive={isAllActive}
           countElement={
             totalUnread > 0 ? (
-              <span className="ui-text-xs text-muted ml-2 shrink-0">({totalUnread})</span>
+              <span className="ui-text-xs text-muted ml-2 shrink-0 tabular-nums">
+                ({totalUnread})
+              </span>
             ) : undefined
           }
           onClick={onClose}
@@ -81,7 +83,9 @@ export function DemoSidebar({ onClose }: DemoSidebarProps) {
           isActive={isHighlightsActive}
           countElement={
             highlightCount > 0 ? (
-              <span className="ui-text-xs text-muted ml-2 shrink-0">({highlightCount})</span>
+              <span className="ui-text-xs text-muted ml-2 shrink-0 tabular-nums">
+                ({highlightCount})
+              </span>
             ) : undefined
           }
           onClick={onClose}

--- a/src/components/admin/AdminFeedsContent.tsx
+++ b/src/components/admin/AdminFeedsContent.tsx
@@ -225,7 +225,7 @@ function FeedRow({ feed, onRetry, isRetrying }: FeedRowProps) {
 
 function StatItem({ label, value }: { label: string; value: string }) {
   return (
-    <span>
+    <span className="tabular-nums">
       <span className="text-body font-medium">{label}:</span> {value}
     </span>
   );

--- a/src/components/admin/AdminOverviewContent.tsx
+++ b/src/components/admin/AdminOverviewContent.tsx
@@ -27,7 +27,7 @@ function StatCard({
   return (
     <div className="border-edge bg-surface rounded-lg border p-4">
       <p className="ui-text-xs text-muted">{label}</p>
-      <p className="ui-text-lg text-strong mt-1 font-semibold">
+      <p className="ui-text-lg text-strong mt-1 font-semibold tabular-nums">
         {typeof value === "number" ? value.toLocaleString() : value}
       </p>
       {detail && <p className="ui-text-xs text-faint mt-1">{detail}</p>}

--- a/src/components/admin/AdminUsersContent.tsx
+++ b/src/components/admin/AdminUsersContent.tsx
@@ -116,7 +116,7 @@ function UserRow({ user }: { user: User }) {
       )}
 
       {/* Stats row */}
-      <div className="ui-text-xs text-muted flex flex-wrap gap-x-4 gap-y-1">
+      <div className="ui-text-xs text-muted flex flex-wrap gap-x-4 gap-y-1 tabular-nums">
         <span>Member since {formatDate(user.createdAt)}</span>
         <span>Last active: {user.lastActiveAt ? formatDate(user.lastActiveAt) : "Never"}</span>
         <span>

--- a/src/components/layout/SidebarNav.tsx
+++ b/src/components/layout/SidebarNav.tsx
@@ -25,7 +25,7 @@ interface SidebarNavProps {
  */
 function CountBadge({ count }: { count: number }) {
   if (count === 0) return null;
-  return <span className="ui-text-xs text-muted ml-2 shrink-0">({count})</span>;
+  return <span className="ui-text-xs text-muted ml-2 shrink-0 tabular-nums">({count})</span>;
 }
 
 /**

--- a/src/components/layout/SubscriptionItem.tsx
+++ b/src/components/layout/SubscriptionItem.tsx
@@ -59,7 +59,7 @@ export function SubscriptionItem({
       >
         <span className="truncate pr-8">{displayTitle}</span>
         {subscription.unreadCount > 0 && (
-          <span className="ui-text-xs text-muted shrink-0 group-hover:hidden">
+          <span className="ui-text-xs text-muted shrink-0 tabular-nums group-hover:hidden">
             ({subscription.unreadCount})
           </span>
         )}

--- a/src/components/narration/EnhancedVoiceList.tsx
+++ b/src/components/narration/EnhancedVoiceList.tsx
@@ -70,7 +70,7 @@ function ProgressBar({ progress, size }: { progress: number; size: number }) {
           style={{ width: `${percent}%` }}
         />
       </div>
-      <p className="ui-text-xs text-muted mt-1">
+      <p className="ui-text-xs text-muted mt-1 tabular-nums">
         {percent}% ({downloadedMB} MB / {totalMB} MB)
       </p>
     </div>
@@ -423,7 +423,7 @@ export function EnhancedVoiceList({ settings, setSettings }: EnhancedVoiceListPr
       {/* Storage info section */}
       {downloadedCount > 0 && (
         <NoteBox padding="sm" className="flex items-center justify-between">
-          <span className="ui-text-xs text-muted">
+          <span className="ui-text-xs text-muted tabular-nums">
             Storage used: {formatStorageSize(storageUsed)} ({downloadedCount}{" "}
             {downloadedCount === 1 ? "voice" : "voices"})
           </span>

--- a/src/components/narration/NarrationControls.tsx
+++ b/src/components/narration/NarrationControls.tsx
@@ -196,7 +196,7 @@ export function NarrationControlsImpl({
 
       {/* Paragraph indicator - only show when active */}
       {isActive && totalParagraphs > 0 && (
-        <span className="ui-text-xs text-muted">
+        <span className="ui-text-xs text-muted tabular-nums">
           {currentParagraph + 1} of {totalParagraphs}
         </span>
       )}

--- a/src/components/narration/NarrationSettings.tsx
+++ b/src/components/narration/NarrationSettings.tsx
@@ -368,7 +368,7 @@ export function NarrationSettings() {
           <div>
             <label
               htmlFor="narration-rate"
-              className="ui-text-sm text-body mb-1.5 block font-medium"
+              className="ui-text-sm text-body mb-1.5 block font-medium tabular-nums"
             >
               Speed: {settings.rate.toFixed(1)}x
             </label>
@@ -395,7 +395,7 @@ export function NarrationSettings() {
             <div>
               <label
                 htmlFor="narration-pitch"
-                className="ui-text-sm text-body mb-1.5 block font-medium"
+                className="ui-text-sm text-body mb-1.5 block font-medium tabular-nums"
               >
                 Pitch: {settings.pitch.toFixed(1)}x
               </label>

--- a/src/components/settings/pages/ApiTokensSettingsContent.tsx
+++ b/src/components/settings/pages/ApiTokensSettingsContent.tsx
@@ -258,7 +258,7 @@ export default function ApiTokensSettingsContent() {
 
       {/* Active Tokens List */}
       <div className="mb-6">
-        <h3 className="ui-text-sm text-body mb-3 font-medium">
+        <h3 className="ui-text-sm text-body mb-3 font-medium tabular-nums">
           Active Tokens ({activeTokens.length})
         </h3>
         <SettingsListContainer
@@ -283,7 +283,7 @@ export default function ApiTokensSettingsContent() {
       {/* Revoked/Expired Tokens */}
       {inactiveTokens.length > 0 && (
         <div>
-          <h3 className="ui-text-sm text-body mb-3 font-medium">
+          <h3 className="ui-text-sm text-body mb-3 font-medium tabular-nums">
             Revoked/Expired Tokens ({inactiveTokens.length})
           </h3>
           <div className="space-y-3">

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -109,7 +109,7 @@ function IngestAddressesSection() {
     <section>
       <div className="mb-4 flex items-center justify-between">
         <h3 className="ui-text-sm text-strong font-medium">Ingest Addresses</h3>
-        <span className="ui-text-sm text-muted">{addresses.length} / 5</span>
+        <span className="ui-text-sm text-muted tabular-nums">{addresses.length} / 5</span>
       </div>
 
       <SettingsListContainer

--- a/src/components/settings/pages/FeedStatsSettingsContent.tsx
+++ b/src/components/settings/pages/FeedStatsSettingsContent.tsx
@@ -220,7 +220,7 @@ function SummaryCard({ label, value, variant = "default" }: SummaryCardProps) {
   return (
     <div className="border-edge-strong rounded-lg border bg-zinc-50 p-4 dark:bg-zinc-800">
       <p className="ui-text-sm text-muted">{label}</p>
-      <p className={`ui-text-2xl font-semibold ${variantClasses[variant]}`}>{value}</p>
+      <p className={`ui-text-2xl font-semibold tabular-nums ${variantClasses[variant]}`}>{value}</p>
     </div>
   );
 }
@@ -350,7 +350,7 @@ function StatItem({ icon, label, value }: StatItemProps) {
   return (
     <div className="text-muted flex items-center gap-1.5">
       <span className="h-4 w-4 shrink-0">{icon}</span>
-      <span className="truncate">
+      <span className="truncate tabular-nums">
         <span className="text-body font-medium">{label}:</span> {value}
       </span>
     </div>

--- a/src/components/ui/nav-link.tsx
+++ b/src/components/ui/nav-link.tsx
@@ -115,7 +115,7 @@ export function NavLinkWithIcon({
       {icon && <span className="shrink-0">{icon}</span>}
       <span className="truncate">{label}</span>
       {count !== undefined && count > 0 && (
-        <span className="ui-text-xs text-muted ml-auto shrink-0">({count})</span>
+        <span className="ui-text-xs text-muted ml-auto shrink-0 tabular-nums">({count})</span>
       )}
     </ClientLink>
   );


### PR DESCRIPTION
## Problem

Numbers in the UI jittered as they changed. Geist Sans (our UI font) renders **proportional** figures by default, where `1` is narrower than other digits, so a value like `10 → 11` shifts every digit sideways (worst for `0↔1`). Most visible on the live-updating sidebar unread counts.

## Fix

No font change needed — Geist already ships **tabular figures** (the `tnum` OpenType feature). Enabling `font-variant-numeric: tabular-nums` (Tailwind `tabular-nums`) makes every digit the same advance width, so only the changed digit moves. `tabular-nums` only affects digit glyphs, so it's a no-op on wrappers that also contain label text.

### Sites covered

**Sidebar unread counts** (the original motivation, live-updated via SSE):
- `SidebarNav.tsx` — All / Starred / Saved
- `ui/nav-link.tsx` — tag / uncategorized counts
- `SubscriptionItem.tsx` — per-subscription counts
- `demo/DemoSidebar.tsx` — demo "All Features" / "Highlights" counts

**Narration** (tick live during playback / slider drag):
- `NarrationControls.tsx` — "N of M" paragraph counter
- `NarrationSettings.tsx` — speed / pitch slider labels
- `EnhancedVoiceList.tsx` — download % + storage line

**Admin & settings stats** (grid alignment + consistency):
- `AdminOverviewContent.tsx` — stat cards
- `AdminFeedsContent.tsx` — per-feed `StatItem`
- `AdminUsersContent.tsx` — user stats row (counts + dates)
- `FeedStatsSettingsContent.tsx` — summary cards + per-feed `StatItem`
- `ApiTokensSettingsContent.tsx` — token section headings
- `EmailSettingsContent.tsx` — ingest-address counter

Shared local `StatItem`/`SummaryCard` components are patched once to cover all their call sites.

## Verification

Rendered Geist both ways and confirmed the font honors `tabular-nums` (proportional `(1)`/`(11)` misalign; tabular aligns them). `pnpm typecheck` + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)