### PR TITLE
Fix changelog workflow: give Sonnet 5 room to think

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -165,7 +165,7 @@ jobs:
               --arg input "$INPUT" \
               '{
                 model: "claude-sonnet-5",
-                max_tokens: 1024,
+                max_tokens: 50000,
                 messages: [{
                   role: "user",
                   content: $input
@@ -173,7 +173,9 @@ jobs:
               }')")
 
           # Extract the text content
-          BODY=$(echo "$RESPONSE" | jq -r '.content[0].text // empty')
+          # Sonnet 5 always emits a thinking block first, so select the text block
+          # explicitly instead of assuming it's .content[0]
+          BODY=$(echo "$RESPONSE" | jq -r '[.content[] | select(.type == "text") | .text] | join("")')
 
           if [ -z "$BODY" ]; then
             echo "Error: Empty response from Claude API"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -175,7 +175,7 @@ jobs:
           # Extract the text content
           # Sonnet 5 always emits a thinking block first, so select the text block
           # explicitly instead of assuming it's .content[0]
-          BODY=$(echo "$RESPONSE" | jq -r '[.content[] | select(.type == "text") | .text] | join("")')
+          BODY=$(echo "$RESPONSE" | jq -r '[(.content // [])[] | select(.type == "text") | .text] | join("")')
 
           if [ -z "$BODY" ]; then
             echo "Error: Empty response from Claude API"


### PR DESCRIPTION
## Summary

The weekly changelog job ([failing run](https://github.com/brendanlong/lion-reader/actions/runs/29267817481/job/87151229216)) died with "Empty response from Claude API". The response in the log shows why: `claude-sonnet-5` has always-on thinking, and it spent the entire `max_tokens: 1024` budget on a thinking block (`thinking_tokens: 1024`, `stop_reason: "max_tokens"`) before emitting any text.

## Changes

- Raise `max_tokens` to 50000 — this runs once a week on Sonnet, so cost is negligible, and this gives it ample room to think about the ~18k-token prompt and write the post.
- Extract the text block explicitly (`.content[] | select(.type == "text")`) instead of assuming `.content[0]` is text — on Sonnet 5, `.content[0]` is the thinking block, so the old extraction would grab the wrong block even with a larger budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)