### PR TITLE
Replace to_char timestamp cursors with Temporal.Instant + Drizzle customType (#683)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ See docs/diagrams/ for more detail. These diagrams are very helpful for quickly 
 ## Database Conventions
 
 - **IDs**: UUIDv7, generated in TypeScript via `generateUuidv7()` from `@/lib/uuidv7`. `gen_uuidv7()` is not available in our Postgres version.
-- **Timestamps**: `timestamptz`, store UTC
+- **Timestamps**: `timestamptz`, store UTC. Read as JS `Date` (millisecond precision) by default. Where microseconds matter — keyset cursors built from timestamps — use the `temporalTimestamp` Drizzle column type or `parseTimestamptz`/`.mapWith(parseTimestamptz)` from `src/server/db/temporal.ts` to read a full-precision `Temporal.Instant`; the app pool returns the raw `timestamptz` string (not a truncating `Date`) so this works without `to_char`. See "Pagination" in docs/DESIGN.md (#680, #683).
 - **Soft deletes**: Use `deleted_at`/`unsubscribed_at` patterns
 - **Upserts**: Prefer `onConflictDoNothing()`/`onConflictDoUpdate()` over check-then-act
 - **Migrations**: Must be backward-compatible with the previous release (expand/contract) — they run in Fly's `release_command` before the canary deploy, so old code runs against the new schema during rollout and on rollback. See "Migration Compatibility" in docs/DESIGN.md.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -479,6 +479,16 @@ Cursor-based pagination everywhere:
   the Google Reader `continuation` token, and some clients concatenate query params
   without URL-encoding, where a `+` from standard base64 would arrive as a space and
   corrupt the cursor.
+- **Timestamp cursors keep microsecond precision.** A JavaScript `Date` truncates to
+  milliseconds, so a cursor read back as a `Date` lands in the gap between rows that
+  share a millisecond and silently drops or re-delivers them (#680). The app pool
+  overrides node-postgres's `timestamptz` (OID 1184) parser to hand back Postgres's
+  raw string instead of a `Date`, and the sync/list cursor paths decode it to a
+  `Temporal.Instant` (via `parseTimestamptz` / the `temporalTimestamp` Drizzle column
+  type in `src/server/db/temporal.ts`) — full precision, no `to_char` boilerplate. The
+  cursor string is `Temporal.Instant.toString()` (ISO-8601, trailing-zero-trimmed), and
+  the client compares cursors with `Temporal.Instant.compare` (not `new Date`), which is
+  robust across the format change from the legacy fixed-6-digit `to_char` output (#683).
 
 ### Rate Limiting
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "sentence-splitter": "^5.0.1",
     "sonner": "^2.0.7",
     "superjson": "^2.2.6",
+    "temporal-polyfill": "^0.3.2",
     "trpc-to-openapi": "^3.2.0",
     "tsx": "^4.22.4",
     "undici": "8.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       superjson:
         specifier: ^2.2.6
         version: 2.2.6
+      temporal-polyfill:
+        specifier: ^0.3.2
+        version: 0.3.2
       trpc-to-openapi:
         specifier: ^3.2.0
         version: 3.2.0(@trpc/server@11.10.0(typescript@6.0.3))(zod-openapi@5.4.5(zod@4.4.3))(zod@4.4.3)
@@ -1355,89 +1358,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1544,42 +1563,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -1641,24 +1667,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -1956,41 +1986,49 @@ packages:
     resolution: {integrity: sha512-Cwm6A071ww60QouJ9LoHAwBgEoZzHQ0Qaqk2E7WLfBdiQN9mLXIDhnrpn04hlRElRPhLiu/dtg+o5PPLvaINXQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.17.1':
     resolution: {integrity: sha512-+hwlE2v3m0r3sk93SchJL1uyaKcPjf+NGO/TD2DZUDo+chXx7FfaEj0nUMewigSt7oZ2sQN9Z4NJOtUa75HE5Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.17.1':
     resolution: {integrity: sha512-bO+rsaE5Ox8cFyeL5Ct5tzot1TnQpFa/Wmu5k+hqBYSH2dNVDGoi0NizBN5QV8kOIC6O5MZr81UG4yW/2FyDTA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.17.1':
     resolution: {integrity: sha512-B/P+hxKQ1oX4YstI9Lyh4PGzqB87Ddqj/A4iyRBbPdXTcxa+WW3oRLx1CsJKLmHPdDk461Hmbghq1Bm3pl+8Aw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.17.1':
     resolution: {integrity: sha512-ulp2H3bFXzd/th2maH+QNKj5qgOhJ3v9Yspdf1svTw3CDOuuTl6sRKsWQ7MUw0vnkSNvQndtflBwVXgzZvURsQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.17.1':
     resolution: {integrity: sha512-LAXYVe3rKk09Zo9YKF2ZLBcH8sz8Oj+JIyiUxiHtq0hiYLMsN6dOpCf2hzQEjPAmsSEA/hdC1PVKeXo+oma8mQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.17.1':
     resolution: {integrity: sha512-3RAhxipMKE8RCSPn7O//sj440i+cYTgYbapLeOoDvQEt6R1QcJjTsFgI4iz99FhVj3YbPxlZmcLB5VW+ipyRTA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.17.1':
     resolution: {integrity: sha512-wpjMEubGU8r9VjZTLdZR3aPHaBqTl8Jl8F4DBbgNoZ+yhkhQD1/MGvY70v2TLnAI6kAHSvcqgfvaqKDa2iWsPQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.17.1':
     resolution: {integrity: sha512-XIE4w17RYAVIgx+9Gs3deTREq5tsmalbatYOOBGNdH7n0DfTE600c7wYXsp7ANc3BPDXsInnOzXDEPCvO1F6cg==}
@@ -2180,136 +2218,163 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.6.1':
     resolution: {integrity: sha512-DNGZvZDO5YF7jN5fX8ZqmGLjZEXIJRdJEdTFMhiyXqyXubBa0WVLDWSNlQ5JR2PNgDbEV1VQowhVRUh+74D+RA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -2590,24 +2655,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -2740,6 +2809,9 @@ packages:
 
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
+
+  '@types/node@26.1.0':
+    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
@@ -2911,51 +2983,61 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -3868,9 +3950,6 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
-  es-module-lexer@2.3.1:
-    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
-
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -4778,24 +4857,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4982,11 +5065,6 @@ packages:
 
   nanoid@3.3.14:
     resolution: {integrity: sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5287,10 +5365,6 @@ packages:
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.17:
-    resolution: {integrity: sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -5890,6 +5964,12 @@ packages:
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
+
+  temporal-polyfill@0.3.2:
+    resolution: {integrity: sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==}
+
+  temporal-spec@0.3.1:
+    resolution: {integrity: sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==}
 
   tempy@0.6.0:
     resolution: {integrity: sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==}
@@ -9428,6 +9508,10 @@ snapshots:
     dependencies:
       '@types/node': 26.1.1
 
+  '@types/node@26.1.0':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
@@ -10600,8 +10684,6 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
-  es-module-lexer@2.3.1: {}
-
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -11550,7 +11632,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -11902,8 +11984,6 @@ snapshots:
 
   nanoid@3.3.14: {}
 
-  nanoid@3.3.16: {}
-
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -12201,12 +12281,6 @@ snapshots:
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.14
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.17:
-    dependencies:
-      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -12893,6 +12967,12 @@ snapshots:
 
   temp-dir@2.0.0: {}
 
+  temporal-polyfill@0.3.2:
+    dependencies:
+      temporal-spec: 0.3.1
+
+  temporal-spec@0.3.1: {}
+
   tempy@0.6.0:
     dependencies:
       is-stream: 2.0.1
@@ -13165,7 +13245,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.17
+      postcss: 8.5.15
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -13244,7 +13324,7 @@ snapshots:
       browserslist: 4.28.6
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.2
-      es-module-lexer: 2.3.1
+      es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -18,6 +18,7 @@ import { Pool } from "pg";
 
 import { generateUuidv7 } from "../src/lib/uuidv7";
 import * as schema from "../src/server/db/schema";
+import { timestamptzRawParserConfig } from "../src/server/db/temporal";
 
 const connectionString = process.env.DATABASE_URL;
 
@@ -26,7 +27,8 @@ if (!connectionString) {
   process.exit(1);
 }
 
-const pool = new Pool({ connectionString });
+// Match the app pool so temporalTimestamp columns decode (see temporal.ts).
+const pool = new Pool({ connectionString, types: timestamptzRawParserConfig });
 const db = drizzle(pool, { schema });
 
 // Generate a content hash for entries

--- a/src/lib/events/cursors.ts
+++ b/src/lib/events/cursors.ts
@@ -14,7 +14,22 @@
  * *within* a tied-timestamp group (keyset pagination, same as `listEntries`).
  */
 
+import { Temporal } from "temporal-polyfill";
+
 import type { SyncEvent } from "./schemas";
+
+/**
+ * Compares two ISO-8601 cursor timestamps as instants: -1, 0, or 1. Both come
+ * from the server (`Temporal.Instant.toString()`, microsecond precision). A
+ * `new Date()` comparison would truncate to milliseconds and miss sub-ms
+ * differences, so a newer event sharing a millisecond with the cursor would fail
+ * to advance it (#683). Comparing instants (not strings) is also robust across
+ * the format change: a legacy `to_char` cursor (always 6 fractional digits) and
+ * a Temporal cursor (trailing zeros trimmed) for the same moment compare equal.
+ */
+function compareTimestamps(a: string, b: string): number {
+  return Temporal.Instant.compare(Temporal.Instant.from(a), Temporal.Instant.from(b));
+}
 
 /**
  * Largest possible UUID. Used as the entries id tiebreaker for `mark_all_read`,
@@ -103,11 +118,12 @@ function advanceEntriesCursor(cursors: SyncCursors, event: SyncEvent): SyncCurso
   const afterId = entryEventAfterId(event);
   const current = cursors.entries;
 
-  if (!current || new Date(updatedAt) > new Date(current)) {
+  const cmp = current ? compareTimestamps(updatedAt, current) : 1;
+  if (cmp > 0) {
     // Newer timestamp: reset the keyset to this event.
     return { ...cursors, entries: updatedAt, entriesAfterId: afterId };
   }
-  if (updatedAt === current) {
+  if (cmp === 0) {
     // Same timestamp group: advance the id tiebreaker forward only.
     // UUIDs are lowercase, so string ordering matches Postgres uuid ordering.
     if (!cursors.entriesAfterId || afterId > cursors.entriesAfterId) {
@@ -133,7 +149,7 @@ export function advanceCursors(cursors: SyncCursors, event: SyncEvent): SyncCurs
   }
 
   const currentCursor = cursors[cursorType];
-  if (!currentCursor || new Date(event.updatedAt) > new Date(currentCursor)) {
+  if (!currentCursor || compareTimestamps(event.updatedAt, currentCursor) > 0) {
     return { ...cursors, [cursorType]: event.updatedAt };
   }
   return cursors;

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -4,6 +4,7 @@ import * as Sentry from "@sentry/nextjs";
 
 import { logger } from "@/lib/logger";
 import * as schema from "./schema";
+import { timestamptzRawParserConfig } from "./temporal";
 
 const connectionString = process.env.DATABASE_URL;
 
@@ -11,8 +12,16 @@ if (!connectionString) {
   throw new Error("DATABASE_URL environment variable is not set");
 }
 
+// By default node-postgres parses `timestamptz` into a JS Date, which truncates
+// Postgres's microsecond precision to milliseconds and silently corrupted keyset
+// cursors built from timestamps (#680, #683). timestamptzRawParserConfig returns
+// the raw Postgres string instead: Drizzle's built-in `timestamp` columns still
+// map it to a Date (unchanged), while precision-sensitive reads decode it to a
+// full-precision Temporal.Instant (see src/server/db/temporal.ts). Scoped to this
+// pool's clients, not global, so unrelated pg consumers keep the default behaviour.
 export const pool = new Pool({
   connectionString,
+  types: timestamptzRawParserConfig,
   // Default pg pool is 10, which can cause request queuing under moderate concurrency.
   // Fly.io managed Postgres allows 300 connections; with 2 app + 1 worker + 1 discord
   // process, peak usage during deploys (3 app) is ~3×20 + 10 + 10 = 80, well under limit.

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -21,6 +21,7 @@ import {
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import type { ParagraphMapEntry } from "@/lib/narration/paragraph-map";
+import { temporalTimestamp } from "./temporal";
 
 /**
  * Postgres citext (case-insensitive text). Behaves as a plain string in
@@ -726,7 +727,9 @@ export const userEntries = pgTable(
     // user_entries_fill_denormalized trigger) to enable a single (user_id, sort_key, id)
     // index that covers the timeline list query's filter + sort. The DB enforces
     // NOT NULL; left optional here so callers may rely on the trigger to fill it.
-    publishedOrFetchedAt: timestamp("published_or_fetched_at", { withTimezone: true }),
+    // temporalTimestamp so reads keep microsecond precision — this is the timeline
+    // cursor sort key, where a Date's millisecond truncation corrupts pagination.
+    publishedOrFetchedAt: temporalTimestamp("published_or_fetched_at"),
 
     // Direct 1:1 subscription attribution (issue #1117). NULL = saved/uploaded
     // article (per-user feed with no subscription row). Filled inline by the bulk
@@ -842,7 +845,7 @@ export const visibleEntries = pgView("visible_entries", {
   subscriptionId: uuid("subscription_id"), // nullable - null for orphaned starred entries
   unsubscribeUrl: text("unsubscribe_url"), // extracted from email HTML body
   readChangedAt: timestamp("read_changed_at", { withTimezone: true }),
-  publishedOrFetchedAt: timestamp("published_or_fetched_at", { withTimezone: true }).notNull(), // denormalized timeline sort key
+  publishedOrFetchedAt: temporalTimestamp("published_or_fetched_at").notNull(), // denormalized timeline sort key (temporalTimestamp: µs-precise cursor sort key)
   contentOriginalSanitized: text("content_original_sanitized"),
   contentCleanedSanitized: text("content_cleaned_sanitized"),
   contentSanitizedVersion: smallint("content_sanitized_version"),

--- a/src/server/db/temporal.ts
+++ b/src/server/db/temporal.ts
@@ -1,0 +1,79 @@
+import { customType } from "drizzle-orm/pg-core";
+import { types as pgTypes, type CustomTypesConfig } from "pg";
+import { Temporal } from "temporal-polyfill";
+
+/**
+ * Full-precision timestamp handling for Postgres `timestamptz`.
+ *
+ * node-postgres parses `timestamptz` (OID 1184) into a JavaScript `Date` by
+ * default, and a `Date` truncates to millisecond precision — silently dropping
+ * the microseconds Postgres stores. That truncation corrupted keyset cursors
+ * built from timestamps: a cursor read back as a `Date` would land in the gap
+ * between two rows sharing a millisecond, dropping or re-delivering entries
+ * (#680, #683).
+ *
+ * The app pool (`src/server/db/index.ts`) overrides the OID 1184 parser to hand
+ * back Postgres's raw string instead of a `Date`, so a `timestamptz` read keeps
+ * full precision. Drizzle's built-in `timestamp` columns still map that string to
+ * a `Date` (unchanged behaviour, still millisecond precision). The helpers below
+ * decode the same raw string to a `Temporal.Instant`, which preserves microseconds
+ * and — via `toString()` — round-trips to ISO-8601 without a `to_char` expression.
+ */
+
+// node-postgres OID for `timestamp with time zone`.
+const TIMESTAMPTZ_OID = 1184;
+
+/**
+ * A node-postgres `types` config that returns the raw Postgres string for
+ * `timestamptz` (OID 1184) instead of parsing it into a truncating `Date`.
+ *
+ * **Every Drizzle pool that might read a `temporalTimestamp` column (or decode a
+ * timestamp via {@link parseTimestamptz}) MUST use this config**, or `fromDriver`
+ * receives a `Date`, `String(date)` yields a non-ISO string, and
+ * `Temporal.Instant.from` throws. The app pool (`src/server/db/index.ts`) and the
+ * test/seed pools (`tests/e2e/helpers.ts`, `scripts/seed.ts`) all install it.
+ * Text format only: binary result mode (unused here) keeps the default parser.
+ */
+export const timestamptzRawParserConfig: CustomTypesConfig = {
+  getTypeParser: (oid, format) =>
+    oid === TIMESTAMPTZ_OID && format !== "binary"
+      ? (value: string) => value
+      : pgTypes.getTypeParser(oid, format),
+};
+
+/**
+ * Parse a Postgres `timestamptz` driver value into a `Temporal.Instant`.
+ *
+ * `Temporal.Instant.from` accepts both Postgres's space-separated
+ * `2026-07-14 05:34:56.789012-07` form (what the OID 1184 parser override yields)
+ * and ISO-8601 `2026-07-14T12:34:56.789012Z`, normalising either to a UTC instant.
+ */
+export function parseTimestamptz(value: unknown): Temporal.Instant {
+  return Temporal.Instant.from(String(value));
+}
+
+/**
+ * Null-tolerant {@link parseTimestamptz}, for nullable expressions such as
+ * `MAX(...)`/`GREATEST(...)` aggregates over an empty set.
+ */
+export function parseTimestamptzOrNull(value: unknown): Temporal.Instant | null {
+  return value == null ? null : parseTimestamptz(value);
+}
+
+/**
+ * Drizzle column type mapping Postgres `timestamptz` to a full-precision
+ * `Temporal.Instant` on read and an ISO-8601 string on write. Use for columns
+ * read as cursor sort keys, where the millisecond truncation of a `Date` would
+ * corrupt keyset pagination.
+ */
+export const temporalTimestamp = customType<{ data: Temporal.Instant; driverData: string }>({
+  dataType() {
+    return "timestamptz";
+  },
+  fromDriver(value) {
+    return parseTimestamptz(value);
+  },
+  toDriver(value) {
+    return value.toString();
+  },
+});

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -19,6 +19,7 @@ import {
 } from "drizzle-orm";
 import type { db as dbType, DbOrTx } from "@/server/db";
 import { entries, feeds, userEntries, subscriptions, visibleEntries } from "@/server/db/schema";
+import { parseTimestamptzOrNull } from "@/server/db/temporal";
 import { isValidUuid } from "@/lib/uuidv7";
 import { SANITIZER_VERSION } from "@/server/html/sanitize";
 import { sanitizeEntryHtmlInWorker } from "@/server/worker-thread/pool";
@@ -650,9 +651,18 @@ export async function listEntries(
       ? visibleEntries.readChangedAt
       : visibleEntries.publishedOrFetchedAt;
 
-  // Raw ISO string version of sortColumn with microsecond precision.
-  // Used for cursor encoding to avoid JavaScript Date truncation.
-  const sortTsRawExpr = sql<string>`to_char(${sortColumn} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`;
+  // Full-precision sort key for cursor encoding. The pool hands back Postgres's
+  // raw microsecond string for timestamptz (see parseTimestamptz); mapWith decodes
+  // it to a Temporal.Instant so the cursor never loses the microseconds a JS Date
+  // would truncate — which corrupted keyset pagination (#680, #683).
+  //
+  // Null-tolerant: the "archived" sort (Wallabag) orders by readChangedAt WITHOUT
+  // the readChanged view's isNotNull filter, so a row can have a null sort key.
+  // That path is offset-paginated and ignores nextCursor, but the decoder still
+  // runs on every row — matching the old to_char(NULL) → NULL behaviour. For the
+  // cursor-paginated sorts (published is NOT NULL; readChanged filters non-null)
+  // the sort key is always present.
+  const sortTsInstant = sql`${sortColumn}`.mapWith(parseTimestamptzOrNull);
 
   // Cursor condition
   // Pass timestamp string directly to Postgres (::timestamptz) to preserve
@@ -707,7 +717,7 @@ export async function listEntries(
       siteName: visibleEntries.siteName,
       feedTitle: feeds.title,
       readChangedAt: visibleEntries.readChangedAt,
-      sortTsRaw: sortTsRawExpr,
+      sortTs: sortTsInstant,
     })
     .from(visibleEntries)
     .innerJoin(feeds, eq(visibleEntries.feedId, feeds.id))
@@ -723,7 +733,11 @@ export async function listEntries(
   let nextCursor: string | undefined;
   if (hasMore && resultEntries.length > 0) {
     const lastEntry = resultEntries[resultEntries.length - 1];
-    nextCursor = encodeCursor(lastEntry.sortTsRaw, lastEntry.id);
+    // sortTs is only null for the offset-paginated "archived" sort (which ignores
+    // nextCursor); the cursor-paginated sorts always have a non-null sort key.
+    if (lastEntry.sortTs) {
+      nextCursor = encodeCursor(lastEntry.sortTs.toString(), lastEntry.id);
+    }
   }
 
   return { items, nextCursor };

--- a/src/server/trpc/routers/sync.ts
+++ b/src/server/trpc/routers/sync.ts
@@ -7,6 +7,7 @@
 
 import { z } from "zod";
 import { eq, and, inArray, sql, type SQL, type SQLWrapper } from "drizzle-orm";
+import { Temporal } from "temporal-polyfill";
 
 import { createTRPCRouter, confirmedProtectedProcedure as protectedProcedure } from "../trpc";
 import {
@@ -20,6 +21,7 @@ import {
 } from "@/server/db/schema";
 import { syncTagSchema, serverSyncEventSchema, toNewEntryListData } from "@/lib/events/schemas";
 import type { Database } from "@/server/db";
+import { parseTimestamptz, parseTimestamptzOrNull } from "@/server/db/temporal";
 import { getBulkEntryRelatedCounts } from "@/server/services/counts";
 import { getSavedFeedId } from "@/server/feed/saved-feed";
 
@@ -122,10 +124,10 @@ export const syncRouter = createTRPCRouter({
   cursors: protectedProcedure.output(syncCursorsSchema).query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 
-    // Run all max queries in parallel for efficiency
-    // Use to_char to format timestamps as ISO 8601 with microsecond precision.
-    // Avoids JavaScript Date truncation which loses microseconds and causes
-    // cursor comparison bugs (see #680).
+    // Run all max queries in parallel for efficiency.
+    // The pool returns Postgres's raw microsecond string for timestamptz, which
+    // mapWith decodes to a full-precision Temporal.Instant — avoiding the
+    // JavaScript Date truncation that caused cursor comparison bugs (#680, #683).
     const [entriesResult, subscriptionsResult, tagsResult] = await Promise.all([
       // Entries: newest GREATEST(entries.updated_at, user_entries.updated_at)
       // plus the id of the entry achieving it, forming the `(entries,
@@ -134,9 +136,9 @@ export const syncRouter = createTRPCRouter({
       // timestamp group. Ordered by (key DESC, id DESC) so LIMIT 1 is the argmax.
       ctx.db
         .select({
-          max: sql<
-            string | null
-          >`to_char(GREATEST(${entries.updatedAt}, ${userEntries.updatedAt}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+          max: sql`GREATEST(${entries.updatedAt}, ${userEntries.updatedAt})`.mapWith(
+            parseTimestamptzOrNull
+          ),
           maxId: entries.id,
         })
         .from(userEntries)
@@ -152,9 +154,7 @@ export const syncRouter = createTRPCRouter({
       // updated_at is set when unsubscribing, so this covers both cases
       ctx.db
         .select({
-          max: sql<
-            string | null
-          >`to_char(MAX(${subscriptions.updatedAt}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+          max: sql`MAX(${subscriptions.updatedAt})`.mapWith(parseTimestamptzOrNull),
         })
         .from(subscriptions)
         .where(eq(subscriptions.userId, userId)),
@@ -162,19 +162,17 @@ export const syncRouter = createTRPCRouter({
       // Tags: max(updated_at) - captures creates, updates, and soft deletes
       ctx.db
         .select({
-          max: sql<
-            string | null
-          >`to_char(MAX(${tags.updatedAt}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+          max: sql`MAX(${tags.updatedAt})`.mapWith(parseTimestamptzOrNull),
         })
         .from(tags)
         .where(eq(tags.userId, userId)),
     ]);
 
     return {
-      entries: entriesResult[0]?.max ?? null,
+      entries: entriesResult[0]?.max?.toString() ?? null,
       entriesAfterId: entriesResult[0]?.maxId ?? null,
-      subscriptions: subscriptionsResult[0]?.max ?? null,
-      tags: tagsResult[0]?.max ?? null,
+      subscriptions: subscriptionsResult[0]?.max?.toString() ?? null,
+      tags: tagsResult[0]?.max?.toString() ?? null,
     };
   }),
 
@@ -229,8 +227,12 @@ export const syncRouter = createTRPCRouter({
         };
       }
 
-      // Collect all events with their timestamps for sorting
-      const allEvents: Array<z.infer<typeof serverSyncEventSchema> & { _sortTime: Date }> = [];
+      // Collect all events with their timestamps for sorting. _sortTime is a
+      // full-precision Temporal.Instant so tied-timestamp events sort correctly
+      // (a JS Date would collapse sub-millisecond differences).
+      const allEvents: Array<
+        z.infer<typeof serverSyncEventSchema> & { _sortTime: Temporal.Instant }
+      > = [];
 
       // Track if we hit any limits
       let hasMore = false;
@@ -376,8 +378,9 @@ export const syncRouter = createTRPCRouter({
             metadataChanged: sql<boolean>`${afterCursor(entries.updatedAt)}`,
             stateChanged: sql<boolean>`${afterCursor(userEntries.updatedAt)}`,
             isNew: sql<boolean>`${afterCursor(entries.createdAt)}`,
-            // Raw ISO string with µs precision for cursor/timestamp output
-            maxUpdatedAtRaw: sql<string>`to_char(${greatest} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+            // Full-precision Temporal.Instant for cursor/timestamp output (both
+            // updatedAt columns are NOT NULL, so GREATEST is never null here).
+            maxUpdatedAt: sql`${greatest}`.mapWith(parseTimestamptz),
           })
           .from(changed)
           .innerJoin(
@@ -467,8 +470,8 @@ export const syncRouter = createTRPCRouter({
                 type: "new_entry" as const,
                 subscriptionId: row.subscriptionId,
                 entryId: row.id,
-                timestamp: row.maxUpdatedAtRaw,
-                updatedAt: row.maxUpdatedAtRaw,
+                timestamp: row.maxUpdatedAt.toString(),
+                updatedAt: row.maxUpdatedAt.toString(),
                 feedType: row.feedType,
                 feedId: row.feedId,
                 ...(row.isSpam
@@ -480,7 +483,7 @@ export const syncRouter = createTRPCRouter({
                       }),
                     }),
                 ...(newEntryCounts && { counts: newEntryCounts }),
-                _sortTime: new Date(row.maxUpdatedAtRaw),
+                _sortTime: row.maxUpdatedAt,
               });
             } else {
               // Existing entry with metadata changes
@@ -488,8 +491,8 @@ export const syncRouter = createTRPCRouter({
                 type: "entry_updated" as const,
                 subscriptionId: row.subscriptionId,
                 entryId: row.id,
-                timestamp: row.maxUpdatedAtRaw,
-                updatedAt: row.maxUpdatedAtRaw,
+                timestamp: row.maxUpdatedAt.toString(),
+                updatedAt: row.maxUpdatedAt.toString(),
                 metadata: {
                   title: row.title,
                   author: row.author,
@@ -497,7 +500,7 @@ export const syncRouter = createTRPCRouter({
                   url: row.url,
                   publishedAt: row.publishedAt?.toISOString() ?? null,
                 },
-                _sortTime: new Date(row.maxUpdatedAtRaw),
+                _sortTime: row.maxUpdatedAt,
               });
             }
           }
@@ -511,9 +514,9 @@ export const syncRouter = createTRPCRouter({
               read: row.read,
               starred: row.starred,
               counts: stateChangedCounts,
-              timestamp: row.maxUpdatedAtRaw,
-              updatedAt: row.maxUpdatedAtRaw,
-              _sortTime: new Date(row.maxUpdatedAtRaw),
+              timestamp: row.maxUpdatedAt.toString(),
+              updatedAt: row.maxUpdatedAt.toString(),
+              _sortTime: row.maxUpdatedAt,
             });
           }
         }
@@ -527,7 +530,7 @@ export const syncRouter = createTRPCRouter({
           .select({
             subscription: subscriptions,
             feed: feeds,
-            updatedAtRaw: sql<string>`to_char(${subscriptions.updatedAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+            updatedAtInstant: sql`${subscriptions.updatedAt}`.mapWith(parseTimestamptz),
           })
           .from(subscriptions)
           .innerJoin(feeds, eq(subscriptions.feedId, feeds.id))
@@ -579,7 +582,8 @@ export const syncRouter = createTRPCRouter({
         }
 
         const subscriptionsCursorDate = new Date(subscriptionsCursor);
-        for (const { subscription, feed, updatedAtRaw } of subscriptionResults) {
+        for (const { subscription, feed, updatedAtInstant } of subscriptionResults) {
+          const updatedAtIso = updatedAtInstant.toString();
           if (subscription.unsubscribedAt === null) {
             // Distinguish new subscriptions from updated ones:
             // If subscribedAt is after the cursor, it's a new subscription.
@@ -590,8 +594,8 @@ export const syncRouter = createTRPCRouter({
                 type: "subscription_created" as const,
                 subscriptionId: subscription.id,
                 feedId: subscription.feedId,
-                timestamp: updatedAtRaw,
-                updatedAt: updatedAtRaw,
+                timestamp: updatedAtIso,
+                updatedAt: updatedAtIso,
                 subscription: {
                   id: subscription.id,
                   feedId: subscription.feedId,
@@ -608,7 +612,7 @@ export const syncRouter = createTRPCRouter({
                   description: feed.description,
                   siteUrl: feed.siteUrl,
                 },
-                _sortTime: subscription.updatedAt,
+                _sortTime: updatedAtInstant,
               });
             } else {
               allEvents.push({
@@ -616,18 +620,18 @@ export const syncRouter = createTRPCRouter({
                 subscriptionId: subscription.id,
                 tags: tagsBySubscription.get(subscription.id) ?? [],
                 customTitle: subscription.customTitle,
-                timestamp: updatedAtRaw,
-                updatedAt: updatedAtRaw,
-                _sortTime: subscription.updatedAt,
+                timestamp: updatedAtIso,
+                updatedAt: updatedAtIso,
+                _sortTime: updatedAtInstant,
               });
             }
           } else {
             allEvents.push({
               type: "subscription_deleted" as const,
               subscriptionId: subscription.id,
-              timestamp: updatedAtRaw,
-              updatedAt: updatedAtRaw,
-              _sortTime: subscription.updatedAt,
+              timestamp: updatedAtIso,
+              updatedAt: updatedAtIso,
+              _sortTime: updatedAtInstant,
             });
           }
         }
@@ -643,22 +647,22 @@ export const syncRouter = createTRPCRouter({
             name: tags.name,
             color: tags.color,
             createdAt: tags.createdAt,
-            updatedAt: tags.updatedAt,
             deletedAt: tags.deletedAt,
-            updatedAtRaw: sql<string>`to_char(${tags.updatedAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+            updatedAtInstant: sql`${tags.updatedAt}`.mapWith(parseTimestamptz),
           })
           .from(tags)
           .where(and(eq(tags.userId, userId), sql`${tags.updatedAt} > ${tagsCursor}::timestamptz`))
           .orderBy(tags.updatedAt);
 
         for (const row of tagResults) {
+          const updatedAtIso = row.updatedAtInstant.toString();
           if (row.deletedAt !== null) {
             allEvents.push({
               type: "tag_deleted" as const,
               tagId: row.id,
-              timestamp: row.updatedAtRaw,
-              updatedAt: row.updatedAtRaw,
-              _sortTime: row.updatedAt,
+              timestamp: updatedAtIso,
+              updatedAt: updatedAtIso,
+              _sortTime: row.updatedAtInstant,
             });
           } else if (tagsCursorDate && row.createdAt > tagsCursorDate) {
             allEvents.push({
@@ -668,9 +672,9 @@ export const syncRouter = createTRPCRouter({
                 name: row.name,
                 color: row.color,
               },
-              timestamp: row.updatedAtRaw,
-              updatedAt: row.updatedAtRaw,
-              _sortTime: row.updatedAt,
+              timestamp: updatedAtIso,
+              updatedAt: updatedAtIso,
+              _sortTime: row.updatedAtInstant,
             });
           } else {
             allEvents.push({
@@ -680,16 +684,16 @@ export const syncRouter = createTRPCRouter({
                 name: row.name,
                 color: row.color,
               },
-              timestamp: row.updatedAtRaw,
-              updatedAt: row.updatedAtRaw,
-              _sortTime: row.updatedAt,
+              timestamp: updatedAtIso,
+              updatedAt: updatedAtIso,
+              _sortTime: row.updatedAtInstant,
             });
           }
         }
       }
 
-      // Sort all events by timestamp
-      allEvents.sort((a, b) => a._sortTime.getTime() - b._sortTime.getTime());
+      // Sort all events by timestamp (µs-precise via Temporal.Instant.compare)
+      allEvents.sort((a, b) => Temporal.Instant.compare(a._sortTime, b._sortTime));
 
       // Remove _sortTime from events before returning
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -16,6 +16,7 @@ import { and, eq } from "drizzle-orm";
 import Redis from "ioredis";
 import type { BrowserContext, Page } from "@playwright/test";
 import * as schema from "../../src/server/db/schema";
+import { timestamptzRawParserConfig } from "../../src/server/db/temporal";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 
 // Includes $client so a TestDb satisfies the app's `typeof db` and can be
@@ -36,7 +37,12 @@ function requireEnv(name: string): string {
 }
 
 export function getDb(): TestDb {
-  pool ??= new Pool({ connectionString: requireEnv("DATABASE_URL"), max: 5 });
+  pool ??= new Pool({
+    connectionString: requireEnv("DATABASE_URL"),
+    max: 5,
+    // Match the app pool so temporalTimestamp columns decode (see temporal.ts).
+    types: timestamptzRawParserConfig,
+  });
   return drizzle(pool, { schema });
 }
 
@@ -222,10 +228,11 @@ export async function createUnreadEntry(
     })
     .returning();
 
+  // publishedOrFetchedAt is filled by the user_entries_fill_denormalized trigger
+  // (COALESCE(published_at, fetched_at)), matching the production write paths.
   await db.insert(schema.userEntries).values({
     userId,
     entryId: id,
-    publishedOrFetchedAt: now,
   });
 
   return {
@@ -290,7 +297,8 @@ export async function createSavedArticle(
     })
     .returning();
 
-  await db.insert(schema.userEntries).values({ userId, entryId: id, publishedOrFetchedAt: now });
+  // publishedOrFetchedAt is filled by the user_entries_fill_denormalized trigger.
+  await db.insert(schema.userEntries).values({ userId, entryId: id });
 
   return {
     savedFeedId: feedId,

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -493,6 +493,31 @@ describe("Entries", () => {
       });
       expect(recentlyRead.items.map((e) => e.id)).toEqual([readId]);
     });
+
+    // #683: the cursor sort key is decoded to a Temporal.Instant per row. For the
+    // archived sort a row's readChangedAt can be NULL, so decoding must be
+    // null-tolerant (no throw) and a NULL boundary row must not produce a cursor.
+    it("sortBy=archived tolerates a NULL sort key with pagination (no crash, no cursor)", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/feed.xml");
+      await createTestSubscription(userId, feedId);
+
+      // Two never-read entries: both readChangedAt NULL.
+      const aId = await createTestEntry(feedId, { title: "A" });
+      const bId = await createTestEntry(feedId, { title: "B" });
+      await createUserEntry(userId, aId, { readChangedAt: undefined });
+      await createUserEntry(userId, bId, { readChangedAt: undefined });
+      await db
+        .update(userEntries)
+        .set({ readChangedAt: null })
+        .where(eq(userEntries.userId, userId));
+
+      // limit:1 forces hasMore with a NULL-sort-key boundary row. Must not throw,
+      // and the offset-paginated archived sort emits no keyset cursor.
+      const page = await listEntries(db, { userId, sortBy: "archived", limit: 1, showSpam: false });
+      expect(page.items).toHaveLength(1);
+      expect(page.nextCursor).toBeUndefined();
+    });
   });
 
   describe("get", () => {

--- a/tests/integration/google-reader-unread-count.test.ts
+++ b/tests/integration/google-reader-unread-count.test.ts
@@ -112,11 +112,12 @@ async function addEntry(opts: {
     updatedAt: opts.fetchedAt,
   });
   if (opts.withUserEntry) {
+    // publishedOrFetchedAt is filled by the user_entries_fill_denormalized
+    // trigger (COALESCE(published_at, fetched_at)).
     await db.insert(userEntries).values({
       userId: opts.userId,
       entryId,
       read: opts.read,
-      publishedOrFetchedAt: opts.publishedAt ?? opts.fetchedAt,
     });
   }
 }

--- a/tests/integration/sync-events.test.ts
+++ b/tests/integration/sync-events.test.ts
@@ -1236,4 +1236,77 @@ describe("sync.events", () => {
       expect(planB2).not.toContain("Seq Scan");
     });
   });
+
+  // ==========================================================================
+  // Microsecond precision (#680, #683)
+  // ==========================================================================
+  //
+  // Postgres stores timestamps at microsecond precision. The sync cursor must
+  // preserve those microseconds end-to-end: a JavaScript Date read (millisecond
+  // precision) truncates them, landing the cursor in the gap between rows that
+  // share a millisecond and silently dropping or re-delivering entries. The pool
+  // returns the raw timestamptz string and the router decodes it to a
+  // Temporal.Instant, so the microseconds survive.
+  describe("microsecond precision", () => {
+    it("sync.cursors preserves the microseconds of the newest change", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/us-cursor.xml");
+      await createTestSubscription(userId, feedId);
+      const entryId = await createTestEntry(feedId);
+      await createUserEntry(userId, entryId);
+
+      // Stamp a microsecond-precise updated_at that a millisecond Date cannot
+      // represent (…123456, where 456 is sub-millisecond). The cursor is
+      // GREATEST(entries.updated_at, user_entries.updated_at), so pin the entry's
+      // updated_at older and let the user_entries change be the newest.
+      const micros = "2026-03-04T05:06:07.123456Z";
+      await db.execute(
+        sql`UPDATE entries SET updated_at = '2026-03-04T05:06:07.000000Z'::timestamptz WHERE id = ${entryId}::uuid`
+      );
+      await db.execute(
+        sql`UPDATE user_entries SET updated_at = ${micros}::timestamptz WHERE entry_id = ${entryId}::uuid`
+      );
+
+      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      expect(cursorResult.entries).toBe(micros);
+    });
+
+    it("sync.events emits microsecond-precise timestamps that advance the cursor", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/us-events.xml");
+      await createTestSubscription(userId, feedId);
+      const entryId = await createTestEntry(feedId);
+      await createUserEntry(userId, entryId);
+
+      // Two changes in the same millisecond, differing only in microseconds.
+      // (No trailing zeros — Temporal.Instant.toString() trims them, so these are
+      // the exact strings the router emits.)
+      const older = "2026-03-04T05:06:07.100207Z";
+      const newer = "2026-03-04T05:06:07.100803Z";
+      const pinned = "2026-03-04T05:06:07.100700Z";
+      await db.execute(
+        sql`UPDATE entries SET updated_at = ${older}::timestamptz WHERE id = ${entryId}::uuid`
+      );
+      await db.execute(
+        sql`UPDATE user_entries SET updated_at = ${newer}::timestamptz WHERE entry_id = ${entryId}::uuid`
+      );
+
+      // A cursor pinned to the microsecond just before `newer` must still surface
+      // the change — a millisecond-truncated comparison would have already passed it.
+      const result = await createCaller(createAuthContext(userId)).sync.events({
+        cursors: { entries: pinned },
+      });
+      const stateEvents = result.events.filter((e) => e.type === "entry_state_changed");
+      expect(stateEvents).toHaveLength(1);
+      expect(stateEvents[0].updatedAt).toBe(newer);
+
+      // The emitted timestamp advances the keyset cursor forward (it is strictly
+      // after the pinned cursor at microsecond precision).
+      const advanced = advanceCursors(
+        { entries: pinned, entriesAfterId: null, subscriptions: null, tags: null },
+        stateEvents[0]
+      );
+      expect(advanced.entries).toBe(newer);
+    });
+  });
 });

--- a/tests/unit/frontend/events/cursors.test.ts
+++ b/tests/unit/frontend/events/cursors.test.ts
@@ -129,6 +129,42 @@ describe("advanceCursors", () => {
     expect(advanceCursors(EMPTY_CURSORS, importEvent())).toBe(EMPTY_CURSORS);
   });
 
+  // #683: cursors carry microsecond precision. A new Date() comparison truncates
+  // to milliseconds, so an event newer by microseconds within the same
+  // millisecond would fail to advance the cursor. Temporal.Instant.compare fixes
+  // this — the sub-millisecond-newer event must move the cursor forward.
+  it("advances the cursor for an event newer by microseconds within the same millisecond", () => {
+    const cursors = advanceCursors(EMPTY_CURSORS, subscriptionEvent("2026-01-01T00:00:00.000500Z"));
+    const next = advanceCursors(cursors, subscriptionEvent("2026-01-01T00:00:00.000800Z"));
+    expect(next.subscriptions).toBe("2026-01-01T00:00:00.000800Z");
+  });
+
+  it("does not advance the cursor for an event older by microseconds within the same millisecond", () => {
+    const cursors = advanceCursors(EMPTY_CURSORS, subscriptionEvent("2026-01-01T00:00:00.000800Z"));
+    expect(advanceCursors(cursors, subscriptionEvent("2026-01-01T00:00:00.000500Z"))).toBe(cursors);
+  });
+
+  it("advances the entries keyset for an entry event newer by microseconds", () => {
+    const cursors = advanceCursors(EMPTY_CURSORS, entryEvent("2026-01-01T00:00:00.000100Z", "a"));
+    const next = advanceCursors(cursors, entryEvent("2026-01-01T00:00:00.000200Z", "a"));
+    expect(next.entries).toBe("2026-01-01T00:00:00.000200Z");
+  });
+
+  // A legacy to_char cursor always had 6 fractional digits; Temporal trims
+  // trailing zeros. Comparing as instants (not strings) keeps a same-moment event
+  // in the tied-timestamp group so its id tiebreaker still advances (#683).
+  it("treats a trailing-zero-trimmed event as equal to a legacy 6-digit cursor", () => {
+    const legacy: SyncCursors = {
+      entries: "2026-01-01T00:00:00.123000Z",
+      entriesAfterId: "a",
+      subscriptions: null,
+      tags: null,
+    };
+    const next = advanceCursors(legacy, entryEvent("2026-01-01T00:00:00.123Z", "b"));
+    expect(next.entriesAfterId).toBe("b");
+    expect(next.entries).toBe("2026-01-01T00:00:00.123000Z");
+  });
+
   describe("entries keyset (ts, entriesAfterId)", () => {
     const T = "2026-01-01T00:00:00.000000Z";
 


### PR DESCRIPTION
Closes #683.

## Problem

Sync/list keyset cursors need **microsecond** precision. A JavaScript `Date`
truncates to milliseconds, so a cursor read back as a `Date` lands in the gap
between rows that share a millisecond and silently drops or re-delivers entries
(#680). PR #681 fixed the immediate bug by formatting every cursor timestamp with
`to_char(... 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')` — correct, but verbose and easy to
forget at a new query, where it silently re-truncates.

## Approach

- **Pool parser override** (`src/server/db/index.ts`): node-postgres parses
  `timestamptz` (OID 1184) into a truncating `Date`. Override the parser to return
  Postgres's **raw string** instead. Drizzle's built-in `timestamp` columns still
  map that string to a `Date` (unchanged, ms precision); precision-sensitive reads
  decode it to a full-precision `Temporal.Instant`. Scoped to this pool's clients,
  not global.
- **New `src/server/db/temporal.ts`**: `parseTimestamptz` /
  `parseTimestamptzOrNull` and a `temporalTimestamp` Drizzle `customType`
  (`timestamptz` ↔ `Temporal.Instant`), backed by [`temporal-polyfill`] until Node
  ships native `Temporal`.
- **`entries.ts` / `sync.ts`**: drop **every** `to_char` — read cursor timestamps
  via `.mapWith(parseTimestamptz)` (aggregate/`GREATEST` expressions) or the
  `temporalTimestamp` column, and emit `Temporal.Instant.toString()`.
- **`schema.ts`**: `published_or_fetched_at` (the timeline cursor sort key) uses
  `temporalTimestamp` on `user_entries` + `visible_entries`.
- **`cursors.ts` (client)**: compare cursors with `Temporal.Instant.compare`
  instead of `new Date` — a sub-millisecond-newer event now advances the cursor.
  Comparing **instants** (not strings) is also robust across the format change
  from the legacy fixed-6-digit `to_char` output to Temporal's
  trailing-zero-trimmed form (a legacy `.100800Z` cursor and a new `.1008Z` event
  for the same moment compare equal).

### Why the pool override (and not just a customType)

`node-postgres` type parsers are global per-OID, and pg parses `timestamptz` to a
`Date` **before** Drizzle/the customType sees it — so the microseconds are already
gone. The parser must return the raw string for any column to preserve precision.
Verified that every existing raw `timestamptz` reader (`admin`, `feedStats`,
`google-reader`, Wallabag) either only uses the value in SQL or already wraps it in
`new Date(...)`, so the string is a safe drop-in.

### Scope note

Base `timestamp` columns are **not** wholesale-converted to `Temporal.Instant`
(they serialize into many API responses as `Date`). Only the precision-sensitive
cursor sort key is a `temporalTimestamp` column; other cursor timestamps come from
aggregate expressions decoded via `.mapWith`.

## Testing

- **Unit**: new `cursors.test.ts` cases — µs-newer event advances the cursor,
  µs-older does not, and a trailing-zero-trimmed event equals a legacy 6-digit
  cursor.
- **Integration**: new `sync-events.test.ts` cases proving `sync.cursors` and
  `sync.events` preserve microseconds end-to-end (two changes one millisecond
  apart, differing only in µs).
- Full **unit / integration / e2e** suites pass locally (incl. the realtime
  SSE→cache→UI e2e tests). Test helpers now let the
  `user_entries_fill_denormalized` trigger fill `published_or_fetched_at` (matching
  production, which never Drizzle-writes it).

[`temporal-polyfill`]: https://www.npmjs.com/package/temporal-polyfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)