### PR TITLE
Settings: make the active nav tab clearly visible (primary fill)

### DIFF
--- a/src/components/settings/UnifiedSettingsContent.tsx
+++ b/src/components/settings/UnifiedSettingsContent.tsx
@@ -108,7 +108,7 @@ export function UnifiedSettingsContent() {
                     href={link.href}
                     className={`ui-text-sm block rounded-md px-3 py-2 font-medium whitespace-nowrap transition-colors ${
                       isActive
-                        ? "bg-surface-muted text-strong"
+                        ? "bg-primary-solid text-primary-solid-foreground"
                         : "text-muted hover:bg-surface-muted hover:text-strong"
                     }`}
                   >


### PR DESCRIPTION
The selected settings tab used `bg-surface-muted text-strong` — in light mode that's `zinc-100` on a near-white page, so the active tab was **barely distinguishable from the background**, and it was the *same* color as the inactive-hover state (so hovering a tab looked selected).

Switched the active tab to `bg-primary-solid text-primary-solid-foreground` — the **same filled amber** that the segmented selectors (Auto / Medium / System) on those very settings pages already use for "selected." Now the active tab is clearly visible and consistent with the other selected controls right next to it, in all three themes (amber-700 light / amber-500 dark / black e-paper).

![after](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/settings-active-tab/after-light.png)

Verified on dev:local (light mode, the reported case). Typecheck + lint clean.

## Related, not in this PR
The main **sidebar** nav (`nav-link.tsx`, `SubscriptionItem.tsx`) uses the same faint `bg-surface-muted` active state. I left it alone because making the whole left rail filled-amber is a bigger, heavier change than a settings tab — happy to address it separately if you want (probably with a lighter treatment than a full fill, e.g. accent text + an accent indicator bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
