### PR TITLE
Add entry search UI (#565)

### DIFF
--- a/src/FRONTEND_STATE.md
+++ b/src/FRONTEND_STATE.md
@@ -68,6 +68,8 @@ restored this way; it reappears on the next navigation refresh.)
 
 `sortBy: "readChanged"` backs the `/recently-read` view (entries sorted by `read_changed_at` rather than publish time; defaults to `unreadOnly=false`). Its cache and the search (`query`) caches are **not** patched by SSE `new_entry` inserts: `insertEntryIntoListCaches` (`src/lib/cache/entry-cache.ts`) skips any list cache whose input has a `query` or a `sortBy` other than `"published"`, because their ordering (relevance rank / read-time) can't be derived from a new entry's fields. Those views instead refresh on navigation like any other list.
 
+`query` backs the entry search UI (#565): the `?q=` URL param (set by the search bar in `EntryPageLayout`, opened via the header toggle or `/`) flows through `parseViewPreferencesFromParams` → `buildEntriesListInput` → `useEntriesListInput`, so search results reuse the same `entries.list` infinite-query machinery scoped to the current view's filters, and `EntryListPage` prefetches them server-side for `?q=` deep links. While a `q` is present, the `unreadOnly` **default** flips to `false` (a search is usually for something already read; the toggle still works) and `sortOrder`/`direction` are canonicalized to `"newest"`/`"forward"` in the input (the backend ranks search results by relevance and ignores sort order — a lingering `?sort=` param must not fragment the cache key).
+
 ## Mutations
 
 ### Entry Mutations (`useEntryMutations`)

--- a/src/components/entries/EntryListContainer.tsx
+++ b/src/components/entries/EntryListContainer.tsx
@@ -232,6 +232,11 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
   // (cached entries from parent lists) inline instead of suspending. Resolved/
   // cached data skips this and renders the real list on first paint. Placeholder
   // rows are clickable since the fallback lives here with the list's handlers.
+  // Search results can't be approximated from cached lists (membership depends
+  // on the query), so a pending search shows a plain skeleton instead.
+  if (isLoading && entries.length === 0 && queryInput.query) {
+    return <EntryListSkeleton count={5} />;
+  }
   if (isLoading && entries.length === 0) {
     return (
       <EntryListFallback

--- a/src/components/entries/EntryListPage.tsx
+++ b/src/components/entries/EntryListPage.tsx
@@ -70,12 +70,13 @@ export async function EntryListPage({ pathname, searchParams, children }: EntryL
   const urlParams = new URLSearchParams();
   if (params.unreadOnly) urlParams.set("unreadOnly", String(params.unreadOnly));
   if (params.sort) urlParams.set("sort", String(params.sort));
-  const { unreadOnly, sortOrder } = parseViewPreferencesFromParams(urlParams, {
+  if (typeof params.q === "string") urlParams.set("q", params.q);
+  const { unreadOnly, sortOrder, searchQuery } = parseViewPreferencesFromParams(urlParams, {
     unreadOnly: defaults.unreadOnly,
   });
 
   // Build input using shared function to ensure cache key matches client
-  const input = buildEntriesListInput(filters, { unreadOnly, sortOrder });
+  const input = buildEntriesListInput(filters, { unreadOnly, sortOrder, searchQuery });
 
   // Prefetch the entry list and related data
   void trpc.entries.list.prefetchInfinite(input);

--- a/src/components/entries/EntryListPage.tsx
+++ b/src/components/entries/EntryListPage.tsx
@@ -70,7 +70,10 @@ export async function EntryListPage({ pathname, searchParams, children }: EntryL
   const urlParams = new URLSearchParams();
   if (params.unreadOnly) urlParams.set("unreadOnly", String(params.unreadOnly));
   if (params.sort) urlParams.set("sort", String(params.sort));
-  if (typeof params.q === "string") urlParams.set("q", params.q);
+  // A repeated ?q= arrives as an array; take the first occurrence to match
+  // the client's URLSearchParams.get("q") so the prefetch cache key agrees.
+  const qParam = Array.isArray(params.q) ? params.q[0] : params.q;
+  if (typeof qParam === "string") urlParams.set("q", qParam);
   const { unreadOnly, sortOrder, searchQuery } = parseViewPreferencesFromParams(urlParams, {
     unreadOnly: defaults.unreadOnly,
   });

--- a/src/components/entries/EntryPageLayout.tsx
+++ b/src/components/entries/EntryPageLayout.tsx
@@ -140,6 +140,13 @@ export function EntryPageLayout({
         <div className="mb-4 flex items-center justify-between sm:mb-6">
           {titleSlot}
           <div className="flex gap-2">
+            <StateToggleButton
+              icon={<SearchIcon className="h-5 w-5" />}
+              label="Search"
+              ariaLabel={showSearchBar ? "Close search bar" : "Search entries"}
+              isPressed={showSearchBar}
+              onToggle={handleSearchToggle}
+            />
             {/* While searching, hide the controls that don't apply to search
                 results: mark-all-read acts on the whole view (not just the
                 matches), and search results are relevance-ranked (sort order
@@ -155,13 +162,6 @@ export function EntryPageLayout({
               <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
             )}
             <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
-            <StateToggleButton
-              icon={<SearchIcon className="h-5 w-5" />}
-              label="Search"
-              ariaLabel={showSearchBar ? "Close search bar" : "Search entries"}
-              isPressed={showSearchBar}
-              onToggle={handleSearchToggle}
-            />
           </div>
         </div>
 

--- a/src/components/entries/EntryPageLayout.tsx
+++ b/src/components/entries/EntryPageLayout.tsx
@@ -10,13 +10,19 @@
 
 "use client";
 
-import { type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+import { useHotkeys } from "react-hotkeys-hook";
 import { type MarkAllReadOptions, useEntryMutations } from "@/lib/hooks/useEntryMutations";
 import { useUrlViewPreferences } from "@/lib/hooks/useUrlViewPreferences";
 import { useEntryUrlState } from "@/lib/hooks/useEntryUrlState";
+import { useKeyboardShortcutsContext } from "@/components/keyboard/KeyboardShortcutsProvider";
+import { SearchIcon } from "@/components/ui/icon-button";
+import { StateToggleButton } from "@/components/ui/state-toggle-button";
 import { UnreadToggle } from "./UnreadToggle";
 import { SortToggle } from "./SortToggle";
 import { MarkAllReadButton } from "./MarkAllReadButton";
+import { EntrySearchBar } from "./EntrySearchBar";
 
 /**
  * Loading skeleton for the page title.
@@ -61,10 +67,67 @@ export function EntryPageLayout({
   hideSortToggle = false,
 }: EntryPageLayoutProps) {
   // Use non-suspending hooks directly so buttons render immediately
-  const { showUnreadOnly, toggleShowUnreadOnly, sortOrder, toggleSortOrder } =
-    useUrlViewPreferences();
+  const {
+    showUnreadOnly,
+    toggleShowUnreadOnly,
+    sortOrder,
+    toggleSortOrder,
+    searchQuery,
+    setSearchQuery,
+  } = useUrlViewPreferences();
   const { markAllRead, isMarkAllReadPending } = useEntryMutations();
   const { openEntryId } = useEntryUrlState();
+  const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
+  const pathname = usePathname();
+
+  // The search bar stays out of the way until asked for: it renders only while
+  // explicitly opened (toggle button / `/` shortcut) or a search is active in
+  // the URL (?q=, e.g. a deep link).
+  const [searchOpen, setSearchOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const isSearching = searchQuery !== undefined;
+  const showSearchBar = searchOpen || isSearching;
+
+  // Navigating to a different view closes an empty search bar (an active
+  // search lives in the URL, so it never survives navigation anyway) —
+  // render-time state adjustment, not an effect.
+  const [prevPathname, setPrevPathname] = useState(pathname);
+  if (pathname !== prevPathname) {
+    setPrevPathname(pathname);
+    setSearchOpen(false);
+  }
+
+  const closeSearch = () => {
+    setSearchOpen(false);
+    setSearchQuery(null);
+  };
+
+  const handleSearchToggle = () => {
+    if (showSearchBar) {
+      closeSearch();
+    } else {
+      setSearchOpen(true);
+    }
+  };
+
+  // `/` focuses the search input (opening the bar if needed), matching the
+  // convention of other readers. enableOnFormTags stays false so typing "/"
+  // inside the input itself is unaffected.
+  useHotkeys(
+    "/",
+    (e) => {
+      e.preventDefault();
+      if (searchInputRef.current) {
+        searchInputRef.current.focus();
+      } else {
+        setSearchOpen(true);
+      }
+    },
+    // useKey matches the produced character (event.key) rather than the
+    // physical key code — "/" has no layout-independent code.
+    { enabled: keyboardShortcutsEnabled && !openEntryId, enableOnFormTags: false, useKey: true },
+    [keyboardShortcutsEnabled, openEntryId]
+  );
 
   return (
     <>
@@ -77,15 +140,41 @@ export function EntryPageLayout({
         <div className="mb-4 flex items-center justify-between sm:mb-6">
           {titleSlot}
           <div className="flex gap-2">
-            <MarkAllReadButton
-              contextDescription={markAllReadDescription}
-              isLoading={isMarkAllReadPending}
-              onConfirm={() => markAllRead(markAllReadOptions)}
-            />
-            {!hideSortToggle && <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />}
+            {/* While searching, hide the controls that don't apply to search
+                results: mark-all-read acts on the whole view (not just the
+                matches), and search results are relevance-ranked (sort order
+                is ignored by the backend). */}
+            {!isSearching && (
+              <MarkAllReadButton
+                contextDescription={markAllReadDescription}
+                isLoading={isMarkAllReadPending}
+                onConfirm={() => markAllRead(markAllReadOptions)}
+              />
+            )}
+            {!hideSortToggle && !isSearching && (
+              <SortToggle sortOrder={sortOrder} onToggle={toggleSortOrder} />
+            )}
             <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={toggleShowUnreadOnly} />
+            <StateToggleButton
+              icon={<SearchIcon className="h-5 w-5" />}
+              label="Search"
+              ariaLabel={showSearchBar ? "Close search bar" : "Search entries"}
+              isPressed={showSearchBar}
+              onToggle={handleSearchToggle}
+            />
           </div>
         </div>
+
+        {/* Search bar - hidden until opened or a search is active */}
+        {showSearchBar && (
+          <EntrySearchBar
+            query={searchQuery}
+            onSearch={setSearchQuery}
+            onClose={closeSearch}
+            inputRef={searchInputRef}
+            autoFocus={searchOpen}
+          />
+        )}
 
         {/* Entry list */}
         {entryListSlot}

--- a/src/components/entries/EntrySearchBar.tsx
+++ b/src/components/entries/EntrySearchBar.tsx
@@ -1,0 +1,90 @@
+/**
+ * EntrySearchBar Component
+ *
+ * Full-text search input for entry list pages. The bar is hidden behind the
+ * header search toggle (see EntryPageLayout) so it stays out of the way until
+ * asked for. The draft text is local state; a search is committed (written to
+ * the `?q=` URL param, which drives the entries.list query) only on submit.
+ */
+
+"use client";
+
+import { useState, type KeyboardEvent, type RefObject } from "react";
+import { CloseIcon, SearchIcon } from "@/components/ui/icon-button";
+
+interface EntrySearchBarProps {
+  /** The committed search query from the URL (undefined when not searching). */
+  query: string | undefined;
+
+  /** Commit a search (empty/null clears the active search). */
+  onSearch: (query: string | null) => void;
+
+  /** Close the bar, clearing any active search. */
+  onClose: () => void;
+
+  /**
+   * Ref to the input element so the parent can focus it (search toggle
+   * button, `/` keyboard shortcut).
+   */
+  inputRef: RefObject<HTMLInputElement | null>;
+
+  /** Focus the input when the bar mounts (user-initiated open, not deep link). */
+  autoFocus?: boolean;
+}
+
+export function EntrySearchBar({
+  query,
+  onSearch,
+  onClose,
+  inputRef,
+  autoFocus = false,
+}: EntrySearchBarProps) {
+  // Draft text being typed; committed to the URL only on submit.
+  const [text, setText] = useState(query ?? "");
+
+  // Reset the draft when the committed query changes underneath us
+  // (back/forward navigation, external URL change) — render-time state
+  // adjustment, not an effect (react-hooks/set-state-in-effect).
+  const [prevQuery, setPrevQuery] = useState(query);
+  if (query !== prevQuery) {
+    setPrevQuery(query);
+    setText(query ?? "");
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      onSearch(text);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  return (
+    <div className="relative mb-4 sm:mb-6" role="search">
+      <SearchIcon className="text-faint pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+      <input
+        ref={inputRef}
+        type="search"
+        enterKeyHint="search"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Search entries… (press Enter)"
+        aria-label="Search entries"
+        autoFocus={autoFocus}
+        className="ui-text-sm bg-surface text-body placeholder:text-faint border-edge-input focus:border-focus focus:ring-focus block w-full rounded-md border py-2 pr-10 pl-9 focus:ring-2 focus:ring-offset-2 focus:outline-none [&::-webkit-search-cancel-button]:hidden"
+      />
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close search"
+        title="Close search"
+        className="text-muted hover:text-body absolute top-1/2 right-1 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-md transition-colors"
+      >
+        <CloseIcon className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/entries/UnifiedEntriesContent.tsx
+++ b/src/components/entries/UnifiedEntriesContent.tsx
@@ -265,7 +265,7 @@ function EntryListTitle({ routeInfo }: { routeInfo: RouteInfo }) {
 function UnifiedEntriesContentInner() {
   const routeInfo = useRouteInfo();
   const queryClient = useQueryClient();
-  const { showUnreadOnly } = useUrlViewPreferences();
+  const { showUnreadOnly, searchQuery } = useUrlViewPreferences();
   const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
 
   // Get query input based on current URL - shared with EntryListContainer
@@ -432,13 +432,14 @@ function UnifiedEntriesContentInner() {
   ) : null;
 
   // Entry list - renders its own inline loading fallback (no Suspense)
-  const entryListSlot = (
-    <EntryListContainer
-      emptyMessage={
-        showUnreadOnly ? emptyMessages.emptyMessageUnread : emptyMessages.emptyMessageAll
-      }
-    />
-  );
+  const emptyMessage = searchQuery
+    ? showUnreadOnly
+      ? `No unread entries matching "${searchQuery}". Toggle to search read items too.`
+      : `No entries matching "${searchQuery}".`
+    : showUnreadOnly
+      ? emptyMessages.emptyMessageUnread
+      : emptyMessages.emptyMessageAll;
+  const entryListSlot = <EntryListContainer emptyMessage={emptyMessage} />;
 
   return (
     <EntryPageLayout

--- a/src/components/keyboard/KeyboardShortcutsModal.tsx
+++ b/src/components/keyboard/KeyboardShortcutsModal.tsx
@@ -52,6 +52,7 @@ const SHORTCUT_SECTIONS: ShortcutSection[] = [
       { keys: ["u"], description: "Toggle show/hide read items" },
       { keys: ["v"], description: "Open original URL in new tab" },
       { keys: ["r"], description: "Refresh current view" },
+      { keys: ["/"], description: "Search entries" },
     ],
   },
   {

--- a/src/components/ui/icon-button.tsx
+++ b/src/components/ui/icon-button.tsx
@@ -85,6 +85,22 @@ export function CloseIcon({ className = "h-4 w-4" }: IconProps) {
 }
 
 /**
+ * Search/magnifying-glass icon
+ */
+export function SearchIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+      />
+    </svg>
+  );
+}
+
+/**
  * Edit/pencil icon
  */
 export function EditIcon({ className = "h-3.5 w-3.5" }: IconProps) {

--- a/src/lib/hooks/useEntriesListInput.ts
+++ b/src/lib/hooks/useEntriesListInput.ts
@@ -27,10 +27,10 @@ import {
  */
 export function useEntriesListInput(): EntriesListInput {
   const pathname = usePathname();
-  const { showUnreadOnly, sortOrder } = useUrlViewPreferences();
+  const { showUnreadOnly, sortOrder, searchQuery } = useUrlViewPreferences();
 
   return useMemo(() => {
     const filters = getFiltersFromPathname(pathname);
-    return buildEntriesListInput(filters, { unreadOnly: showUnreadOnly, sortOrder });
-  }, [pathname, showUnreadOnly, sortOrder]);
+    return buildEntriesListInput(filters, { unreadOnly: showUnreadOnly, sortOrder, searchQuery });
+  }, [pathname, showUnreadOnly, sortOrder, searchQuery]);
 }

--- a/src/lib/hooks/useUrlViewPreferences.ts
+++ b/src/lib/hooks/useUrlViewPreferences.ts
@@ -15,7 +15,7 @@
 
 import { useCallback, useMemo } from "react";
 import { useSearchParams, usePathname } from "next/navigation";
-import { clientReplace } from "@/lib/navigation";
+import { clientPush, clientReplace } from "@/lib/navigation";
 import { parseViewPreferencesFromParams } from "./viewPreferences";
 import { getDefaultViewPreferences } from "@/lib/queries/entries-list-input";
 
@@ -42,6 +42,16 @@ export interface UseUrlViewPreferencesResult {
    * Toggle the sortOrder preference (updates URL).
    */
   toggleSortOrder: () => void;
+
+  /**
+   * Active full-text search query (`?q=` URL param); undefined when not searching.
+   */
+  searchQuery: string | undefined;
+
+  /**
+   * Set or clear the search query (updates URL). Pass null/empty to clear.
+   */
+  setSearchQuery: (query: string | null) => void;
 }
 
 /**
@@ -67,13 +77,18 @@ export interface UseUrlViewPreferencesResult {
 export function useUrlViewPreferences(): UseUrlViewPreferencesResult {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const defaultUnreadOnly = getDefaultViewPreferences(pathname).unreadOnly;
+  const routeDefaultUnreadOnly = getDefaultViewPreferences(pathname).unreadOnly;
 
   // Get current values from URL
-  const { unreadOnly, sortOrder } = useMemo(
-    () => parseViewPreferencesFromParams(searchParams, { unreadOnly: defaultUnreadOnly }),
-    [searchParams, defaultUnreadOnly]
+  const { unreadOnly, sortOrder, searchQuery } = useMemo(
+    () => parseViewPreferencesFromParams(searchParams, { unreadOnly: routeDefaultUnreadOnly }),
+    [searchParams, routeDefaultUnreadOnly]
   );
+
+  // While searching, the effective unreadOnly default flips to false (see
+  // parseViewPreferencesFromParams) — use the same default when deciding
+  // whether the param can be dropped from the URL.
+  const defaultUnreadOnly = searchQuery ? false : routeDefaultUnreadOnly;
 
   // Helper to update URL with new params
   const updateUrl = useCallback(
@@ -115,13 +130,38 @@ export function useUrlViewPreferences(): UseUrlViewPreferencesResult {
     updateUrl({ sort: sortOrder === "newest" ? "oldest" : "newest" });
   }, [updateUrl, sortOrder]);
 
+  const setSearchQuery = useCallback(
+    (query: string | null) => {
+      const trimmed = query?.trim() ?? "";
+      const params = new URLSearchParams(searchParams?.toString() ?? "");
+      if (trimmed) {
+        params.set("q", trimmed);
+      } else {
+        params.delete("q");
+      }
+      const queryString = params.toString();
+      const url = queryString ? `${pathname}?${queryString}` : pathname;
+      // Entering a search pushes a history entry so Back exits the search;
+      // refining or clearing one replaces, so each keystroke-level tweak
+      // doesn't pile up in history.
+      if (trimmed && !searchQuery) {
+        clientPush(url);
+      } else {
+        clientReplace(url);
+      }
+    },
+    [pathname, searchParams, searchQuery]
+  );
+
   return useMemo(
     () => ({
       showUnreadOnly: unreadOnly,
       toggleShowUnreadOnly,
       sortOrder,
       toggleSortOrder,
+      searchQuery,
+      setSearchQuery,
     }),
-    [unreadOnly, toggleShowUnreadOnly, sortOrder, toggleSortOrder]
+    [unreadOnly, toggleShowUnreadOnly, sortOrder, toggleSortOrder, searchQuery, setSearchQuery]
   );
 }

--- a/src/lib/hooks/viewPreferences.ts
+++ b/src/lib/hooks/viewPreferences.ts
@@ -54,10 +54,19 @@ export function parseViewPreferencesFromParams(
 ): {
   unreadOnly: boolean;
   sortOrder: "newest" | "oldest";
+  searchQuery: string | undefined;
 } {
-  // Parse unreadOnly - explicit "false" means show all, anything else uses default
+  // Parse the full-text search query - empty/whitespace means "not searching"
+  const searchQuery = searchParams?.get("q")?.trim() || undefined;
+
+  // Parse unreadOnly - explicit "false" means show all, anything else uses default.
+  // While searching, the default flips to showing everything: a search is
+  // usually for something already read, and silently searching only unread
+  // entries would hide the results the user is looking for.
   const unreadOnlyParam = searchParams?.get("unreadOnly");
-  const defaultUnreadOnly = defaults?.unreadOnly ?? DEFAULT_PREFERENCES.showUnreadOnly;
+  const defaultUnreadOnly = searchQuery
+    ? false
+    : (defaults?.unreadOnly ?? DEFAULT_PREFERENCES.showUnreadOnly);
   const unreadOnly =
     unreadOnlyParam === "false" ? false : unreadOnlyParam === "true" ? true : defaultUnreadOnly;
 
@@ -70,5 +79,5 @@ export function parseViewPreferencesFromParams(
         ? "newest"
         : DEFAULT_PREFERENCES.sortOrder;
 
-  return { unreadOnly, sortOrder };
+  return { unreadOnly, sortOrder, searchQuery };
 }

--- a/src/lib/queries/entries-list-input.ts
+++ b/src/lib/queries/entries-list-input.ts
@@ -21,6 +21,7 @@ export type EntryType = "web" | "email" | "saved";
  * All optional fields should be explicitly undefined (not omitted) for cache key matching.
  */
 export interface EntriesListInput {
+  query: string | undefined;
   subscriptionId: string | undefined;
   tagId: string | undefined;
   uncategorized: boolean | undefined;
@@ -56,6 +57,8 @@ export interface EntriesListFilters {
 export interface EntriesListViewPreferences {
   unreadOnly: boolean;
   sortOrder: "newest" | "oldest";
+  /** Full-text search query (`?q=` URL param); undefined when not searching. */
+  searchQuery?: string;
 }
 
 /**
@@ -77,21 +80,28 @@ export function buildEntriesListInput(
   preferences: EntriesListViewPreferences,
   limit: number = 10
 ): EntriesListInput {
+  // Normalize the search query: empty/whitespace means "not searching".
+  const query = preferences.searchQuery?.trim() || undefined;
+  // The backend ignores sortOrder when a query is provided (results are ranked
+  // by relevance), so canonicalize it while searching — a lingering ?sort=
+  // param must not fragment the cache key for the same search.
+  const sortOrder = query ? "newest" : preferences.sortOrder;
   // Construct the input with explicit property order and explicit undefined values.
   // This ensures the object structure is identical regardless of where it's constructed.
   // NOTE: direction is required for tRPC infinite query cache key matching.
   // Direction depends on sort order: "newest" fetches forward, "oldest" fetches backward.
   return {
+    query,
     subscriptionId: filters.subscriptionId,
     tagId: filters.tagId,
     uncategorized: filters.uncategorized,
     unreadOnly: preferences.unreadOnly,
     starredOnly: filters.starredOnly,
-    sortOrder: preferences.sortOrder,
+    sortOrder,
     sortBy: filters.sortBy,
     type: filters.type,
     limit,
-    direction: preferences.sortOrder === "newest" ? "forward" : "backward",
+    direction: sortOrder === "newest" ? "forward" : "backward",
   };
 }
 

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * E2E tests for the entry search UI (#565).
+ *
+ * The search bar lives behind the header toggle (or `/`): submitting writes
+ * the `?q=` URL param, which scopes the entries.list query to the current
+ * view's filters and flips the unread-only default to "show all" (a search is
+ * usually for something already read).
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  getDb,
+  createConfirmedUser,
+  createSubscribedFeed,
+  createUnreadEntry,
+  markEntryRead,
+  loginAs,
+  closeTestConnections,
+} from "./helpers";
+
+test.afterAll(async () => {
+  await closeTestConnections();
+});
+
+test("searches entries from the header toggle and clears back to the list", async ({
+  page,
+  baseURL,
+}) => {
+  const db = getDb();
+  const user = await createConfirmedUser(db);
+  const feed = await createSubscribedFeed(db, user.id);
+
+  await createUnreadEntry(db, {
+    feedId: feed.feedId,
+    userId: user.id,
+    title: "Quantum computing breakthrough",
+  });
+  await createUnreadEntry(db, {
+    feedId: feed.feedId,
+    userId: user.id,
+    title: "Gardening tips for spring",
+  });
+  // A read entry matching the query: search must find it even though the view
+  // was showing unread-only (the default flips to "show all" while searching).
+  const readEntry = await createUnreadEntry(db, {
+    feedId: feed.feedId,
+    userId: user.id,
+    title: "Quantum error correction explained",
+  });
+  await markEntryRead(db, user.id, readEntry.id);
+
+  await loginAs(page.context(), user, baseURL!);
+  await page.goto("/all");
+  await expect(page.locator('[aria-label*="article: Gardening tips"]')).toBeVisible();
+  // Default view is unread-only, so the read entry is hidden.
+  await expect(page.locator('[aria-label*="article: Quantum error"]')).toBeHidden();
+
+  // Open the search bar and search.
+  await page.getByRole("button", { name: "Search entries" }).click();
+  const input = page.getByRole("searchbox", { name: "Search entries" });
+  await expect(input).toBeFocused();
+  await input.fill("quantum");
+  await input.press("Enter");
+
+  await expect(page).toHaveURL(/[?&]q=quantum/);
+  // Both quantum entries match — including the read one — and the
+  // non-matching entry is gone.
+  await expect(page.locator('[aria-label*="article: Quantum computing"]')).toBeVisible();
+  await expect(page.locator('[aria-label*="article: Quantum error"]')).toBeVisible();
+  await expect(page.locator('[aria-label*="article: Gardening tips"]')).toBeHidden();
+
+  // Closing the search (the X inside the bar) restores the unfiltered
+  // (unread-only) view.
+  await page.getByRole("search").getByRole("button", { name: "Close search" }).click();
+  await expect(page).not.toHaveURL(/[?&]q=/);
+  await expect(page.locator('[aria-label*="article: Gardening tips"]')).toBeVisible();
+  await expect(page.locator('[aria-label*="article: Quantum error"]')).toBeHidden();
+});
+
+test("scopes search to the current view and supports the / shortcut", async ({ page, baseURL }) => {
+  const db = getDb();
+  const user = await createConfirmedUser(db);
+  const feedA = await createSubscribedFeed(db, user.id);
+  const feedB = await createSubscribedFeed(db, user.id);
+
+  await createUnreadEntry(db, {
+    feedId: feedA.feedId,
+    userId: user.id,
+    title: "Quantum news from feed A",
+  });
+  await createUnreadEntry(db, {
+    feedId: feedB.feedId,
+    userId: user.id,
+    title: "Quantum news from feed B",
+  });
+
+  await loginAs(page.context(), user, baseURL!);
+  await page.goto(`/subscription/${feedA.subscriptionId}`);
+  await expect(page.locator('[aria-label*="article: Quantum news from feed A"]')).toBeVisible();
+
+  // `/` opens and focuses the search bar.
+  await page.keyboard.press("/");
+  const input = page.getByRole("searchbox", { name: "Search entries" });
+  await expect(input).toBeFocused();
+  await input.fill("quantum");
+  await input.press("Enter");
+
+  // Only the current subscription's match shows up.
+  await expect(page.locator('[aria-label*="article: Quantum news from feed A"]')).toBeVisible();
+  await expect(page.locator('[aria-label*="article: Quantum news from feed B"]')).toBeHidden();
+
+  // Escape closes the search and restores the view.
+  await input.press("Escape");
+  await expect(page).not.toHaveURL(/[?&]q=/);
+  await expect(page.locator('[aria-label*="article: Quantum news from feed A"]')).toBeVisible();
+});
+
+test("loads search results directly from a ?q= deep link", async ({ page, baseURL }) => {
+  const db = getDb();
+  const user = await createConfirmedUser(db);
+  const feed = await createSubscribedFeed(db, user.id);
+
+  await createUnreadEntry(db, {
+    feedId: feed.feedId,
+    userId: user.id,
+    title: "Quantum computing breakthrough",
+  });
+  await createUnreadEntry(db, {
+    feedId: feed.feedId,
+    userId: user.id,
+    title: "Gardening tips for spring",
+  });
+
+  await loginAs(page.context(), user, baseURL!);
+  await page.goto("/all?q=quantum");
+
+  // The bar shows the active query and the list is filtered.
+  await expect(page.getByRole("searchbox", { name: "Search entries" })).toHaveValue("quantum");
+  await expect(page.locator('[aria-label*="article: Quantum computing"]')).toBeVisible();
+  await expect(page.locator('[aria-label*="article: Gardening tips"]')).toBeHidden();
+});

--- a/tests/unit/frontend/entries-list-input.test.ts
+++ b/tests/unit/frontend/entries-list-input.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for the shared entries.list input builder and URL view-preference
+ * parsing, focused on the full-text search (`?q=`) behavior (#565).
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildEntriesListInput } from "@/lib/queries/entries-list-input";
+import { parseViewPreferencesFromParams } from "@/lib/hooks/viewPreferences";
+
+describe("parseViewPreferencesFromParams", () => {
+  it("returns no searchQuery when q is absent", () => {
+    const result = parseViewPreferencesFromParams(new URLSearchParams());
+    expect(result.searchQuery).toBeUndefined();
+    expect(result.unreadOnly).toBe(true);
+    expect(result.sortOrder).toBe("newest");
+  });
+
+  it("parses and trims the q param", () => {
+    const result = parseViewPreferencesFromParams(new URLSearchParams("q=%20hello%20world%20"));
+    expect(result.searchQuery).toBe("hello world");
+  });
+
+  it("treats a whitespace-only q as not searching", () => {
+    const result = parseViewPreferencesFromParams(new URLSearchParams("q=%20%20"));
+    expect(result.searchQuery).toBeUndefined();
+    expect(result.unreadOnly).toBe(true);
+  });
+
+  it("defaults unreadOnly to false while searching", () => {
+    const result = parseViewPreferencesFromParams(new URLSearchParams("q=hello"));
+    expect(result.unreadOnly).toBe(false);
+  });
+
+  it("keeps an explicit unreadOnly=true while searching", () => {
+    const result = parseViewPreferencesFromParams(new URLSearchParams("q=hello&unreadOnly=true"));
+    expect(result.unreadOnly).toBe(true);
+  });
+
+  it("ignores the route default for unreadOnly while searching", () => {
+    const result = parseViewPreferencesFromParams(new URLSearchParams("q=hello"), {
+      unreadOnly: true,
+    });
+    expect(result.unreadOnly).toBe(false);
+  });
+});
+
+describe("buildEntriesListInput", () => {
+  it("includes the search query in the input", () => {
+    const input = buildEntriesListInput(
+      { subscriptionId: "sub-1" },
+      { unreadOnly: false, sortOrder: "newest", searchQuery: "hello" }
+    );
+    expect(input.query).toBe("hello");
+    expect(input.subscriptionId).toBe("sub-1");
+  });
+
+  it("normalizes an empty or whitespace-only query to undefined", () => {
+    for (const searchQuery of [undefined, "", "   "]) {
+      const input = buildEntriesListInput(
+        {},
+        { unreadOnly: true, sortOrder: "newest", searchQuery }
+      );
+      expect(input.query).toBeUndefined();
+    }
+  });
+
+  it("canonicalizes sortOrder and direction while searching", () => {
+    const input = buildEntriesListInput(
+      {},
+      { unreadOnly: false, sortOrder: "oldest", searchQuery: "hello" }
+    );
+    expect(input.sortOrder).toBe("newest");
+    expect(input.direction).toBe("forward");
+  });
+
+  it("respects sortOrder when not searching", () => {
+    const input = buildEntriesListInput({}, { unreadOnly: true, sortOrder: "oldest" });
+    expect(input.sortOrder).toBe("oldest");
+    expect(input.direction).toBe("backward");
+  });
+});


### PR DESCRIPTION
Closes #565.

Exposes the existing `entries.list` full-text search (previously MCP-only) in the web UI. Per the issue, the design goal was to add search without letting it get in the way of the other list controls — so it stays collapsed behind a single header toggle until asked for.

## How it works

- A **Search toggle** in the entry-list header (all list views) expands a search bar; submitting (Enter) writes a `?q=` URL param, so searches are shareable/bookmarkable and Back exits the search. Escape or the ✕ clears and closes.
- **`/`** opens and focuses the search bar (added to the shortcuts modal). The hotkey uses `useKey: true` since `/` has no layout-independent key code.
- Search is **scoped to the current view** — it composes with the subscription/tag/starred/saved filters through the same `entries.list` infinite-query machinery, and `EntryListPage` prefetches results server-side for `?q=` deep links.
- While searching:
  - the **unreadOnly default flips to false** (a search is usually for something already read; the unread toggle still works to narrow),
  - `sortOrder`/`direction` are **canonicalized** in the query input (the backend ranks search results by relevance and ignores sort order — a lingering `?sort=` param must not fragment the cache key),
  - **Mark All Read and the sort toggle are hidden** (mark-all-read acts on the whole view, not the matches; sort doesn't apply).
- A pending search renders a plain skeleton instead of the cache-reading fallback (cached parent-list entries can't approximate search membership).
- SSE `new_entry` inserts already skip `query` caches (`insertEntryIntoListCaches`), so no cache-consistency changes were needed; search views refresh on navigation like Recently Read. `FRONTEND_STATE.md` updated.

## Screenshots

| Default (search collapsed) | Searching (light) | Searching (dark) |
| --- | --- | --- |
| ![default](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/entry-search-565/search-1-default-light.png) | ![light](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/entry-search-565/search-2-results-light.png) | ![dark](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/entry-search-565/search-3-results-dark.png) |

Note the searching shots: the read "history of quantum mechanics" entry appears (unread-only default flipped), results are relevance-ranked, and Mark All Read / sort are hidden.

## Testing

- `tests/unit/frontend/entries-list-input.test.ts` — `?q=` parsing/trimming, unread-default flip, sort canonicalization, empty-query normalization.
- `tests/e2e/search.spec.ts` — header-toggle flow incl. finding a read entry and clearing back to the list, per-subscription scoping + `/` shortcut + Escape, and `?q=` deep links.
- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (2377 passed), full `pnpm test:e2e:local` (45 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)