### PR TITLE
Google Reader API: implement subscription/import (OPML) (#1059)

### DIFF
--- a/src/app/api/greader.php/reader/api/0/subscription/import/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/import/route.ts
@@ -1,0 +1,59 @@
+/**
+ * Google Reader API: Import Subscriptions (OPML)
+ *
+ * POST /api/greader.php/reader/api/0/subscription/import
+ *
+ * Imports feed subscriptions from an OPML document. Unlike most Google Reader
+ * endpoints, the OPML is sent as the **raw request body** (not form-encoded):
+ * FreshRSS reads `php://input` directly, and the greader_api client used by
+ * Newsflash POSTs the OPML string as the body (issue #1059). We therefore read
+ * the raw body rather than going through `parseFormData`.
+ *
+ * On success we return `OK: {count}`, where {count} is the number of unique
+ * feeds queued for import. The import itself runs asynchronously in a background
+ * job (mirroring the tRPC `subscriptions.import` flow), so the count reflects
+ * feeds queued, not yet subscribed. FreshRSS returns a bare `OK`; the `OK: N`
+ * form is what the greader_api client parses (it checks for the `OK: ` prefix).
+ */
+
+import { requireAuth } from "@/server/google-reader/auth";
+import { textResponse, errorResponse } from "@/server/google-reader/parse";
+import { importOpml, MAX_OPML_BYTES } from "@/server/services/imports";
+import { OpmlParseError } from "@/server/feed/opml";
+import { checkRouteRateLimit } from "@/server/rate-limit";
+import { db } from "@/server/db";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  const session = await requireAuth(request);
+  if (session instanceof Response) return session;
+
+  // OPML import queues a subscribe job per feed — the tRPC equivalent is an
+  // "expensive" procedure, so rate-limit this compat path the same way.
+  const rateLimited = await checkRouteRateLimit(request, "expensive");
+  if (rateLimited) return rateLimited;
+
+  const opml = await request.text();
+
+  if (opml.trim().length === 0) {
+    return errorResponse("Missing OPML content in request body", 400);
+  }
+
+  // Guard against oversized payloads (byte length, matching the tRPC limit).
+  if (new TextEncoder().encode(opml).length > MAX_OPML_BYTES) {
+    return errorResponse("OPML file too large (max 5MB)", 413);
+  }
+
+  try {
+    const { totalFeeds } = await importOpml(db, session.user.id, opml);
+    return textResponse(`OK: ${totalFeeds}`);
+  } catch (err) {
+    if (err instanceof OpmlParseError) {
+      return errorResponse(`Failed to parse OPML: ${err.message}`, 400);
+    }
+    console.error("Failed to import OPML:", err);
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(`Failed to import OPML: ${message}`, 500);
+  }
+}

--- a/src/server/services/imports.ts
+++ b/src/server/services/imports.ts
@@ -1,0 +1,126 @@
+/**
+ * Imports Service
+ *
+ * Shared OPML-import business logic: parse OPML, deduplicate feeds, create the
+ * `opml_imports` tracking record, and queue the background job that actually
+ * subscribes to each feed. Used by the tRPC `subscriptions.import` mutation and
+ * the Google Reader `subscription/import` compat endpoint (issue #1059).
+ */
+
+import type { db as dbType } from "@/server/db";
+import { opmlImports, type OpmlImportFeedData } from "@/server/db/schema";
+import { parseOpml } from "@/server/feed/opml";
+import { createJob } from "@/server/jobs/queue";
+import { generateUuidv7 } from "@/lib/uuidv7";
+import { logger } from "@/lib/logger";
+
+/** Maximum OPML payload we accept (5 MB), shared by all callers. */
+export const MAX_OPML_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Result of queueing an OPML import.
+ */
+export interface ImportOpmlResult {
+  importId: string;
+  /** Number of unique feeds queued for import (after deduplication by URL). */
+  totalFeeds: number;
+}
+
+/**
+ * Parses OPML content, deduplicates feeds by URL (merging their tags), records
+ * an `opml_imports` row, and queues a `process_opml_import` background job.
+ *
+ * Returns immediately — the feeds are subscribed asynchronously by the worker.
+ * Throws `OpmlParseError` (from {@link parseOpml}) if the content is not valid
+ * OPML; callers translate that into their own error format.
+ */
+export async function importOpml(
+  db: typeof dbType,
+  userId: string,
+  opml: string
+): Promise<ImportOpmlResult> {
+  // Step 1: Parse the OPML content (throws OpmlParseError on malformed input).
+  const opmlFeeds = parseOpml(opml);
+
+  const importId = generateUuidv7();
+  const now = new Date();
+
+  if (opmlFeeds.length === 0) {
+    // Record a completed import with no feeds — nothing to queue.
+    await db.insert(opmlImports).values({
+      id: importId,
+      userId,
+      status: "completed",
+      totalFeeds: 0,
+      importedCount: 0,
+      skippedCount: 0,
+      failedCount: 0,
+      feedsData: [],
+      results: [],
+      completedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return { importId, totalFeeds: 0 };
+  }
+
+  // Step 2: Deduplicate feeds by URL, merging categories. A feed listed under
+  // five tags counts as one import, not five.
+  const feedsByUrl = new Map<string, OpmlImportFeedData>();
+  for (const feed of opmlFeeds) {
+    const existing = feedsByUrl.get(feed.xmlUrl);
+    if (existing) {
+      // Merge categories (use first level of category path as tag).
+      if (feed.category && feed.category.length > 0) {
+        const tagName = feed.category[0];
+        if (!existing.category) {
+          existing.category = [tagName];
+        } else if (!existing.category.includes(tagName)) {
+          existing.category.push(tagName);
+        }
+      }
+      // Keep the title from the first occurrence.
+    } else {
+      feedsByUrl.set(feed.xmlUrl, {
+        xmlUrl: feed.xmlUrl,
+        title: feed.title,
+        htmlUrl: feed.htmlUrl,
+        category: feed.category && feed.category.length > 0 ? [feed.category[0]] : undefined,
+      });
+    }
+  }
+
+  const feedsData = Array.from(feedsByUrl.values());
+
+  // Step 3: Create the import tracking record.
+  await db.insert(opmlImports).values({
+    id: importId,
+    userId,
+    status: "pending",
+    totalFeeds: feedsData.length, // deduplicated count
+    importedCount: 0,
+    skippedCount: 0,
+    failedCount: 0,
+    feedsData,
+    results: [],
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  // Step 4: Queue the background job that subscribes to each feed.
+  await createJob({
+    type: "process_opml_import",
+    payload: { importId },
+    nextRunAt: now, // run immediately
+  });
+
+  logger.info("OPML import queued", {
+    importId,
+    userId,
+    totalFeeds: feedsData.length,
+    originalCount: opmlFeeds.length, // log original for debugging
+  });
+
+  return { importId, totalFeeds: feedsData.length };
+}

--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -25,23 +25,22 @@ import {
   tags,
   subscriptionTags,
   blockedSenders,
-  opmlImports,
   userFeeds,
   visibleEntries,
-  type OpmlImportFeedData,
 } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
 import { parseFeedInWorker } from "@/server/worker-thread/pool";
 import { discoverFeeds } from "@/server/feed/discovery";
 import { getDomainFromUrl } from "@/server/feed/types";
 import { extractUserIdFromFeedUrl, fetchLessWrongUserById } from "@/server/feed/lesswrong";
-import { parseOpml, generateOpml, type OpmlFeed, type OpmlSubscription } from "@/server/feed/opml";
-import { createJob, scheduleFeedRefreshNow } from "@/server/jobs/queue";
+import { generateOpml, OpmlParseError, type OpmlSubscription } from "@/server/feed/opml";
+import { scheduleFeedRefreshNow } from "@/server/jobs/queue";
 import { shouldRefetchOnSubscribe } from "@/server/feed/scheduling";
 import { publishSubscriptionDeleted, publishSubscriptionUpdated } from "@/server/redis/pubsub";
 import { attemptUnsubscribe, getLatestUnsubscribeMailto } from "@/server/email/unsubscribe";
 import { logger } from "@/lib/logger";
 import * as subscriptionsService from "@/server/services/subscriptions";
+import { importOpml } from "@/server/services/imports";
 import { getSubscriptionDeletionCounts } from "@/server/services/counts";
 import { unreadCountsSchema } from "@/lib/events/schemas";
 
@@ -705,109 +704,14 @@ export const subscriptionsRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const userId = ctx.session.user.id;
-
-      // Step 1: Parse the OPML content
-      let opmlFeeds: OpmlFeed[];
       try {
-        opmlFeeds = await parseOpml(input.opml);
+        return await importOpml(ctx.db, ctx.session.user.id, input.opml);
       } catch (error) {
-        throw errors.validation(
-          `Failed to parse OPML: ${error instanceof Error ? error.message : "Invalid OPML format"}`
-        );
-      }
-
-      if (opmlFeeds.length === 0) {
-        // Create a completed import record with no feeds
-        const importId = generateUuidv7();
-        const now = new Date();
-
-        await ctx.db.insert(opmlImports).values({
-          id: importId,
-          userId,
-          status: "completed",
-          totalFeeds: 0,
-          importedCount: 0,
-          skippedCount: 0,
-          failedCount: 0,
-          feedsData: [],
-          results: [],
-          completedAt: now,
-          createdAt: now,
-          updatedAt: now,
-        });
-
-        return {
-          importId,
-          totalFeeds: 0,
-        };
-      }
-
-      // Step 2: Deduplicate feeds by URL, merging categories
-      // This ensures a feed in 5 tags counts as 1 import, not 5
-      const feedsByUrl = new Map<string, OpmlImportFeedData>();
-      for (const feed of opmlFeeds) {
-        const existing = feedsByUrl.get(feed.xmlUrl);
-        if (existing) {
-          // Merge categories (use first level of category path as tag)
-          if (feed.category && feed.category.length > 0) {
-            const tagName = feed.category[0]; // Use first level as tag
-            if (!existing.category) {
-              existing.category = [tagName];
-            } else if (!existing.category.includes(tagName)) {
-              existing.category.push(tagName);
-            }
-          }
-          // Use title from first occurrence (don't overwrite)
-        } else {
-          feedsByUrl.set(feed.xmlUrl, {
-            xmlUrl: feed.xmlUrl,
-            title: feed.title,
-            htmlUrl: feed.htmlUrl,
-            // Use first level of category path as tag name
-            category: feed.category && feed.category.length > 0 ? [feed.category[0]] : undefined,
-          });
+        if (error instanceof OpmlParseError) {
+          throw errors.validation(`Failed to parse OPML: ${error.message}`);
         }
+        throw error;
       }
-
-      const feedsData = Array.from(feedsByUrl.values());
-
-      // Step 3: Create import record
-      const importId = generateUuidv7();
-      const now = new Date();
-
-      await ctx.db.insert(opmlImports).values({
-        id: importId,
-        userId,
-        status: "pending",
-        totalFeeds: feedsData.length, // Use deduplicated count
-        importedCount: 0,
-        skippedCount: 0,
-        failedCount: 0,
-        feedsData,
-        results: [],
-        createdAt: now,
-        updatedAt: now,
-      });
-
-      // Step 4: Queue background job to process the import
-      await createJob({
-        type: "process_opml_import",
-        payload: { importId },
-        nextRunAt: now, // Run immediately
-      });
-
-      logger.info("OPML import queued", {
-        importId,
-        userId,
-        totalFeeds: feedsData.length,
-        originalCount: opmlFeeds.length, // Log original for debugging
-      });
-
-      return {
-        importId,
-        totalFeeds: feedsData.length, // Return deduplicated count
-      };
     }),
 
   /**

--- a/tests/integration/google-reader-subscription-import.test.ts
+++ b/tests/integration/google-reader-subscription-import.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Integration tests for the Google Reader `subscription/import` (OPML) endpoint.
+ *
+ * Newsflash (via the greader_api client) POSTs a raw OPML document to this path
+ * and expects an `OK: {count}` response; we queue the same async import the
+ * tRPC `subscriptions.import` mutation does (issue #1059). These tests exercise
+ * the route handler directly with a reader-scoped session.
+ */
+
+import { describe, it, expect, afterAll, beforeEach } from "vitest";
+import * as argon2 from "argon2";
+import { eq, inArray } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users, opmlImports, jobs } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createSession } from "../../src/server/auth/session";
+import { OAUTH_SCOPES } from "../../src/server/oauth/utils";
+import { MAX_OPML_BYTES } from "../../src/server/services/imports";
+import { POST } from "../../src/app/api/greader.php/reader/api/0/subscription/import/route";
+
+const createdUserIds: string[] = [];
+const PASSWORD = "correct-horse-battery-staple";
+
+async function createConfirmedUser(): Promise<string> {
+  const id = generateUuidv7();
+  await db.insert(users).values({
+    id,
+    email: `greader-import-${id}@test.com`,
+    passwordHash: await argon2.hash(PASSWORD),
+    tosAgreedAt: new Date(),
+    privacyPolicyAgreedAt: new Date(),
+    notEuAgreedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  createdUserIds.push(id);
+  return id;
+}
+
+async function readerToken(userId: string): Promise<string> {
+  const { token } = await createSession(db, {
+    userId,
+    scopes: [OAUTH_SCOPES.READER_FULL_ACCESS],
+  });
+  return token;
+}
+
+function importRequest(body: string, token?: string): Request {
+  return new Request("https://example.com/api/greader.php/reader/api/0/subscription/import", {
+    method: "POST",
+    headers: {
+      ...(token ? { authorization: `GoogleLogin auth=${token}` } : {}),
+      // The greader_api client labels the raw-OPML body as form-urlencoded.
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+}
+
+function sampleOpml(urls: string[]): string {
+  const outlines = urls
+    .map(
+      (url, i) =>
+        `    <outline type="rss" text="Feed ${i + 1}" title="Feed ${i + 1}" xmlUrl="${url}" htmlUrl="https://site${i + 1}.example.com" />`
+    )
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Test OPML</title></head>
+  <body>
+${outlines}
+  </body>
+</opml>`;
+}
+
+beforeEach(async () => {
+  await db.delete(opmlImports);
+});
+
+afterAll(async () => {
+  if (createdUserIds.length > 0) {
+    await db.delete(opmlImports).where(inArray(opmlImports.userId, createdUserIds));
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+});
+
+describe("POST reader/api/0/subscription/import", () => {
+  it("queues an import and returns OK with the feed count", async () => {
+    const userId = await createConfirmedUser();
+    const token = await readerToken(userId);
+
+    const opml = sampleOpml(["https://a.example.com/feed.xml", "https://b.example.com/feed.xml"]);
+    const res = await POST(importRequest(opml, token));
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("OK: 2");
+
+    // An import record was created for this user with the deduplicated count.
+    const records = await db.select().from(opmlImports).where(eq(opmlImports.userId, userId));
+    expect(records).toHaveLength(1);
+    expect(records[0].totalFeeds).toBe(2);
+    expect(records[0].status).toBe("pending");
+
+    // A background job was queued to process it.
+    const queued = await db.select().from(jobs).where(eq(jobs.type, "process_opml_import"));
+    const forThisImport = queued.filter(
+      (j) => (j.payload as { importId?: string }).importId === records[0].id
+    );
+    expect(forThisImport).toHaveLength(1);
+
+    await db.delete(jobs).where(
+      inArray(
+        jobs.id,
+        queued.map((j) => j.id)
+      )
+    );
+  });
+
+  it("deduplicates feeds listed multiple times", async () => {
+    const userId = await createConfirmedUser();
+    const token = await readerToken(userId);
+
+    const opml = sampleOpml([
+      "https://dup.example.com/feed.xml",
+      "https://dup.example.com/feed.xml",
+      "https://other.example.com/feed.xml",
+    ]);
+    const res = await POST(importRequest(opml, token));
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("OK: 2");
+
+    await db.delete(jobs).where(eq(jobs.type, "process_opml_import"));
+  });
+
+  it("returns OK: 0 for OPML with no feeds", async () => {
+    const userId = await createConfirmedUser();
+    const token = await readerToken(userId);
+
+    const opml = `<?xml version="1.0"?><opml version="2.0"><head/><body></body></opml>`;
+    const res = await POST(importRequest(opml, token));
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("OK: 0");
+
+    const [record] = await db.select().from(opmlImports).where(eq(opmlImports.userId, userId));
+    expect(record.status).toBe("completed");
+  });
+
+  it("rejects an empty body with 400", async () => {
+    const userId = await createConfirmedUser();
+    const token = await readerToken(userId);
+
+    const res = await POST(importRequest("", token));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects malformed OPML with 400", async () => {
+    const userId = await createConfirmedUser();
+    const token = await readerToken(userId);
+
+    const res = await POST(importRequest("this is not xml at all", token));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an oversized payload with 413", async () => {
+    const userId = await createConfirmedUser();
+    const token = await readerToken(userId);
+
+    // Exceed the byte limit; the size guard runs before parsing, so the content
+    // need not be valid OPML.
+    const res = await POST(importRequest("x".repeat(MAX_OPML_BYTES + 1), token));
+    expect(res.status).toBe(413);
+  });
+
+  it("returns 401 without a token", async () => {
+    const opml = sampleOpml(["https://x.example.com/feed.xml"]);
+    const res = await POST(importRequest(opml));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a session scoped to something other than reader access", async () => {
+    const userId = await createConfirmedUser();
+    const { token } = await createSession(db, {
+      userId,
+      scopes: [OAUTH_SCOPES.SAVED_WRITE],
+    });
+
+    const opml = sampleOpml(["https://y.example.com/feed.xml"]);
+    const res = await POST(importRequest(opml, token));
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `POST reader/api/0/subscription/import` (OPML import) in the Google Reader compatibility API. Newsflash's FreshRSS/Google Reader backend calls this endpoint from its `import_opml` action (via the [greader_api](https://gitlab.com/news-flash/greader_api) client), POSTing the raw OPML as the request body and expecting an `OK: {count}` response. We previously returned 404 for this path, so importing OPML from within Newsflash failed. Fixes #1059.

## Changes

- **New service `src/server/services/imports.ts`** — extracts the existing tRPC OPML-import logic (parse → dedup feeds by URL merging tags → create the `opml_imports` record → queue the `process_opml_import` background job) into a reusable `importOpml(db, userId, opml)` function.
- **`subscriptions.import` tRPC mutation** now delegates to `importOpml` (behavior unchanged; still translates `OpmlParseError` → validation error).
- **New route `.../subscription/import/route.ts`** — authenticates with the reader scope, reads the **raw** request body (the greader_api client sends the OPML string as the body, matching FreshRSS reading `php://input`; it is *not* form-encoded), queues the import, and returns `OK: {count}` where count is the number of unique feeds queued.

The import runs asynchronously in the background job, mirroring the tRPC flow — the returned count reflects feeds queued, not yet subscribed. The `OK: {count}` form is what the greader_api client parses (it checks for the `OK: ` prefix); FreshRSS returns a bare `OK`.

## Testing

- New integration test `tests/integration/google-reader-subscription-import.test.ts` (6 cases): success + count, dedup, empty-OPML `OK: 0`, empty-body 400, malformed 400, missing-token 401.
- Existing `opml-import.test.ts` still passes (router refactor).
- `pnpm typecheck`, `pnpm lint`, and the full integration suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)