### PR TITLE
Save URLs sent or forwarded to the Discord bot in DMs

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -66,7 +66,7 @@ To render these diagrams, use the [D2 CLI](https://d2lang.com/) or [D2 Playgroun
    │  ┌─────────────────┐   ┌──────────────────┐
    │  │  Worker (min 1) │   │  Discord Bot     │
    │  │  feed fetching, │   │  save via emoji  │
-   │  │  background jobs│   │  reactions       │
+   │  │  background jobs│   │  reactions or DM │
    │  └────────┬────────┘   └────────┬─────────┘
    │           │                     │
    ▼           ▼                     ▼
@@ -105,7 +105,7 @@ not embedded in the app servers.
 | ----------------- | ----------------------------------------------------- |
 | **App Server**    | HTTP API, SSE connections                             |
 | **Worker**        | Background job execution (feed fetching)              |
-| **Discord Bot**   | Save articles via emoji reactions in Discord          |
+| **Discord Bot**   | Save articles via emoji reactions or DMs in Discord   |
 | **Postgres**      | Persistent storage, job queue (pg-boss style)         |
 | **Redis**         | Session cache, rate limiting, pub/sub for real-time   |
 | **Email Service** | Inbound email processing for newsletter subscriptions |

--- a/src/app/demo/articles/discord-bot.ts
+++ b/src/app/demo/articles/discord-bot.ts
@@ -8,17 +8,17 @@ const article: DemoArticle = {
   title: "Discord Bot",
   author: null,
   summary:
-    "Save articles to Lion Reader directly from Discord by reacting to messages with a lion emoji.",
+    "Save articles to Lion Reader directly from Discord by reacting to messages with a lion emoji, or by sending a link to the bot in a DM.",
   publishedAt: new Date("2026-01-18T01:20:31Z"),
   starred: false,
   heroImage: "/demo/discord-bot.png",
   heroImageAlt:
     "The Lion Reader lion beside a chat bubble where an article is saved with the book-reading Lion Reader emoji reaction, with a saluting lion emoji confirming.",
-  summaryHtml: `<p>The Lion Reader Discord bot automatically saves articles when users react to messages with a lion emoji. After linking accounts through Discord OAuth or API tokens, the bot provides instant visual feedback using custom emojis to confirm successful saves or indicate errors.</p>`,
+  summaryHtml: `<p>The Lion Reader Discord bot automatically saves articles when users react to messages with a lion emoji or send a link to the bot in a DM. After linking accounts through Discord OAuth or API tokens, the bot provides instant visual feedback using custom emojis to confirm successful saves or indicate errors.</p>`,
   contentHtml: `
     <h2>Save Articles from Discord</h2>
 
-    <p>The Lion Reader Discord bot lets you save articles without leaving <a href="https://discord.com/" target="_blank" rel="noopener noreferrer">Discord</a>. When someone shares a link in a channel, just react to the message with the save emoji and the article is automatically saved to your Lion Reader account. The bot extracts URLs from message content, fetches the article, and adds it to your Saved articles.</p>
+    <p>The Lion Reader Discord bot lets you save articles without leaving <a href="https://discord.com/" target="_blank" rel="noopener noreferrer">Discord</a>. When someone shares a link in a channel, just react to the message with the save emoji and the article is automatically saved to your Lion Reader account. You can also send or forward a message with a link directly to the bot in a DM. Either way, the bot extracts URLs from the message content, fetches the article, and adds it to your Saved articles.</p>
 
     <h3>Custom Lion Reader Emojis</h3>
 
@@ -56,8 +56,8 @@ const article: DemoArticle = {
     <h3>How It Works</h3>
 
     <ol>
-      <li>React to any message containing a URL with the save emoji (default: <span style="font-size: 1.25rem;">&#x1F981;</span>)</li>
-      <li>The bot extracts URLs from the message, filtering out Discord CDN links, Tenor, Giphy, and media file URLs</li>
+      <li>React to any message containing a URL with the save emoji (default: <span style="font-size: 1.25rem;">&#x1F981;</span>), or send or forward a message with a link directly to the bot in a DM</li>
+      <li>The bot extracts URLs from the message (including forwarded content), filtering out Discord CDN links, Tenor, Giphy, and media file URLs</li>
       <li>Each URL is saved using the same <code>saveArticle</code> service as the web UI and <a href="/demo/all?entry=mcp-server">MCP server</a></li>
       <li>The bot reacts with <img src="/emojis/saluting-lion-reader.png" alt="saluting lion" style="display: inline; margin: 0; width: 1.25em; height: 1.25em; vertical-align: middle;" /> on success or <img src="/emojis/crying-lion-reader.png" alt="crying lion" style="display: inline; margin: 0; width: 1.25em; height: 1.25em; vertical-align: middle;" /> on failure</li>
     </ol>

--- a/src/components/settings/DiscordBotSettings.tsx
+++ b/src/components/settings/DiscordBotSettings.tsx
@@ -63,7 +63,7 @@ export function DiscordBotSettings() {
   return (
     <SettingsSection
       title="Discord Bot"
-      description="Save articles to Lion Reader by reacting to Discord messages. When you react to a message containing a URL, the article will be saved to your account."
+      description="Save articles to Lion Reader by reacting to Discord messages, or by sending a link to the bot in a DM. When you react to (or DM the bot) a message containing a URL, the article will be saved to your account."
     >
       {/* Invite Button */}
       <div className="mt-6">
@@ -115,6 +115,7 @@ export function DiscordBotSettings() {
             ) : (
               "Add the configured emoji reaction to any message containing a URL"
             )}
+            . You can also send or forward a message with a link directly to the bot in a DM.
           </li>
           <li>
             <strong className="text-emphasis">Look for the reaction</strong> -{" "}

--- a/src/server/discord/bot.ts
+++ b/src/server/discord/bot.ts
@@ -1,7 +1,12 @@
 /**
  * Discord Bot for Lion Reader
  *
- * Saves articles when users react to messages with a configured emoji.
+ * Saves articles when users:
+ * - React to a message with the configured save emoji, or
+ * - Send/forward a message containing a URL directly to the bot in a DM.
+ *
+ * Either way the bot reacts to the message with the success/error emoji.
+ *
  * Users can link their account either by:
  * 1. Signing in with Discord on the web app (OAuth)
  * 2. Using /link with an API token
@@ -59,12 +64,35 @@ const IGNORED_DOMAINS = new Set([
   "giphy.com",
 ]);
 
+/**
+ * Gather all text that might contain URLs from a message, including the content
+ * of any forwarded messages (Discord delivers a forward's text in
+ * `messageSnapshots`, not `message.content`).
+ */
+function gatherMessageText(message: Message): string {
+  const parts: string[] = [];
+  if (message.content) parts.push(message.content);
+  for (const snapshot of message.messageSnapshots.values()) {
+    if (snapshot.content) parts.push(snapshot.content);
+  }
+  // Embeds (e.g. link previews on a forwarded post) can carry the canonical URL.
+  for (const embed of message.embeds) {
+    if (embed.url) parts.push(embed.url);
+  }
+  for (const snapshot of message.messageSnapshots.values()) {
+    for (const embed of snapshot.embeds) {
+      if (embed.url) parts.push(embed.url);
+    }
+  }
+  return parts.join("\n");
+}
+
 function extractUrls(content: string): string[] {
   if (!content) return [];
 
   const matches = content.match(URL_REGEX) || [];
 
-  return matches
+  const urls = matches
     .map((url) => url.replace(/[.,;:!?)]+$/, ""))
     .filter((url) => {
       try {
@@ -80,6 +108,10 @@ function extractUrls(content: string): string[] {
         return false;
       }
     });
+
+  // Dedupe: the same URL commonly appears in both the message text and its
+  // embed/forward snapshot, and we don't want to save it twice.
+  return [...new Set(urls)];
 }
 
 // ============================================================================
@@ -175,11 +207,14 @@ export async function startDiscordBot(): Promise<void> {
       GatewayIntentBits.Guilds,
       GatewayIntentBits.GuildMessages,
       GatewayIntentBits.GuildMessageReactions,
+      GatewayIntentBits.DirectMessages,
       GatewayIntentBits.MessageContent,
     ],
     // User partial: guild reaction payloads carry the full member, but DM
     // reactions from uncached users are silently dropped without it.
-    partials: [Partials.Message, Partials.Reaction, Partials.User],
+    // Channel partial: DM channels aren't cached, so messageCreate/reaction
+    // events for DMs are dropped without it.
+    partials: [Partials.Message, Partials.Reaction, Partials.User, Partials.Channel],
   });
 
   // Gateway diagnostics. `client.login()` resolves as soon as the token
@@ -266,6 +301,27 @@ export async function startDiscordBot(): Promise<void> {
       Sentry.captureException(error);
       logger.error("Discord save-reaction handler failed", {
         messageId: reaction.message.id,
+        error,
+      });
+    }
+  });
+
+  // Handle direct messages: a URL sent (or forwarded) to the bot in a DM is
+  // saved just like a save-emoji reaction, and the DM is reacted to the same way.
+  client.on("messageCreate", async (message) => {
+    if (message.author.bot) return;
+    // Only DMs — guild messages are handled via the save-emoji reaction, not by
+    // treating every posted link as a save.
+    if (message.guildId) return;
+
+    try {
+      await handleDirectMessage(message);
+    } catch (error) {
+      // Same rationale as interactionCreate: a rejection here would otherwise
+      // crash the whole bot process.
+      Sentry.captureException(error);
+      logger.error("Discord direct-message handler failed", {
+        messageId: message.id,
         error,
       });
     }
@@ -374,7 +430,8 @@ async function handleLinkCommand(
   await interaction.reply({
     content:
       `Your Lion Reader account is now linked via API token. ` +
-      `React to any message containing a URL with ${DISCORD_SAVE_EMOJI} to save it.`,
+      `React to any message containing a URL with ${DISCORD_SAVE_EMOJI}, ` +
+      `or send/forward a link to me in a DM, to save it.`,
     flags: MessageFlags.Ephemeral,
   });
 
@@ -426,7 +483,7 @@ async function handleStatusCommand(
   if (resolved) {
     const methodText = resolved.method === "oauth" ? "Discord OAuth" : "API token";
     await interaction.reply({
-      content: `Your account is linked via ${methodText}. React to messages with ${DISCORD_SAVE_EMOJI} to save articles.`,
+      content: `Your account is linked via ${methodText}. React to messages with ${DISCORD_SAVE_EMOJI}, or send/forward a link to me in a DM, to save articles.`,
       flags: MessageFlags.Ephemeral,
     });
   } else {
@@ -469,7 +526,7 @@ async function handleSaveReaction(
   }
 
   // Extract URLs
-  const urls = extractUrls(message.content);
+  const urls = extractUrls(gatherMessageText(message));
   if (urls.length === 0) {
     logger.info("Save reaction message contained no URLs", {
       messageId: message.id,
@@ -478,7 +535,57 @@ async function handleSaveReaction(
     return;
   }
 
-  // Save each URL
+  await saveUrlsAndReact(message, urls, resolved, user);
+}
+
+/**
+ * Handle a direct message to the bot: save any URLs it contains (or that were
+ * forwarded to the bot) and react to the DM the same way as a save reaction.
+ */
+async function handleDirectMessage(message: Message): Promise<void> {
+  const urls = extractUrls(gatherMessageText(message));
+  if (urls.length === 0) {
+    // No URL to save — stay silent rather than replying to every chit-chat DM.
+    logger.info("Direct message contained no URLs", {
+      messageId: message.id,
+      contentLength: message.content?.length ?? 0,
+    });
+    return;
+  }
+
+  // Look up Lion Reader user
+  const resolved = await resolveUser(message.author.id);
+  if (!resolved) {
+    logger.info("Ignoring direct message from unlinked Discord user", {
+      discordId: message.author.id,
+    });
+    // They sent a link but we can't save it — tell them how to link, rather
+    // than staying silent.
+    try {
+      await message.reply(
+        "Your Discord account isn't linked to Lion Reader yet. " +
+          "Sign in with Discord on the Lion Reader website, or use `/link` with an API token."
+      );
+    } catch (error) {
+      logger.warn("Failed to reply to unlinked DM", { error });
+    }
+    return;
+  }
+
+  await saveUrlsAndReact(message, urls, resolved, message.author);
+}
+
+/**
+ * Save each URL for the resolved user and react to the message with the
+ * success/error emoji based on the results. Shared by the save-reaction and
+ * direct-message paths so both surfaces behave identically.
+ */
+async function saveUrlsAndReact(
+  message: Message,
+  urls: string[],
+  resolved: ResolvedUser,
+  user: User | PartialUser
+): Promise<void> {
   let hasSuccess = false;
   let hasFailure = false;
 


### PR DESCRIPTION
## Summary

Adds a second way to save articles with the Discord bot: a linked user can now **send or forward a message containing a URL directly to the bot in a DM**, and the bot saves it and reacts to the DM with the same success/error emoji it uses for the emoji-reaction flow.

Previously the bot only saved when a linked user reacted to a message with the save emoji.

## Changes

- **Intents/partials**: add `DirectMessages` intent and `Channel` partial so DM `messageCreate` events are delivered (DM channels aren't cached, so they'd otherwise be silently dropped).
- **`messageCreate` handler**: processes DMs only — guild messages keep using the emoji-reaction path so we don't treat every posted link as a save. Wrapped in the same Sentry-capture/try-catch as the other async listeners so a rejection can't crash the bot process.
- **Shared save-and-react**: extracted the per-URL `saveArticle` loop + `addResultReaction` into `saveUrlsAndReact`, reused by both the reaction and DM paths so they behave identically. In DMs the success/error emojis resolve via the bot's **application emojis** (guild emojis are unavailable in a DM), which already works for the default `salutinglionreader`/`😿`.
- **Forwarded messages & embeds**: `gatherMessageText` pulls URLs from the message content, forwarded message snapshots (`messageSnapshots`), and embed URLs. `extractUrls` now dedupes so a URL repeated across content/embed/snapshot isn't saved twice.
- **Onboarding nudge**: an unlinked user who DMs a link gets a one-time reply explaining how to link; non-URL chit-chat is ignored silently.
- **Docs/UI**: updated `/link` and `/status` help text, the Discord bot settings section, the demo article, and `DESIGN.md`.

## Testing

- `pnpm typecheck` ✅
- `pnpm lint` ✅

The Discord bot has no existing automated test harness (it's driven by a live discord.js gateway connection), so this was verified by typecheck/lint and manual review; runtime behavior should be smoke-tested against the live bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)