### PR TITLE
Support narration OS media controls in PWA (#410)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -575,6 +575,9 @@ app/
 - `components/feeds/` - Feed list, add feed dialog
 - `components/narration/` - Audio playback controls
 - `components/saved/` - Saved article views
+
+**Narration OS media controls.** Narration plays through the Web Speech API (browser voices) or the Web Audio API (Piper enhanced voices), neither of which the browser treats as media playback — so setting `navigator.mediaSession` metadata alone surfaces no OS controls (lock screen / notification widget, Bluetooth & media-key buttons), especially in an installed PWA. To make them appear, a **silent looping `<audio>` element** (`src/lib/narration/silent-audio.ts`, a runtime-generated silent WAV data URI) is played while narration is active; that element is what the browser recognizes as media, which surfaces the controls and routes hardware buttons into our action handlers. `src/lib/narration/media-session.ts` is provider-agnostic (plain `play`/`pause`/`stop`/`prev`/`next` callbacks) and the `useMediaSession` hook (`src/components/narration/`) keeps metadata, action handlers, and playback state in sync for **both** providers. Artwork falls back to the PWA manifest icons when no per-article image is supplied.
+
 - `components/settings/` - Settings page components
 - `components/subscribe/` - Subscription flow components
 - `components/summarization/` - AI summary display

--- a/src/components/narration/useMediaSession.ts
+++ b/src/components/narration/useMediaSession.ts
@@ -1,0 +1,97 @@
+/**
+ * useMediaSession Hook
+ *
+ * Wires narration into the OS Media Session so an installed PWA (and any browser)
+ * shows native media controls — the lock-screen/notification widget and
+ * hardware/Bluetooth play-pause & track buttons — while narration is active.
+ *
+ * Provider-agnostic: it takes plain control callbacks and the current status, so
+ * the same hook covers both browser voices and Piper enhanced voices.
+ *
+ * @module narration/useMediaSession
+ */
+
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { NarrationStatus } from "@/lib/narration/ArticleNarrator";
+import {
+  setupMediaSession,
+  updateMediaSessionPlaybackState,
+  clearMediaSession,
+  type MediaSessionControls,
+} from "@/lib/narration/media-session";
+
+/**
+ * Parameters for {@link useMediaSession}.
+ */
+export interface UseMediaSessionParams {
+  /**
+   * Whether an OS media session should exist. Typically
+   * `isSupported && narrationHasBeenGenerated`. When false, the session is torn
+   * down and no controls are shown.
+   */
+  active: boolean;
+  /** Article title shown in the OS controls. */
+  title: string;
+  /** Feed/site name shown as the artist. */
+  feedTitle: string;
+  /** Optional artwork URL. */
+  artwork?: string;
+  /** Current narration status, mirrored onto the OS controls. */
+  status: NarrationStatus;
+  /** Playback controls invoked by OS media buttons. */
+  controls: MediaSessionControls;
+}
+
+/**
+ * Keeps the OS Media Session (metadata, action handlers, playback state) in sync
+ * with narration.
+ *
+ * OS button handlers are registered once per session but always dispatch to the
+ * latest `controls` via a ref, so they never call stale closures.
+ */
+export function useMediaSession({
+  active,
+  title,
+  feedTitle,
+  artwork,
+  status,
+  controls,
+}: UseMediaSessionParams): void {
+  // Keep the latest controls in a ref so the action handlers registered with the
+  // OS always call current callbacks without needing to re-register. Updated in
+  // an effect (not during render); the handlers only fire from async OS button
+  // events, never during render, so the effect-timing is safe.
+  const controlsRef = useRef(controls);
+  useEffect(() => {
+    controlsRef.current = controls;
+  }, [controls]);
+
+  // Set up / tear down the session and its metadata.
+  useEffect(() => {
+    if (!active) return;
+
+    setupMediaSession(
+      { articleTitle: title, feedTitle, artwork },
+      {
+        play: () => controlsRef.current.play(),
+        pause: () => controlsRef.current.pause(),
+        stop: () => controlsRef.current.stop(),
+        previousTrack: () => controlsRef.current.previousTrack(),
+        nextTrack: () => controlsRef.current.nextTrack(),
+      }
+    );
+
+    return () => {
+      clearMediaSession();
+    };
+  }, [active, title, feedTitle, artwork]);
+
+  // Mirror playback status onto the OS controls (and drive the silent-audio
+  // element that keeps them visible).
+  useEffect(() => {
+    if (!active) return;
+    updateMediaSessionPlaybackState(status);
+  }, [active, status]);
+}

--- a/src/components/narration/useMediaSession.ts
+++ b/src/components/narration/useMediaSession.ts
@@ -68,6 +68,15 @@ export function useMediaSession({
     controlsRef.current = controls;
   }, [controls]);
 
+  // Keep the latest status in a ref so the setup effect can re-assert playback
+  // state (and restart the silent audio) when it re-runs for a metadata change
+  // mid-playback, without depending on `status` (which would tear down and
+  // re-register handlers on every play/pause/buffer flip).
+  const statusRef = useRef(status);
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
   // Set up / tear down the session and its metadata.
   useEffect(() => {
     if (!active) return;
@@ -82,6 +91,12 @@ export function useMediaSession({
         nextTrack: () => controlsRef.current.nextTrack(),
       }
     );
+    // Re-assert playback state so the silent audio is (re)started even when this
+    // effect re-runs mid-playback because the title/feed/artwork changed — its
+    // cleanup stopped the silent audio, and the status effect below won't re-run
+    // if `status` is unchanged. Without this the OS controls would silently
+    // disappear on a title change while narration keeps playing.
+    updateMediaSessionPlaybackState(statusRef.current);
 
     return () => {
       clearMediaSession();

--- a/src/components/narration/useNarration.ts
+++ b/src/components/narration/useNarration.ts
@@ -32,6 +32,7 @@ import { ArticleNarrator, type NarrationState } from "@/lib/narration/ArticleNar
 import { useNarrationSettings } from "@/lib/narration/settings";
 import { findVoiceByUri, waitForVoices } from "@/lib/narration/voices";
 import { isNarrationSupported } from "@/lib/narration/feature-detection";
+import { primeMediaSessionAudio, stopMediaSessionAudio } from "@/lib/narration/media-session";
 import { useMediaSession } from "./useMediaSession";
 import { trackNarrationPlaybackStarted } from "@/lib/telemetry";
 import { getPiperTTSProvider } from "@/lib/narration/piper-tts-provider";
@@ -224,6 +225,12 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
   const play = useCallback(async () => {
     if (!isSupported) return;
 
+    // Start the OS media session's silent audio within this user gesture, before
+    // any async narration generation, so the browser grants it while the gesture's
+    // autoplay activation is still valid (issue #410). It's released below if
+    // generation fails; on success the media-session effects keep it going.
+    primeMediaSessionAudio();
+
     // Handle Piper provider with StreamingAudioPlayer
     if (usePiper && settings.voiceId) {
       const player = getOrCreateStreamingPlayer();
@@ -303,10 +310,15 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
 
           // Start playback
           await player.play();
+        } else {
+          // Nothing to narrate — release the primed media-session audio.
+          stopMediaSessionAudio();
         }
       } catch (error) {
         console.error("Failed to generate narration:", error);
         setState((prev) => ({ ...prev, status: "idle" }));
+        // Release the media-session audio primed within the play() gesture.
+        stopMediaSessionAudio();
       } finally {
         setIsLoading(false);
       }
@@ -390,10 +402,15 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
         narrator.play(voice, settings.rate, settings.pitch);
         // Track playback start with the current provider
         trackNarrationPlaybackStarted(settings.provider);
+      } else {
+        // Nothing to narrate — release the primed media-session audio.
+        stopMediaSessionAudio();
       }
     } catch (error) {
       console.error("Failed to generate narration:", error);
       setState((prev) => ({ ...prev, status: "idle" }));
+      // Release the media-session audio primed within the play() gesture.
+      stopMediaSessionAudio();
     } finally {
       setIsLoading(false);
     }

--- a/src/components/narration/useNarration.ts
+++ b/src/components/narration/useNarration.ts
@@ -31,12 +31,8 @@ import { trpc } from "@/lib/trpc/client";
 import { ArticleNarrator, type NarrationState } from "@/lib/narration/ArticleNarrator";
 import { useNarrationSettings } from "@/lib/narration/settings";
 import { findVoiceByUri, waitForVoices } from "@/lib/narration/voices";
-import {
-  setupMediaSession,
-  clearMediaSession,
-  createMediaSessionStateHandler,
-} from "@/lib/narration/media-session";
 import { isNarrationSupported } from "@/lib/narration/feature-detection";
+import { useMediaSession } from "./useMediaSession";
 import { trackNarrationPlaybackStarted } from "@/lib/telemetry";
 import { getPiperTTSProvider } from "@/lib/narration/piper-tts-provider";
 import { isEnhancedVoice } from "@/lib/narration/enhanced-voices";
@@ -91,7 +87,6 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
 
   // Refs
   const narratorRef = useRef<ArticleNarrator | null>(null);
-  const mediaSessionUnsubscribeRef = useRef<(() => void) | null>(null);
 
   // Streaming audio player for Piper TTS (sentence-level buffering)
   const streamingPlayerRef = useRef<StreamingAudioPlayer | null>(null);
@@ -137,31 +132,6 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
       narratorRef.current = null;
     };
   }, [isSupported, usePiper]);
-
-  // Set up Media Session when we have narration text (browser voices only for now)
-  useEffect(() => {
-    if (!isSupported || !narrationText || !narratorRef.current || usePiper) return;
-
-    // Set up Media Session
-    setupMediaSession({
-      articleTitle: title,
-      feedTitle: feedTitle,
-      narrator: narratorRef.current,
-      artwork,
-    });
-
-    // Subscribe to state changes for Media Session updates
-    const stateHandler = createMediaSessionStateHandler();
-    mediaSessionUnsubscribeRef.current = narratorRef.current.onStateChange(stateHandler);
-
-    return () => {
-      clearMediaSession();
-      if (mediaSessionUnsubscribeRef.current) {
-        mediaSessionUnsubscribeRef.current();
-        mediaSessionUnsubscribeRef.current = null;
-      }
-    };
-  }, [isSupported, narrationText, title, feedTitle, artwork, usePiper]);
 
   // Apply user settings when they change (browser voices only)
   useEffect(() => {
@@ -556,9 +526,27 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
         streamingPlayerRef.current.stop();
         streamingPlayerRef.current.clearCache();
       }
-      clearMediaSession();
     };
   }, []);
+
+  // Expose OS-level media controls (lock screen, notification, Bluetooth/media
+  // keys) while narration is active. Works for both browser voices and Piper by
+  // driving the provider-agnostic play/pause/skip callbacks above. A session
+  // exists once narration text has been generated for this article.
+  useMediaSession({
+    active: isSupported && narrationText !== null,
+    title,
+    feedTitle,
+    artwork,
+    status: state.status,
+    controls: {
+      play,
+      pause,
+      stop,
+      previousTrack: skipBackward,
+      nextTrack: skipForward,
+    },
+  });
 
   return {
     state,

--- a/src/lib/narration/media-session.ts
+++ b/src/lib/narration/media-session.ts
@@ -1,87 +1,103 @@
 /**
  * Media Session API Integration for Lion Reader's Narration Feature
  *
- * Enables OS-level playback controls:
- * - Lock screen controls (iOS/Android)
+ * Enables OS-level playback controls when narration is active:
+ * - Lock screen / notification media controls (iOS/Android, incl. installed PWA)
  * - Keyboard media keys (play/pause, prev/next)
- * - Headphone buttons
- * - Notification center media controls
+ * - Headphone / Bluetooth device buttons
+ *
+ * Narration plays through the Web Speech API (browser voices) or the Web Audio
+ * API (Piper enhanced voices). Neither registers as media playback, so the OS
+ * won't show media controls just because we set `mediaSession.metadata`. A silent
+ * looping audio element (see `./silent-audio`) is played while narration is
+ * active to make the browser treat narration as "media", which is what surfaces
+ * the controls and routes hardware buttons to our action handlers.
+ *
+ * This module is provider-agnostic: callers pass plain control callbacks, so the
+ * same integration works for both browser voices and Piper TTS.
  *
  * Usage:
  * ```typescript
- * import { setupMediaSession, clearMediaSession } from "@/lib/narration/media-session";
+ * setupMediaSession(
+ *   { articleTitle: "Article Title", feedTitle: "Feed Name", artwork },
+ *   { play, pause, stop, previousTrack, nextTrack },
+ * );
  *
- * // When starting narration
- * setupMediaSession({
- *   articleTitle: "Article Title",
- *   feedTitle: "Feed Name",
- *   narrator: articleNarrator,
- *   artwork: "https://example.com/icon.png" // optional
- * });
+ * // Keep the OS controls in sync with playback:
+ * updateMediaSessionPlaybackState("playing");
  *
- * // When leaving the article
+ * // When leaving the article:
  * clearMediaSession();
  * ```
  */
 
 import { isMediaSessionSupported } from "./feature-detection";
-import type { ArticleNarrator } from "./ArticleNarrator";
+import type { NarrationStatus } from "./ArticleNarrator";
+import { startSilentAudio, stopSilentAudio } from "./silent-audio";
 
 /**
- * Options for setting up the media session.
+ * Provider-agnostic playback controls invoked by OS media buttons.
+ *
+ * These map directly onto the narration hook's controls so both browser voices
+ * and Piper TTS share one integration.
  */
-export interface MediaSessionOptions {
+export interface MediaSessionControls {
+  /** Resume/start playback (OS "play" button, media key). */
+  play: () => void;
+  /** Pause playback (OS "pause" button, media key). */
+  pause: () => void;
+  /** Stop playback entirely. */
+  stop: () => void;
+  /** Skip to the previous paragraph (prev-track button). */
+  previousTrack: () => void;
+  /** Skip to the next paragraph (next-track button). */
+  nextTrack: () => void;
+}
+
+/**
+ * Metadata describing the currently-narrated article.
+ */
+export interface MediaSessionMetadataInput {
   /** Title of the article being narrated */
   articleTitle: string;
-  /** Name of the feed the article is from */
+  /** Name of the feed/site the article is from */
   feedTitle: string;
-  /** The ArticleNarrator instance to control */
-  narrator: ArticleNarrator;
   /** Optional URL to artwork/icon to display in media controls */
   artwork?: string;
 }
 
 /**
- * Playback state for the media session.
+ * The narration statuses that keep an OS media session active. `idle` tears it
+ * down; the rest keep the silent loop playing so the controls persist.
  */
-type MediaSessionPlaybackState = "playing" | "paused" | "none";
+const ACTIVE_STATUSES: ReadonlySet<NarrationStatus> = new Set<NarrationStatus>([
+  "loading",
+  "playing",
+  "paused",
+]);
 
 /**
  * Sets up the Media Session API for OS-level playback controls.
  *
- * This function:
- * - Sets metadata (title, artist, album, artwork)
- * - Registers action handlers (play, pause, stop, prev, next)
- * - Enables lock screen and keyboard media key controls
+ * Sets metadata (title, artist, album, artwork) and registers action handlers.
+ * Playback state (and the silent-audio element that makes the controls appear)
+ * is driven separately by {@link updateMediaSessionPlaybackState}.
  *
- * If the Media Session API is not supported, this function does nothing
- * (graceful degradation).
+ * No-op when the Media Session API is unsupported (graceful degradation).
  *
- * @param options - Configuration for the media session
- *
- * @example
- * ```typescript
- * const narrator = new ArticleNarrator();
- * narrator.loadArticle("...");
- *
- * setupMediaSession({
- *   articleTitle: "How to Build a Feed Reader",
- *   feedTitle: "Tech Blog",
- *   narrator,
- * });
- *
- * narrator.play();
- * updateMediaSessionState("playing");
- * ```
+ * @param metadata - What to display in the OS controls
+ * @param controls - Callbacks invoked by the OS media buttons
  */
-export function setupMediaSession(options: MediaSessionOptions): void {
+export function setupMediaSession(
+  metadata: MediaSessionMetadataInput,
+  controls: MediaSessionControls
+): void {
   if (!isMediaSessionSupported()) {
     return;
   }
 
-  const { articleTitle, feedTitle, narrator, artwork } = options;
+  const { articleTitle, feedTitle, artwork } = metadata;
 
-  // Set up metadata for the media session
   const artworkArray: MediaImage[] = artwork
     ? [
         { src: artwork, sizes: "96x96", type: "image/png" },
@@ -100,150 +116,66 @@ export function setupMediaSession(options: MediaSessionOptions): void {
     artwork: artworkArray,
   });
 
-  // Register action handlers
-  // Play: Resume narration
-  navigator.mediaSession.setActionHandler("play", () => {
-    narrator.resume();
-    updateMediaSessionState("playing");
-  });
-
-  // Pause: Pause narration
-  navigator.mediaSession.setActionHandler("pause", () => {
-    narrator.pause();
-    updateMediaSessionState("paused");
-  });
-
-  // Stop: Stop narration completely
-  navigator.mediaSession.setActionHandler("stop", () => {
-    narrator.stop();
-    updateMediaSessionState("none");
-  });
-
-  // Previous track: Skip to previous paragraph
-  navigator.mediaSession.setActionHandler("previoustrack", () => {
-    narrator.skipBackward();
-  });
-
-  // Next track: Skip to next paragraph
-  navigator.mediaSession.setActionHandler("nexttrack", () => {
-    narrator.skipForward();
-  });
-
-  // Initialize playback state
-  navigator.mediaSession.playbackState = "none";
+  navigator.mediaSession.setActionHandler("play", () => controls.play());
+  navigator.mediaSession.setActionHandler("pause", () => controls.pause());
+  navigator.mediaSession.setActionHandler("stop", () => controls.stop());
+  navigator.mediaSession.setActionHandler("previoustrack", () => controls.previousTrack());
+  navigator.mediaSession.setActionHandler("nexttrack", () => controls.nextTrack());
 }
 
 /**
- * Updates the media session playback state.
+ * Synchronizes the OS media session with the current narration status and drives
+ * the silent audio element that keeps the controls visible.
  *
- * Call this whenever the narration state changes to keep the OS
- * media controls in sync with the actual playback state.
+ * - `loading` / `playing` / `paused`: keeps the silent loop playing so the OS
+ *   session stays active, and reflects play vs. pause on the controls.
+ * - `idle`: stops the silent loop, deactivating the OS session.
  *
- * @param state - The current playback state
+ * Call this whenever narration status changes. Reachability from a user gesture
+ * (or sticky activation) matters for the first `loading`/`playing` transition so
+ * autoplay policies allow the silent audio to start.
  *
- * @example
- * ```typescript
- * // When play is pressed
- * narrator.play();
- * updateMediaSessionState("playing");
- *
- * // When paused
- * narrator.pause();
- * updateMediaSessionState("paused");
- *
- * // When stopped or article ends
- * narrator.stop();
- * updateMediaSessionState("none");
- * ```
+ * @param status - The current narration status
  */
-function updateMediaSessionState(state: MediaSessionPlaybackState): void {
+export function updateMediaSessionPlaybackState(status: NarrationStatus): void {
   if (!isMediaSessionSupported()) {
     return;
   }
 
-  navigator.mediaSession.playbackState = state;
+  if (ACTIVE_STATUSES.has(status)) {
+    // Keep (or start) the silent loop so the OS treats narration as media.
+    startSilentAudio();
+    navigator.mediaSession.playbackState = status === "paused" ? "paused" : "playing";
+  } else {
+    stopSilentAudio();
+    navigator.mediaSession.playbackState = "none";
+  }
 }
 
 /**
  * Clears the media session when leaving an article.
  *
- * This function:
- * - Resets the playback state to "none"
- * - Clears the metadata
- * - Removes all action handlers
- *
- * Call this when navigating away from an article to clean up
- * the media session and prevent stale controls from appearing.
- *
- * @example
- * ```typescript
- * // In a React component's cleanup
- * useEffect(() => {
- *   setupMediaSession({ ... });
- *
- *   return () => {
- *     clearMediaSession();
- *   };
- * }, []);
- * ```
+ * Stops the silent audio loop, resets playback state, clears metadata, and
+ * removes all action handlers so stale controls don't linger.
  */
 export function clearMediaSession(): void {
+  // Always stop the silent loop, even if the Media Session API itself is
+  // unsupported, so the element never keeps looping.
+  stopSilentAudio();
+
   if (!isMediaSessionSupported()) {
     return;
   }
 
-  // Reset playback state
   navigator.mediaSession.playbackState = "none";
-
-  // Clear metadata
   navigator.mediaSession.metadata = null;
 
-  // Remove all action handlers by setting them to null
   const actions: MediaSessionAction[] = ["play", "pause", "stop", "previoustrack", "nexttrack"];
-
   for (const action of actions) {
     try {
       navigator.mediaSession.setActionHandler(action, null);
     } catch {
-      // Some browsers may throw if the action is not supported
-      // We can safely ignore this
+      // Some browsers throw for unsupported actions; safe to ignore.
     }
   }
-}
-
-/**
- * Creates a state change callback that automatically updates the media session.
- *
- * This is a convenience function that returns a callback suitable for use with
- * `ArticleNarrator.onStateChange()`. It maps narration status to media session
- * playback state.
- *
- * @returns A callback function for ArticleNarrator.onStateChange()
- *
- * @example
- * ```typescript
- * const narrator = new ArticleNarrator();
- * const unsubscribe = narrator.onStateChange(createMediaSessionStateHandler());
- *
- * // Later, clean up
- * unsubscribe();
- * ```
- */
-export function createMediaSessionStateHandler(): (state: {
-  status: "idle" | "loading" | "playing" | "paused";
-}) => void {
-  return (state) => {
-    switch (state.status) {
-      case "playing":
-        updateMediaSessionState("playing");
-        break;
-      case "paused":
-        updateMediaSessionState("paused");
-        break;
-      case "idle":
-      case "loading":
-        updateMediaSessionState("none");
-        break;
-    }
-  };
 }

--- a/src/lib/narration/media-session.ts
+++ b/src/lib/narration/media-session.ts
@@ -153,6 +153,35 @@ export function updateMediaSessionPlaybackState(status: NarrationStatus): void {
 }
 
 /**
+ * Starts the silent audio loop immediately.
+ *
+ * Call this synchronously from within the user gesture that begins narration, so
+ * the browser grants the media session before any async work (e.g. LLM narration
+ * generation) consumes the gesture's autoplay activation — otherwise the later
+ * `startSilentAudio()` from {@link updateMediaSessionPlaybackState} can be
+ * rejected by autoplay policy and the OS controls never appear. Safe to call
+ * before metadata is set; {@link updateMediaSessionPlaybackState} keeps it going
+ * once playback begins. If playback never starts (generation fails), release it
+ * with {@link stopMediaSessionAudio} or {@link clearMediaSession}.
+ */
+export function primeMediaSessionAudio(): void {
+  if (!isMediaSessionSupported()) {
+    return;
+  }
+  startSilentAudio();
+}
+
+/**
+ * Stops the silent audio loop without clearing metadata/action handlers.
+ *
+ * Used to release a session primed by {@link primeMediaSessionAudio} when
+ * narration generation fails before playback actually begins.
+ */
+export function stopMediaSessionAudio(): void {
+  stopSilentAudio();
+}
+
+/**
  * Clears the media session when leaving an article.
  *
  * Stops the silent audio loop, resets playback state, clears metadata, and

--- a/src/lib/narration/silent-audio.ts
+++ b/src/lib/narration/silent-audio.ts
@@ -1,0 +1,149 @@
+/**
+ * Silent looping audio for the Media Session API.
+ *
+ * The Media Session API (`navigator.mediaSession`) only surfaces OS-level media
+ * controls — the lock-screen / notification widget, and hardware/Bluetooth
+ * play-pause buttons — while the browser believes an `HTMLMediaElement` is
+ * actively playing. Lion Reader's narration plays through the Web Speech API
+ * (`speechSynthesis`) or the Web Audio API (Piper TTS via `AudioBufferSourceNode`),
+ * neither of which registers as media playback. Without a real media element,
+ * setting `mediaSession.metadata` and action handlers has no visible effect: the
+ * notification never appears and Bluetooth buttons aren't routed to us.
+ *
+ * The standard workaround is to play a silent, looping audio element alongside
+ * the narration. That element is what the browser treats as "the media", so the
+ * OS controls appear and the media-key/Bluetooth events flow into our action
+ * handlers. This module owns generating that silent clip and the element.
+ *
+ * The clip is generated at runtime as a tiny silent WAV data URI so we don't ship
+ * a binary asset. It loops, so it can be very short.
+ *
+ * @module narration/silent-audio
+ */
+
+/** Sample rate for the generated silent clip. Low rate keeps the clip tiny. */
+const SILENT_SAMPLE_RATE = 8000;
+
+/** Duration of the generated silent clip in seconds. It loops, so this is short. */
+const SILENT_DURATION_SECONDS = 0.5;
+
+/**
+ * Generates the bytes of a mono, 8-bit PCM WAV file containing pure silence.
+ *
+ * 8-bit PCM samples are unsigned, so the silence value is 128 (0x80), not 0.
+ * This is a pure function so the WAV structure can be unit-tested without a DOM.
+ *
+ * @param durationSeconds - Length of the clip
+ * @param sampleRate - Samples per second
+ * @returns A `Uint8Array` containing a complete WAV file
+ */
+export function createSilentWavBytes(
+  durationSeconds: number = SILENT_DURATION_SECONDS,
+  sampleRate: number = SILENT_SAMPLE_RATE
+): Uint8Array {
+  const numChannels = 1;
+  const bitsPerSample = 8;
+  const bytesPerSample = bitsPerSample / 8;
+  const numSamples = Math.max(1, Math.floor(durationSeconds * sampleRate));
+  const dataSize = numSamples * numChannels * bytesPerSample;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  const writeAscii = (offset: number, text: string): void => {
+    for (let i = 0; i < text.length; i++) {
+      view.setUint8(offset + i, text.charCodeAt(i));
+    }
+  };
+
+  // RIFF header
+  writeAscii(0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true); // chunk size
+  writeAscii(8, "WAVE");
+
+  // fmt subchunk
+  writeAscii(12, "fmt ");
+  view.setUint32(16, 16, true); // subchunk1 size (PCM)
+  view.setUint16(20, 1, true); // audio format (1 = PCM)
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * numChannels * bytesPerSample, true); // byte rate
+  view.setUint16(32, numChannels * bytesPerSample, true); // block align
+  view.setUint16(34, bitsPerSample, true);
+
+  // data subchunk
+  writeAscii(36, "data");
+  view.setUint32(40, dataSize, true);
+
+  // Fill samples with 8-bit silence (unsigned midpoint = 128).
+  const bytes = new Uint8Array(buffer);
+  bytes.fill(128, 44);
+
+  return bytes;
+}
+
+/**
+ * Encodes the silent WAV as a `data:` URI usable as an `<audio>` element `src`.
+ */
+export function createSilentAudioDataUri(): string {
+  const bytes = createSilentWavBytes();
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  const base64 = typeof btoa === "function" ? btoa(binary) : "";
+  return `data:audio/wav;base64,${base64}`;
+}
+
+/**
+ * Lazily-created singleton silent audio element. Shared across narrations since
+ * only one narration plays at a time.
+ */
+let silentAudio: HTMLAudioElement | null = null;
+
+/**
+ * Gets (creating if needed) the shared silent, looping audio element.
+ *
+ * Returns null when there is no DOM (SSR) or `Audio` is unavailable.
+ */
+function getSilentAudioElement(): HTMLAudioElement | null {
+  if (typeof document === "undefined" || typeof Audio === "undefined") {
+    return null;
+  }
+  if (!silentAudio) {
+    silentAudio = new Audio(createSilentAudioDataUri());
+    silentAudio.loop = true;
+    // Keep the volume audible-but-silent (the clip itself is silent); muting can
+    // cause some browsers to ignore the element for Media Session purposes.
+    silentAudio.volume = 1;
+    silentAudio.preload = "auto";
+  }
+  return silentAudio;
+}
+
+/**
+ * Starts the silent loop, activating the OS media session.
+ *
+ * Must be reachable from a user gesture (or sticky activation) so autoplay
+ * policies allow playback; the returned promise rejection is swallowed so a
+ * blocked autoplay degrades gracefully (no controls) rather than throwing.
+ */
+export function startSilentAudio(): void {
+  const audio = getSilentAudioElement();
+  if (!audio) return;
+  const playResult = audio.play();
+  if (playResult && typeof playResult.catch === "function") {
+    playResult.catch(() => {
+      // Autoplay blocked (e.g. no user activation). Media controls simply won't
+      // appear; narration itself is unaffected.
+    });
+  }
+}
+
+/**
+ * Stops the silent loop and releases it, deactivating the OS media session.
+ */
+export function stopSilentAudio(): void {
+  if (!silentAudio) return;
+  silentAudio.pause();
+  silentAudio.currentTime = 0;
+}

--- a/tests/unit/frontend/narration-media-session.test.ts
+++ b/tests/unit/frontend/narration-media-session.test.ts
@@ -144,6 +144,29 @@ describe("updateMediaSessionPlaybackState", () => {
   });
 });
 
+describe("primeMediaSessionAudio / stopMediaSessionAudio", () => {
+  it("starts the silent audio without registering metadata or handlers", async () => {
+    const { primeMediaSessionAudio } = await loadModule();
+
+    primeMediaSessionAudio();
+
+    expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalled();
+    // Priming must not register controls or metadata — it only holds the session
+    // open within the user gesture until generation finishes.
+    expect(mediaSession.metadata).toBeNull();
+    expect(mediaSession.setActionHandler).not.toHaveBeenCalled();
+  });
+
+  it("releases a primed session's silent audio", async () => {
+    const { primeMediaSessionAudio, stopMediaSessionAudio } = await loadModule();
+
+    primeMediaSessionAudio();
+    stopMediaSessionAudio();
+
+    expect(window.HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+  });
+});
+
 describe("clearMediaSession", () => {
   it("tears down metadata, handlers, and the silent audio", async () => {
     const { setupMediaSession, updateMediaSessionPlaybackState, clearMediaSession } =

--- a/tests/unit/frontend/narration-media-session.test.ts
+++ b/tests/unit/frontend/narration-media-session.test.ts
@@ -1,0 +1,164 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Integration tests for the Media Session wiring that surfaces native narration
+ * controls in a PWA (issue #410).
+ *
+ * jsdom implements neither `navigator.mediaSession` nor `HTMLMediaElement.play()`,
+ * so we stub those browser primitives (not internal code) and assert that the
+ * module sets metadata, registers action handlers that dispatch to the provided
+ * controls, mirrors playback state, and drives the silent audio element that
+ * makes the OS controls appear.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Mock } from "vitest";
+
+interface StubMediaSession {
+  metadata: unknown;
+  playbackState: string;
+  setActionHandler: Mock;
+}
+
+let mediaSession: StubMediaSession;
+let actionHandlers: Record<string, (() => void) | null>;
+
+beforeEach(() => {
+  actionHandlers = {};
+  mediaSession = {
+    metadata: null,
+    playbackState: "none",
+    setActionHandler: vi.fn((action: string, handler: (() => void) | null) => {
+      actionHandlers[action] = handler;
+    }),
+  };
+
+  Object.defineProperty(navigator, "mediaSession", {
+    value: mediaSession,
+    configurable: true,
+    writable: true,
+  });
+
+  // Minimal MediaMetadata stand-in (jsdom lacks it).
+  (globalThis as unknown as { MediaMetadata: unknown }).MediaMetadata = class {
+    constructor(init: unknown) {
+      Object.assign(this, init);
+    }
+  };
+
+  // jsdom's HTMLMediaElement.play/pause are unimplemented; stub them.
+  vi.spyOn(window.HTMLMediaElement.prototype, "play").mockImplementation(() => Promise.resolve());
+  vi.spyOn(window.HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+async function loadModule() {
+  // Re-import per test so the silent-audio singleton is fresh.
+  return await import("@/lib/narration/media-session");
+}
+
+function makeControls() {
+  return {
+    play: vi.fn(),
+    pause: vi.fn(),
+    stop: vi.fn(),
+    previousTrack: vi.fn(),
+    nextTrack: vi.fn(),
+  };
+}
+
+describe("setupMediaSession", () => {
+  it("sets metadata and registers all action handlers", async () => {
+    const { setupMediaSession } = await loadModule();
+    const controls = makeControls();
+
+    setupMediaSession(
+      { articleTitle: "My Article", feedTitle: "My Feed", artwork: "https://x/icon.png" },
+      controls
+    );
+
+    expect(mediaSession.metadata).toMatchObject({
+      title: "My Article",
+      artist: "My Feed",
+      album: "Lion Reader",
+    });
+    for (const action of ["play", "pause", "stop", "previoustrack", "nexttrack"]) {
+      expect(actionHandlers[action]).toBeTypeOf("function");
+    }
+  });
+
+  it("dispatches OS media buttons to the provided controls", async () => {
+    const { setupMediaSession } = await loadModule();
+    const controls = makeControls();
+
+    setupMediaSession({ articleTitle: "T", feedTitle: "F" }, controls);
+
+    actionHandlers.play?.();
+    actionHandlers.pause?.();
+    actionHandlers.stop?.();
+    actionHandlers.previoustrack?.();
+    actionHandlers.nexttrack?.();
+
+    expect(controls.play).toHaveBeenCalledTimes(1);
+    expect(controls.pause).toHaveBeenCalledTimes(1);
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+    expect(controls.previousTrack).toHaveBeenCalledTimes(1);
+    expect(controls.nextTrack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("updateMediaSessionPlaybackState", () => {
+  it("starts the silent audio and reports playing while active", async () => {
+    const { updateMediaSessionPlaybackState } = await loadModule();
+
+    updateMediaSessionPlaybackState("playing");
+
+    expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalled();
+    expect(mediaSession.playbackState).toBe("playing");
+  });
+
+  it("keeps the silent audio playing but reports paused when paused", async () => {
+    const { updateMediaSessionPlaybackState } = await loadModule();
+
+    updateMediaSessionPlaybackState("paused");
+
+    expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalled();
+    expect(window.HTMLMediaElement.prototype.pause).not.toHaveBeenCalled();
+    expect(mediaSession.playbackState).toBe("paused");
+  });
+
+  it("stops the silent audio and clears state when idle", async () => {
+    const { updateMediaSessionPlaybackState } = await loadModule();
+
+    updateMediaSessionPlaybackState("playing");
+    updateMediaSessionPlaybackState("idle");
+
+    expect(window.HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+    expect(mediaSession.playbackState).toBe("none");
+  });
+});
+
+describe("clearMediaSession", () => {
+  it("tears down metadata, handlers, and the silent audio", async () => {
+    const { setupMediaSession, updateMediaSessionPlaybackState, clearMediaSession } =
+      await loadModule();
+    const controls = makeControls();
+
+    setupMediaSession({ articleTitle: "T", feedTitle: "F" }, controls);
+    updateMediaSessionPlaybackState("playing");
+    clearMediaSession();
+
+    expect(mediaSession.metadata).toBeNull();
+    expect(mediaSession.playbackState).toBe("none");
+    expect(window.HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+    for (const action of ["play", "pause", "stop", "previoustrack", "nexttrack"]) {
+      expect(actionHandlers[action]).toBeNull();
+    }
+  });
+});

--- a/tests/unit/narration-silent-audio.test.ts
+++ b/tests/unit/narration-silent-audio.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the silent-audio WAV generation used to activate the OS Media
+ * Session while narration plays (issue #410).
+ *
+ * These cover the pure byte-level generator; the DOM element wiring is exercised
+ * by the media-session integration test.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createSilentWavBytes, createSilentAudioDataUri } from "@/lib/narration/silent-audio";
+
+/** Reads a little-endian uint32 from a byte array. */
+function readUint32LE(bytes: Uint8Array, offset: number): number {
+  return (
+    bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 24)
+  );
+}
+
+/** Reads a little-endian uint16 from a byte array. */
+function readUint16LE(bytes: Uint8Array, offset: number): number {
+  return bytes[offset] | (bytes[offset + 1] << 8);
+}
+
+/** Reads an ASCII string of the given length. */
+function readAscii(bytes: Uint8Array, offset: number, length: number): string {
+  let out = "";
+  for (let i = 0; i < length; i++) {
+    out += String.fromCharCode(bytes[offset + i]);
+  }
+  return out;
+}
+
+describe("createSilentWavBytes", () => {
+  it("produces a well-formed RIFF/WAVE header", () => {
+    const bytes = createSilentWavBytes();
+
+    expect(readAscii(bytes, 0, 4)).toBe("RIFF");
+    expect(readAscii(bytes, 8, 4)).toBe("WAVE");
+    expect(readAscii(bytes, 12, 4)).toBe("fmt ");
+    expect(readAscii(bytes, 36, 4)).toBe("data");
+  });
+
+  it("declares mono 8-bit PCM and consistent chunk sizes", () => {
+    const durationSeconds = 0.5;
+    const sampleRate = 8000;
+    const bytes = createSilentWavBytes(durationSeconds, sampleRate);
+
+    const dataSize = sampleRate * durationSeconds; // mono, 8-bit => 1 byte/sample
+
+    expect(readUint32LE(bytes, 16)).toBe(16); // PCM fmt chunk size
+    expect(readUint16LE(bytes, 20)).toBe(1); // audio format = PCM
+    expect(readUint16LE(bytes, 22)).toBe(1); // channels = mono
+    expect(readUint32LE(bytes, 24)).toBe(sampleRate);
+    expect(readUint16LE(bytes, 34)).toBe(8); // bits per sample
+    expect(readUint32LE(bytes, 40)).toBe(dataSize); // data chunk size
+    expect(readUint32LE(bytes, 4)).toBe(36 + dataSize); // RIFF chunk size
+    expect(bytes.length).toBe(44 + dataSize);
+  });
+
+  it("fills the sample data with 8-bit silence (unsigned midpoint 128)", () => {
+    const bytes = createSilentWavBytes(0.1, 8000);
+    const data = bytes.subarray(44);
+
+    expect(data.length).toBeGreaterThan(0);
+    expect(data.every((sample) => sample === 128)).toBe(true);
+  });
+
+  it("always emits at least one sample even for a zero duration", () => {
+    const bytes = createSilentWavBytes(0, 8000);
+    expect(bytes.length).toBe(44 + 1);
+  });
+});
+
+describe("createSilentAudioDataUri", () => {
+  it("returns a base64 audio/wav data URI", () => {
+    const uri = createSilentAudioDataUri();
+    expect(uri.startsWith("data:audio/wav;base64,")).toBe(true);
+    expect(uri.length).toBeGreaterThan("data:audio/wav;base64,".length);
+  });
+});


### PR DESCRIPTION
Closes #410.

## Problem

Narration was supposed to expose native OS media controls when installed as a PWA (lock-screen/notification widget, and play/pause + track buttons from Bluetooth/headphone devices), but it didn't work:

- Narration plays through the **Web Speech API** (browser voices) or the **Web Audio API** (Piper enhanced voices, via `AudioBufferSourceNode`). **Neither registers as media playback** with the browser, so setting `navigator.mediaSession` metadata + action handlers had **no visible effect** — the OS controls never appeared and hardware buttons weren't routed to us.
- Media Session was also only wired for **browser voices**, explicitly skipped for Piper.

## Fix

- **`src/lib/narration/silent-audio.ts`** (new): plays a **silent, looping `<audio>` element** while narration is active. Browsers only surface OS media controls while an `HTMLMediaElement` is playing, so this silent element is what makes the notification/lock-screen controls appear and routes Bluetooth/media-key events into our handlers. The clip is a runtime-generated silent WAV `data:` URI — no binary asset shipped.
- **`src/lib/narration/media-session.ts`** (rewritten): now **provider-agnostic** — takes plain `play`/`pause`/`stop`/`previousTrack`/`nextTrack` callbacks instead of a concrete `ArticleNarrator`, and owns the silent-audio lifecycle via `updateMediaSessionPlaybackState` / `clearMediaSession`.
- **`src/components/narration/useMediaSession.ts`** (new hook): keeps metadata, action handlers, and playback state in sync; OS button handlers dispatch through a ref so they always call current callbacks without re-registering.
- **`useNarration`**: calls `useMediaSession` for **both** providers, replacing the old browser-voices-only effect.

Artwork falls back to the PWA manifest icons when no per-article image is supplied. (Wiring per-article `imageUrl` through would require exposing it on the entry read model — left as a follow-up to keep this focused.)

## Testing

- `tests/unit/narration-silent-audio.test.ts` — pure WAV-byte structure/silence generation.
- `tests/unit/frontend/narration-media-session.test.ts` — jsdom test stubbing `navigator.mediaSession` and `HTMLMediaElement.play/pause`; verifies metadata, handler→controls dispatch, playback-state mirroring, and silent-audio start/stop.
- `pnpm typecheck`, `pnpm lint`, and full `pnpm test:unit` (2299 tests) pass.

Note: the silent-audio activation depends on autoplay being permitted, which installed PWAs and post-interaction pages allow; if blocked, it degrades gracefully (no controls, narration unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)