### PR TITLE
Fix invisible unread dots after --color-strong removal (#1227)

### DIFF
--- a/src/app/demo/DemoEntryListSSR.tsx
+++ b/src/app/demo/DemoEntryListSSR.tsx
@@ -36,7 +36,7 @@ export function DemoEntryListSSR({ entries, backHref, title }: DemoEntryListSSRP
             >
               <div className="flex items-start gap-3">
                 <div className="mt-1.5 shrink-0">
-                  <span className="bg-strong block h-2.5 w-2.5 rounded-full" aria-hidden="true" />
+                  <span className="bg-body block h-2.5 w-2.5 rounded-full" aria-hidden="true" />
                 </div>
                 <div className="min-w-0 flex-1">
                   <h3 className="ui-text-sm text-body line-clamp-2 font-medium">{displayTitle}</h3>

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -198,14 +198,14 @@ export const EntryListItem = memo(function EntryListItem({
                 className={`block h-2.5 w-2.5 rounded-full transition-colors ${
                   read
                     ? "group-hover/toggle:border-edge-strong group-hover/toggle:bg-surface-muted border-edge-input border bg-transparent"
-                    : "bg-strong group-hover/toggle:bg-muted"
+                    : "bg-body group-hover/toggle:bg-muted"
                 }`}
               />
             </button>
           ) : (
             <span
               className={`block h-2.5 w-2.5 rounded-full ${
-                read ? "border-edge-input border bg-transparent" : "bg-strong"
+                read ? "border-edge-input border bg-transparent" : "bg-body"
               }`}
               aria-hidden="true"
             />

--- a/tests/unit/frontend/components/EntryListItem.test.tsx
+++ b/tests/unit/frontend/components/EntryListItem.test.tsx
@@ -169,7 +169,7 @@ describe("EntryListItem", () => {
       // Color lives on the inner dot span; the button is the 44px touch target.
       // Unread is a neutral filled dot (amber is reserved for the star); read is
       // a hollow outline. See the unread/star color language in globals.css.
-      expect(button.querySelector("span")).toHaveClass("bg-strong");
+      expect(button.querySelector("span")).toHaveClass("bg-body");
     });
 
     it("shows empty indicator for read entries", () => {


### PR DESCRIPTION
## Problem

The #1227 token consolidation removed the `--text-strong` / `--color-strong` (and `--emphasis`) theme aliases and folded them into `--text-body`. But the entry-list **unread dot** was still styled with `bg-strong`.

With `--color-strong` gone, Tailwind v4 no longer emits a `bg-strong` utility at all, so the class became inert (no CSS) and the unread dot lost its fill — appearing invisible against the card surface (reading as white in light mode / black in dark mode) instead of matching the body text color.

The regression slipped through because the `EntryListItem` unit test asserted `toHaveClass("bg-strong")` as a literal string, which stayed true even though the class produced no styling.

## Fix

- Point the unread dot at `bg-body` (where the strong tone now lives) in `EntryListItem` and the demo SSR list (`DemoEntryListSSR`).
- Read-state hollow outline and the hover `bg-muted` step are unchanged.
- Update the test assertion to `bg-body`.

## Screenshots (`/demo`)

### Light
| Before | After |
| --- | --- |
| ![before light](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/unread-dot-color-1233/before-light.png) | ![after light](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/unread-dot-color-1233/after-light.png) |

### Dark
| Before | After |
| --- | --- |
| ![before dark](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/unread-dot-color-1233/before-dark.png) | ![after dark](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/unread-dot-color-1233/after-dark.png) |

### E-paper (after — pure-black dots match near-black body text)
![after epaper](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/unread-dot-color-1233/after-epaper.png)

## Testing

- `pnpm typecheck` ✓
- `pnpm test:unit` ✓ (2367 passed)
- `pnpm check:colors` ✓
- Manually verified all three themes on `/demo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)