### PR TITLE
Add Button danger variant + migrate destructive buttons; fix design-doc link (Phase 2)

### DIFF
--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -1,8 +1,12 @@
 # Lion Reader design system — colors & components
 
 The canonical, minimal set of theme colors and components, and the plan to finish
-moving the app onto it. Companion to the accent rationale in
-[`accent-exploration.md`](accent-exploration.md).
+moving the app onto it. The warm-amber accent rationale, with before/after
+screenshots across all three themes, is in the exploration PR
+([#1172](https://github.com/brendanlong/lion-reader/pull/1172)); those screenshots
+and other design assets live on the orphan
+[`assets`](https://github.com/brendanlong/lion-reader/tree/assets) branch so they
+stay out of `master`'s history.
 
 Principle: **one token per role, themed once.** A component never writes a raw
 Tailwind color (`bg-red-50 dark:bg-red-950`); it writes a role (`bg-danger-subtle`),

--- a/src/app/complete-signup/page.tsx
+++ b/src/app/complete-signup/page.tsx
@@ -171,12 +171,11 @@ export default function CompleteSignupPage() {
                 Cancel
               </Button>
               <Button
-                variant="primary"
+                variant="danger"
                 size="sm"
                 onClick={handleDelete}
                 loading={deleteMutation.isPending}
                 disabled={!isDeleteConfirmed || deleteMutation.isPending}
-                className="bg-danger-solid text-danger-solid-foreground hover:bg-danger-solid-hover"
               >
                 Delete account
               </Button>

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -8,25 +8,25 @@ Reusable UI primitives are in `src/components/ui/`. **Always check for existing 
 
 ### Available Components
 
-| Component             | Purpose                                                   |
-| --------------------- | --------------------------------------------------------- |
-| **Button**            | Primary, secondary, ghost variants with loading state     |
-| **Input**             | Text input with label and error handling                  |
-| **Alert**             | Status messages (error, success, warning, info)           |
-| **Dialog**            | Modal dialogs with backdrop, focus trap, escape handling  |
-| **Card**              | Container with border, background, and consistent padding |
-| **CardSection**       | Subsection within a Card, separated by a top border       |
-| **NoteBox**           | Subtle zinc-tinted box for notes and secondary content    |
-| **StatusCard**        | Colored card for info/success/warning/error states        |
-| **ClientLink**        | Internal navigation links (use instead of Next.js Link)   |
-| **TextLink**          | Accent-colored inline text link (`external` for new tab)  |
-| **InlineCode**        | Small monospace chip for inline code, URLs, file names    |
-| **Kbd**               | Keyboard key chip for displaying shortcut keys            |
-| **NavLink**           | Sidebar navigation links with active state and counts     |
-| **IconButton**        | Small icon-only action buttons (edit, close, etc.)        |
-| **NotFoundCard**      | Card for 404/missing content states                       |
-| **ColorPicker**       | Color selection with `ColorDot` preview                   |
-| **StateToggleButton** | Toggle button with visual state indicator                 |
+| Component             | Purpose                                                       |
+| --------------------- | ------------------------------------------------------------- |
+| **Button**            | Primary, secondary, ghost, danger variants with loading state |
+| **Input**             | Text input with label and error handling                      |
+| **Alert**             | Status messages (error, success, warning, info)               |
+| **Dialog**            | Modal dialogs with backdrop, focus trap, escape handling      |
+| **Card**              | Container with border, background, and consistent padding     |
+| **CardSection**       | Subsection within a Card, separated by a top border           |
+| **NoteBox**           | Subtle zinc-tinted box for notes and secondary content        |
+| **StatusCard**        | Colored card for info/success/warning/error states            |
+| **ClientLink**        | Internal navigation links (use instead of Next.js Link)       |
+| **TextLink**          | Accent-colored inline text link (`external` for new tab)      |
+| **InlineCode**        | Small monospace chip for inline code, URLs, file names        |
+| **Kbd**               | Keyboard key chip for displaying shortcut keys                |
+| **NavLink**           | Sidebar navigation links with active state and counts         |
+| **IconButton**        | Small icon-only action buttons (edit, close, etc.)            |
+| **NotFoundCard**      | Card for 404/missing content states                           |
+| **ColorPicker**       | Color selection with `ColorDot` preview                       |
+| **StateToggleButton** | Toggle button with visual state indicator                     |
 
 ### Common Icons
 

--- a/src/components/feeds/UnsubscribeDialog.tsx
+++ b/src/components/feeds/UnsubscribeDialog.tsx
@@ -54,12 +54,7 @@ export function UnsubscribeDialog({
         <Button ref={cancelButtonRef} variant="secondary" onClick={onCancel} disabled={isLoading}>
           Cancel
         </Button>
-        <Button
-          variant="primary"
-          onClick={onConfirm}
-          loading={isLoading}
-          className="bg-danger-solid hover:bg-danger-solid-hover focus:ring-danger"
-        >
+        <Button variant="danger" onClick={onConfirm} loading={isLoading}>
           Unsubscribe
         </Button>
       </DialogFooter>

--- a/src/components/settings/TagManagement.tsx
+++ b/src/components/settings/TagManagement.tsx
@@ -289,10 +289,10 @@ function TagItem({ tag, onSuccess, onError }: TagItemProps) {
             Cancel
           </Button>
           <Button
+            variant="danger"
             size="sm"
             onClick={handleDelete}
             loading={deleteMutation.isPending}
-            className="bg-danger-solid text-danger-solid-foreground hover:bg-danger-solid-hover focus:ring-danger"
           >
             Delete
           </Button>

--- a/src/components/settings/pages/DeleteAccountSettingsContent.tsx
+++ b/src/components/settings/pages/DeleteAccountSettingsContent.tsx
@@ -83,10 +83,7 @@ export default function DeleteAccountSettingsContent() {
             account data.
           </p>
           <div className="mt-4">
-            <Button
-              onClick={handleOpenDialog}
-              className="bg-danger-solid text-danger-solid-foreground hover:bg-danger-solid-hover"
-            >
+            <Button variant="danger" onClick={handleOpenDialog}>
               Delete account
             </Button>
           </div>
@@ -136,10 +133,10 @@ export default function DeleteAccountSettingsContent() {
             Cancel
           </Button>
           <Button
+            variant="danger"
             onClick={handleDelete}
             loading={deleteAccountMutation.isPending}
             disabled={!isConfirmed}
-            className="bg-danger-solid text-danger-solid-foreground hover:bg-danger-solid-hover"
           >
             Delete my account
           </Button>

--- a/src/components/settings/pages/EmailSettingsContent.tsx
+++ b/src/components/settings/pages/EmailSettingsContent.tsx
@@ -272,11 +272,7 @@ function IngestAddressRow({ address }: IngestAddressRowProps) {
           >
             Cancel
           </Button>
-          <Button
-            onClick={handleDelete}
-            loading={deleteMutation.isPending}
-            className="bg-danger-solid hover:bg-danger-solid-hover"
-          >
+          <Button variant="danger" onClick={handleDelete} loading={deleteMutation.isPending}>
             Delete
           </Button>
         </DialogFooter>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -8,7 +8,7 @@ import type { ButtonHTMLAttributes, Ref } from "react";
 import { SpinnerIcon } from "@/components/ui/icon-button";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: "primary" | "secondary" | "ghost";
+  variant?: "primary" | "secondary" | "ghost" | "danger";
   size?: "sm" | "md" | "lg";
   loading?: boolean;
   ref?: Ref<HTMLButtonElement>;
@@ -32,6 +32,8 @@ export function Button({
     secondary:
       "border border-edge-input bg-surface text-strong hover:bg-surface-muted focus:ring-focus",
     ghost: "text-strong hover:bg-surface-muted focus:ring-focus",
+    danger:
+      "bg-danger-solid text-danger-solid-foreground hover:bg-danger-solid-hover focus:ring-danger",
   };
 
   // Ensure minimum 44px height for touch targets on mobile (WCAG touch target guidelines)


### PR DESCRIPTION
Closes #1186. Phase 2 of the design-system migration.

## Button `danger` variant

Adds a fourth Button variant driven by the `--danger-solid` tokens:
`bg-danger-solid text-danger-solid-foreground hover:bg-danger-solid-hover focus:ring-danger`.

Migrates the **six** hand-rolled destructive buttons from per-call-site `className` onto `variant="danger"`:
- `feeds/UnsubscribeDialog` (Unsubscribe)
- `settings/pages/DeleteAccountSettingsContent` (Delete account ×2)
- `settings/pages/EmailSettingsContent` (delete ingest address)
- `settings/TagManagement` (delete tag)
- `app/complete-signup/page` (delete account)

Appearance is unchanged (they already used the `--danger-solid` tokens after #1169) — this removes the duplicated class strings and makes destructive intent a first-class prop. The one status-dot `<span>` that also uses `bg-danger-solid` is left as-is (not a button). Doc: added `danger` to the Button row in `src/components/CLAUDE.md`.

## Design-doc link fix

`docs/design/design-system.md` linked to `accent-exploration.md`, which was never merged to `master` (it lived only on exploration PR #1172), so the link was broken. Repointed it to the PR (which renders the rationale + before/after screenshots) and noted design assets live on the orphan `assets` branch — no image-heavy doc added to `master`.

## Verification (real `dev:local` build, seeded session)

`pnpm typecheck` passes; eslint/prettier clean. Screenshots of the delete-account page — note the **amber primary** ("Subscribe") next to the **red danger** ("Delete account"), the exact variant distinction this adds:

| Light | Dark | E-paper |
| --- | --- | --- |
| ![light](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/phase2-danger-button/light.png) | ![dark](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/phase2-danger-button/dark.png) | ![epaper](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/phase2-danger-button/epaper.png) |

Screenshots hosted on the orphan `assets` branch (not committed to `master`).

Next: #1187 (finish zinc mop-up), #1188 (CI guardrail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)