### PR TITLE
Wallabag: honor sort, domain_name; reject unsupported tags (#1062)

### DIFF
--- a/src/app/api/wallabag/api/entries/route.ts
+++ b/src/app/api/wallabag/api/entries/route.ts
@@ -11,8 +11,10 @@
  * - order: asc|desc - sort order (default: desc)
  * - page: number - page number (default: 1)
  * - perPage: number - items per page (default: 30, max: 100)
- * - tags: string - comma-separated tag names
+ * - tags: string - comma-separated tag names (unsupported: saved articles carry
+ *   no tags, so any tag filter returns an empty result rather than being ignored)
  * - since: number - unix timestamp, return entries modified since
+ * - domain_name: string - filter by the entry URL's hostname
  * - detail: metadata|full - level of detail (default: full)
  *
  * POST body:
@@ -49,10 +51,19 @@ export async function GET(request: Request): Promise<Response> {
   if (auth instanceof Response) return auth;
   const url = new URL(request.url);
   const params = parseEntryListParams(url);
+  const baseUrl = `${url.origin}/api/wallabag/api/entries`;
+
+  // Tag filtering is unsupported: Lion Reader tags are per-subscription, and
+  // saved articles (the Wallabag surface) have no subscription, so they carry no
+  // tags. Rather than silently ignore `?tags=...` and return an unfiltered list,
+  // return an empty result — nothing can match a tag filter (issue #1062).
+  if (params.tags.length > 0) {
+    return jsonResponse(createPaginatedResponse([], params.page, params.perPage, 0, baseUrl));
+  }
 
   // Scope to saved articles only — the Wallabag API is a read-it-later interface.
-  // The read/starred/since filters are shared by the page query and the count so
-  // the two can't drift.
+  // The read/starred/since/domain filters are shared by the page query and the
+  // count so the two can't drift.
   const filter = {
     type: "saved" as const,
     showSpam: false,
@@ -65,7 +76,16 @@ export async function GET(request: Request): Promise<Response> {
     // updatedAfter filters on GREATEST(entry.updated_at, user_entries.updated_at),
     // which captures all three, so this is correct (not a lossy save-time proxy).
     updatedAfter: params.since ? new Date(params.since * 1000) : undefined,
+    // Wallabag `domain_name`: filter by the entry URL's hostname.
+    domainName: params.domainName,
   };
+
+  // Wallabag `sort` field → listEntries sort column. `created` (default) is our
+  // publish/fetch-time sort; `updated` is last-modified (GREATEST(entry,
+  // user_entry), so it also moves on read/star changes); `archived` sorts by when
+  // read state last changed (our closest analogue to Wallabag's archived_at).
+  const sortBy =
+    params.sort === "updated" ? "updated" : params.sort === "archived" ? "archived" : "published";
 
   // Serve the requested page with a single indexed query via LIMIT/OFFSET, and
   // fetch the total count in parallel (Wallabag needs it for page metadata).
@@ -76,6 +96,7 @@ export async function GET(request: Request): Promise<Response> {
       limit: params.perPage,
       offset: (params.page - 1) * params.perPage,
       sortOrder: params.order === "asc" ? "oldest" : "newest",
+      sortBy,
     }),
     entriesService.countTotalEntries(db, auth.userId, filter),
   ]);
@@ -97,7 +118,6 @@ export async function GET(request: Request): Promise<Response> {
     formattedItems = result.items.map(formatEntryListItem);
   }
 
-  const baseUrl = `${url.origin}/api/wallabag/api/entries`;
   return jsonResponse(
     createPaginatedResponse(formattedItems, params.page, params.perPage, total, baseUrl)
   );

--- a/src/app/api/wallabag/api/entries/route.ts
+++ b/src/app/api/wallabag/api/entries/route.ts
@@ -7,14 +7,17 @@
  * Query parameters for GET:
  * - archive: 0|1 - filter by archived (read) state
  * - starred: 0|1 - filter by starred state
- * - sort: created|updated|archived - sort field (default: created)
+ * - sort: created|updated|archived - sort field (default: created). `created` and
+ *   `archived` are index-backed; `updated` (last-modified) would require an
+ *   un-indexed GREATEST sort (see #1070) so it is approximated as `created`.
  * - order: asc|desc - sort order (default: desc)
  * - page: number - page number (default: 1)
  * - perPage: number - items per page (default: 30, max: 100)
  * - tags: string - comma-separated tag names (unsupported: saved articles carry
  *   no tags, so any tag filter returns an empty result rather than being ignored)
  * - since: number - unix timestamp, return entries modified since
- * - domain_name: string - filter by the entry URL's hostname
+ * - domain_name: string - filter by domain (unsupported: matching it would mean a
+ *   per-row regex over the URL with no index, so any domain filter returns empty)
  * - detail: metadata|full - level of detail (default: full)
  *
  * POST body:
@@ -53,17 +56,20 @@ export async function GET(request: Request): Promise<Response> {
   const params = parseEntryListParams(url);
   const baseUrl = `${url.origin}/api/wallabag/api/entries`;
 
-  // Tag filtering is unsupported: Lion Reader tags are per-subscription, and
-  // saved articles (the Wallabag surface) have no subscription, so they carry no
-  // tags. Rather than silently ignore `?tags=...` and return an unfiltered list,
-  // return an empty result — nothing can match a tag filter (issue #1062).
-  if (params.tags.length > 0) {
+  // Two filters we deliberately don't support, each answered with an empty result
+  // rather than a silently-unfiltered list (issue #1062):
+  //  - `tags`: Lion Reader tags are per-subscription, and saved articles (the
+  //    Wallabag surface) have no subscription, so nothing can carry a tag.
+  //  - `domain_name`: matching a domain means a per-row regex over the entry URL
+  //    with no index — a potential per-user table scan (DB CPU is expensive), and
+  //    not worth it for a rarely-used compat knob (issue #1070 has the analysis).
+  if (params.tags.length > 0 || params.domainName) {
     return jsonResponse(createPaginatedResponse([], params.page, params.perPage, 0, baseUrl));
   }
 
   // Scope to saved articles only — the Wallabag API is a read-it-later interface.
-  // The read/starred/since/domain filters are shared by the page query and the
-  // count so the two can't drift.
+  // The read/starred/since filters are shared by the page query and the count so
+  // the two can't drift.
   const filter = {
     type: "saved" as const,
     showSpam: false,
@@ -76,16 +82,15 @@ export async function GET(request: Request): Promise<Response> {
     // updatedAfter filters on GREATEST(entry.updated_at, user_entries.updated_at),
     // which captures all three, so this is correct (not a lossy save-time proxy).
     updatedAfter: params.since ? new Date(params.since * 1000) : undefined,
-    // Wallabag `domain_name`: filter by the entry URL's hostname.
-    domainName: params.domainName,
   };
 
   // Wallabag `sort` field → listEntries sort column. `created` (default) is our
-  // publish/fetch-time sort; `updated` is last-modified (GREATEST(entry,
-  // user_entry), so it also moves on read/star changes); `archived` sorts by when
-  // read state last changed (our closest analogue to Wallabag's archived_at).
-  const sortBy =
-    params.sort === "updated" ? "updated" : params.sort === "archived" ? "archived" : "published";
+  // publish/fetch-time sort; `archived` sorts by when read state last changed
+  // (our closest analogue to Wallabag's archived_at). `updated` (last-modified)
+  // would need an un-indexed GREATEST(entry, user_entry) sort with no LIMIT
+  // pushdown (issue #1070), so we approximate it as the default `created` sort
+  // rather than risk a per-user scan.
+  const sortBy = params.sort === "archived" ? "archived" : "published";
 
   // Serve the requested page with a single indexed query via LIMIT/OFFSET, and
   // fetch the total count in parallel (Wallabag needs it for page metadata).

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -37,7 +37,6 @@ import { persistResanitizedFamily } from "./resanitize";
 import {
   buildEntrySubscriptionFilter,
   buildEntryFilterConditions,
-  buildDomainNameCondition,
   buildTaggedSubscriptionIdsSubquery,
   buildUncategorizedSubscriptionIdsSubquery,
 } from "./entry-filters";
@@ -60,11 +59,13 @@ export interface ListEntriesParams {
   unstarredOnly?: boolean;
   sortOrder?: "newest" | "oldest";
   // Which column to sort by (default: published). "published" = publish/fetch
-  // time; "readChanged" = read-state-change time (the recently-read view, which
-  // also excludes never-read entries); "updated" = last-modified
-  // (GREATEST(entry, user_entry); Wallabag sort=updated); "archived" = read-state
-  // -change time WITHOUT the recently-read exclusion (Wallabag sort=archived).
-  sortBy?: "published" | "readChanged" | "updated" | "archived";
+  // time (index-backed); "readChanged" = read-state-change time (the recently-read
+  // view, which also excludes never-read entries); "archived" = read-state-change
+  // time WITHOUT the recently-read exclusion (Wallabag sort=archived). All three
+  // are served by an existing index; there is deliberately no "updated"
+  // (GREATEST(entry, user_entry)) sort — it can't be index-served (see #1070), so
+  // the Wallabag route approximates sort=updated as the default published sort.
+  sortBy?: "published" | "readChanged" | "archived";
   cursor?: string;
   offset?: number; // Skip this many rows (for page/offset-based compat APIs like Wallabag). Mutually exclusive with cursor.
   limit?: number;
@@ -72,7 +73,6 @@ export interface ListEntriesParams {
   publishedAfter?: Date; // Only entries published/fetched after this timestamp
   publishedBefore?: Date; // Only entries published/fetched before this timestamp
   updatedAfter?: Date; // Only entries modified at/after this timestamp (GREATEST(entry.updated_at, user_entries.updated_at); powers Wallabag `since` delta sync)
-  domainName?: string; // Only entries whose URL hostname matches (Wallabag `domain_name`)
   showSpam: boolean;
 }
 
@@ -96,7 +96,6 @@ export interface SearchEntriesParams {
   publishedAfter?: Date;
   publishedBefore?: Date;
   updatedAfter?: Date; // Only entries modified at/after this timestamp (see ListEntriesParams.updatedAfter)
-  domainName?: string; // Only entries whose URL hostname matches (Wallabag `domain_name`)
   showSpam: boolean;
 }
 
@@ -615,11 +614,6 @@ export async function listEntries(
     conditions.push(sql`${visibleEntries.updatedAt} >= ${params.updatedAfter}`);
   }
 
-  // Domain filter (Wallabag `domain_name`): match the URL hostname.
-  if (params.domainName) {
-    conditions.push(buildDomainNameCondition(params.domainName));
-  }
-
   // Recently Read: exclude entries that were never explicitly read-state-changed.
   // This exclusion is specific to that view (sortBy=readChanged); the Wallabag
   // "archived" sort orders by the same column but keeps unarchived entries.
@@ -627,18 +621,15 @@ export async function listEntries(
     conditions.push(isNotNull(visibleEntries.readChangedAt));
   }
 
-  // Sort column:
+  // Sort column (all choices are served by an existing index):
   //  - "published" (default) uses the denormalized user_entries sort key so the
   //    planner can serve filter + sort from idx_user_entries_published_or_fetched.
-  //  - "readChanged"/"archived" sort by when read state was last changed.
-  //  - "updated" sorts by GREATEST(entry.updated_at, user_entries.updated_at)
-  //    (Wallabag sort=updated — last-modified, including read/star flips).
+  //  - "readChanged"/"archived" sort by when read state was last changed
+  //    (idx_user_entries_read_changed_at).
   const sortColumn =
     params.sortBy === "readChanged" || params.sortBy === "archived"
       ? visibleEntries.readChangedAt
-      : params.sortBy === "updated"
-        ? visibleEntries.updatedAt
-        : visibleEntries.publishedOrFetchedAt;
+      : visibleEntries.publishedOrFetchedAt;
 
   // Raw ISO string version of sortColumn with microsecond precision.
   // Used for cursor encoding to avoid JavaScript Date truncation.
@@ -778,9 +769,6 @@ async function searchEntries(
   }
   if (params.updatedAfter) {
     conditions.push(sql`${visibleEntries.updatedAt} >= ${params.updatedAfter}`);
-  }
-  if (params.domainName) {
-    conditions.push(buildDomainNameCondition(params.domainName));
   }
 
   // Cursor for search results (based on rank)
@@ -1510,7 +1498,6 @@ export async function countTotalEntries(
     starredOnly?: boolean;
     unstarredOnly?: boolean;
     updatedAfter?: Date;
-    domainName?: string;
     showSpam: boolean;
   }
 ): Promise<number> {
@@ -1540,9 +1527,6 @@ export async function countTotalEntries(
 
   if (params.updatedAfter) {
     conditions.push(sql`${visibleEntries.updatedAt} >= ${params.updatedAfter}`);
-  }
-  if (params.domainName) {
-    conditions.push(buildDomainNameCondition(params.domainName));
   }
 
   // One row per (user, entry), so count(*) is exact (see countEntries).

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -37,6 +37,7 @@ import { persistResanitizedFamily } from "./resanitize";
 import {
   buildEntrySubscriptionFilter,
   buildEntryFilterConditions,
+  buildDomainNameCondition,
   buildTaggedSubscriptionIdsSubquery,
   buildUncategorizedSubscriptionIdsSubquery,
 } from "./entry-filters";
@@ -58,7 +59,12 @@ export interface ListEntriesParams {
   starredOnly?: boolean;
   unstarredOnly?: boolean;
   sortOrder?: "newest" | "oldest";
-  sortBy?: "published" | "readChanged"; // Which column to sort by (default: published)
+  // Which column to sort by (default: published). "published" = publish/fetch
+  // time; "readChanged" = read-state-change time (the recently-read view, which
+  // also excludes never-read entries); "updated" = last-modified
+  // (GREATEST(entry, user_entry); Wallabag sort=updated); "archived" = read-state
+  // -change time WITHOUT the recently-read exclusion (Wallabag sort=archived).
+  sortBy?: "published" | "readChanged" | "updated" | "archived";
   cursor?: string;
   offset?: number; // Skip this many rows (for page/offset-based compat APIs like Wallabag). Mutually exclusive with cursor.
   limit?: number;
@@ -66,6 +72,7 @@ export interface ListEntriesParams {
   publishedAfter?: Date; // Only entries published/fetched after this timestamp
   publishedBefore?: Date; // Only entries published/fetched before this timestamp
   updatedAfter?: Date; // Only entries modified at/after this timestamp (GREATEST(entry.updated_at, user_entries.updated_at); powers Wallabag `since` delta sync)
+  domainName?: string; // Only entries whose URL hostname matches (Wallabag `domain_name`)
   showSpam: boolean;
 }
 
@@ -89,6 +96,7 @@ export interface SearchEntriesParams {
   publishedAfter?: Date;
   publishedBefore?: Date;
   updatedAfter?: Date; // Only entries modified at/after this timestamp (see ListEntriesParams.updatedAfter)
+  domainName?: string; // Only entries whose URL hostname matches (Wallabag `domain_name`)
   showSpam: boolean;
 }
 
@@ -607,25 +615,34 @@ export async function listEntries(
     conditions.push(sql`${visibleEntries.updatedAt} >= ${params.updatedAfter}`);
   }
 
-  // Recently Read: exclude entries that were never explicitly read-state-changed
+  // Domain filter (Wallabag `domain_name`): match the URL hostname.
+  if (params.domainName) {
+    conditions.push(buildDomainNameCondition(params.domainName));
+  }
+
+  // Recently Read: exclude entries that were never explicitly read-state-changed.
+  // This exclusion is specific to that view (sortBy=readChanged); the Wallabag
+  // "archived" sort orders by the same column but keeps unarchived entries.
   if (params.sortBy === "readChanged") {
     conditions.push(isNotNull(visibleEntries.readChangedAt));
   }
 
-  // Sort column - readChanged sorts by when read state was last changed.
-  // The default "published" sort uses the denormalized user_entries sort key so the
-  // planner can serve filter + sort from idx_user_entries_published_or_fetched.
+  // Sort column:
+  //  - "published" (default) uses the denormalized user_entries sort key so the
+  //    planner can serve filter + sort from idx_user_entries_published_or_fetched.
+  //  - "readChanged"/"archived" sort by when read state was last changed.
+  //  - "updated" sorts by GREATEST(entry.updated_at, user_entries.updated_at)
+  //    (Wallabag sort=updated — last-modified, including read/star flips).
   const sortColumn =
-    params.sortBy === "readChanged"
+    params.sortBy === "readChanged" || params.sortBy === "archived"
       ? visibleEntries.readChangedAt
-      : visibleEntries.publishedOrFetchedAt;
+      : params.sortBy === "updated"
+        ? visibleEntries.updatedAt
+        : visibleEntries.publishedOrFetchedAt;
 
   // Raw ISO string version of sortColumn with microsecond precision.
   // Used for cursor encoding to avoid JavaScript Date truncation.
-  const sortTsRawExpr =
-    params.sortBy === "readChanged"
-      ? sql<string>`to_char(${visibleEntries.readChangedAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`
-      : sql<string>`to_char(${visibleEntries.publishedOrFetchedAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`;
+  const sortTsRawExpr = sql<string>`to_char(${sortColumn} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`;
 
   // Cursor condition
   // Pass timestamp string directly to Postgres (::timestamptz) to preserve
@@ -761,6 +778,9 @@ async function searchEntries(
   }
   if (params.updatedAfter) {
     conditions.push(sql`${visibleEntries.updatedAt} >= ${params.updatedAfter}`);
+  }
+  if (params.domainName) {
+    conditions.push(buildDomainNameCondition(params.domainName));
   }
 
   // Cursor for search results (based on rank)
@@ -1490,6 +1510,7 @@ export async function countTotalEntries(
     starredOnly?: boolean;
     unstarredOnly?: boolean;
     updatedAfter?: Date;
+    domainName?: string;
     showSpam: boolean;
   }
 ): Promise<number> {
@@ -1519,6 +1540,9 @@ export async function countTotalEntries(
 
   if (params.updatedAfter) {
     conditions.push(sql`${visibleEntries.updatedAt} >= ${params.updatedAfter}`);
+  }
+  if (params.domainName) {
+    conditions.push(buildDomainNameCondition(params.domainName));
   }
 
   // One row per (user, entry), so count(*) is exact (see countEntries).

--- a/src/server/services/entry-filters.ts
+++ b/src/server/services/entry-filters.ts
@@ -5,7 +5,7 @@
  * countEntries, and markAllRead.
  */
 
-import { eq, and, isNull, notInArray, type SQL, type SQLWrapper } from "drizzle-orm";
+import { eq, and, isNull, notInArray, sql, type SQL, type SQLWrapper } from "drizzle-orm";
 import type { db as dbType } from "@/server/db";
 import { subscriptionTags, subscriptions, tags, visibleEntries } from "@/server/db/schema";
 
@@ -215,4 +215,21 @@ export function buildEntryFilterConditions(params: EntryConditionParams): SQL[] 
   }
 
   return conditions;
+}
+
+/**
+ * Builds a condition that filters entries to those whose URL hostname matches
+ * `domainName` (case-insensitive), backing the Wallabag `domain_name` query
+ * parameter.
+ *
+ * Postgres has no URL parser, so we pull the authority host out of the URL with
+ * a POSIX regex — `scheme://HOST[:port][/path...]` — and `substring(... from
+ * pattern)` returns the first parenthesized group. This matches what
+ * `extractDomain` (`new URL().hostname`) produces for the entry's response
+ * `domain_name`, so the filter and the reported field agree. A URL that fails to
+ * match the pattern (or a NULL url) yields NULL, which the `=` comparison drops
+ * — the correct behavior for a domain filter.
+ */
+export function buildDomainNameCondition(domainName: string): SQL {
+  return sql`lower(substring(${visibleEntries.url} from '^[a-zA-Z][a-zA-Z0-9+.-]*://([^/:?#]+)')) = lower(${domainName})`;
 }

--- a/src/server/services/entry-filters.ts
+++ b/src/server/services/entry-filters.ts
@@ -5,7 +5,7 @@
  * countEntries, and markAllRead.
  */
 
-import { eq, and, isNull, notInArray, sql, type SQL, type SQLWrapper } from "drizzle-orm";
+import { eq, and, isNull, notInArray, type SQL, type SQLWrapper } from "drizzle-orm";
 import type { db as dbType } from "@/server/db";
 import { subscriptionTags, subscriptions, tags, visibleEntries } from "@/server/db/schema";
 
@@ -215,27 +215,4 @@ export function buildEntryFilterConditions(params: EntryConditionParams): SQL[] 
   }
 
   return conditions;
-}
-
-/**
- * Builds a condition that filters entries to those whose URL hostname matches
- * `domainName` (case-insensitive), backing the Wallabag `domain_name` query
- * parameter.
- *
- * Postgres has no URL parser, so we pull the authority host out of the URL with
- * a POSIX regex and `substring(... from pattern)` returns the first *capturing*
- * group. The pattern reproduces `new URL().hostname` semantics — which is what
- * `extractDomain` uses for the entry's reported `domain_name`, so the filter and
- * the reported field agree:
- *   `scheme://` then optional userinfo `(?:...@)?` (dropped, matching hostname)
- *   then the host — either a bracketed IPv6 literal `[...]` (brackets kept, as
- *   hostname does) or a reg-name/IPv4 up to the first `:`/`/`/`?`/`#` (so the
- *   port is dropped). A URL that fails to match (or a NULL url) yields NULL,
- *   which the `=` comparison drops — the correct behavior for a domain filter.
- *
- * The `\[`/`\]` bracket escapes are doubled (`\\[`, `\\]`) because a JS template
- * literal collapses `\[` to `[` before Postgres ever sees the pattern.
- */
-export function buildDomainNameCondition(domainName: string): SQL {
-  return sql`lower(substring(${visibleEntries.url} from '^[a-zA-Z][a-zA-Z0-9+.-]*://(?:[^/?#@]*@)?(\\[[^\\]]+\\]|[^/:?#]+)')) = lower(${domainName})`;
 }

--- a/src/server/services/entry-filters.ts
+++ b/src/server/services/entry-filters.ts
@@ -223,13 +223,19 @@ export function buildEntryFilterConditions(params: EntryConditionParams): SQL[] 
  * parameter.
  *
  * Postgres has no URL parser, so we pull the authority host out of the URL with
- * a POSIX regex — `scheme://HOST[:port][/path...]` — and `substring(... from
- * pattern)` returns the first parenthesized group. This matches what
- * `extractDomain` (`new URL().hostname`) produces for the entry's response
- * `domain_name`, so the filter and the reported field agree. A URL that fails to
- * match the pattern (or a NULL url) yields NULL, which the `=` comparison drops
- * — the correct behavior for a domain filter.
+ * a POSIX regex and `substring(... from pattern)` returns the first *capturing*
+ * group. The pattern reproduces `new URL().hostname` semantics — which is what
+ * `extractDomain` uses for the entry's reported `domain_name`, so the filter and
+ * the reported field agree:
+ *   `scheme://` then optional userinfo `(?:...@)?` (dropped, matching hostname)
+ *   then the host — either a bracketed IPv6 literal `[...]` (brackets kept, as
+ *   hostname does) or a reg-name/IPv4 up to the first `:`/`/`/`?`/`#` (so the
+ *   port is dropped). A URL that fails to match (or a NULL url) yields NULL,
+ *   which the `=` comparison drops — the correct behavior for a domain filter.
+ *
+ * The `\[`/`\]` bracket escapes are doubled (`\\[`, `\\]`) because a JS template
+ * literal collapses `\[` to `[` before Postgres ever sees the pattern.
  */
 export function buildDomainNameCondition(domainName: string): SQL {
-  return sql`lower(substring(${visibleEntries.url} from '^[a-zA-Z][a-zA-Z0-9+.-]*://([^/:?#]+)')) = lower(${domainName})`;
+  return sql`lower(substring(${visibleEntries.url} from '^[a-zA-Z][a-zA-Z0-9+.-]*://(?:[^/?#@]*@)?(\\[[^\\]]+\\]|[^/:?#]+)')) = lower(${domainName})`;
 }

--- a/tests/e2e/wallabag-api.spec.ts
+++ b/tests/e2e/wallabag-api.spec.ts
@@ -342,7 +342,7 @@ test.describe("Wallabag API happy path", () => {
     }
   });
 
-  test("tags/domain_name/sort filters are honored, not silently ignored (#1062)", async ({
+  test("tags/domain_name unsupported filters return empty; sort is accepted (#1062)", async ({
     request,
   }) => {
     const { access_token } = await getTokens(request);
@@ -358,36 +358,22 @@ test.describe("Wallabag API happy path", () => {
         ).json()
       ).id;
 
-      // tags: we don't support tags on saved articles, so any tag filter returns
-      // an empty result rather than an unfiltered list.
-      const tagged = await request.get("/api/wallabag/api/entries?tags=foo&detail=metadata", {
-        headers: auth,
-      });
-      expect(tagged.status()).toBe(200);
-      const taggedBody = await tagged.json();
-      expect(taggedBody._embedded.items).toHaveLength(0);
-      expect(taggedBody.total).toBe(0);
+      // tags and domain_name are unsupported filters: rather than silently ignore
+      // them (returning an unfiltered list) or run an un-indexed per-user scan, we
+      // return an empty result.
+      for (const query of [`tags=foo`, `domain_name=${domain}`]) {
+        const res = await request.get(`/api/wallabag/api/entries?${query}&detail=metadata`, {
+          headers: auth,
+        });
+        expect(res.status(), query).toBe(200);
+        const body = await res.json();
+        expect(body._embedded.items, query).toHaveLength(0);
+        expect(body.total, query).toBe(0);
+      }
 
-      // domain_name: the article's host matches; a different host does not.
-      const matchDomain = await request.get(
-        `/api/wallabag/api/entries?domain_name=${domain}&detail=metadata`,
-        { headers: auth }
-      );
-      expect(matchDomain.status()).toBe(200);
-      expect((await matchDomain.json())._embedded.items.map((e: { id: number }) => e.id)).toContain(
-        id
-      );
-
-      const otherDomain = await request.get(
-        "/api/wallabag/api/entries?domain_name=nope.example&detail=metadata",
-        { headers: auth }
-      );
-      expect(
-        (await otherDomain.json())._embedded.items.map((e: { id: number }) => e.id)
-      ).not.toContain(id);
-
-      // sort=updated and sort=archived are accepted (not 500) and still return
-      // the article.
+      // All three sort fields are accepted (not 500) and return the article.
+      // `updated` is approximated as `created` (no un-indexed GREATEST sort), but
+      // still yields the article — the client just gets it in created order.
       for (const sort of ["updated", "archived", "created"]) {
         const sorted = await request.get(
           `/api/wallabag/api/entries?sort=${sort}&detail=metadata&perPage=100`,

--- a/tests/e2e/wallabag-api.spec.ts
+++ b/tests/e2e/wallabag-api.spec.ts
@@ -341,6 +341,69 @@ test.describe("Wallabag API happy path", () => {
       await b.close();
     }
   });
+
+  test("tags/domain_name/sort filters are honored, not silently ignored (#1062)", async ({
+    request,
+  }) => {
+    const { access_token } = await getTokens(request);
+    const auth = { Authorization: `Bearer ${access_token}` };
+
+    const { url, close } = await startArticleServer();
+    const domain = new URL(url).hostname; // 127.0.0.1
+    let id: number | undefined;
+    try {
+      id = (
+        await (
+          await request.post("/api/wallabag/api/entries", { headers: auth, form: { url } })
+        ).json()
+      ).id;
+
+      // tags: we don't support tags on saved articles, so any tag filter returns
+      // an empty result rather than an unfiltered list.
+      const tagged = await request.get("/api/wallabag/api/entries?tags=foo&detail=metadata", {
+        headers: auth,
+      });
+      expect(tagged.status()).toBe(200);
+      const taggedBody = await tagged.json();
+      expect(taggedBody._embedded.items).toHaveLength(0);
+      expect(taggedBody.total).toBe(0);
+
+      // domain_name: the article's host matches; a different host does not.
+      const matchDomain = await request.get(
+        `/api/wallabag/api/entries?domain_name=${domain}&detail=metadata`,
+        { headers: auth }
+      );
+      expect(matchDomain.status()).toBe(200);
+      expect((await matchDomain.json())._embedded.items.map((e: { id: number }) => e.id)).toContain(
+        id
+      );
+
+      const otherDomain = await request.get(
+        "/api/wallabag/api/entries?domain_name=nope.example&detail=metadata",
+        { headers: auth }
+      );
+      expect(
+        (await otherDomain.json())._embedded.items.map((e: { id: number }) => e.id)
+      ).not.toContain(id);
+
+      // sort=updated and sort=archived are accepted (not 500) and still return
+      // the article.
+      for (const sort of ["updated", "archived", "created"]) {
+        const sorted = await request.get(
+          `/api/wallabag/api/entries?sort=${sort}&detail=metadata&perPage=100`,
+          { headers: auth }
+        );
+        expect(sorted.status(), `sort=${sort}`).toBe(200);
+        expect(
+          (await sorted.json())._embedded.items.map((e: { id: number }) => e.id),
+          `sort=${sort}`
+        ).toContain(id);
+      }
+    } finally {
+      if (id) await request.delete(`/api/wallabag/api/entries/${id}`, { headers: auth });
+      await close();
+    }
+  });
 });
 
 /**

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -560,12 +560,17 @@ describe("Entries", () => {
         // Uppercase host + port: the hostname match is case-insensitive and ignores the port.
         url: "https://EXAMPLE.com:8443/other",
       });
+      const exampleUserinfoId = await createTestEntry(feedId, {
+        title: "ExampleUserinfo",
+        // Userinfo is stripped, matching new URL().hostname.
+        url: "https://user:pass@example.com/x",
+      });
       const otherId = await createTestEntry(feedId, {
         title: "Other",
         url: "https://other.org/story",
       });
       const noUrlId = await createTestEntry(feedId, { title: "NoUrl" });
-      for (const id of [exampleId, exampleUpperId, otherId, noUrlId]) {
+      for (const id of [exampleId, exampleUpperId, exampleUserinfoId, otherId, noUrlId]) {
         await createUserEntry(userId, id);
       }
 
@@ -574,14 +579,29 @@ describe("Entries", () => {
         domainName: "example.com",
         showSpam: false,
       });
-      expect(result.items.map((e) => e.id).sort()).toEqual([exampleId, exampleUpperId].sort());
+      expect(result.items.map((e) => e.id).sort()).toEqual(
+        [exampleId, exampleUpperId, exampleUserinfoId].sort()
+      );
 
       // countTotalEntries applies the same filter so pagination totals agree.
       const total = await countTotalEntries(db, userId, {
         domainName: "example.com",
         showSpam: false,
       });
-      expect(total).toBe(2);
+      expect(total).toBe(3);
+
+      // Bracketed IPv6 literal host (brackets preserved, like new URL().hostname).
+      const ipv6Id = await createTestEntry(feedId, {
+        title: "Ipv6",
+        url: "https://[2001:db8::1]:8443/x",
+      });
+      await createUserEntry(userId, ipv6Id);
+      const ipv6 = await listEntries(db, {
+        userId,
+        domainName: "[2001:db8::1]",
+        showSpam: false,
+      });
+      expect(ipv6.items.map((e) => e.id)).toEqual([ipv6Id]);
 
       // A non-matching domain returns nothing.
       const none = await listEntries(db, {

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -23,6 +23,7 @@ import {
   markAllEntriesRead,
   markEntriesRead,
   listEntries,
+  countTotalEntries,
 } from "../../src/server/services/entries";
 
 // ============================================================================
@@ -139,6 +140,7 @@ async function createTestEntry(
   options: {
     guid?: string;
     title?: string;
+    url?: string;
     contentCleaned?: string;
     publishedAt?: Date;
     isSpam?: boolean;
@@ -159,6 +161,7 @@ async function createTestEntry(
     type,
     guid,
     title: options.title ?? `Entry ${entryId}`,
+    url: options.url,
     contentCleaned: options.contentCleaned ?? `Content for ${options.title ?? entryId}`,
     contentHash: `hash-${entryId}`,
     fetchedAt: options.publishedAt ?? now,
@@ -462,6 +465,131 @@ describe("Entries", () => {
       );
       // The untouched entry stays out of the delta.
       expect(after.items.map((e) => e.id)).not.toContain(untouchedId);
+    });
+  });
+
+  describe("list with sortBy (Wallabag `sort` field)", () => {
+    it("sortBy=updated orders by last-modified (GREATEST(entry, user_entry))", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/feed.xml");
+      await createTestSubscription(userId, feedId);
+
+      // Publish order is a, b, c (a oldest). Modify order will be the reverse of
+      // publish order so sortBy=updated diverges from the default published sort.
+      const aId = await createTestEntry(feedId, {
+        title: "A",
+        publishedAt: new Date("2026-01-01T00:00:00Z"),
+      });
+      const bId = await createTestEntry(feedId, {
+        title: "B",
+        publishedAt: new Date("2026-01-02T00:00:00Z"),
+      });
+      const cId = await createTestEntry(feedId, {
+        title: "C",
+        publishedAt: new Date("2026-01-03T00:00:00Z"),
+      });
+      for (const id of [aId, bId, cId]) await createUserEntry(userId, id);
+
+      // Pin entries.updated_at old for all three so the user_entries.updated_at
+      // side of GREATEST(entry, user_entry) drives the "updated" sort.
+      await db
+        .update(entries)
+        .set({ updatedAt: new Date("2026-01-01T00:00:00Z") })
+        .where(inArray(entries.id, [aId, bId, cId]));
+
+      // Bump user_entries.updated_at in the order a (newest) → c (oldest).
+      await db
+        .update(userEntries)
+        .set({ updatedAt: new Date("2026-02-03T00:00:00Z") })
+        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, aId)));
+      await db
+        .update(userEntries)
+        .set({ updatedAt: new Date("2026-02-02T00:00:00Z") })
+        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, bId)));
+      await db
+        .update(userEntries)
+        .set({ updatedAt: new Date("2026-02-01T00:00:00Z") })
+        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, cId)));
+
+      const result = await listEntries(db, { userId, sortBy: "updated", showSpam: false });
+      // Most-recently-modified first: a, b, c — the reverse of the published sort.
+      expect(result.items.map((e) => e.id)).toEqual([aId, bId, cId]);
+    });
+
+    it("sortBy=archived orders by read-change time and keeps never-read entries", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/feed.xml");
+      await createTestSubscription(userId, feedId);
+
+      const readId = await createTestEntry(feedId, { title: "Read" });
+      const unreadId = await createTestEntry(feedId, { title: "Unread" });
+      // Unread entry: no read-state change (readChangedAt NULL).
+      await createUserEntry(userId, readId);
+      await createUserEntry(userId, unreadId, { readChangedAt: undefined });
+      await db
+        .update(userEntries)
+        .set({ readChangedAt: null })
+        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, unreadId)));
+
+      // sortBy=archived must NOT drop the never-read entry (unlike readChanged).
+      const archived = await listEntries(db, { userId, sortBy: "archived", showSpam: false });
+      expect(archived.items.map((e) => e.id).sort()).toEqual([readId, unreadId].sort());
+
+      // sortBy=readChanged (recently-read view) DOES exclude the never-read entry.
+      const recentlyRead = await listEntries(db, {
+        userId,
+        sortBy: "readChanged",
+        showSpam: false,
+      });
+      expect(recentlyRead.items.map((e) => e.id)).toEqual([readId]);
+    });
+  });
+
+  describe("list/count with domainName (Wallabag `domain_name`)", () => {
+    it("filters entries to those whose URL hostname matches", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/feed.xml");
+      await createTestSubscription(userId, feedId);
+
+      const exampleId = await createTestEntry(feedId, {
+        title: "Example",
+        url: "https://example.com/article?ref=1",
+      });
+      const exampleUpperId = await createTestEntry(feedId, {
+        title: "ExampleUpper",
+        // Uppercase host + port: the hostname match is case-insensitive and ignores the port.
+        url: "https://EXAMPLE.com:8443/other",
+      });
+      const otherId = await createTestEntry(feedId, {
+        title: "Other",
+        url: "https://other.org/story",
+      });
+      const noUrlId = await createTestEntry(feedId, { title: "NoUrl" });
+      for (const id of [exampleId, exampleUpperId, otherId, noUrlId]) {
+        await createUserEntry(userId, id);
+      }
+
+      const result = await listEntries(db, {
+        userId,
+        domainName: "example.com",
+        showSpam: false,
+      });
+      expect(result.items.map((e) => e.id).sort()).toEqual([exampleId, exampleUpperId].sort());
+
+      // countTotalEntries applies the same filter so pagination totals agree.
+      const total = await countTotalEntries(db, userId, {
+        domainName: "example.com",
+        showSpam: false,
+      });
+      expect(total).toBe(2);
+
+      // A non-matching domain returns nothing.
+      const none = await listEntries(db, {
+        userId,
+        domainName: "nope.example",
+        showSpam: false,
+      });
+      expect(none.items).toHaveLength(0);
     });
   });
 

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -23,7 +23,6 @@ import {
   markAllEntriesRead,
   markEntriesRead,
   listEntries,
-  countTotalEntries,
 } from "../../src/server/services/entries";
 
 // ============================================================================
@@ -140,7 +139,6 @@ async function createTestEntry(
   options: {
     guid?: string;
     title?: string;
-    url?: string;
     contentCleaned?: string;
     publishedAt?: Date;
     isSpam?: boolean;
@@ -161,7 +159,6 @@ async function createTestEntry(
     type,
     guid,
     title: options.title ?? `Entry ${entryId}`,
-    url: options.url,
     contentCleaned: options.contentCleaned ?? `Content for ${options.title ?? entryId}`,
     contentHash: `hash-${entryId}`,
     fetchedAt: options.publishedAt ?? now,
@@ -469,53 +466,6 @@ describe("Entries", () => {
   });
 
   describe("list with sortBy (Wallabag `sort` field)", () => {
-    it("sortBy=updated orders by last-modified (GREATEST(entry, user_entry))", async () => {
-      const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/feed.xml");
-      await createTestSubscription(userId, feedId);
-
-      // Publish order is a, b, c (a oldest). Modify order will be the reverse of
-      // publish order so sortBy=updated diverges from the default published sort.
-      const aId = await createTestEntry(feedId, {
-        title: "A",
-        publishedAt: new Date("2026-01-01T00:00:00Z"),
-      });
-      const bId = await createTestEntry(feedId, {
-        title: "B",
-        publishedAt: new Date("2026-01-02T00:00:00Z"),
-      });
-      const cId = await createTestEntry(feedId, {
-        title: "C",
-        publishedAt: new Date("2026-01-03T00:00:00Z"),
-      });
-      for (const id of [aId, bId, cId]) await createUserEntry(userId, id);
-
-      // Pin entries.updated_at old for all three so the user_entries.updated_at
-      // side of GREATEST(entry, user_entry) drives the "updated" sort.
-      await db
-        .update(entries)
-        .set({ updatedAt: new Date("2026-01-01T00:00:00Z") })
-        .where(inArray(entries.id, [aId, bId, cId]));
-
-      // Bump user_entries.updated_at in the order a (newest) → c (oldest).
-      await db
-        .update(userEntries)
-        .set({ updatedAt: new Date("2026-02-03T00:00:00Z") })
-        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, aId)));
-      await db
-        .update(userEntries)
-        .set({ updatedAt: new Date("2026-02-02T00:00:00Z") })
-        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, bId)));
-      await db
-        .update(userEntries)
-        .set({ updatedAt: new Date("2026-02-01T00:00:00Z") })
-        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, cId)));
-
-      const result = await listEntries(db, { userId, sortBy: "updated", showSpam: false });
-      // Most-recently-modified first: a, b, c — the reverse of the published sort.
-      expect(result.items.map((e) => e.id)).toEqual([aId, bId, cId]);
-    });
-
     it("sortBy=archived orders by read-change time and keeps never-read entries", async () => {
       const userId = await createTestUser();
       const feedId = await createTestFeed("https://example.com/feed.xml");
@@ -542,74 +492,6 @@ describe("Entries", () => {
         showSpam: false,
       });
       expect(recentlyRead.items.map((e) => e.id)).toEqual([readId]);
-    });
-  });
-
-  describe("list/count with domainName (Wallabag `domain_name`)", () => {
-    it("filters entries to those whose URL hostname matches", async () => {
-      const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/feed.xml");
-      await createTestSubscription(userId, feedId);
-
-      const exampleId = await createTestEntry(feedId, {
-        title: "Example",
-        url: "https://example.com/article?ref=1",
-      });
-      const exampleUpperId = await createTestEntry(feedId, {
-        title: "ExampleUpper",
-        // Uppercase host + port: the hostname match is case-insensitive and ignores the port.
-        url: "https://EXAMPLE.com:8443/other",
-      });
-      const exampleUserinfoId = await createTestEntry(feedId, {
-        title: "ExampleUserinfo",
-        // Userinfo is stripped, matching new URL().hostname.
-        url: "https://user:pass@example.com/x",
-      });
-      const otherId = await createTestEntry(feedId, {
-        title: "Other",
-        url: "https://other.org/story",
-      });
-      const noUrlId = await createTestEntry(feedId, { title: "NoUrl" });
-      for (const id of [exampleId, exampleUpperId, exampleUserinfoId, otherId, noUrlId]) {
-        await createUserEntry(userId, id);
-      }
-
-      const result = await listEntries(db, {
-        userId,
-        domainName: "example.com",
-        showSpam: false,
-      });
-      expect(result.items.map((e) => e.id).sort()).toEqual(
-        [exampleId, exampleUpperId, exampleUserinfoId].sort()
-      );
-
-      // countTotalEntries applies the same filter so pagination totals agree.
-      const total = await countTotalEntries(db, userId, {
-        domainName: "example.com",
-        showSpam: false,
-      });
-      expect(total).toBe(3);
-
-      // Bracketed IPv6 literal host (brackets preserved, like new URL().hostname).
-      const ipv6Id = await createTestEntry(feedId, {
-        title: "Ipv6",
-        url: "https://[2001:db8::1]:8443/x",
-      });
-      await createUserEntry(userId, ipv6Id);
-      const ipv6 = await listEntries(db, {
-        userId,
-        domainName: "[2001:db8::1]",
-        showSpam: false,
-      });
-      expect(ipv6.items.map((e) => e.id)).toEqual([ipv6Id]);
-
-      // A non-matching domain returns nothing.
-      const none = await listEntries(db, {
-        userId,
-        domainName: "nope.example",
-        showSpam: false,
-      });
-      expect(none.items).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
Closes #1062.
Closes #1070 (decided: don't denormalize — see below).

The Wallabag entries handler parsed `sort`, `domain_name`, and `tags` but never
used them, so clients got default-sorted, unfiltered responses with no error.
Rather than support everything (some paths would be un-indexed and could spike
DB CPU on a large library), this supports only the cheap, index-backed paths and
answers the expensive ones with an empty result instead of a silent no-op.

## What's supported

- **`sort=created`** (default) — publish/fetch-time sort, served by
  `idx_user_entries_published_or_fetched`.
- **`sort=archived`** — new `archived` service `sortBy`: sorts by read-state-change
  time (`idx_user_entries_read_changed_at`) but, unlike the recently-read
  `readChanged` view, keeps never-archived entries.

## What's deliberately *not* supported (returns empty / approximated)

- **`tags`** — Lion Reader tags are per-subscription; saved articles have no
  subscription, so nothing can carry a tag. Any tag filter returns an **empty**
  result.
- **`domain_name`** — matching a domain means a per-row regex over the entry URL
  with no index (a potential per-user scan). Returns an **empty** result rather
  than run it.
- **`sort=updated`** — "last modified" is `GREATEST(entry.updated_at,
  user_entries.updated_at)`, which can't be index-served and loses LIMIT pushdown
  (this is exactly #1070). Approximated as the default `created` sort rather than
  risk a per-user scan.

### Why close #1070

#1070 proposed denormalizing an indexed `modified_at` onto `user_entries` to make
the GREATEST sort/filter cheap. Decision: **not worth the write-amplification**
(a content refetch on a shared feed would have to fan the new timestamp out to
every subscriber's row). Instead we simply don't offer the un-indexed sort — the
`since`/`updatedAfter` **filter** stays as a bounded per-user residual (already
accepted), and `sort=updated` degrades to `created`. Closing #1070 as
won't-do with that rationale recorded here.

## Tests

- Integration (`tests/integration/entries.test.ts`): `sortBy=archived` orders by
  read-change time and keeps never-read entries (vs `readChanged` excluding them).
- E2E (`tests/e2e/wallabag-api.spec.ts`): `tags`/`domain_name` return empty; all
  three `sort` values return 200 with the saved article.

`typecheck`, `lint`, integration, and e2e all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)