### PR TITLE
Fix Wallabag archive/star/delete on .json-suffixed entry endpoints (#1229)

### DIFF
--- a/src/server/wallabag/id.ts
+++ b/src/server/wallabag/id.ts
@@ -39,12 +39,19 @@ export interface ResolvedWallabagEntry {
  * entries its user can see. Returns null for unknown/invisible entries and for
  * values that can't be a stored serial (non-numeric, or beyond bigint range —
  * which Postgres would reject as a parameter).
+ *
+ * Real Wallabag routes are `/api/entries/{entry}.{_format}` (the Android app and
+ * others append a `.json` suffix), so a trailing `.json`/`.xml` format suffix is
+ * stripped before resolution — otherwise `123.json` parses as neither a serial
+ * nor a UUID and archiving/starring/deleting silently 404s (issue #1229).
  */
 export async function resolveWallabagEntry(
   db: typeof dbType,
   userId: string,
   entryParam: string
 ): Promise<ResolvedWallabagEntry | null> {
+  entryParam = entryParam.replace(/\.(json|xml)$/i, "");
+
   const selection = { id: visibleEntries.id, greaderItemId: visibleEntries.greaderItemId };
 
   let rows: Array<{ id: string; greaderItemId: bigint }>;

--- a/tests/e2e/wallabag-api.spec.ts
+++ b/tests/e2e/wallabag-api.spec.ts
@@ -390,6 +390,53 @@ test.describe("Wallabag API happy path", () => {
       await close();
     }
   });
+
+  test("archive via PATCH with a .json format suffix marks the entry read (#1229)", async ({
+    request,
+  }) => {
+    const { access_token } = await getTokens(request);
+    const auth = { Authorization: `Bearer ${access_token}` };
+
+    const { url, close } = await startArticleServer();
+    let id: number | undefined;
+    try {
+      id = (
+        await (
+          await request.post("/api/wallabag/api/entries", { headers: auth, form: { url } })
+        ).json()
+      ).id;
+
+      // The Wallabag Android app (and others) append a `.json` format suffix to
+      // the single-entry endpoint. That must resolve the same as the bare id —
+      // otherwise the archive silently 404s and the entry reappears on re-sync.
+      const patchRes = await request.patch(`/api/wallabag/api/entries/${id}.json`, {
+        headers: auth,
+        form: { archive: "1" },
+      });
+      expect(patchRes.status()).toBe(200);
+      expect((await patchRes.json()).is_archived).toBe(1);
+
+      // It's gone from the unread (archive=0) list and present in the archived
+      // (archive=1) list — the read state actually persisted.
+      const unread = await request.get(
+        "/api/wallabag/api/entries?archive=0&detail=metadata&perPage=100",
+        { headers: auth }
+      );
+      expect((await unread.json())._embedded.items.map((e: { id: number }) => e.id)).not.toContain(
+        id
+      );
+      const archived = await request.get(
+        "/api/wallabag/api/entries?archive=1&detail=metadata&perPage=100",
+        { headers: auth }
+      );
+      expect((await archived.json())._embedded.items.map((e: { id: number }) => e.id)).toContain(
+        id
+      );
+    } finally {
+      if (id) await request.delete(`/api/wallabag/api/entries/${id}`, { headers: auth });
+      await close();
+    }
+  });
 });
 
 /**


### PR DESCRIPTION
## Problem

Archiving an entry in Wallabag didn't mark it read: the main UI was unaffected and the entry reappeared on the next re-sync (issue #1229).

## Root cause

Real Wallabag routes are `/api/entries/{entry}.{_format}`, and the Wallabag Android app (among others) appends a `.json` suffix — e.g. `PATCH /api/entries/123.json`. That request hits the `[entry]` dynamic route with `entryParam = "123.json"`, which `resolveWallabagEntry` can parse as neither a stored serial (fails `^\d+$`) nor a UUID, so it returns `null` → **404**. The archive/star/delete therefore never persisted.

The collection endpoints already handle the `.json` suffix (`entries.json`, `exists.json`), but the single-entry route did not.

## Fix

Strip a trailing `.json`/`.xml` format suffix in `resolveWallabagEntry` — the single choke point for GET/PATCH/DELETE on a single entry — before resolution. Serials and UUIDs never contain a dot, so this is safe.

## Test

Adds an e2e regression test that PATCHes `archive=1` via the `.json`-suffixed endpoint and asserts the entry is marked read (drops from the unread list, appears in the archived list). All 16 Wallabag e2e tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)