### PR TITLE
Allow-list common iframe embed providers in entry content (#922)

### DIFF
--- a/src/server/html/embed-providers.ts
+++ b/src/server/html/embed-providers.ts
@@ -1,0 +1,282 @@
+/**
+ * Allow-listed iframe embed providers, used by the sanitizer (`sanitize.ts`) to
+ * decide which cross-origin iframes may survive in entry content.
+ *
+ * Iframes are the sanitizer's only cross-origin escape hatch. An unrestricted
+ * iframe would let a feed embed an arbitrary page full-bleed inside the reader's
+ * trusted UI — a phishing / clickjacking / tracking surface (issue #922). So the
+ * policy is **block-by-default, opt-in per provider**: an iframe survives only if
+ * its src matches one of the known media-embed providers below.
+ *
+ * Every provider follows the same defense-in-depth recipe (same as the original
+ * YouTube-only handling in #1115):
+ *
+ *  1. Parse the src as an http(s) URL (protocol-relative `//host` is treated as
+ *     https, since feeds commonly use it).
+ *  2. Reject unless the hostname is one of the provider's known embed hosts.
+ *  3. Validate the path against a strict, bounded regex so a pathological path
+ *     can't smuggle arbitrary content through.
+ *  4. Rebuild the URL from scratch on the provider's *canonical* host, copying
+ *     only an allow-list of query params (each validated where it carries a
+ *     nested URL). Autoplay / JS-API / tracking params are dropped.
+ *  5. The sanitizer then forces a per-provider `sandbox`/`allow` regardless of
+ *     what the feed supplied.
+ *
+ * Because step 4 rewrites every surviving src to a canonical host, the set of
+ * canonical hosts (`EMBED_CANONICAL_HOSTNAMES`) also backstops the rule via
+ * sanitize-html's `allowedIframeHostnames`.
+ *
+ * To add a provider: append an `EmbedProvider` here and (if it introduces a new
+ * canonical host) it is picked up automatically by `EMBED_CANONICAL_HOSTNAMES`.
+ * Keep `matchUrl`/path regexes selective — a provider must only match URLs it
+ * can actually render as an embed, never "any URL on my hosts".
+ */
+
+import {
+  normalizeYouTubeEmbedUrl,
+  YOUTUBE_IFRAME_ALLOW,
+  YOUTUBE_IFRAME_SANDBOX,
+} from "./youtube-embed";
+
+/** A normalized, safe-to-render embed derived from an untrusted iframe src. */
+export interface NormalizedEmbed {
+  /** Canonical, rewritten src URL. */
+  src: string;
+  /** Human-readable provider name (for a "removed embed" placeholder, etc.). */
+  provider: string;
+  /** Forced `sandbox` attribute value. */
+  sandbox: string;
+  /** Forced `allow` (Permissions-Policy) attribute value. */
+  allow: string;
+}
+
+interface EmbedProvider {
+  name: string;
+  /**
+   * Validates and normalizes an iframe src for this provider. Returns the
+   * canonical rewritten URL, or null if the src is not a valid embed for it.
+   */
+  normalize: (src: string) => string | null;
+  sandbox: string;
+  allow: string;
+}
+
+/**
+ * Sandbox shared by the media-player embeds. Players need scripts and their own
+ * origin's storage; popups (with sandbox escape) let "Watch/Listen on <site>"
+ * open a normal tab. `allow-same-origin` is safe because the framed content is
+ * always cross-origin (a canonical provider host), never our own origin — so it
+ * grants the frame *its* origin, not ours.
+ *
+ * This is the same sandbox the YouTube handling has always used
+ * (`YOUTUBE_IFRAME_SANDBOX`); the other players have the same needs.
+ */
+const STANDARD_EMBED_SANDBOX = YOUTUBE_IFRAME_SANDBOX;
+
+/**
+ * Parses an untrusted iframe src into an http(s) URL, treating protocol-relative
+ * `//host/...` as https (common in feeds). Returns null for anything unparseable
+ * or non-http(s).
+ */
+function parseHttpUrl(src: string | null | undefined): URL | null {
+  if (!src) return null;
+  const trimmed = src.trim();
+  const absolute = trimmed.startsWith("//") ? `https:${trimmed}` : trimmed;
+  let url: URL;
+  try {
+    url = new URL(absolute);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+  return url;
+}
+
+/** Copies only allow-listed query params from `from` onto `to`. */
+function copyParams(from: URL, to: URL, allowed: ReadonlySet<string>): void {
+  for (const [key, value] of from.searchParams) {
+    if (allowed.has(key)) to.searchParams.set(key, value);
+  }
+}
+
+// --- Vimeo -----------------------------------------------------------------
+// https://player.vimeo.com/video/{numericId}?h={hash}
+const VIMEO_HOSTS = new Set(["player.vimeo.com"]);
+const VIMEO_PATH_RE = /^\/video\/(\d{1,20})$/;
+const VIMEO_PARAMS = new Set([
+  "h", // private/unlisted video hash — required for those, must be preserved
+  "title",
+  "byline",
+  "portrait",
+  "badge",
+  "color",
+  "loop",
+  "muted",
+  "dnt",
+]);
+function normalizeVimeoEmbedUrl(src: string): string | null {
+  const url = parseHttpUrl(src);
+  if (!url || !VIMEO_HOSTS.has(url.hostname.toLowerCase())) return null;
+  const match = VIMEO_PATH_RE.exec(url.pathname);
+  if (!match) return null;
+  const out = new URL(`https://player.vimeo.com/video/${match[1]}`);
+  copyParams(url, out, VIMEO_PARAMS);
+  return out.toString();
+}
+
+// --- Spotify ---------------------------------------------------------------
+// https://open.spotify.com/embed[-podcast]/{type}/{id}
+const SPOTIFY_HOSTS = new Set(["open.spotify.com"]);
+const SPOTIFY_PATH_RE =
+  /^\/embed(?:-podcast)?\/(track|album|playlist|episode|show|artist)\/([A-Za-z0-9]{1,64})$/;
+const SPOTIFY_PARAMS = new Set(["theme", "t"]);
+function normalizeSpotifyEmbedUrl(src: string): string | null {
+  const url = parseHttpUrl(src);
+  if (!url || !SPOTIFY_HOSTS.has(url.hostname.toLowerCase())) return null;
+  const match = SPOTIFY_PATH_RE.exec(url.pathname);
+  if (!match) return null;
+  const out = new URL(`https://open.spotify.com${url.pathname}`);
+  copyParams(url, out, SPOTIFY_PARAMS);
+  return out.toString();
+}
+
+// --- SoundCloud ------------------------------------------------------------
+// https://w.soundcloud.com/player/?url={soundcloud track url}&...visual flags
+const SOUNDCLOUD_HOSTS = new Set(["w.soundcloud.com"]);
+const SOUNDCLOUD_PATH_RE = /^\/player\/?$/;
+const SOUNDCLOUD_PARAMS = new Set([
+  "color",
+  "hide_related",
+  "show_comments",
+  "show_user",
+  "show_reposts",
+  "show_teaser",
+  "visual",
+  "start_track",
+  "single_active",
+]);
+function isSoundCloudResourceUrl(value: string): boolean {
+  const url = parseHttpUrl(value);
+  if (!url) return false;
+  const host = url.hostname.toLowerCase();
+  return (
+    host === "soundcloud.com" || host === "api.soundcloud.com" || host.endsWith(".soundcloud.com")
+  );
+}
+function normalizeSoundCloudEmbedUrl(src: string): string | null {
+  const url = parseHttpUrl(src);
+  if (!url || !SOUNDCLOUD_HOSTS.has(url.hostname.toLowerCase())) return null;
+  if (!SOUNDCLOUD_PATH_RE.test(url.pathname)) return null;
+  // The `url` param carries the actual track/playlist — required, and it must
+  // point at SoundCloud so the frame can't be pointed at an arbitrary resource.
+  const resource = url.searchParams.get("url");
+  if (!resource || !isSoundCloudResourceUrl(resource)) return null;
+  const out = new URL("https://w.soundcloud.com/player/");
+  out.searchParams.set("url", resource);
+  copyParams(url, out, SOUNDCLOUD_PARAMS);
+  return out.toString();
+}
+
+// --- Bandcamp --------------------------------------------------------------
+// https://bandcamp.com/EmbeddedPlayer/album=123/size=large/.../ (params in path)
+const BANDCAMP_HOSTS = new Set(["bandcamp.com"]);
+const BANDCAMP_PATH_RE = /^\/EmbeddedPlayer(?:\/[a-z_]+=[A-Za-z0-9]+)+\/?$/;
+function normalizeBandcampEmbedUrl(src: string): string | null {
+  const url = parseHttpUrl(src);
+  if (!url || !BANDCAMP_HOSTS.has(url.hostname.toLowerCase())) return null;
+  if (!BANDCAMP_PATH_RE.test(url.pathname)) return null;
+  // Path is fully validated above; no query params are used by the player.
+  return `https://bandcamp.com${url.pathname}`;
+}
+
+// --- CodePen ---------------------------------------------------------------
+// https://codepen.io/{user}/embed[/preview]/{slug}
+const CODEPEN_HOSTS = new Set(["codepen.io", "cdpn.io"]);
+const CODEPEN_PATH_RE = /^\/[A-Za-z0-9_-]+\/embed\/(?:preview\/)?[A-Za-z0-9]+\/?$/;
+const CODEPEN_PARAMS = new Set(["default-tab", "theme-id", "height", "editable"]);
+function normalizeCodePenEmbedUrl(src: string): string | null {
+  const url = parseHttpUrl(src);
+  if (!url || !CODEPEN_HOSTS.has(url.hostname.toLowerCase())) return null;
+  if (!CODEPEN_PATH_RE.test(url.pathname)) return null;
+  const out = new URL(`https://codepen.io${url.pathname}`);
+  copyParams(url, out, CODEPEN_PARAMS);
+  return out.toString();
+}
+
+/**
+ * Registry of allow-listed embed providers. Order matters only in that the
+ * first match wins; hosts are disjoint so order is effectively irrelevant.
+ */
+const EMBED_PROVIDERS: readonly EmbedProvider[] = [
+  {
+    name: "YouTube",
+    normalize: normalizeYouTubeEmbedUrl,
+    sandbox: STANDARD_EMBED_SANDBOX,
+    allow: YOUTUBE_IFRAME_ALLOW,
+  },
+  {
+    name: "Vimeo",
+    normalize: normalizeVimeoEmbedUrl,
+    sandbox: STANDARD_EMBED_SANDBOX,
+    allow: "fullscreen; encrypted-media; picture-in-picture",
+  },
+  {
+    name: "Spotify",
+    normalize: normalizeSpotifyEmbedUrl,
+    sandbox: STANDARD_EMBED_SANDBOX,
+    allow: "encrypted-media; clipboard-write; fullscreen; picture-in-picture",
+  },
+  {
+    name: "SoundCloud",
+    normalize: normalizeSoundCloudEmbedUrl,
+    sandbox: STANDARD_EMBED_SANDBOX,
+    allow: "encrypted-media; fullscreen",
+  },
+  {
+    name: "Bandcamp",
+    normalize: normalizeBandcampEmbedUrl,
+    sandbox: STANDARD_EMBED_SANDBOX,
+    allow: "encrypted-media",
+  },
+  {
+    name: "CodePen",
+    normalize: normalizeCodePenEmbedUrl,
+    sandbox: STANDARD_EMBED_SANDBOX,
+    allow: "",
+  },
+];
+
+/**
+ * The canonical hostnames every surviving embed src is rewritten to. Used as
+ * sanitize-html's `allowedIframeHostnames` backstop, so even if `normalizeEmbed`
+ * were somehow bypassed, only these hosts can appear in an iframe src.
+ */
+export const EMBED_CANONICAL_HOSTNAMES: readonly string[] = [
+  "www.youtube-nocookie.com",
+  "player.vimeo.com",
+  "open.spotify.com",
+  "w.soundcloud.com",
+  "bandcamp.com",
+  "codepen.io",
+];
+
+/**
+ * Validates an untrusted iframe src against the allow-listed providers and
+ * returns the normalized embed (canonical src + forced sandbox/allow), or null
+ * if the src is not a recognized embed and the iframe should be dropped.
+ */
+export function normalizeEmbed(src: string | null | undefined): NormalizedEmbed | null {
+  if (!src) return null;
+  for (const provider of EMBED_PROVIDERS) {
+    const normalized = provider.normalize(src);
+    if (normalized) {
+      return {
+        src: normalized,
+        provider: provider.name,
+        sandbox: provider.sandbox,
+        allow: provider.allow,
+      };
+    }
+  }
+  return null;
+}

--- a/src/server/html/embed-providers.ts
+++ b/src/server/html/embed-providers.ts
@@ -190,8 +190,10 @@ function normalizeBandcampEmbedUrl(src: string): string | null {
 }
 
 // --- CodePen ---------------------------------------------------------------
-// https://codepen.io/{user}/embed[/preview]/{slug}
-const CODEPEN_HOSTS = new Set(["codepen.io", "cdpn.io"]);
+// https://codepen.io/{user}/embed[/preview]/{slug}. Only codepen.io serves this
+// embed path shape; cdpn.io (CodePen's debug/fullpage host) uses a different
+// path structure, so it's deliberately not accepted here.
+const CODEPEN_HOSTS = new Set(["codepen.io"]);
 const CODEPEN_PATH_RE = /^\/[A-Za-z0-9_-]+\/embed\/(?:preview\/)?[A-Za-z0-9]+\/?$/;
 const CODEPEN_PARAMS = new Set(["default-tab", "theme-id", "height", "editable"]);
 function normalizeCodePenEmbedUrl(src: string): string | null {

--- a/src/server/html/sanitize.ts
+++ b/src/server/html/sanitize.ts
@@ -17,12 +17,8 @@
 import sanitizeHtml from "sanitize-html";
 
 import { logger } from "@/lib/logger";
+import { EMBED_CANONICAL_HOSTNAMES, normalizeEmbed } from "./embed-providers";
 import { convertMathJaxChtmlToMathml } from "./mathjax-chtml";
-import {
-  normalizeYouTubeEmbedUrl,
-  YOUTUBE_IFRAME_ALLOW,
-  YOUTUBE_IFRAME_SANDBOX,
-} from "./youtube-embed";
 
 /**
  * Version of the sanitization config. Bump this whenever `SANITIZE_OPTIONS`
@@ -37,7 +33,7 @@ import {
  * stale and transparently re-sanitizes it on next read instead of serving stale
  * output.
  */
-export const SANITIZER_VERSION = 6;
+export const SANITIZER_VERSION = 7;
 
 // Tags allowed in entry content. Superset of sanitize-html's defaults covering
 // the formatting, table, and media elements real articles use. `script` and
@@ -124,13 +120,14 @@ const ALLOWED_TAGS = [
   "audio",
   "video",
   "track",
-  // `iframe` is allowed ONLY for YouTube embeds (issue #1115). An unrestricted
-  // cross-origin iframe would let a feed embed an arbitrary page full-bleed
-  // inside the reader's trusted UI (phishing / tracking surface), so the
-  // `transformTags.iframe` hook validates the src as a YouTube embed URL and
-  // normalizes it to youtube-nocookie.com with a forced `sandbox`; anything
-  // else loses its src and is dropped by `exclusiveFilter`.
-  // `allowedIframeHostnames` backstops the same rule.
+  // `iframe` is allowed ONLY for allow-listed media-embed providers (issue
+  // #922; originally YouTube-only in #1115). An unrestricted cross-origin iframe
+  // would let a feed embed an arbitrary page full-bleed inside the reader's
+  // trusted UI (phishing / tracking surface), so the `transformTags.iframe` hook
+  // validates the src against `normalizeEmbed` (YouTube, Vimeo, Spotify,
+  // SoundCloud, Bandcamp, CodePen), rewrites it to the provider's canonical host
+  // with a forced per-provider `sandbox`; anything else loses its src and is
+  // dropped by `exclusiveFilter`. `allowedIframeHostnames` backstops the rule.
   "iframe",
 ];
 
@@ -272,10 +269,10 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   },
   allowProtocolRelative: true,
   // Defense in depth for iframes: even if the transform below were bypassed,
-  // sanitize-html strips the src of any iframe not pointing at this hostname
-  // (every surviving src is normalized to it), and src-less iframes are then
-  // removed entirely by `exclusiveFilter`.
-  allowedIframeHostnames: ["www.youtube-nocookie.com"],
+  // sanitize-html strips the src of any iframe not pointing at one of these
+  // canonical provider hostnames (every surviving src is normalized to one of
+  // them), and src-less iframes are then removed entirely by `exclusiveFilter`.
+  allowedIframeHostnames: [...EMBED_CANONICAL_HOSTNAMES],
   exclusiveFilter: (frame) => frame.tag === "iframe" && !frame.attribs.src,
   transformTags: {
     // External links open in a new tab with a safe rel (was the old
@@ -298,14 +295,14 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     },
     // Lazy-load all images.
     img: (tagName, attribs) => ({ tagName, attribs: { ...attribs, loading: "lazy" } }),
-    // Iframes: only YouTube embeds survive. The src is validated and rewritten
-    // to the privacy-enhanced youtube-nocookie.com host with a filtered query
+    // Iframes: only allow-listed embed providers survive. The src is validated
+    // and rewritten to the provider's canonical host with a filtered query
     // string, and sandbox/allow/loading are forced regardless of what the feed
-    // supplied. A non-YouTube iframe has all attributes dropped here, then the
+    // supplied. An unrecognized iframe has all attributes dropped here, then the
     // src-less shell is removed by `exclusiveFilter`.
     iframe: (tagName, attribs) => {
-      const src = normalizeYouTubeEmbedUrl(attribs.src);
-      if (!src) return { tagName, attribs: {} };
+      const embed = normalizeEmbed(attribs.src);
+      if (!embed) return { tagName, attribs: {} };
       const kept: Record<string, string> = {};
       for (const attr of ["width", "height", "title"]) {
         if (attribs[attr] !== undefined) kept[attr] = attribs[attr];
@@ -314,9 +311,9 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
         tagName,
         attribs: {
           ...kept,
-          src,
-          sandbox: YOUTUBE_IFRAME_SANDBOX,
-          allow: YOUTUBE_IFRAME_ALLOW,
+          src: embed.src,
+          sandbox: embed.sandbox,
+          allow: embed.allow,
           allowfullscreen: "",
           loading: "lazy",
         },

--- a/src/server/html/youtube-embed.ts
+++ b/src/server/html/youtube-embed.ts
@@ -1,7 +1,8 @@
 /**
- * YouTube embed URL handling, shared by the sanitizer (which validates and
- * normalizes iframes found in feed content) and the YouTube plugin (which
- * synthesizes embed iframes for YouTube's own feeds).
+ * YouTube embed URL handling, shared by the sanitizer's embed allow-list
+ * (`embed-providers.ts`, which registers YouTube as one provider and validates
+ * iframes found in feed content) and the YouTube plugin (which synthesizes
+ * embed iframes for YouTube's own feeds).
  *
  * Iframes are the sanitizer's only cross-origin escape hatch, so everything
  * here is allow-list based: only known YouTube embed hosts and the /embed/

--- a/tests/unit/embed-providers.test.ts
+++ b/tests/unit/embed-providers.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { normalizeEmbed, EMBED_CANONICAL_HOSTNAMES } from "@/server/html/embed-providers";
+
+describe("normalizeEmbed", () => {
+  it("returns null for empty/unrecognized srcs", () => {
+    expect(normalizeEmbed(null)).toBeNull();
+    expect(normalizeEmbed(undefined)).toBeNull();
+    expect(normalizeEmbed("")).toBeNull();
+    expect(normalizeEmbed("https://evil.example/fake-login")).toBeNull();
+    expect(normalizeEmbed("javascript:alert(1)")).toBeNull();
+  });
+
+  it("rejects lookalike hostnames", () => {
+    expect(normalizeEmbed("https://player.vimeo.com.evil.com/video/123")).toBeNull();
+    expect(normalizeEmbed("https://open.spotify.com.evil.com/embed/track/x")).toBeNull();
+    expect(normalizeEmbed("https://evil.com/player.vimeo.com/video/123")).toBeNull();
+  });
+
+  describe("YouTube", () => {
+    it("normalizes to youtube-nocookie", () => {
+      const out = normalizeEmbed("https://www.youtube.com/embed/dQw4w9WgXcQ");
+      expect(out?.provider).toBe("YouTube");
+      expect(out?.src).toBe("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ");
+      expect(out?.sandbox).toContain("allow-scripts");
+    });
+  });
+
+  describe("Vimeo", () => {
+    it("keeps a numeric video id and the private hash", () => {
+      const out = normalizeEmbed("https://player.vimeo.com/video/123456789?h=abc123&autoplay=1");
+      expect(out?.provider).toBe("Vimeo");
+      expect(out?.src).toBe("https://player.vimeo.com/video/123456789?h=abc123");
+      expect(out?.src).not.toContain("autoplay");
+    });
+
+    it("treats protocol-relative srcs as https", () => {
+      const out = normalizeEmbed("//player.vimeo.com/video/42");
+      expect(out?.src).toBe("https://player.vimeo.com/video/42");
+    });
+
+    it("rejects non-video paths", () => {
+      expect(normalizeEmbed("https://player.vimeo.com/video/abc")).toBeNull();
+      expect(normalizeEmbed("https://player.vimeo.com/login")).toBeNull();
+    });
+  });
+
+  describe("Spotify", () => {
+    it("keeps track/album/playlist/episode embeds", () => {
+      const out = normalizeEmbed("https://open.spotify.com/embed/track/4cOdK2wGLETKBW3PvgPWqT");
+      expect(out?.provider).toBe("Spotify");
+      expect(out?.src).toBe("https://open.spotify.com/embed/track/4cOdK2wGLETKBW3PvgPWqT");
+    });
+
+    it("supports the embed-podcast path and keeps the theme param", () => {
+      const out = normalizeEmbed(
+        "https://open.spotify.com/embed-podcast/episode/abc123?theme=0&utm_source=x"
+      );
+      expect(out?.src).toBe("https://open.spotify.com/embed-podcast/episode/abc123?theme=0");
+      expect(out?.src).not.toContain("utm_source");
+    });
+
+    it("rejects unknown resource types", () => {
+      expect(normalizeEmbed("https://open.spotify.com/embed/user/x")).toBeNull();
+    });
+  });
+
+  describe("SoundCloud", () => {
+    it("keeps the player when url points at SoundCloud, dropping auto_play", () => {
+      const out = normalizeEmbed(
+        "https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F123&auto_play=true&color=%23ff5500"
+      );
+      expect(out?.provider).toBe("SoundCloud");
+      expect(out?.src).toContain("url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F123");
+      expect(out?.src).toContain("color=");
+      expect(out?.src).not.toContain("auto_play");
+    });
+
+    it("rejects a player whose url points off SoundCloud", () => {
+      expect(
+        normalizeEmbed("https://w.soundcloud.com/player/?url=https%3A%2F%2Fevil.com%2Fx")
+      ).toBeNull();
+      expect(normalizeEmbed("https://w.soundcloud.com/player/")).toBeNull();
+    });
+  });
+
+  describe("Bandcamp", () => {
+    it("keeps a validated EmbeddedPlayer path", () => {
+      const src =
+        "https://bandcamp.com/EmbeddedPlayer/album=123456/size=large/bgcol=ffffff/linkcol=0687f5/transparent=true/";
+      const out = normalizeEmbed(src);
+      expect(out?.provider).toBe("Bandcamp");
+      expect(out?.src).toBe(src);
+    });
+
+    it("rejects malformed player paths", () => {
+      expect(normalizeEmbed("https://bandcamp.com/EmbeddedPlayer/album=<script>")).toBeNull();
+      expect(normalizeEmbed("https://bandcamp.com/login")).toBeNull();
+    });
+  });
+
+  describe("CodePen", () => {
+    it("keeps embed and embed/preview pens", () => {
+      expect(normalizeEmbed("https://codepen.io/team/embed/abcDEF")?.provider).toBe("CodePen");
+      expect(
+        normalizeEmbed("https://codepen.io/team/embed/preview/abcDEF?default-tab=result")?.src
+      ).toBe("https://codepen.io/team/embed/preview/abcDEF?default-tab=result");
+    });
+
+    it("rejects the non-embed pen page", () => {
+      expect(normalizeEmbed("https://codepen.io/team/pen/abcDEF")).toBeNull();
+    });
+  });
+
+  it("only ever rewrites to a canonical hostname", () => {
+    const srcs = [
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      "https://player.vimeo.com/video/123",
+      "https://open.spotify.com/embed/track/abc",
+      "https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fa%2Fb",
+      "https://bandcamp.com/EmbeddedPlayer/album=1/size=large/",
+      "https://codepen.io/a/embed/b",
+    ];
+    for (const src of srcs) {
+      const out = normalizeEmbed(src);
+      expect(out).not.toBeNull();
+      const host = new URL(out!.src).hostname;
+      expect(EMBED_CANONICAL_HOSTNAMES).toContain(host);
+    }
+  });
+});

--- a/tests/unit/sanitize-entry-html.test.ts
+++ b/tests/unit/sanitize-entry-html.test.ts
@@ -146,7 +146,7 @@ describe("sanitizeEntryHtml", () => {
       expect(out).toContain('colspan="2"');
     });
 
-    it("strips non-YouTube iframes (phishing/tracking surface)", () => {
+    it("strips iframes from non-allow-listed hosts (phishing/tracking surface)", () => {
       const out =
         sanitizeEntryHtml(
           '<iframe src="https://evil.example/fake-login" allowfullscreen></iframe>'
@@ -228,6 +228,50 @@ describe("sanitizeEntryHtml", () => {
       expect(
         sanitizeEntryHtml('<iframe src="https://www.youtube.com.evil.com/embed/x"></iframe>')
       ).toBe("");
+    });
+  });
+
+  describe("other allow-listed embed providers (issue #922)", () => {
+    it("keeps a Vimeo embed with a forced sandbox", () => {
+      const out =
+        sanitizeEntryHtml(
+          '<iframe src="https://player.vimeo.com/video/76979871?h=abc" width="640" height="360"></iframe>'
+        ) ?? "";
+      expect(out).toContain('src="https://player.vimeo.com/video/76979871?h=abc"');
+      expect(out).toContain('sandbox="allow-scripts');
+      expect(out).toContain('loading="lazy"');
+      expect(out).toContain('width="640"');
+    });
+
+    it("keeps a Spotify embed", () => {
+      const out =
+        sanitizeEntryHtml(
+          '<iframe src="https://open.spotify.com/embed/track/4cOdK2wGLETKBW3PvgPWqT"></iframe>'
+        ) ?? "";
+      expect(out).toContain('src="https://open.spotify.com/embed/track/4cOdK2wGLETKBW3PvgPWqT"');
+    });
+
+    it("keeps a SoundCloud player pointing at SoundCloud", () => {
+      const out =
+        sanitizeEntryHtml(
+          '<iframe src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F123"></iframe>'
+        ) ?? "";
+      expect(out).toContain("w.soundcloud.com/player/");
+      expect(out).toContain("api.soundcloud.com");
+    });
+
+    it("keeps a Bandcamp EmbeddedPlayer", () => {
+      const out =
+        sanitizeEntryHtml(
+          '<iframe src="https://bandcamp.com/EmbeddedPlayer/album=123/size=large/"></iframe>'
+        ) ?? "";
+      expect(out).toContain("bandcamp.com/EmbeddedPlayer/album=123/size=large/");
+    });
+
+    it("keeps a CodePen embed", () => {
+      const out =
+        sanitizeEntryHtml('<iframe src="https://codepen.io/team/embed/abcDEF"></iframe>') ?? "";
+      expect(out).toContain('src="https://codepen.io/team/embed/abcDEF"');
     });
   });
 });


### PR DESCRIPTION
Fixes #922.

## What & why

Entry-body sanitization previously allowed `<iframe>` **only** from YouTube (#1115), silently dropping every other embed. This generalizes that to a **block-by-default, opt-in allow-list** of known media-embed providers, matching the maintainer's guidance on the issue:

> We should continue to block generic iframes, but we should add support for common/standard iframes if we can tell what they're supposed to be … as broad as we can reasonably handle but be opt-in with block-by-default.

This lets feeds embed the common players without reopening the "any `https` iframe" phishing / clickjacking / tracking surface #921 flagged.

## Approach

New `src/server/html/embed-providers.ts` registers a small registry of providers — **YouTube, Vimeo, Spotify, SoundCloud, Bandcamp, CodePen**. Each follows the exact defense-in-depth recipe the YouTube-only handling already used:

1. Parse the src as an `http(s)` URL (protocol-relative `//host` → https, as feeds commonly use).
2. Reject unless the hostname is a known embed host for that provider.
3. Validate the path against a strict, bounded regex.
4. Rebuild the URL from scratch on the provider's **canonical** host, copying only an allow-list of query params (autoplay / JS-API / tracking params dropped). SoundCloud's nested `url` param is additionally required to point at SoundCloud.
5. Force a per-provider `sandbox` / `allow` regardless of what the feed supplied.

`normalizeEmbed()` drives the sanitizer's `transformTags.iframe`; the set of canonical hosts backstops the rule via sanitize-html's `allowedIframeHostnames`. Anything unrecognized still loses its `src` here and is removed entirely by `exclusiveFilter` — so the default remains "drop".

The YouTube provider reuses the existing `youtube-embed.ts` normalize/sandbox/allow constants (still shared with the YouTube plugin's embed synthesis), so the plugin-stamped raw HTML and the sanitizer's forced output stay in sync.

Adding a provider later is a single registry entry; new canonical hosts are picked up automatically.

## Versioning

Bumps `SANITIZER_VERSION` 6 → 7 so stored entry HTML is marked stale and re-sanitized on next read — previously-dropped embeds from these providers reappear via the existing read-path self-heal / bulk re-sanitize path. (The worker-thread bundle embeds a build-time sanitizer snapshot and is rebuilt at deploy via `build:all`; the pool self-disables offload on a version mismatch, so there's no stale-bundle window.)

## Tests

- `tests/unit/embed-providers.test.ts` — per-provider normalization, param filtering, lookalike-host rejection, and a canonical-host invariant.
- `tests/unit/sanitize-entry-html.test.ts` — end-to-end sanitizer cases for each new provider, plus the existing non-allow-listed-host drop.

`pnpm typecheck`, `pnpm lint`, and `pnpm test:unit` all pass.

## Notes / follow-ups

- The issue also floated replacing dropped iframes with a visible "embedded content removed" placeholder. I left that out deliberately: for the common case (trackers/ad iframes) it'd be noisy, and echoing an attacker-controlled hostname isn't ideal. Easy to add later if wanted — `NormalizedEmbed.provider` is already exposed for a placeholder.
- Twitch was intentionally omitted: its embeds require a `parent=<host>` param we can't reliably know at sanitize time, so they'd render broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)