### PR TITLE
Fix narration highlight desync on <br><br>-formatted articles

### DIFF
--- a/migrations/0095_narration_paragraph_map.sql
+++ b/migrations/0095_narration_paragraph_map.sql
@@ -1,0 +1,17 @@
+-- Persist the narration paragraph map alongside the cached narration text.
+--
+-- The paragraph map translates a narration paragraph index (what the TTS player
+-- reports as it speaks) into the `data-para-id` of the block element to
+-- highlight. It used to be reconstructed on every cache hit by positionally
+-- pairing the source's block elements with the cached narration's paragraphs —
+-- which silently mis-mapped whenever the LLM dropped a paragraph or a block's
+-- narration text spanned multiple paragraphs, shifting every subsequent
+-- highlight onto the wrong element.
+--
+-- Storing the map that generation actually produced makes cache hits return the
+-- correct alignment. Nullable + no default: existing rows keep NULL and the read
+-- path re-derives a best-effort map from the source content until they're
+-- regenerated. Expand-only, backward compatible (old code ignores the column).
+
+ALTER TABLE narration_content
+  ADD COLUMN paragraph_map jsonb;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -659,6 +659,13 @@
       "when": 1782952700000,
       "tag": "0094_entries_feed_updated_at_index",
       "breakpoints": true
+    },
+    {
+      "idx": 94,
+      "version": "7",
+      "when": 1782952800000,
+      "tag": "0095_narration_paragraph_map",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -310,7 +310,8 @@ CREATE TABLE public.narration_content (
     generated_at timestamp with time zone,
     error text,
     error_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    paragraph_map jsonb
 );
 
 CREATE TABLE public.oauth_access_tokens (

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -18,6 +18,7 @@ import { NarrationHighlightStyles } from "@/components/narration/NarrationHighli
 import { useNarration } from "@/components/narration/useNarration";
 import { useNarrationHighlight } from "@/components/narration/useNarrationHighlight";
 import { processHtmlForHighlighting } from "@/lib/narration/client-paragraph-ids";
+import { selectDisplayedContent } from "@/lib/narration/select-content";
 import { useNarrationSettings } from "@/lib/narration/settings";
 import { useEntryTextStyles } from "@/lib/appearance/AppearanceProvider";
 import { useImagePrefetch } from "@/lib/hooks/useImagePrefetch";
@@ -172,7 +173,7 @@ export function EntryContentBody({
   const hasFullContent = Boolean(
     (fullContentCleaned || fullContentOriginal) && fullContentFetchedAt && !fullContentError
   );
-  const showFullContent = fetchFullContent && hasFullContent;
+  const showFullContent = Boolean(fetchFullContent && hasFullContent);
 
   // Check if both feed content versions are available for toggle
   // Only show this toggle when NOT showing full content
@@ -180,21 +181,21 @@ export function EntryContentBody({
 
   // Select content based on state
   // Priority: full content (if enabled and available) > cleaned feed content > original feed content
-  let contentToDisplay: string | null;
-  if (showFullContent) {
-    contentToDisplay = fullContentCleaned ?? fullContentOriginal ?? null;
-  } else if (showOriginal) {
-    contentToDisplay = contentOriginal;
-  } else {
-    contentToDisplay = contentCleaned ?? contentOriginal;
-  }
+  const contentToDisplay = selectDisplayedContent(
+    { fullContentCleaned, fullContentOriginal, contentCleaned, contentOriginal },
+    { showFullContent, showOriginal }
+  );
 
-  // Set up narration with highlighting support
+  // Set up narration with highlighting support. Pass the current view state so
+  // the server narrates (and maps highlights against) exactly the variant on
+  // screen, not a fixed full/cleaned/original priority.
   const narration = useNarration({
     id: articleId,
     title,
     feedTitle: source,
     content: contentToDisplay,
+    showFullContent,
+    showOriginal,
   });
 
   const { highlightedParagraphIds } = useNarrationHighlight({

--- a/src/components/narration/useNarration.ts
+++ b/src/components/narration/useNarration.ts
@@ -393,6 +393,8 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
         const result = await generateMutation.mutateAsync({
           id,
           useLlmNormalization: settings.useLlmNormalization,
+          showFullContent: showFullContent ?? false,
+          showOriginal: showOriginal ?? false,
         });
         narration = result.narration;
         // Store the paragraph map from server for index translation during highlighting
@@ -517,9 +519,13 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
     narratorRef.current.stop();
   }, [isSupported, usePiper]);
 
-  // Reset narration state when article or voice changes (render-time pattern
-  // avoids cascading renders from calling setState inside an effect)
-  const narrationResetKey = `${id}:${settings.voiceId}`;
+  // Reset narration state when the article, voice, or displayed content variant
+  // changes (render-time pattern avoids cascading renders from calling setState
+  // inside an effect). The variant is part of the key because narration text and
+  // its paragraph map are variant-specific: replaying a cached "cleaned"
+  // narration while the DOM now shows "full"/"original" would highlight the
+  // wrong elements. Resetting forces the next play to re-narrate what's on screen.
+  const narrationResetKey = `${id}:${settings.voiceId}:${showFullContent ?? false}:${showOriginal ?? false}`;
   const [prevNarrationResetKey, setPrevNarrationResetKey] = useState(narrationResetKey);
   if (narrationResetKey !== prevNarrationResetKey) {
     setPrevNarrationResetKey(narrationResetKey);
@@ -527,18 +533,19 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
     setNarrationText(null);
   }
 
-  // Clear audio cache and refs when article or voice changes
+  // Clear audio cache and refs when the article, voice, or displayed content
+  // variant changes
   useEffect(() => {
-    // Stop and clear the streaming player when article or voice changes
+    // Stop and clear the streaming player
     if (streamingPlayerRef.current) {
       streamingPlayerRef.current.stop();
       streamingPlayerRef.current.clearCache();
     }
     // Reset playback tracking
     hasTrackedPlaybackRef.current = false;
-    // Clear paragraph map when article changes
+    // Clear paragraph map (it's specific to the previous article/variant)
     paragraphMapRef.current = [];
-  }, [id, settings.voiceId]);
+  }, [id, settings.voiceId, showFullContent, showOriginal]);
 
   // Clean up on unmount
   useEffect(() => {

--- a/src/components/narration/useNarration.ts
+++ b/src/components/narration/useNarration.ts
@@ -74,7 +74,7 @@ export type { UseNarrationConfig, UseNarrationReturn };
  * @returns Object with narration state and control functions
  */
 export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
-  const { id, title, feedTitle, artwork, content } = config;
+  const { id, title, feedTitle, artwork, content, showFullContent, showOriginal } = config;
 
   // State
   const [state, setState] = useState<NarrationState>(DEFAULT_NARRATION_STATE);
@@ -309,6 +309,8 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
           const result = await generateMutation.mutateAsync({
             id,
             useLlmNormalization: settings.useLlmNormalization,
+            showFullContent: showFullContent ?? false,
+            showOriginal: showOriginal ?? false,
           });
           narration = result.narration;
           // Store the paragraph map from server for index translation during highlighting
@@ -438,6 +440,8 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
     generateMutation,
     id,
     content,
+    showFullContent,
+    showOriginal,
     getOrCreateStreamingPlayer,
   ]);
 

--- a/src/components/narration/useNarrationTypes.ts
+++ b/src/components/narration/useNarrationTypes.ts
@@ -30,6 +30,13 @@ export interface UseNarrationConfig {
    * generated client-side without a server call.
    */
   content?: string | null;
+  /**
+   * Which content variant is currently on screen. Forwarded to the server so
+   * LLM narration reads (and highlights against) the same variant the user
+   * sees. Defaults to false/false (cleaned feed content) when omitted.
+   */
+  showFullContent?: boolean;
+  showOriginal?: boolean;
 }
 
 /**

--- a/src/components/narration/useNarrationTypes.ts
+++ b/src/components/narration/useNarrationTypes.ts
@@ -6,6 +6,7 @@
 
 import type { NarrationState } from "@/lib/narration/ArticleNarrator";
 import type { PlaybackStatus } from "@/lib/narration/streaming-audio-player";
+import { splitNarrationParagraphs } from "@/lib/narration/paragraph-map";
 
 // ============================================================================
 // Configuration Types
@@ -75,12 +76,13 @@ export const DEFAULT_NARRATION_STATE: NarrationState = {
 
 /**
  * Splits narration text into paragraphs.
+ *
+ * Delegates to the shared {@link splitNarrationParagraphs} so the player's
+ * paragraph indexing stays identical to how `buildAlignedNarration` chunks the
+ * text and builds the paragraph map (see `@/lib/narration/paragraph-map`).
  */
 export function splitIntoParagraphs(text: string): string[] {
-  return text
-    .split(/\n\n+/)
-    .map((p) => p.trim())
-    .filter((p) => p.length > 0);
+  return splitNarrationParagraphs(text);
 }
 
 /**

--- a/src/lib/narration/ArticleNarrator.ts
+++ b/src/lib/narration/ArticleNarrator.ts
@@ -22,6 +22,7 @@
  */
 
 import { isFirefox } from "./feature-detection";
+import { splitNarrationParagraphs } from "./paragraph-map";
 import {
   DEFAULT_RATE,
   DEFAULT_PITCH,
@@ -109,11 +110,10 @@ export class ArticleNarrator {
    * @param narrationText - The text content to narrate
    */
   loadArticle(narrationText: string): void {
-    // Split by double newlines (paragraph breaks), trim, and filter empty
-    this.paragraphs = narrationText
-      .split(/\n\n+/)
-      .map((p) => p.trim())
-      .filter((p) => p.length > 0);
+    // Split by double newlines (paragraph breaks), trim, and filter empty.
+    // Uses the shared splitter so paragraph indices align with the paragraph
+    // map built by `buildAlignedNarration` (see `./paragraph-map`).
+    this.paragraphs = splitNarrationParagraphs(narrationText);
 
     this.currentIndex = 0;
     this.stop(); // Reset any current playback

--- a/src/lib/narration/client-paragraph-ids.ts
+++ b/src/lib/narration/client-paragraph-ids.ts
@@ -9,9 +9,15 @@
  */
 
 import { BLOCK_ELEMENTS } from "./block-elements";
+import {
+  buildAlignedNarration,
+  type NarrationElement,
+  type ParagraphMapEntry,
+} from "./paragraph-map";
 
 // Re-export for backwards compatibility
 export { BLOCK_ELEMENTS };
+export type { ParagraphMapEntry };
 
 /**
  * Result of adding paragraph IDs to HTML content.
@@ -175,17 +181,6 @@ export function createMemoizedAddParagraphIds(
 }
 
 /**
- * Paragraph mapping entry for highlighting support.
- * Maps a narration paragraph index to the original HTML element index.
- */
-export interface ParagraphMapEntry {
-  /** Narration paragraph index */
-  n: number;
-  /** Original HTML element index (corresponds to data-para-id) */
-  o: number;
-}
-
-/**
  * Result of converting HTML to narration input on the client side.
  */
 export interface ClientNarrationResult {
@@ -320,7 +315,7 @@ function getElementNarrationText(el: Element): string {
  * @example
  * const result = htmlToClientNarration('<p>Hello</p><img src="x" alt="photo"><p>World</p>');
  * // result.narrationText: "Hello\n\nImage: photo\n\nWorld"
- * // result.paragraphMap: [{ n: 0, o: [0] }, { n: 1, o: [1] }, { n: 2, o: [2] }]
+ * // result.paragraphMap: [{ n: 0, o: 0 }, { n: 1, o: 1 }, { n: 2, o: 2 }]
  * // result.processedHtml: '<p data-para-id="para-0">Hello</p>...'
  */
 export function htmlToClientNarration(html: string): ClientNarrationResult {
@@ -384,29 +379,23 @@ export function htmlToClientNarration(html: string): ClientNarrationResult {
     return 0;
   });
 
-  const narrationParagraphs: string[] = [];
-  const paragraphMap: ParagraphMapEntry[] = [];
-
-  // Process each element: add data-para-id and extract narration text
+  // Process each element: add data-para-id and collect its narration text.
+  // Every combined element gets a data-para-id (matching its document-order
+  // index) so the rendered DOM has a highlight target for each block; empty
+  // elements simply contribute no narration paragraph.
+  const elements: NarrationElement[] = [];
   combinedElements.forEach((el, elementIndex) => {
-    const id = `para-${elementIndex}`;
-    el.setAttribute("data-para-id", id);
-
-    const text = getElementNarrationText(el);
-
-    // Only add non-empty text to narration
-    if (text) {
-      const narrationIndex = narrationParagraphs.length;
-      narrationParagraphs.push(text);
-      paragraphMap.push({
-        n: narrationIndex,
-        o: elementIndex,
-      });
-    }
+    el.setAttribute("data-para-id", `para-${elementIndex}`);
+    elements.push({ o: elementIndex, text: getElementNarrationText(el) });
   });
 
+  // Build the narration text and paragraph map together so the map has exactly
+  // one entry per player paragraph even when a single block's text spans
+  // multiple blank-line-separated paragraphs (see `./paragraph-map`).
+  const { narrationText, paragraphMap } = buildAlignedNarration(elements);
+
   return {
-    narrationText: narrationParagraphs.join("\n\n"),
+    narrationText,
     paragraphMap,
     processedHtml: container.innerHTML,
   };

--- a/src/lib/narration/paragraph-map.ts
+++ b/src/lib/narration/paragraph-map.ts
@@ -1,0 +1,98 @@
+/**
+ * Narration paragraph mapping.
+ *
+ * The narration player splits the narration text into paragraphs on blank lines
+ * (`\n\n`) and reports the index of the paragraph it is currently speaking. The
+ * highlighter turns that index into a DOM element via the `paragraphMap`, which
+ * maps each narration paragraph index (`n`) to the `data-para-id` of the block
+ * element it came from (`o`).
+ *
+ * For highlighting to stay in sync, the map MUST have exactly one entry per
+ * paragraph the player sees — i.e. per `\n\n`-delimited segment of the narration
+ * text, in order. A block element's narration text can itself contain blank-line
+ * breaks (source newlines around `<br><br>`, or an LLM that reflows a run-on
+ * block into multiple paragraphs), so "one map entry per block element" is NOT
+ * the same as "one map entry per player paragraph". When they diverge, every
+ * highlight after the first multi-paragraph block lands on the wrong element
+ * (issue: highlighting desynced on `<br><br>`-formatted articles while clean
+ * per-`<p>` articles worked).
+ *
+ * `buildAlignedNarration` is the single place that derives the narration text and
+ * its map together so the invariant `splitNarrationParagraphs(narrationText)[i]`
+ * ↔ `paragraphMap[i]` holds by construction, regardless of how the source text
+ * is chunked. Every generation path (client-side, server LLM, server fallback)
+ * goes through it.
+ *
+ * @module narration/paragraph-map
+ */
+
+/**
+ * Paragraph mapping entry for highlighting support.
+ * Maps a narration paragraph index to the original HTML element index.
+ */
+export interface ParagraphMapEntry {
+  /** Narration paragraph index (0-based, matches the player's paragraph index) */
+  n: number;
+  /** Original HTML element index (corresponds to `data-para-id="para-{o}"`) */
+  o: number;
+}
+
+/**
+ * Splits narration text into paragraphs exactly as the playback engines do.
+ *
+ * This MUST stay identical to the splitting in `ArticleNarrator.loadArticle`,
+ * `StreamingAudioPlayer` (fed via `splitIntoParagraphs`), and
+ * `useNarrationTypes.splitIntoParagraphs` — they all consume the output of this
+ * module's `buildAlignedNarration`, so a divergent split would break the
+ * paragraph-index ↔ map alignment.
+ */
+export function splitNarrationParagraphs(text: string): string[] {
+  return text
+    .split(/\n\n+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+/**
+ * A block element's contribution to the narration: its narration text and the
+ * original element index (`data-para-id`) it should highlight.
+ */
+export interface NarrationElement {
+  /** Original HTML element index (corresponds to `data-para-id="para-{o}"`) */
+  o: number;
+  /** The element's narration text (may be empty, may contain blank-line breaks) */
+  text: string;
+}
+
+/**
+ * Builds the narration text and a paragraph map that are guaranteed to stay
+ * aligned with `splitNarrationParagraphs(narrationText)`.
+ *
+ * Each element may expand into zero, one, or many narration paragraphs:
+ * - empty (or whitespace-only) text contributes nothing (and no map entry);
+ * - text with blank-line breaks contributes one paragraph per segment, all
+ *   mapping back to the same original element index `o`.
+ *
+ * The returned `narrationText` is the segments joined by `\n\n`, so
+ * `splitNarrationParagraphs(narrationText)[i]` corresponds to `paragraphMap[i]`
+ * for every `i`.
+ */
+export function buildAlignedNarration(elements: NarrationElement[]): {
+  narrationText: string;
+  paragraphMap: ParagraphMapEntry[];
+} {
+  const paragraphs: string[] = [];
+  const paragraphMap: ParagraphMapEntry[] = [];
+
+  for (const el of elements) {
+    for (const segment of splitNarrationParagraphs(el.text)) {
+      paragraphMap.push({ n: paragraphs.length, o: el.o });
+      paragraphs.push(segment);
+    }
+  }
+
+  return {
+    narrationText: paragraphs.join("\n\n"),
+    paragraphMap,
+  };
+}

--- a/src/lib/narration/select-content.ts
+++ b/src/lib/narration/select-content.ts
@@ -1,0 +1,45 @@
+/**
+ * Selects which stored content variant is currently on screen.
+ *
+ * Narration must read aloud (and highlight against) exactly the HTML the user is
+ * looking at. The entry view can show one of three variants — fetched full
+ * content, cleaned feed content, or the original feed content — chosen by the
+ * `fetchFullContent`/"show original" toggles. This selector is the single source
+ * of truth for that choice, shared by the renderer (`EntryContentBody`) and the
+ * narration router, so the server narrates the same variant the client displays
+ * and the paragraph map's element indices line up with the rendered DOM.
+ *
+ * @module narration/select-content
+ */
+
+export interface NarrationContentFields {
+  fullContentCleaned?: string | null;
+  fullContentOriginal?: string | null;
+  contentCleaned: string | null;
+  contentOriginal: string | null;
+}
+
+export interface NarrationContentView {
+  /** Full (fetched-from-URL) content is being shown. */
+  showFullContent: boolean;
+  /** The original (uncleaned) feed content is being shown. */
+  showOriginal: boolean;
+}
+
+/**
+ * Returns the content variant currently displayed, mirroring the priority in
+ * `EntryContentBody`: full content > cleaned feed content > original feed
+ * content, with "show original" forcing the original variant.
+ */
+export function selectDisplayedContent(
+  fields: NarrationContentFields,
+  view: NarrationContentView
+): string | null {
+  if (view.showFullContent) {
+    return fields.fullContentCleaned ?? fields.fullContentOriginal ?? null;
+  }
+  if (view.showOriginal) {
+    return fields.contentOriginal;
+  }
+  return fields.contentCleaned ?? fields.contentOriginal;
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -20,6 +20,7 @@ import {
   type AnyPgColumn,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
+import type { ParagraphMapEntry } from "@/lib/narration/paragraph-map";
 
 /**
  * Postgres citext (case-insensitive text). Behaves as a plain string in
@@ -949,6 +950,12 @@ export const narrationContent = pgTable("narration_content", {
   contentHash: text("content_hash").unique().notNull(), // SHA256 of source content
 
   contentNarration: text("content_narration"), // null until generated
+  // Paragraph map for highlighting (narration paragraph index -> data-para-id).
+  // Persisted alongside the narration so cache hits return the exact map built
+  // at generation time instead of reconstructing it heuristically. Null for
+  // rows generated before this column existed (read path falls back to
+  // re-deriving from source content).
+  paragraphMap: jsonb("paragraph_map").$type<ParagraphMapEntry[]>(),
   generatedAt: timestamp("generated_at", { withTimezone: true }),
 
   // Error tracking for retry logic

--- a/src/server/services/narration.ts
+++ b/src/server/services/narration.ts
@@ -9,10 +9,13 @@ import Groq from "groq-sdk";
 import { z } from "zod";
 import { logger } from "@/lib/logger";
 import { htmlToNarrationInput } from "@/lib/narration/html-to-narration-input";
+import { buildAlignedNarration, type ParagraphMapEntry } from "@/lib/narration/paragraph-map";
+import type { NarrationInputParagraph } from "@/lib/narration/html-to-narration-input";
 import { trackNarrationHighlightFallback } from "@/server/metrics/metrics";
 
 // Re-export pure functions for backward compatibility
 export { htmlToNarrationInput };
+export type { ParagraphMapEntry };
 
 /**
  * Schema for a single paragraph from the LLM.
@@ -113,14 +116,21 @@ function getGroqClient(userApiKey?: string | null): Groq | null {
 }
 
 /**
- * Paragraph mapping entry for highlighting support.
- * Maps a narration paragraph index to the original HTML element index.
+ * Builds a fallback narration result (plain input text, no LLM) with a paragraph
+ * map aligned to how the player splits paragraphs. Shared by every fallback arm
+ * (no Groq key, empty/invalid LLM response).
  */
-export interface ParagraphMapEntry {
-  /** Narration paragraph index */
-  n: number;
-  /** Original HTML element index (corresponds to data-para-id) */
-  o: number;
+function buildFallbackNarration(
+  inputParagraphs: NarrationInputParagraph[]
+): GenerateNarrationResult {
+  const { narrationText, paragraphMap } = buildAlignedNarration(
+    inputParagraphs.map((p) => ({ o: p.id, text: p.text }))
+  );
+  return {
+    text: narrationText,
+    source: "fallback",
+    paragraphMap,
+  };
 }
 
 /**
@@ -173,17 +183,7 @@ export async function generateNarration(
   if (!client) {
     logger.debug("Groq API key not configured, using fallback text conversion");
     trackNarrationHighlightFallback();
-    // Build paragraph map from input paragraphs (1:1 mapping for fallback)
-    const paragraphMap: ParagraphMapEntry[] = inputParagraphs.map((p, idx) => ({
-      n: idx,
-      o: p.id,
-    }));
-    const fallbackText = inputParagraphs.map((p) => p.text).join("\n\n");
-    return {
-      text: fallbackText,
-      source: "fallback",
-      paragraphMap,
-    };
+    return buildFallbackNarration(inputParagraphs);
   }
 
   try {
@@ -212,17 +212,7 @@ export async function generateNarration(
     if (!rawOutput) {
       logger.warn("Groq returned empty response, using fallback");
       trackNarrationHighlightFallback();
-      // Build paragraph map from input paragraphs (1:1 mapping for fallback)
-      const paragraphMap: ParagraphMapEntry[] = inputParagraphs.map((p, idx) => ({
-        n: idx,
-        o: p.id,
-      }));
-      const fallbackText = inputParagraphs.map((p) => p.text).join("\n\n");
-      return {
-        text: fallbackText,
-        source: "fallback",
-        paragraphMap,
-      };
+      return buildFallbackNarration(inputParagraphs);
     }
 
     // Parse and validate JSON output
@@ -236,17 +226,7 @@ export async function generateNarration(
         rawOutput: rawOutput.substring(0, 200), // Log first 200 chars for debugging
       });
       trackNarrationHighlightFallback();
-      // Build paragraph map from input paragraphs (1:1 mapping for fallback)
-      const paragraphMap: ParagraphMapEntry[] = inputParagraphs.map((p, idx) => ({
-        n: idx,
-        o: p.id,
-      }));
-      const fallbackText = inputParagraphs.map((p) => p.text).join("\n\n");
-      return {
-        text: fallbackText,
-        source: "fallback",
-        paragraphMap,
-      };
+      return buildFallbackNarration(inputParagraphs);
     }
 
     // Build a Map from LLM output: id → text
@@ -257,39 +237,24 @@ export async function generateNarration(
       }
     }
 
-    // For each input paragraph, look up in LLM output map
-    // Track the paragraph mapping as we build the final output
-    const finalParagraphs: string[] = [];
-    const paragraphMap: ParagraphMapEntry[] = [];
-
-    for (const inputPara of inputParagraphs) {
+    // For each input paragraph, pick the LLM's rewrite (falling back to the
+    // original input text when the LLM omitted that id). An empty string means
+    // the LLM deliberately dropped the paragraph (junk/garbage) — it produces
+    // no narration paragraph and no map entry. `buildAlignedNarration` filters
+    // empties and, crucially, keeps the map aligned to the player's paragraph
+    // split even if a rewrite contains blank-line breaks.
+    const elements = inputParagraphs.map((inputPara) => {
       const llmText = llmTextMap.get(inputPara.id);
+      return {
+        o: inputPara.id,
+        text: llmText !== undefined ? llmText : inputPara.text,
+      };
+    });
 
-      if (llmText !== undefined) {
-        // Found in LLM output
-        if (llmText !== "") {
-          // Non-empty text → use it, track the mapping
-          paragraphMap.push({
-            n: finalParagraphs.length,
-            o: inputPara.id,
-          });
-          finalParagraphs.push(llmText);
-        }
-        // Empty string → skip (don't include in output, no mapping entry)
-      } else {
-        // Not found or id is NaN → fall back to original input text
-        if (inputPara.text !== "") {
-          paragraphMap.push({
-            n: finalParagraphs.length,
-            o: inputPara.id,
-          });
-          finalParagraphs.push(inputPara.text);
-        }
-      }
-    }
+    const { narrationText, paragraphMap } = buildAlignedNarration(elements);
 
     return {
-      text: finalParagraphs.join("\n\n"),
+      text: narrationText,
       source: "llm",
       paragraphMap,
     };

--- a/src/server/trpc/routers/narration.ts
+++ b/src/server/trpc/routers/narration.ts
@@ -7,6 +7,7 @@
 
 import { z } from "zod";
 import { eq, and } from "drizzle-orm";
+import { createHash } from "node:crypto";
 
 import { createTRPCRouter, confirmedProtectedProcedure as protectedProcedure } from "../trpc";
 import { errors } from "../errors";
@@ -19,6 +20,7 @@ import {
   isGroqAvailable,
 } from "@/server/services/narration";
 import { buildAlignedNarration } from "@/lib/narration/paragraph-map";
+import { selectDisplayedContent } from "@/lib/narration/select-content";
 import { getUserApiKeys } from "@/server/auth/session";
 import { logger } from "@/lib/logger";
 import {
@@ -51,6 +53,13 @@ const generateInputSchema = z.object({
    * Defaults to true if not specified.
    */
   useLlmNormalization: z.boolean().optional().default(true),
+  /**
+   * Which content variant the client is displaying, so narration reads (and
+   * highlights against) exactly what's on screen. Default false/false =
+   * cleaned feed content.
+   */
+  showFullContent: z.boolean().optional().default(false),
+  showOriginal: z.boolean().optional().default(false),
 });
 
 // ============================================================================
@@ -121,8 +130,8 @@ export const narrationRouter = createTRPCRouter({
           id: entries.id,
           contentCleaned: entries.contentCleaned,
           contentOriginal: entries.contentOriginal,
-          contentHash: entries.contentHash,
           fullContentCleaned: entries.fullContentCleaned,
+          fullContentOriginal: entries.fullContentOriginal,
         })
         .from(entries)
         .innerJoin(userEntries, eq(userEntries.entryId, entries.id))
@@ -134,10 +143,17 @@ export const narrationRouter = createTRPCRouter({
       }
 
       const entry = entryResult[0];
-      // Prefer full content (fetched from URL) over feed content for narration
+      // Narrate exactly the variant the user is viewing (same selector the
+      // renderer uses), so the paragraph map's element indices line up with the
+      // displayed DOM.
       const sourceContent =
-        entry.fullContentCleaned || entry.contentCleaned || entry.contentOriginal || "";
-      const contentHash = entry.contentHash;
+        selectDisplayedContent(entry, {
+          showFullContent: input.showFullContent,
+          showOriginal: input.showOriginal,
+        }) ?? "";
+      // Key the narration cache by the exact content being narrated, so
+      // different variants of the same entry don't collide.
+      const contentHash = createHash("sha256").update(sourceContent, "utf8").digest("hex");
 
       // Handle empty content
       if (!sourceContent.trim()) {

--- a/src/server/trpc/routers/narration.ts
+++ b/src/server/trpc/routers/narration.ts
@@ -17,8 +17,8 @@ import {
   generateNarration,
   htmlToNarrationInput,
   isGroqAvailable,
-  type ParagraphMapEntry,
 } from "@/server/services/narration";
+import { buildAlignedNarration } from "@/lib/narration/paragraph-map";
 import { getUserApiKeys } from "@/server/auth/session";
 import { logger } from "@/lib/logger";
 import {
@@ -178,23 +178,17 @@ export const narrationRouter = createTRPCRouter({
       // Return cached narration if available
       if (narrationRecord.contentNarration) {
         trackNarrationGenerated(true, "llm");
-        // Regenerate paragraph mapping from the source content
-        // We need this because we don't cache the mapping in the database
-        const { paragraphs } = htmlToNarrationInput(sourceContent);
-        // Count paragraphs in cached narration to build the mapping
-        const cachedParagraphs = narrationRecord.contentNarration
-          .split(/\n\n+/)
-          .filter((p) => p.trim().length > 0);
-        // Build mapping: assume 1:1 correspondence with non-empty input paragraphs
-        // This works because the LLM maintains paragraph order
-        const paragraphMap: ParagraphMapEntry[] = [];
-        let narrationIdx = 0;
-        for (const p of paragraphs) {
-          if (narrationIdx < cachedParagraphs.length) {
-            paragraphMap.push({ n: narrationIdx, o: p.id });
-            narrationIdx++;
-          }
-        }
+        // Prefer the paragraph map persisted at generation time — it is the only
+        // map guaranteed to align with the cached narration text. Legacy rows
+        // (generated before the paragraph_map column existed) have no stored
+        // map, so re-derive a best-effort one from the source content. This is
+        // aligned to the player's paragraph split (unlike the old positional
+        // reconstruction) and self-heals as those rows are regenerated.
+        const paragraphMap =
+          narrationRecord.paragraphMap ??
+          buildAlignedNarration(
+            htmlToNarrationInput(sourceContent).paragraphs.map((p) => ({ o: p.id, text: p.text }))
+          ).paragraphMap;
         return {
           narration: narrationRecord.contentNarration,
           cached: true,
@@ -209,13 +203,11 @@ export const narrationRouter = createTRPCRouter({
 
       // If user disabled LLM normalization, Groq is not configured, or we had a recent error, fall back to plain text
       if (!input.useLlmNormalization || !isGroqAvailable(userGroqApiKey) || !canRetryLLM) {
-        // Generate narration with paragraph mapping using the same path as LLM
-        const { paragraphs } = htmlToNarrationInput(sourceContent);
-        const paragraphMap: ParagraphMapEntry[] = paragraphs.map((p, idx) => ({
-          n: idx,
-          o: p.id,
-        }));
-        const fallbackText = paragraphs.map((p) => p.text).join("\n\n");
+        // Generate a fallback (plain-text) narration with a paragraph map aligned
+        // to the player's paragraph split.
+        const { narrationText: fallbackText, paragraphMap } = buildAlignedNarration(
+          htmlToNarrationInput(sourceContent).paragraphs.map((p) => ({ o: p.id, text: p.text }))
+        );
         trackNarrationGenerated(false, "fallback");
         return {
           narration: fallbackText,
@@ -247,11 +239,14 @@ export const narrationRouter = createTRPCRouter({
           };
         }
 
-        // Cache in narration_content table, clear any previous error
+        // Cache in narration_content table, clear any previous error.
+        // Persist the paragraph map so future cache hits return the exact
+        // alignment produced here instead of reconstructing it.
         await ctx.db
           .update(narrationContent)
           .set({
             contentNarration: result.text,
+            paragraphMap: result.paragraphMap,
             generatedAt: new Date(),
             error: null,
             errorAt: null,
@@ -287,13 +282,10 @@ export const narrationRouter = createTRPCRouter({
           })
           .where(eq(narrationContent.id, narrationRecord.id));
 
-        // Fall back to plain text with paragraph mapping
-        const { paragraphs } = htmlToNarrationInput(sourceContent);
-        const paragraphMap: ParagraphMapEntry[] = paragraphs.map((p, idx) => ({
-          n: idx,
-          o: p.id,
-        }));
-        const fallbackText = paragraphs.map((p) => p.text).join("\n\n");
+        // Fall back to plain text with a paragraph map aligned to the split
+        const { narrationText: fallbackText, paragraphMap } = buildAlignedNarration(
+          htmlToNarrationInput(sourceContent).paragraphs.map((p) => ({ o: p.id, text: p.text }))
+        );
         trackNarrationGenerated(false, "fallback");
         return {
           narration: fallbackText,

--- a/tests/integration/narration.test.ts
+++ b/tests/integration/narration.test.ts
@@ -18,12 +18,18 @@
 
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { eq } from "drizzle-orm";
+import { createHash } from "node:crypto";
 import { db } from "../../src/server/db";
 import { users, feeds, entries, userEntries, narrationContent } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
 import { splitNarrationParagraphs } from "../../src/lib/narration/paragraph-map";
+
+/** The narration cache key: sha256 of the exact content being narrated. */
+function narrationHash(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
 
 async function createTestUser(): Promise<string> {
   const userId = generateUuidv7();
@@ -38,10 +44,10 @@ async function createTestUser(): Promise<string> {
   return userId;
 }
 
-async function createTestFeedAndEntry(
-  contentHash: string,
-  contentCleaned: string
-): Promise<string> {
+async function createTestFeedAndEntry(content: {
+  contentCleaned?: string;
+  contentOriginal?: string;
+}): Promise<string> {
   const feedId = generateUuidv7();
   const entryId = generateUuidv7();
   const now = new Date();
@@ -61,8 +67,11 @@ async function createTestFeedAndEntry(
     type: "web",
     guid: `guid-${entryId}`,
     title: "Test Entry",
-    contentCleaned,
-    contentHash,
+    contentCleaned: content.contentCleaned ?? null,
+    contentOriginal: content.contentOriginal ?? null,
+    // Entry content hash is unrelated to the narration cache key (which now
+    // hashes the exact narrated content); any stable value works here.
+    contentHash: `entry-${entryId}`,
     fetchedAt: now,
     publishedAt: now,
     lastSeenAt: now,
@@ -151,11 +160,9 @@ describe("narration.generate cached read path", () => {
   });
 
   it("returns the persisted paragraph map verbatim on a cache hit", async () => {
-    const contentHash = `hash-${generateUuidv7()}`;
-    const entryId = await createTestFeedAndEntry(
-      contentHash,
-      "<p>First</p><p>Second</p><p>Third</p>"
-    );
+    const contentCleaned = "<p>First</p><p>Second</p><p>Third</p>";
+    const contentHash = narrationHash(contentCleaned);
+    const entryId = await createTestFeedAndEntry({ contentCleaned });
     await createUserEntry(userId, entryId);
 
     // A stored map that is deliberately NOT what naive reconstruction would
@@ -182,13 +189,13 @@ describe("narration.generate cached read path", () => {
   });
 
   it("re-derives an aligned map for a legacy row with no stored map", async () => {
-    const contentHash = `hash-${generateUuidv7()}`;
     // A <br><br>-formatted block: the second <p> holds two paragraphs, exactly
     // the shape that used to desync highlighting.
     const contentCleaned = ["<p>Intro.</p>", "<p>Line one.", "<br /><br />", "Line two.</p>"].join(
       "\n"
     );
-    const entryId = await createTestFeedAndEntry(contentHash, contentCleaned);
+    const contentHash = narrationHash(contentCleaned);
+    const entryId = await createTestFeedAndEntry({ contentCleaned });
     await createUserEntry(userId, entryId);
 
     // Legacy cached row: narration text present, paragraph_map NULL.
@@ -215,5 +222,32 @@ describe("narration.generate cached read path", () => {
       { n: 1, o: 1 },
       { n: 2, o: 1 },
     ]);
+  });
+});
+
+describe("narration.generate narrates the displayed variant", () => {
+  let userId: string;
+
+  beforeEach(async () => {
+    userId = await createTestUser();
+    createdUserIds.push(userId);
+  });
+
+  // No Groq key in the unit/integration env, so generate() takes the fallback
+  // (plain-text) path — its narration text is exactly the selected variant's
+  // text, which lets us assert *which* variant was narrated.
+  it("narrates cleaned content by default and original content when showOriginal is set", async () => {
+    const entryId = await createTestFeedAndEntry({
+      contentCleaned: "<p>Cleaned body paragraph.</p>",
+      contentOriginal: "<p>Original body paragraph.</p>",
+    });
+    await createUserEntry(userId, entryId);
+    const caller = createCaller(createAuthContext(userId));
+
+    const cleaned = await caller.narration.generate({ id: entryId });
+    expect(cleaned.narration).toBe("Cleaned body paragraph.");
+
+    const original = await caller.narration.generate({ id: entryId, showOriginal: true });
+    expect(original.narration).toBe("Original body paragraph.");
   });
 });

--- a/tests/integration/narration.test.ts
+++ b/tests/integration/narration.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Integration tests for the narration router's cached read path.
+ *
+ * The paragraph map translates a narration paragraph index (what the TTS player
+ * reports as it speaks) into the `data-para-id` of the block element to
+ * highlight. It is persisted alongside the cached narration text so a cache hit
+ * returns the exact alignment produced at generation time. Previously the map
+ * was reconstructed on every cache hit by positionally pairing the source's
+ * block elements with the cached narration's paragraphs, which silently
+ * mis-mapped whenever a block's narration text spanned multiple paragraphs
+ * (e.g. <br><br>-encoded articles) or the LLM dropped a paragraph.
+ *
+ * These tests lock in:
+ *  1. a persisted map is returned verbatim on a cache hit;
+ *  2. a legacy row (no stored map) still yields a map aligned with how the
+ *     player splits the narration text — length(map) === length(split).
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users, feeds, entries, userEntries, narrationContent } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createCaller } from "../../src/server/trpc/root";
+import type { Context } from "../../src/server/trpc/context";
+import { splitNarrationParagraphs } from "../../src/lib/narration/paragraph-map";
+
+async function createTestUser(): Promise<string> {
+  const userId = generateUuidv7();
+  const now = new Date();
+  await db.insert(users).values({
+    id: userId,
+    email: `narr-${userId}@test.com`,
+    passwordHash: "test-hash",
+    createdAt: now,
+    updatedAt: now,
+  });
+  return userId;
+}
+
+async function createTestFeedAndEntry(
+  contentHash: string,
+  contentCleaned: string
+): Promise<string> {
+  const feedId = generateUuidv7();
+  const entryId = generateUuidv7();
+  const now = new Date();
+  await db.insert(feeds).values({
+    id: feedId,
+    type: "web",
+    url: `https://example.com/${feedId}.xml`,
+    title: "Test Feed",
+    lastFetchedAt: now,
+    lastEntriesUpdatedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.insert(entries).values({
+    id: entryId,
+    feedId,
+    type: "web",
+    guid: `guid-${entryId}`,
+    title: "Test Entry",
+    contentCleaned,
+    contentHash,
+    fetchedAt: now,
+    publishedAt: now,
+    lastSeenAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return entryId;
+}
+
+async function createUserEntry(userId: string, entryId: string): Promise<void> {
+  const now = new Date();
+  await db.insert(userEntries).values({
+    userId,
+    entryId,
+    read: false,
+    starred: false,
+    readChangedAt: now,
+    starredChangedAt: now,
+    updatedAt: now,
+  });
+}
+
+function createAuthContext(userId: string): Context {
+  const now = new Date();
+  return {
+    db,
+    session: {
+      session: {
+        id: generateUuidv7(),
+        userId,
+        tokenHash: "test-hash",
+        scopes: null,
+        userAgent: null,
+        ipAddress: null,
+        createdAt: now,
+        expiresAt: new Date(Date.now() + 3600000),
+        revokedAt: null,
+        lastActiveAt: now,
+      },
+      user: {
+        id: userId,
+        email: `${userId}@test.com`,
+        emailVerifiedAt: null,
+        tosAgreedAt: new Date(),
+        privacyPolicyAgreedAt: new Date(),
+        notEuAgreedAt: new Date(),
+        passwordHash: "test-hash",
+        inviteId: null,
+        showSpam: false,
+        lastActiveAt: null,
+        groqApiKey: null,
+        anthropicApiKey: null,
+        summarizationModel: null,
+        summarizationMaxWords: null,
+        summarizationPrompt: null,
+        savedUnreadCount: 0,
+        starredUnreadCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      },
+      hasGroqApiKey: false,
+      hasAnthropicApiKey: false,
+    },
+    apiToken: null,
+    authType: "session",
+    scopes: [],
+    sessionToken: "test-token",
+    headers: new Headers(),
+  };
+}
+
+const createdUserIds: string[] = [];
+
+afterAll(async () => {
+  for (const userId of createdUserIds) {
+    await db.delete(users).where(eq(users.id, userId));
+  }
+});
+
+describe("narration.generate cached read path", () => {
+  let userId: string;
+
+  beforeEach(async () => {
+    userId = await createTestUser();
+    createdUserIds.push(userId);
+  });
+
+  it("returns the persisted paragraph map verbatim on a cache hit", async () => {
+    const contentHash = `hash-${generateUuidv7()}`;
+    const entryId = await createTestFeedAndEntry(
+      contentHash,
+      "<p>First</p><p>Second</p><p>Third</p>"
+    );
+    await createUserEntry(userId, entryId);
+
+    // A stored map that is deliberately NOT what naive reconstruction would
+    // produce (element 1 dropped, so two narration paragraphs map to o=0 and
+    // o=2). If the router reconstructs instead of reading, this won't match.
+    const storedMap = [
+      { n: 0, o: 0 },
+      { n: 1, o: 2 },
+    ];
+    await db.insert(narrationContent).values({
+      id: generateUuidv7(),
+      contentHash,
+      contentNarration: "First\n\nThird",
+      paragraphMap: storedMap,
+      generatedAt: new Date(),
+      createdAt: new Date(),
+    });
+
+    const caller = createCaller(createAuthContext(userId));
+    const result = await caller.narration.generate({ id: entryId, useLlmNormalization: true });
+
+    expect(result.cached).toBe(true);
+    expect(result.paragraphMap).toEqual(storedMap);
+  });
+
+  it("re-derives an aligned map for a legacy row with no stored map", async () => {
+    const contentHash = `hash-${generateUuidv7()}`;
+    // A <br><br>-formatted block: the second <p> holds two paragraphs, exactly
+    // the shape that used to desync highlighting.
+    const contentCleaned = ["<p>Intro.</p>", "<p>Line one.", "<br /><br />", "Line two.</p>"].join(
+      "\n"
+    );
+    const entryId = await createTestFeedAndEntry(contentHash, contentCleaned);
+    await createUserEntry(userId, entryId);
+
+    // Legacy cached row: narration text present, paragraph_map NULL.
+    const cachedNarration = "Intro.\n\nLine one.\n\nLine two.";
+    await db.insert(narrationContent).values({
+      id: generateUuidv7(),
+      contentHash,
+      contentNarration: cachedNarration,
+      paragraphMap: null,
+      generatedAt: new Date(),
+      createdAt: new Date(),
+    });
+
+    const caller = createCaller(createAuthContext(userId));
+    const result = await caller.narration.generate({ id: entryId, useLlmNormalization: true });
+
+    expect(result.cached).toBe(true);
+    // The re-derived map is aligned with the player's paragraph split: one entry
+    // per paragraph, and the two paragraphs from the second <p> both point at it.
+    const segments = splitNarrationParagraphs(result.narration);
+    expect(result.paragraphMap.length).toBe(segments.length);
+    expect(result.paragraphMap).toEqual([
+      { n: 0, o: 0 },
+      { n: 1, o: 1 },
+      { n: 2, o: 1 },
+    ]);
+  });
+});

--- a/tests/unit/client-paragraph-ids.test.ts
+++ b/tests/unit/client-paragraph-ids.test.ts
@@ -702,6 +702,91 @@ describe("htmlToClientNarration", () => {
     });
   });
 
+  describe("paragraph map alignment with internal blank lines", () => {
+    // Regression for the highlight-desync bug: articles that encode paragraphs
+    // as <br><br> inside a single block (common on old CMS pages, e.g. the
+    // Crittenden Automotive Library) produce block narration text that itself
+    // contains blank lines. The player splits narration on \n\n, so such a block
+    // becomes several player paragraphs — but the map used to record only ONE
+    // entry per block, so every highlight after the first multi-paragraph block
+    // shifted onto the wrong element. Clean per-<p> articles (e.g. LessWrong)
+    // never hit this, which is why they highlighted correctly.
+    const splitParagraphs = (text: string): string[] =>
+      text
+        .split(/\n\n+/)
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0);
+
+    it("keeps map length equal to the player's paragraph count for a <br><br> block", () => {
+      const html = [
+        "<p>Intro sentence.</p>",
+        "<blockquote>First quote paragraph.",
+        "<br /><br />",
+        "Second quote paragraph.</blockquote>",
+        "<p>Outro sentence.</p>",
+      ].join("\n");
+      const result = htmlToClientNarration(html);
+
+      // The blockquote (para-1) yields two player paragraphs, both mapping to it.
+      const segments = splitParagraphs(result.narrationText);
+      expect(segments).toEqual([
+        "Intro sentence.",
+        "First quote paragraph.",
+        "Second quote paragraph.",
+        "Outro sentence.",
+      ]);
+      expect(result.paragraphMap).toEqual([
+        { n: 0, o: 0 },
+        { n: 1, o: 1 },
+        { n: 2, o: 1 },
+        { n: 3, o: 2 },
+      ]);
+      // The invariant that was violated before the fix.
+      expect(result.paragraphMap.length).toBe(segments.length);
+    });
+
+    it("every narration paragraph points at a data-para-id present in the DOM", () => {
+      // A giant block holding most of the article via <br><br>, plus a nested
+      // heading in a table and a trailing standalone image — the shape that
+      // desynced in production.
+      const html = [
+        "<table><tr><th><h2>Article Title</h2></th></tr></table>",
+        "<p>Byline<br />2 May 2017",
+        "<br /><br />",
+        "How many times have we heard this?",
+        "<br /><br />",
+        "<b>Section Heading</b>",
+        "<br /><br />",
+        "The body continues here.</p>",
+        '<img src="x.png" alt="Site Logo" />',
+      ].join("\n");
+      const result = htmlToClientNarration(html);
+
+      const segments = splitParagraphs(result.narrationText);
+      // Map is one-to-one with the player's paragraphs.
+      expect(result.paragraphMap.length).toBe(segments.length);
+      result.paragraphMap.forEach((entry, i) => expect(entry.n).toBe(i));
+
+      // Every mapped element index resolves to a real data-para-id in the HTML.
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(`<div>${result.processedHtml}</div>`, "text/html");
+      const container = doc.body.firstElementChild!;
+      for (const mapping of result.paragraphMap) {
+        expect(container.querySelector(`[data-para-id="para-${mapping.o}"]`)).not.toBeNull();
+      }
+
+      // The four paragraphs from the single big <p> all map to the same element.
+      const bigBlockEntries = result.paragraphMap.filter((_, i) =>
+        ["Byline", "How many times", "Section Heading", "The body continues"].some((s) =>
+          segments[i].includes(s)
+        )
+      );
+      expect(bigBlockEntries.length).toBe(4);
+      const uniqueTargets = new Set(bigBlockEntries.map((e) => e.o));
+      expect(uniqueTargets.size).toBe(1);
+    });
+  });
+
   describe("blockquote handling", () => {
     it("includes blockquote text in narration", () => {
       const html = "<blockquote>A famous quote goes here.</blockquote>";

--- a/tests/unit/generate-narration-fallback.test.ts
+++ b/tests/unit/generate-narration-fallback.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for generateNarration's fallback path (no Groq key configured).
+ *
+ * The fallback converts HTML to plain-text narration and must produce a
+ * paragraph map aligned with how the player splits paragraphs — including when a
+ * single block element's text contains blank-line breaks (e.g. <br><br>-encoded
+ * paragraphs), which is exactly the case that used to desync highlighting.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { generateNarration } from "../../src/server/services/narration";
+import { splitNarrationParagraphs } from "../../src/lib/narration/paragraph-map";
+
+describe("generateNarration fallback paragraph map", () => {
+  const prevKey = process.env.GROQ_API_KEY;
+
+  // Force the no-LLM fallback path deterministically.
+  beforeAll(() => {
+    delete process.env.GROQ_API_KEY;
+  });
+  afterAll(() => {
+    if (prevKey !== undefined) process.env.GROQ_API_KEY = prevKey;
+  });
+
+  it("aligns the map with the split for clean per-<p> content", async () => {
+    const result = await generateNarration("<p>First.</p><p>Second.</p>", null);
+
+    expect(result.source).toBe("fallback");
+    const segments = splitNarrationParagraphs(result.text);
+    expect(segments).toEqual(["First.", "Second."]);
+    expect(result.paragraphMap.length).toBe(segments.length);
+    expect(result.paragraphMap).toEqual([
+      { n: 0, o: 0 },
+      { n: 1, o: 1 },
+    ]);
+  });
+
+  it("keeps the map aligned when a block encodes multiple paragraphs with <br><br>", async () => {
+    // Source newlines around <br><br> put a blank line inside a single block's
+    // narration text — the shape that desynced highlighting.
+    const html = ["<p>Intro.</p>", "<p>Line one.", "<br /><br />", "Line two.</p>"].join("\n");
+    const result = await generateNarration(html, null);
+
+    const segments = splitNarrationParagraphs(result.text);
+    // The second <p> (element index 1) becomes two player paragraphs.
+    expect(segments).toEqual(["Intro.", "Line one.", "Line two."]);
+    expect(result.paragraphMap.length).toBe(segments.length);
+    expect(result.paragraphMap).toEqual([
+      { n: 0, o: 0 },
+      { n: 1, o: 1 },
+      { n: 2, o: 1 },
+    ]);
+  });
+
+  it("maintains the length invariant for every narration paragraph", async () => {
+    const html = [
+      "<h1>Title</h1>",
+      "<blockquote>Quote part one.",
+      "<br /><br />",
+      "Quote part two.</blockquote>",
+      "<p>Closing.</p>",
+    ].join("\n");
+    const result = await generateNarration(html, null);
+
+    const segments = splitNarrationParagraphs(result.text);
+    expect(result.paragraphMap.length).toBe(segments.length);
+    result.paragraphMap.forEach((entry, i) => expect(entry.n).toBe(i));
+  });
+});

--- a/tests/unit/narration-paragraph-map.test.ts
+++ b/tests/unit/narration-paragraph-map.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the narration paragraph map builder.
+ *
+ * These pin the invariant that keeps TTS playback in sync with paragraph
+ * highlighting: the paragraph map must have exactly one entry per paragraph the
+ * player sees (per `\n\n`-delimited segment of the narration text), in order.
+ * A block element whose narration text spans multiple blank-line-separated
+ * paragraphs must contribute one map entry per paragraph, all pointing back to
+ * that element's `data-para-id`.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildAlignedNarration,
+  splitNarrationParagraphs,
+  type NarrationElement,
+} from "../../src/lib/narration/paragraph-map";
+
+describe("splitNarrationParagraphs", () => {
+  it("splits on blank lines, trims, and drops empties", () => {
+    expect(splitNarrationParagraphs("a\n\nb")).toEqual(["a", "b"]);
+    expect(splitNarrationParagraphs("  a  \n\n\n  b  ")).toEqual(["a", "b"]);
+    expect(splitNarrationParagraphs("a\n\n\n\nb")).toEqual(["a", "b"]);
+    expect(splitNarrationParagraphs("")).toEqual([]);
+    expect(splitNarrationParagraphs("\n\n")).toEqual([]);
+  });
+
+  it("does not split on single newlines", () => {
+    expect(splitNarrationParagraphs("a\nb")).toEqual(["a\nb"]);
+  });
+});
+
+describe("buildAlignedNarration", () => {
+  it("keeps the map aligned with the player's paragraph split", () => {
+    const elements: NarrationElement[] = [
+      { o: 0, text: "First" },
+      { o: 1, text: "Second" },
+    ];
+    const { narrationText, paragraphMap } = buildAlignedNarration(elements);
+
+    expect(narrationText).toBe("First\n\nSecond");
+    expect(paragraphMap).toEqual([
+      { n: 0, o: 0 },
+      { n: 1, o: 1 },
+    ]);
+  });
+
+  it("expands a block with internal blank lines into multiple entries sharing its element index", () => {
+    // A single block (o=4) whose narration text holds three paragraphs — the
+    // exact shape produced by <br><br>-formatted content and by an LLM that
+    // reflows a run-on block. All three must map back to o=4.
+    const elements: NarrationElement[] = [
+      { o: 3, text: "Intro line." },
+      { o: 4, text: "Byline\n\nHow many times...\n\nSurvivorship Bias" },
+      { o: 5, text: "Next block." },
+    ];
+    const { narrationText, paragraphMap } = buildAlignedNarration(elements);
+
+    const segments = splitNarrationParagraphs(narrationText);
+    expect(segments).toEqual([
+      "Intro line.",
+      "Byline",
+      "How many times...",
+      "Survivorship Bias",
+      "Next block.",
+    ]);
+    // One map entry per player paragraph, in order.
+    expect(paragraphMap).toEqual([
+      { n: 0, o: 3 },
+      { n: 1, o: 4 },
+      { n: 2, o: 4 },
+      { n: 3, o: 4 },
+      { n: 4, o: 5 },
+    ]);
+  });
+
+  it("drops empty elements without consuming a paragraph slot (LLM-blanked / non-narratable blocks)", () => {
+    const elements: NarrationElement[] = [
+      { o: 0, text: "Kept." },
+      { o: 1, text: "" }, // e.g. code block, empty list container, LLM-blanked junk
+      { o: 2, text: "   " }, // whitespace-only
+      { o: 3, text: "Also kept." },
+    ];
+    const { narrationText, paragraphMap } = buildAlignedNarration(elements);
+
+    expect(narrationText).toBe("Kept.\n\nAlso kept.");
+    expect(paragraphMap).toEqual([
+      { n: 0, o: 0 },
+      { n: 1, o: 3 },
+    ]);
+  });
+
+  it("handles empty input", () => {
+    const { narrationText, paragraphMap } = buildAlignedNarration([]);
+    expect(narrationText).toBe("");
+    expect(paragraphMap).toEqual([]);
+  });
+
+  it("guarantees length(map) === length(split) and correct back-references for any input", () => {
+    // Mixed: empties, single-paragraph blocks, and multi-paragraph blocks.
+    const elements: NarrationElement[] = [
+      { o: 0, text: "a\n\nb" },
+      { o: 1, text: "" },
+      { o: 2, text: "c" },
+      { o: 3, text: "d\n\n\ne\n\nf" },
+      { o: 4, text: "   " },
+      { o: 5, text: "g" },
+    ];
+    const { narrationText, paragraphMap } = buildAlignedNarration(elements);
+    const segments = splitNarrationParagraphs(narrationText);
+
+    // The core invariant: the player's split and the map are the same length,
+    // index for index, and re-splitting the built text is a fixed point.
+    expect(paragraphMap.length).toBe(segments.length);
+    paragraphMap.forEach((entry, i) => {
+      expect(entry.n).toBe(i);
+    });
+    // Every segment traces back to the element it came from.
+    expect(paragraphMap.map((e) => e.o)).toEqual([0, 0, 2, 3, 3, 3, 5]);
+    expect(segments).toEqual(["a", "b", "c", "d", "e", "f", "g"]);
+  });
+});

--- a/tests/unit/narration-select-content.test.ts
+++ b/tests/unit/narration-select-content.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for the narration content-variant selector.
+ *
+ * This is the single source of truth for "which content is on screen" shared by
+ * the renderer and the narration router, so narration reads (and highlights
+ * against) exactly the variant the user is viewing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { selectDisplayedContent } from "../../src/lib/narration/select-content";
+
+const fields = {
+  fullContentCleaned: "<p>full cleaned</p>",
+  fullContentOriginal: "<p>full original</p>",
+  contentCleaned: "<p>cleaned</p>",
+  contentOriginal: "<p>original</p>",
+};
+
+describe("selectDisplayedContent", () => {
+  it("defaults to cleaned feed content", () => {
+    expect(selectDisplayedContent(fields, { showFullContent: false, showOriginal: false })).toBe(
+      "<p>cleaned</p>"
+    );
+  });
+
+  it("returns original feed content when showOriginal is set", () => {
+    expect(selectDisplayedContent(fields, { showFullContent: false, showOriginal: true })).toBe(
+      "<p>original</p>"
+    );
+  });
+
+  it("returns full content when showFullContent is set (winning over showOriginal)", () => {
+    expect(selectDisplayedContent(fields, { showFullContent: true, showOriginal: true })).toBe(
+      "<p>full cleaned</p>"
+    );
+  });
+
+  it("falls back full-cleaned -> full-original", () => {
+    expect(
+      selectDisplayedContent(
+        { ...fields, fullContentCleaned: null },
+        { showFullContent: true, showOriginal: false }
+      )
+    ).toBe("<p>full original</p>");
+  });
+
+  it("falls back cleaned -> original when cleaned is missing", () => {
+    expect(
+      selectDisplayedContent(
+        { ...fields, contentCleaned: null },
+        { showFullContent: false, showOriginal: false }
+      )
+    ).toBe("<p>original</p>");
+  });
+
+  it("returns null when the requested variant has no content", () => {
+    expect(
+      selectDisplayedContent(
+        { contentCleaned: null, contentOriginal: null },
+        { showFullContent: true, showOriginal: false }
+      )
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Narration highlighting tracked correctly on a well-formatted LessWrong article but **desynced on a saved article** (the Crittenden Automotive Library). Reported by @self.

## Two root causes, both fixed

### 1. Map/split misalignment (the reported desync)

The paragraph map translates the TTS player's current paragraph index → the `data-para-id` to highlight. The map was built with **one entry per block element**, but the player splits narration text on blank lines (`\n\n`). When a single block's narration text itself spans multiple paragraphs — common when an article encodes paragraphs as `<br><br>` inside one `<p>`/`<blockquote>`, or when the LLM reflows a run-on block — the split produced **more** paragraphs than the map had entries, so every highlight after the first multi-paragraph block shifted onto the wrong element. Clean per-`<p>` articles (LessWrong) never hit it.

Diagnostic on the reported article's structure — before: `paragraphMap` length **8** vs. split count **16**; after: **16 vs. 16**.

**Fix:** a shared `buildAlignedNarration` (`src/lib/narration/paragraph-map.ts`) builds the narration text and map together so the map always has exactly one entry per player paragraph (multi-paragraph blocks map each sub-paragraph back to the same element). Every generation path routes through it; the player-side splitters delegate to one shared splitter so it can't drift. The cached path now **persists** the map (`migration 0095` adds `narration_content.paragraph_map`) and returns it verbatim, since it can't be reconstructed correctly from flat text once the LLM drops/reflows paragraphs.

### 2. Narrating the wrong content variant

The server narrated a fixed priority (`fullContentCleaned || contentCleaned || contentOriginal`), regardless of what the reader was showing. Opening a feed entry (cleaned view) when full content existed narrated the full variant, whose element indices don't match the cleaned DOM on screen.

**Fix:** a shared `selectDisplayedContent` selector (`src/lib/narration/select-content.ts`), used by both `EntryContentBody` and the router; the current view state (`showFullContent`/`showOriginal`) is threaded from the component through `useNarration` into `narration.generate`, so the server narrates exactly the variant on screen. The narration cache is now keyed by a hash of the **exact narrated content** (not the entry's `content_hash`), so different variants of the same entry can't collide.

## Tests

- **unit** `narration-paragraph-map.test.ts` — builder/splitter invariants.
- **unit** `client-paragraph-ids.test.ts` — `<br><br>` regression (map length == player paragraph count).
- **unit** `generate-narration-fallback.test.ts` — server fallback alignment via the real HTML parser.
- **unit** `narration-select-content.test.ts` — content-variant selection.
- **integration** `narration.test.ts` — persisted map returned verbatim; legacy null-map re-derivation; **narrates cleaned by default / original when `showOriginal`**.

Full unit suite (2280) + integration tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)