### PR TITLE
Switch TOAST compression to lz4 on large content columns (#1117)

### DIFF
--- a/migrations/0099_lz4_toast_compression.sql
+++ b/migrations/0099_lz4_toast_compression.sql
@@ -1,0 +1,44 @@
+-- Switch TOAST compression from pglz (the default) to lz4 on the large
+-- content columns (issue #1117).
+--
+-- Database CPU is far more expensive than storage for this project. The
+-- per-column size audit on prod (issue #1117) showed entry content is ~96%
+-- of the 4.2 GB database, and pglz compress/decompress of these TOASTed
+-- values is suspected to be a major share of DB CPU on content reads/writes
+-- (DB CPU cost is what forced removal of the background resanitize job in
+-- issue #1116). lz4 is roughly an order of magnitude faster than pglz in
+-- both directions at a slightly worse compression ratio (~few % larger) —
+-- the right trade here.
+--
+-- SET COMPRESSION is a catalog-only change: instant, no table rewrite, brief
+-- ACCESS EXCLUSIVE lock — safe in the Fly release_command migration step. It
+-- affects only newly written values; existing TOAST values stay pglz until
+-- their row's column is rewritten (e.g. by the upcoming sanitized-column
+-- rewrites planned in #1117 step 7). Decompression of old pglz values keeps
+-- working forever regardless.
+--
+-- Expand/contract: trivially backward compatible — old code is unaffected by
+-- the compression method. Requires the server to be built with lz4 support
+-- (--with-lz4, standard in Debian/most distro builds, Postgres >= 14); the
+-- migration fails loudly at release time if unsupported.
+
+ALTER TABLE entries
+  ALTER COLUMN content_original SET COMPRESSION lz4,
+  ALTER COLUMN content_cleaned SET COMPRESSION lz4,
+  ALTER COLUMN content_original_sanitized SET COMPRESSION lz4,
+  ALTER COLUMN content_cleaned_sanitized SET COMPRESSION lz4,
+  ALTER COLUMN full_content_original SET COMPRESSION lz4,
+  ALTER COLUMN full_content_cleaned SET COMPRESSION lz4,
+  ALTER COLUMN full_content_original_sanitized SET COMPRESSION lz4,
+  ALTER COLUMN full_content_cleaned_sanitized SET COMPRESSION lz4,
+  ALTER COLUMN summary SET COMPRESSION lz4;
+
+--> statement-breakpoint
+
+ALTER TABLE narration_content
+  ALTER COLUMN content_narration SET COMPRESSION lz4;
+
+--> statement-breakpoint
+
+ALTER TABLE entry_summaries
+  ALTER COLUMN summary_text SET COMPRESSION lz4;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -687,6 +687,13 @@
       "when": 1782953100000,
       "tag": "0098_drop_wallabag_id",
       "breakpoints": true
+    },
+    {
+      "idx": 98,
+      "version": "7",
+      "when": 1782953200000,
+      "tag": "0099_lz4_toast_compression",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -227,6 +227,15 @@ CREATE TABLE public.entries (
     CONSTRAINT entries_spam_only_email CHECK (((type = 'email'::public.feed_type) OR ((spam_score IS NULL) AND (is_spam = false)))),
     CONSTRAINT entries_unsubscribe_only_email CHECK (((type = 'email'::public.feed_type) OR ((list_unsubscribe_mailto IS NULL) AND (list_unsubscribe_https IS NULL) AND (list_unsubscribe_post IS NULL))))
 );
+ALTER TABLE ONLY public.entries ALTER COLUMN content_original SET COMPRESSION lz4;
+ALTER TABLE ONLY public.entries ALTER COLUMN summary SET COMPRESSION lz4;
+ALTER TABLE ONLY public.entries ALTER COLUMN content_cleaned SET COMPRESSION lz4;
+ALTER TABLE ONLY public.entries ALTER COLUMN full_content_original SET COMPRESSION lz4;
+ALTER TABLE ONLY public.entries ALTER COLUMN full_content_cleaned SET COMPRESSION lz4;
+ALTER TABLE ONLY public.entries ALTER COLUMN content_original_sanitized SET COMPRESSION lz4;
+ALTER TABLE ONLY public.entries ALTER COLUMN content_cleaned_sanitized SET COMPRESSION lz4;
+ALTER TABLE ONLY public.entries ALTER COLUMN full_content_original_sanitized SET COMPRESSION lz4;
+ALTER TABLE ONLY public.entries ALTER COLUMN full_content_cleaned_sanitized SET COMPRESSION lz4;
 
 CREATE SEQUENCE public.entries_greader_item_id_seq
     AS bigint
@@ -260,6 +269,7 @@ CREATE TABLE public.entry_summaries (
     max_words integer,
     prompt_hash text
 );
+ALTER TABLE ONLY public.entry_summaries ALTER COLUMN summary_text SET COMPRESSION lz4;
 
 CREATE TABLE public.feeds (
     id uuid NOT NULL,
@@ -332,6 +342,7 @@ CREATE TABLE public.narration_content (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     paragraph_map jsonb
 );
+ALTER TABLE ONLY public.narration_content ALTER COLUMN content_narration SET COMPRESSION lz4;
 
 CREATE TABLE public.oauth_access_tokens (
     id uuid NOT NULL,


### PR DESCRIPTION
## Motivation

Database CPU is far more expensive than storage for this project. The per-column size audit on prod (#1117) showed entry content is ~96% of the 4.2 GB database, and pglz compress/decompress of these TOASTed values is suspected to be a major share of DB CPU on content reads/writes — DB CPU cost is what forced removal of the background resanitize job in #1116. lz4 is roughly an order of magnitude faster than pglz in both directions at a slightly worse compression ratio (~few % larger) — the right trade here.

Prod audit (per-column compressed sizes):

```
 type  |  rows  | c_orig | c_clean  | c_orig_san | c_clean_san | fc_orig | fc_clean | fc_orig_san | fc_clean_san
 web   | 271097 | 468 MB | 10039 kB | 446 MB     | 9502 kB     | 1350 MB | 72 MB    | 403 MB      | 66 MB
 email |   2574 | 66 MB  | 24 MB    | 43 MB      | 24 MB       | 6471 kB | 875 kB   | 1591 kB     | 878 kB
 saved |    524 | 35 MB  | 15 MB    | 17 MB      | 13 MB       |         |          |             |
```

## What this does

Migration `0099_lz4_toast_compression.sql` runs `ALTER TABLE ... ALTER COLUMN ... SET COMPRESSION lz4` on the large content/body columns:

- **entries** (9): `content_original`, `content_cleaned`, `content_original_sanitized`, `content_cleaned_sanitized`, `full_content_original`, `full_content_cleaned`, `full_content_original_sanitized`, `full_content_cleaned_sanitized`, plus `summary` (feed-provided summaries are routinely multi-KB — some feeds duplicate the whole article there)
- **narration_content**: `content_narration`
- **entry_summaries**: `summary_text`

Small metadata columns (titles, hashes, URLs, `paragraph_map`) are left at the default.

## Safety / rollout notes

- `SET COMPRESSION` is a **catalog-only** change: instant, no table rewrite, takes a brief ACCESS EXCLUSIVE lock. Safe in the Fly `release_command` migration step.
- It affects **only newly written values**. Existing TOAST values stay pglz until their row's column is rewritten (e.g. by the upcoming sanitized-column rewrites planned in #1117 step 7). Decompression of old pglz values keeps working forever regardless.
- Trivially backward-compatible (expand/contract safe): old code is unaffected by the compression method.
- Requires the server to be built with lz4 support (`--with-lz4`, standard in Debian/most distro builds, Postgres >= 14). The migration fails loudly at release time if unsupported.

## Testing

- Full from-scratch migration replay via `pnpm services` + `pnpm db:migrate:local` (Postgres 18.4): clean.
- Verified `pg_attribute.attcompression = 'l'` for all 11 columns, and `pg_column_compression()` returns `lz4` for a freshly inserted large value.
- `pnpm typecheck`, `pnpm test:unit` (2364 passed), `pnpm test:integration:local` (648 passed, 15 pre-existing skips) all pass.
- `migrations/schema.sql` updated with the `ALTER TABLE ONLY ... SET COMPRESSION lz4;` statements pg_dump emits for non-default column compression (hand-applied to the committed file: regenerating on this box's PG 18 pg_dump introduces unrelated version-specific noise — named NOT NULL constraints etc. — that a PG 16 dump would flip back).

## Pre-merge checklist

- [x] Verify prod Postgres is built with lz4 support before merging (verified 2026-07-14: `CREATE TEMP TABLE _lz4_check (t text COMPRESSION lz4);` succeeded on prod — Claude), e.g.:

  ```sql
  CREATE TEMP TABLE _lz4_check (t text COMPRESSION lz4);
  DROP TABLE _lz4_check;
  ```

  (errors immediately if the server lacks `--with-lz4`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

