### PR TITLE
Make keyboard focus consistently amber instead of flickering blue↔amber

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -485,6 +485,31 @@ body {
 }
 
 /* =================================
+   Global Focus Indicator
+
+   Single source of truth for keyboard-focus visibility: every focusable
+   element gets the brand amber outline (--focus) so tabbing around the app
+   is consistently amber. Without this, elements that set no focus style of
+   their own (nav links, entry rows, icon buttons, links) fell back to the
+   browser default blue outline, so tabbing flickered blue↔amber depending on
+   which control had focus.
+
+   - `:focus-visible`, not `:focus`, so it only shows for keyboard navigation,
+     not mouse clicks.
+   - Lives in `@layer base` so a component that opts out with
+     `focus:outline-none` (utilities layer, always paired with its own
+     `focus:ring-focus`) wins — otherwise buttons/inputs would show both their
+     ring and this outline. Modern browsers follow the element's border-radius,
+     so rounded controls get a rounded outline for free.
+   ================================= */
+@layer base {
+  :focus-visible {
+    outline: 2px solid var(--focus);
+    outline-offset: 2px;
+  }
+}
+
+/* =================================
    UI Typography Utilities
 
    Semantic classes for consistent UI text sizing.

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -96,6 +96,8 @@ The `ui-text-*` classes are defined in `src/app/globals.css` and provide respons
 - **`star`**: `text-star` (+ `hover:text-star-hover`, `bg-star`) is the formalized amber favorite/star color. Use it only for the star/favorite icon; amber used for alerts/offline/"unsaved changes" is `warning`, not `star`.
 - `StatusCard`, `Alert`, and the `Input` error state are already token-driven — reuse them instead of rebuilding a colored box.
 
+**Global focus outline.** Every focusable element gets an amber `:focus-visible` outline by default via a single `@layer base` rule in `globals.css` (`outline: 2px solid var(--focus)`), so bare focusable elements (nav links, entry rows, plain links) are already covered and no longer fall back to the browser-default blue outline. Add `focus:ring-focus` only for controls that want a box-shadow ring instead (buttons, inputs) — those pair it with `focus:outline-none`, which wins from the utilities layer and suppresses the global outline so there's no double indicator. Don't set `focus:outline-none` without also adding a ring, or the element ends up with no focus indicator at all.
+
 Tokens work under variants (`hover:bg-surface-muted`, `focus:ring-focus`), so interactive states use them too. Notes:
 
 - **Filled** "on"/selected controls (a solid pill/toggle, not an outline) use `bg-primary-solid text-primary-solid-foreground` — the same token as primary buttons (now the branded amber fill). `control-selected` is the **outline/indicator** color for the same states; it aliases the accent (amber) and shares `ring-focus`'s value today, but is a separate token so the two roles can diverge.

--- a/src/components/admin/AdminFeedsContent.tsx
+++ b/src/components/admin/AdminFeedsContent.tsx
@@ -391,7 +391,7 @@ export default function AdminFeedsContent() {
               type="checkbox"
               checked={hasSubscribers}
               onChange={(e) => setHasSubscribers(e.target.checked)}
-              className="text-accent focus:ring-accent border-edge-input h-4 w-4 rounded dark:bg-zinc-800"
+              className="text-accent focus:ring-focus border-edge-input h-4 w-4 rounded dark:bg-zinc-800"
             />
             Has subscribers
           </label>

--- a/src/components/settings/pages/ApiTokensSettingsContent.tsx
+++ b/src/components/settings/pages/ApiTokensSettingsContent.tsx
@@ -201,7 +201,7 @@ export default function ApiTokensSettingsContent() {
                       type="checkbox"
                       checked={selectedScopes.includes(scope)}
                       onChange={() => toggleScope(scope)}
-                      className="text-accent focus:ring-accent border-edge-input mt-1 h-4 w-4 rounded dark:bg-zinc-800"
+                      className="text-accent focus:ring-focus border-edge-input mt-1 h-4 w-4 rounded dark:bg-zinc-800"
                     />
                     <div className="flex-1">
                       <p className="text-strong font-medium">{label}</p>


### PR DESCRIPTION
## Problem

Tabbing around the interface, the keyboard focus indicator randomly switched between **blue** and **orange**. Buttons and inputs set an explicit `focus:ring-focus` (the brand amber), but many interactive elements — nav links (`NavLink`), entry rows (`EntryListItem`'s `<article role="button" tabindex=0>`), icon buttons, `ClientLink`/`TextLink`, copy buttons — set **no focus style at all** and fell through to the browser's default focus outline (blue in most browsers). So which color you saw depended on which control had focus.

## Fix

Add a **single global `:focus-visible` outline** in `src/app/globals.css` using `var(--focus)` (amber-700 light / amber-500 dark / amber-800 e-paper), so every focusable element gets the same amber focus treatment by default:

```css
@layer base {
  :focus-visible {
    outline: 2px solid var(--focus);
    outline-offset: 2px;
  }
}
```

- Lives in `@layer base` so components that opt out with `focus:outline-none` (utilities layer, always paired with their own `focus:ring-focus`) still win — no double indicator. Every `outline-none` in the codebase is already paired with a ring, so nothing is left without a focus indicator.
- `:focus-visible` (not `:focus`) so it only shows for keyboard navigation, not mouse clicks.
- This is the same single-source-of-truth pattern already used to theme native form controls via `accent-color` on `body`.

Also switched the two checkboxes still on `focus:ring-accent` to the semantic `focus:ring-focus` token (`AdminFeedsContent`, `ApiTokensSettingsContent`) — both resolve to amber, but `ring-focus` is the designated focus role.

## Verification

Drove a local dev server with Playwright and confirmed nav links, entry rows, and buttons all show a consistent 2px amber outline/ring on keyboard focus — no more blue — in **light**, **dark**, and **e-paper** themes. (`--focus` resolves to `#b45309` / `#f59e0b` / `#92400e` respectively.)

`pnpm typecheck` and `pnpm check:colors` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)