### PR TITLE
PWA: make the mobile status bar track the app theme (was a fixed orange)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono, Merriweather, Literata, Inter, Source_Sans_3 } from "next/font/google";
 import { defaultOpenGraph } from "@/lib/metadata";
 import { appUrl } from "@/server/config/env";
@@ -50,6 +50,17 @@ export const metadata: Metadata = {
     apple: "/apple-touch-icon.png",
   },
   openGraph: defaultOpenGraph,
+};
+
+// SSR default for the mobile status-bar / PWA toolbar color, matching the
+// `bg-surface` header per system preference. ThemeColorMeta (ThemeProvider) then
+// overrides this to the *resolved app theme* after hydration, so a forced theme
+// (e.g. dark on a light-scheme phone) still matches. See ThemeProvider.tsx.
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#18181b" },
+  ],
 };
 
 /**

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -9,7 +9,11 @@ export default function manifest(): MetadataRoute.Manifest {
     display: "standalone",
     orientation: "portrait",
     background_color: "#ffffff",
-    theme_color: "#f97316",
+    // Single-value fallback for contexts that don't honor the per-theme
+    // <meta name="theme-color"> (see ThemeProvider.tsx / layout viewport): the
+    // dark-grey top-bar color (--surface dark = zinc-900), which reads as
+    // intentional in both modes. Was a hardcoded orange that matched nothing.
+    theme_color: "#18181b",
     icons: [
       {
         src: "/android-chrome-192x192.png",

--- a/src/lib/theme/ThemeProvider.tsx
+++ b/src/lib/theme/ThemeProvider.tsx
@@ -67,6 +67,38 @@ function EInkSystemThemeOverride() {
 }
 
 /**
+ * Syncs `<meta name="theme-color">` (the mobile status-bar / PWA toolbar color)
+ * to the resolved app theme's top-bar color, so the status bar blends with the
+ * `bg-surface` header instead of showing a fixed brand color (issue: the PWA
+ * status bar was a hardcoded orange that matched nothing).
+ *
+ * Uses `resolvedTheme` — the *app's* theme, not the OS `prefers-color-scheme` —
+ * so a user who forces dark on a light-scheme phone still gets the dark status
+ * bar. It overwrites every `theme-color` meta (including the media-scoped SSR
+ * defaults from `viewport.themeColor`) so the app theme always wins.
+ *
+ * Colors mirror `--surface`: white in light/e-paper, zinc-900 in dark.
+ */
+function ThemeColorMeta() {
+  const { resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    const color = resolvedTheme === "dark" ? "#18181b" : "#ffffff";
+    const metas = document.querySelectorAll('meta[name="theme-color"]');
+    if (metas.length === 0) {
+      const meta = document.createElement("meta");
+      meta.name = "theme-color";
+      meta.content = color;
+      document.head.appendChild(meta);
+    } else {
+      metas.forEach((meta) => meta.setAttribute("content", color));
+    }
+  }, [resolvedTheme]);
+
+  return null;
+}
+
+/**
  * Theme provider that wraps the app with next-themes.
  *
  * Configuration:
@@ -89,6 +121,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       storageKey="lion-reader-theme"
     >
       <EInkSystemThemeOverride />
+      <ThemeColorMeta />
       {children}
     </NextThemesProvider>
   );


### PR DESCRIPTION
You were right — the PWA status bar was a hardcoded `theme_color: "#f97316"` (orange-500, a *different* orange from the brand accent) in the web manifest, and it never adapted to light/dark. This makes the status bar blend with the `bg-surface` header instead.

## What it does
- **`ThemeColorMeta`** (in `ThemeProvider`) syncs `<meta name="theme-color">` to the **resolved app theme's** surface color — the same color as the top bar: `#ffffff` in light / e-paper, `#18181b` (zinc-900) in dark. It overwrites the media-scoped defaults, so a user who **forces** dark on a light-scheme phone still gets the dark status bar (important here since dark mode is a deliberate choice for many).
- **`viewport.themeColor`** SSR default (light `#ffffff` / dark `#18181b`, by system preference) so the first paint is correct before hydration.
- **manifest `theme_color`** → `#18181b` (dark-grey top-bar color) as the single-value fallback for the few contexts that ignore the per-theme meta (Android task switcher, cold-launch splash).

Net result, matching your suggestion: **dark grey in dark mode, white in light mode** — the status bar becomes a seamless extension of the header.

## Verified (dev:local)
The `theme-color` meta resolves to `#ffffff` (light), `#18181b` (dark), `#ffffff` (e-paper), tracking the actual html theme; `manifest.webmanifest` serves `theme_color: #18181b`. `pnpm typecheck` + `pnpm check:colors` green.

## The one judgment call
You floated "light grey or the primary dark orange" for **light** mode. I went with **white** (the exact header/`--surface` color) so it truly blends — a light-grey or orange bar would reintroduce a seam against the white header. If you'd rather have a **branded orange** status bar in light mode (dark stays dark), it's a one-line change in `ThemeColorMeta` (light → `#b45309`) — happy to switch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
