### PR TITLE
Show feed site link on feed stats page and subscription list header

### DIFF
--- a/src/components/entries/UnifiedEntriesContent.tsx
+++ b/src/components/entries/UnifiedEntriesContent.tsx
@@ -20,6 +20,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { EntryPageLayout, TitleSkeleton, TitleText } from "./EntryPageLayout";
 import { EntryContent } from "./EntryContent";
 import { EntryListContainer } from "./EntryListContainer";
+import { FeedSiteLink } from "@/components/feeds/FeedSiteLink";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { NotFoundCard } from "@/components/ui/not-found-card";
 import { useEntryUrlState } from "@/lib/hooks/useEntryUrlState";
@@ -191,7 +192,8 @@ function useRouteInfo(): RouteInfo {
  * Title component for subscription pages. Non-suspending (to avoid React's
  * 300ms fallback throttle): renders a deterministic skeleton until hydrated,
  * then the title from subscriptions.get, falling back to the sidebar list cache
- * so the real title shows even before subscriptions.get resolves.
+ * so the real title shows even before subscriptions.get resolves. Renders the
+ * feed's website link beneath the title when the feed advertises one.
  */
 function SubscriptionTitle({ subscriptionId }: { subscriptionId: string }) {
   const isHydrated = useIsHydrated();
@@ -204,17 +206,18 @@ function SubscriptionTitle({ subscriptionId }: { subscriptionId: string }) {
   if (!isHydrated) {
     return <TitleSkeleton />;
   }
-  if (subscription) {
-    return (
-      <TitleText>{subscription.title ?? subscription.originalTitle ?? "Untitled Feed"}</TitleText>
-    );
+  // Prefer the freshly fetched subscription; fall back to the sidebar list cache
+  // so the real title shows even before subscriptions.get resolves.
+  const sub = subscription ?? findCachedSubscription(queryClient, subscriptionId);
+  if (!sub) {
+    return <TitleSkeleton />;
   }
-  // Not loaded yet — show the title from the sidebar list cache if present.
-  const cached = findCachedSubscription(queryClient, subscriptionId);
-  if (cached) {
-    return <TitleText>{cached.title ?? cached.originalTitle ?? "Untitled Feed"}</TitleText>;
-  }
-  return <TitleSkeleton />;
+  return (
+    <div className="min-w-0">
+      <TitleText>{sub.title ?? sub.originalTitle ?? "Untitled Feed"}</TitleText>
+      <FeedSiteLink siteUrl={sub.siteUrl} className="mt-0.5" />
+    </div>
+  );
 }
 
 /**

--- a/src/components/feeds/FeedSiteLink.tsx
+++ b/src/components/feeds/FeedSiteLink.tsx
@@ -1,0 +1,42 @@
+/**
+ * FeedSiteLink
+ *
+ * Renders an external link to a feed's website (the `<link rel="alternate">` /
+ * RSS `<link>` / JSON Feed `home_page_url` parsed into `feeds.site_url`). Shown
+ * beneath the subscription entry-list title and on the feed stats page. Displays
+ * the hostname as a compact, clean label and opens in a new tab. Renders nothing
+ * when the feed has no site URL.
+ */
+
+import { ExternalLinkIcon } from "@/components/ui/icon-button";
+
+interface FeedSiteLinkProps {
+  siteUrl: string | null | undefined;
+  /** Extra classes for spacing/sizing at the call site. */
+  className?: string;
+}
+
+export function FeedSiteLink({ siteUrl, className = "" }: FeedSiteLinkProps) {
+  if (!siteUrl) return null;
+
+  // Prefer the bare hostname as the label; fall back to the raw URL if it isn't
+  // parseable (a malformed value the parser stored verbatim).
+  let label = siteUrl;
+  try {
+    label = new URL(siteUrl).hostname;
+  } catch {
+    label = siteUrl;
+  }
+
+  return (
+    <a
+      href={siteUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`text-muted hover:text-accent ui-text-sm inline-flex max-w-full items-center gap-1 ${className}`}
+    >
+      <ExternalLinkIcon className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">{label}</span>
+    </a>
+  );
+}

--- a/src/components/settings/pages/FeedStatsSettingsContent.tsx
+++ b/src/components/settings/pages/FeedStatsSettingsContent.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/format";
 import { Alert } from "@/components/ui/alert";
 import { Card } from "@/components/ui/card";
+import { FeedSiteLink } from "@/components/feeds/FeedSiteLink";
 import { SettingsListSkeleton } from "@/components/settings/SettingsListSkeleton";
 import {
   RssIcon,
@@ -272,6 +273,9 @@ function FeedStatsRow({ feed }: FeedStatsRowProps) {
 
           {/* Feed URL */}
           {feed.url && <p className="ui-text-sm text-muted mt-0.5 truncate">{feed.url}</p>}
+
+          {/* Site link (feed's website) */}
+          <FeedSiteLink siteUrl={feed.siteUrl} className="mt-0.5" />
 
           {/* Error Message (if any) */}
           {feed.lastError && (

--- a/src/components/subscribe/SubscribeContent.tsx
+++ b/src/components/subscribe/SubscribeContent.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
 import { Card } from "@/components/ui/card";
+import { FeedSiteLink } from "@/components/feeds/FeedSiteLink";
 import {
   CheckCircleIcon,
   SpinnerIcon,
@@ -367,16 +368,7 @@ export function SubscribeContent() {
                 <h2 className="ui-text-xl text-strong font-semibold">
                   {previewQuery.data?.feed.title ?? "Untitled Feed"}
                 </h2>
-                {previewQuery.data?.feed.siteUrl && (
-                  <a
-                    href={previewQuery.data.feed.siteUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="ui-text-sm text-muted hover:underline"
-                  >
-                    {new URL(previewQuery.data.feed.siteUrl).hostname}
-                  </a>
-                )}
+                <FeedSiteLink siteUrl={previewQuery.data?.feed.siteUrl} className="mt-0.5" />
               </div>
             </div>
 

--- a/tests/unit/frontend/components/FeedSiteLink.test.tsx
+++ b/tests/unit/frontend/components/FeedSiteLink.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Unit tests for FeedSiteLink component.
+ *
+ * Renders an external link to a feed's website (feeds.site_url), showing the
+ * hostname as a compact label. Renders nothing when there is no site URL.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FeedSiteLink } from "@/components/feeds/FeedSiteLink";
+
+describe("FeedSiteLink", () => {
+  it("renders a link to the site URL labeled with the hostname", () => {
+    render(<FeedSiteLink siteUrl="https://announcements.lionreader.com/" />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "https://announcements.lionreader.com/");
+    expect(link).toHaveTextContent("announcements.lionreader.com");
+  });
+
+  it("opens in a new tab with a safe rel", () => {
+    render(<FeedSiteLink siteUrl="https://example.com/blog" />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders nothing when siteUrl is null", () => {
+    const { container } = render(<FeedSiteLink siteUrl={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when siteUrl is undefined", () => {
+    const { container } = render(<FeedSiteLink siteUrl={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when siteUrl is an empty string", () => {
+    const { container } = render(<FeedSiteLink siteUrl="" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("falls back to the raw value when the URL is not parseable", () => {
+    render(<FeedSiteLink siteUrl="not a url" />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "not a url");
+    expect(link).toHaveTextContent("not a url");
+  });
+
+  it("applies extra classes passed via className", () => {
+    render(<FeedSiteLink siteUrl="https://example.com" className="mt-0.5" />);
+    expect(screen.getByRole("link").className).toContain("mt-0.5");
+  });
+});

--- a/tests/unit/frontend/components/UnifiedEntriesContent.test.tsx
+++ b/tests/unit/frontend/components/UnifiedEntriesContent.test.tsx
@@ -91,6 +91,30 @@ describe("UnifiedEntriesContent not-found guards", () => {
     expect(await screen.findByText("Subscription not found")).toBeInTheDocument();
   });
 
+  it("renders the feed's site link beneath the title when subscriptions.get returns a siteUrl", async () => {
+    mockPathname.mockReturnValue("/subscription/sub-1");
+    renderUnified(
+      baseHandlers({
+        "subscriptions.get": () => ({
+          id: "sub-1",
+          type: "web" as const,
+          url: "https://announcements.lionreader.com/changelog.xml",
+          title: "Lion Reader Announcements",
+          originalTitle: "Lion Reader Announcements",
+          description: null,
+          siteUrl: "https://announcements.lionreader.com/",
+          subscribedAt: new Date(),
+          unreadCount: 0,
+          tags: [],
+          fetchFullContent: false,
+        }),
+      })
+    );
+
+    const link = await screen.findByRole("link", { name: /announcements\.lionreader\.com/ });
+    expect(link).toHaveAttribute("href", "https://announcements.lionreader.com/");
+  });
+
   it("surfaces a transient subscriptions.get error to the ErrorBoundary, not a not-found message", async () => {
     mockPathname.mockReturnValue("/subscription/sub-1");
     renderUnified(


### PR DESCRIPTION
## What

Surfaces each feed's **website link** (the site homepage) in two places:

1. Beneath the title at the top of a subscription's entry list
2. On each row of the **Feed Statistics** page (settings → Feed Health)

For example, `https://announcements.lionreader.com/changelog.xml` advertises
`<link href="https://announcements.lionreader.com/" rel="alternate" type="text/html"/>`,
so we now show a link to `announcements.lionreader.com`.

## Why this is display-only

The site link was **already parsed and stored** — no parsing or schema changes were needed:

- `feeds.site_url` already exists and is populated from Atom `<link rel="alternate">`, RSS `<link>`, and JSON Feed `home_page_url` (`atom-parser.ts` / `rss-parser.ts` / `json-parser.ts`, written in `jobs/handlers.ts`).
- It already flows through `subscriptions.get`/`subscriptions.list` and `feedStats.list`.

It was simply never rendered. This PR renders the existing data.

## Changes

- **New `FeedSiteLink` component** (`src/components/feeds/FeedSiteLink.tsx`): external link, hostname label, opens in a new tab, renders nothing when the feed has no site URL, and falls back to the raw value if the URL isn't parseable.
- **Subscription entry-list header** (`UnifiedEntriesContent.tsx`): renders the link under the title (works from both the `subscriptions.get` result and the sidebar cache fallback).
- **Feed Statistics page** (`FeedStatsSettingsContent.tsx`): renders the link under each feed's URL.
- **Subscribe preview** (`SubscribeContent.tsx`): refactored to reuse `FeedSiteLink` instead of a hand-rolled anchor that could throw on a malformed URL.

## Tests

- New unit tests for `FeedSiteLink` (hostname extraction, null/empty handling, malformed-URL fallback, new-tab rel).
- New case in `UnifiedEntriesContent` tests asserting the site link renders in the subscription title.
- `pnpm typecheck`, lint, and `check:colors` all pass.

## Screenshots

**Subscription entry-list header** — site link beneath the title:

![subscription header](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/feed-site-link-1213/subscription-header.png)

**Feed Statistics page** — site link under each feed URL (the "No Site Feed" row with no `site_url` correctly shows nothing):

![feed stats](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/feed-site-link-1213/feed-stats.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)