### PR TITLE
Fix entry action-button color inconsistencies + white focus ring (#1193)

### DIFF
--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -252,11 +252,6 @@ function DemoRouterContent() {
                 variant={selectedEntry.starred ? "primary" : "secondary"}
                 size="sm"
                 onClick={() => demoState.toggleStar(selectedEntry.id)}
-                className={
-                  selectedEntry.starred
-                    ? "bg-warning-solid text-warning-solid-foreground hover:bg-warning-solid-hover"
-                    : ""
-                }
                 aria-label={selectedEntry.starred ? "Remove from starred" : "Add to starred"}
               >
                 {selectedEntry.starred ? (
@@ -290,11 +285,6 @@ function DemoRouterContent() {
                   setShowSummaryForEntry(
                     showSummaryForEntry === selectedEntry.id ? null : selectedEntry.id
                   )
-                }
-                className={
-                  showSummaryForEntry === selectedEntry.id
-                    ? "bg-accent-muted hover:bg-accent dark:bg-accent dark:hover:bg-accent-hover text-white dark:text-zinc-900"
-                    : ""
                 }
                 aria-label={
                   showSummaryForEntry === selectedEntry.id ? "Hide summary" : "Show AI summary"

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -351,11 +351,6 @@ export function EntryContentBody({
             variant={starred ? "primary" : "secondary"}
             size="sm"
             onClick={onToggleStar}
-            className={
-              starred
-                ? "bg-warning-solid text-warning-solid-foreground hover:bg-warning-solid-hover"
-                : ""
-            }
             aria-label={starred ? "Remove from starred" : "Add to starred"}
           >
             {starred ? <StarFilledIcon className="h-5 w-5" /> : <StarIcon className="h-5 w-5" />}
@@ -394,11 +389,7 @@ export function EntryContentBody({
               onClick={onToggleFetchFullContent}
               disabled={isFullContentFetching}
               className={
-                fullContentError
-                  ? "border-danger-border text-danger hover:bg-danger-subtle"
-                  : fetchFullContent
-                    ? "bg-accent-muted hover:bg-accent dark:bg-accent dark:hover:bg-accent-hover text-white dark:text-zinc-900"
-                    : ""
+                fullContentError ? "border-danger-border text-danger hover:bg-danger-subtle" : ""
               }
               aria-label={
                 fullContentError
@@ -442,11 +433,6 @@ export function EntryContentBody({
               size="sm"
               onClick={onSummarize}
               disabled={isSummarizing}
-              className={
-                showSummary && summary
-                  ? "bg-accent-muted hover:bg-accent dark:bg-accent dark:hover:bg-accent-hover text-white dark:text-zinc-900"
-                  : ""
-              }
               aria-label={summary ? "Toggle summary" : "Generate AI summary"}
             >
               {isSummarizing ? (

--- a/src/components/entries/EntryContentFallback.tsx
+++ b/src/components/entries/EntryContentFallback.tsx
@@ -154,11 +154,6 @@ export function EntryContentFallback({ entryId, onBack }: EntryContentFallbackPr
               variant={cachedEntry.starred ? "primary" : "secondary"}
               size="sm"
               onClick={handleStarToggle}
-              className={
-                cachedEntry.starred
-                  ? "bg-warning-solid text-warning-solid-foreground hover:bg-warning-solid-hover"
-                  : ""
-              }
               aria-label={cachedEntry.starred ? "Remove from starred" : "Add to starred"}
             >
               {cachedEntry.starred ? (

--- a/src/components/settings/WallabagApiSettings.tsx
+++ b/src/components/settings/WallabagApiSettings.tsx
@@ -102,7 +102,7 @@ export function WallabagApiSettings() {
             <div className="flex flex-col gap-3">
               <a
                 href={wallabagDeepLink}
-                className="bg-accent hover:bg-accent-hover inline-flex items-center gap-2 rounded-md px-4 py-2 font-medium text-white transition-colors"
+                className="btn-primary inline-flex items-center gap-2 rounded-md px-4 py-2 font-medium"
               >
                 <MobileIcon className="h-4 w-4" />
                 Open in Wallabag App

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -25,7 +25,7 @@ export function Button({
   ...props
 }: ButtonProps) {
   const baseStyles =
-    "inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+    "inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ring-offset-background disabled:cursor-not-allowed disabled:opacity-50";
 
   const variantStyles = {
     primary: "btn-primary",


### PR DESCRIPTION
Addresses the first three points of #1193. All confirmed real; here's the root cause and the fix.

## Root cause
The Star, full-content, and Summarize toggle buttons each **hand-rolled their own "active" amber** via `className` instead of using the `primary` token:
- Star → `bg-warning-solid` (amber-500) + white text
- full-content / Summarize → `bg-accent-muted` (amber-500 light / amber-400 dark) + white/black

…so the filled buttons in the action row were **three different oranges with different text colors**, none matching the real primary button (`--primary-solid` = amber-700 light / amber-400 dark). That's exactly the "starred is a different orange with white text/star" (#1 in the issue) and "read/unread inconsistent in light mode" (#2).

**Fix:** drop the overrides so every filled toggle uses `variant="primary"` — same orange, same themed text/star color, matching each other and every other primary button. Same fix in the cached-entry fallback's Star button.

For **#3** (blazing-white ring in dark mode): the shared `Button` had `focus:ring-offset-2` with no offset color, so it used Tailwind's default **white**. Added `ring-offset-background` so the gap blends into the page (near-black in dark), with the amber ring outside it — exactly your "make it black in dark mode" suggestion.

## Before / after (dev:local, on /demo)

**Dark** — before: Starred = amber-500 + white; Unread = amber-400 + black (mismatched). After: both amber-400 + black.
| Before | After |
| --- | --- |
| ![bd](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/ui-color-fixes-1193/before-dark.png) | ![ad](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/ui-color-fixes-1193/after-dark.png) |

**Light** — before: Starred (amber-500) vs Unread (amber-700) were two oranges. After: both amber-700 + white.
| Before | After |
| --- | --- |
| ![bl](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/ui-color-fixes-1193/before-light.png) | ![al](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/ui-color-fixes-1193/after-light.png) |

**Focus ring (dark)** — the offset gap is now dark, not white:
![ring](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/ui-color-fixes-1193/after-ring.png)

`pnpm typecheck` + eslint/prettier clean.

## The 4th point (dark-mode orange) — not in this PR, needs your call
Your "make the dark orange slightly darker / closer to light mode" is a **palette** change (it moves links, unread dots, and every primary button in dark mode), so I kept it out of this bug-fix PR. My recommendation below — happy to do it as a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Update — additional copies fixed

The entry action buttons are rendered in **three** places, not one: the real app (`EntryContentBody` + its `EntryContentFallback`) **and** the public demo (`app/demo/DemoRouter.tsx`), which keeps its own copy. The first commit only fixed the app, so the `/demo` screenshots still showed the old mismatch. Fixed the demo copy too; now verified by **computed style** (not eyeballing): Starred and Unread are both `rgb(180,83,9)` amber-700 + white in light and `rgb(251,191,36)` amber-400 + `rgb(24,24,27)` zinc-900 in dark — byte-identical. (Above screenshots updated.)

Also swept the rest of the app and fixed one related bug: the **"Open in Wallabag App"** CTA (`WallabagApiSettings`) used `bg-accent … text-white` with no `dark:` foreground, so in dark mode it was white text on amber-400 (failing contrast). Now uses the shared `btn-primary` utility.
