### PR TITLE
Remove underline-on-hover for entry titles

### DIFF
--- a/src/components/entries/EntryArticle.tsx
+++ b/src/components/entries/EntryArticle.tsx
@@ -107,7 +107,7 @@ export function EntryArticle({
                 href={url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="ui-text-xl sm:ui-text-2xl hover:text-accent text-strong block leading-tight font-bold underline-offset-2 transition-colors hover:underline md:text-3xl"
+                className="ui-text-xl sm:ui-text-2xl hover:text-accent text-strong block leading-tight font-bold transition-colors md:text-3xl"
               >
                 {title}
               </a>

--- a/src/components/entries/EntryContentFallback.tsx
+++ b/src/components/entries/EntryContentFallback.tsx
@@ -113,7 +113,7 @@ export function EntryContentFallback({ entryId, onBack }: EntryContentFallbackPr
                     href={url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="ui-text-xl sm:ui-text-2xl hover:text-accent text-strong block leading-tight font-bold underline-offset-2 transition-colors hover:underline md:text-3xl"
+                    className="ui-text-xl sm:ui-text-2xl hover:text-accent text-strong block leading-tight font-bold transition-colors md:text-3xl"
                   >
                     {title}
                   </a>


### PR DESCRIPTION
## Summary

Removes the `hover:underline` (and now-unused `underline-offset-2`) from the entry-title link in both entry views. On hover the title now only changes to the accent color (`hover:text-accent transition-colors`), matching the requested behavior.

Body prose links are **unchanged** — they get their underline from the `@tailwindcss/typography` prose defaults (always underlined), which this change does not touch.

## Changes

- `src/components/entries/EntryArticle.tsx` — entry title link
- `src/components/entries/EntryContentFallback.tsx` — entry title link (fallback view)

## Testing

- `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)