### PR TITLE
Share target: open Subscribe (pre-filled) for shared feed URLs

### DIFF
--- a/src/app/save/page.tsx
+++ b/src/app/save/page.tsx
@@ -44,6 +44,15 @@ function SaveContent() {
     onSuccess: (data) => {
       setArticleTitle(data.article.title);
     },
+    onError: (error) => {
+      // The shared URL is actually a feed, not an article — send the user to the
+      // Subscribe page pre-filled with it instead of failing the save. The
+      // server signals this via the machine-readable `URL_IS_FEED` message (tRPC
+      // doesn't ship the error `cause` to the client).
+      if (error.message === "URL_IS_FEED" && urlToSave) {
+        window.location.replace(`/subscribe?url=${encodeURIComponent(urlToSave)}&shared=true`);
+      }
+    },
   });
 
   const uploadFileMutation = trpc.saved.uploadFile.useMutation({
@@ -197,6 +206,10 @@ function SaveContent() {
     requestGoogleDocsAccessMutation.mutate({});
   };
 
+  // The shared URL turned out to be a feed; we're redirecting to /subscribe.
+  // Keep showing a spinner rather than flashing the error card.
+  const isFeedRedirect = activeMutation.error?.message === "URL_IS_FEED";
+
   // Check if error is an auth error (session expired, revoked, etc.)
   const isAuthError = activeMutation.error?.data?.code === "UNAUTHORIZED";
 
@@ -250,14 +263,18 @@ function SaveContent() {
         <div className="text-center">
           <h1 className="ui-text-lg text-body font-semibold">Save to Lion Reader</h1>
 
-          {/* Saving State (includes idle and pending) */}
-          {(activeMutation.isIdle || activeMutation.isPending) && (
+          {/* Saving State (includes idle, pending, and the feed→subscribe redirect) */}
+          {(activeMutation.isIdle || activeMutation.isPending || isFeedRedirect) && (
             <div className="mt-6">
               <div className="flex justify-center">
                 <SpinnerIcon className="text-muted h-8 w-8" />
               </div>
               <p className="ui-text-sm text-muted mt-3">
-                {shareType === "file" ? "Uploading file..." : "Saving article..."}
+                {isFeedRedirect
+                  ? "This is a feed — opening Subscribe..."
+                  : shareType === "file"
+                    ? "Uploading file..."
+                    : "Saving article..."}
               </p>
               {urlToSave && <p className="ui-text-xs text-muted mt-2 truncate">{urlToSave}</p>}
             </div>
@@ -281,7 +298,7 @@ function SaveContent() {
           )}
 
           {/* Error State */}
-          {activeMutation.isError && (
+          {activeMutation.isError && !isFeedRedirect && (
             <div className="mt-6">
               {/* Authentication Required */}
               {isAuthError ? (

--- a/src/app/save/page.tsx
+++ b/src/app/save/page.tsx
@@ -50,7 +50,7 @@ function SaveContent() {
       // server signals this via the machine-readable `URL_IS_FEED` message (tRPC
       // doesn't ship the error `cause` to the client).
       if (error.message === "URL_IS_FEED" && urlToSave) {
-        window.location.replace(`/subscribe?url=${encodeURIComponent(urlToSave)}&shared=true`);
+        window.location.replace(`/subscribe?url=${encodeURIComponent(urlToSave)}`);
       }
     },
   });

--- a/src/components/subscribe/SubscribeContent.tsx
+++ b/src/components/subscribe/SubscribeContent.tsx
@@ -8,7 +8,8 @@
 
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc/client";
@@ -44,7 +45,12 @@ type Step = "input" | "discovery" | "preview";
 
 export function SubscribeContent() {
   const queryClient = useQueryClient();
-  const [url, setUrl] = useState("");
+  // A shared URL (e.g. from the PWA share target, which routes feeds here as
+  // /subscribe?url=...) pre-fills the field. useSearchParams is consistent
+  // across SSR and hydration, so initializing state from it avoids a mismatch.
+  const searchParams = useSearchParams();
+  const sharedUrl = searchParams.get("url");
+  const [url, setUrl] = useState(sharedUrl ?? "");
   const [urlError, setUrlError] = useState<string | undefined>();
   const [step, setStep] = useState<Step>("input");
   const [discoveredFeeds, setDiscoveredFeeds] = useState<DiscoveredFeed[]>([]);
@@ -162,6 +168,19 @@ export function SubscribeContent() {
     }
     // If preview failed for other reasons (network error, etc.), the error will be shown via previewQuery.error
   };
+
+  // When the field was pre-filled from a shared URL, auto-run the preview once
+  // so the user lands straight on the feed preview / discovery step. The ref
+  // guard keeps this from firing again as they edit the field afterwards.
+  const autoPreviewedRef = useRef(false);
+  useEffect(() => {
+    if (!autoPreviewedRef.current && sharedUrl && step === "input") {
+      autoPreviewedRef.current = true;
+      void handlePreview();
+    }
+    // handlePreview is intentionally excluded — this runs once, guarded by the ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sharedUrl, step]);
 
   const handleSelectFeed = async (feedUrl: string) => {
     setSelectedFeedUrl(feedUrl);

--- a/src/server/http/fetch.ts
+++ b/src/server/http/fetch.ts
@@ -45,6 +45,22 @@ export class HttpFetchError extends Error {
 }
 
 /**
+ * Error thrown when a page fetch returns a content type we don't treat as an
+ * article (e.g. a feed served as `application/rss+xml`). Carries the offending
+ * content type so callers can decide whether the URL is actually a feed and
+ * route the user to Subscribe instead of failing the save.
+ */
+export class InvalidContentTypeError extends Error {
+  constructor(
+    public readonly contentType: string,
+    public readonly url: string
+  ) {
+    super(`Invalid content type: ${contentType}`);
+    this.name = "InvalidContentTypeError";
+  }
+}
+
+/**
  * Error thrown when a response body exceeds the maximum allowed size.
  * Checked during streaming to avoid loading the full body into memory.
  */
@@ -325,7 +341,7 @@ export async function fetchHtmlPage(
     !contentType.includes("text/html") &&
     !contentType.includes("application/xhtml+xml")
   ) {
-    throw new Error(`Invalid content type: ${contentType}`);
+    throw new InvalidContentTypeError(contentType, url);
   }
 
   const content = await readResponseWithSizeLimit(response, maxSizeBytes, url);

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -13,7 +13,14 @@ import type { db as dbType } from "@/server/db";
 import { entries, userEntries } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
 import { normalizeUrl } from "@/lib/url";
-import { fetchHtmlPage, HttpFetchError, ContentTooLargeError } from "@/server/http/fetch";
+import {
+  fetchHtmlPage,
+  fetchUrl as fetchRawUrl,
+  HttpFetchError,
+  ContentTooLargeError,
+  InvalidContentTypeError,
+} from "@/server/http/fetch";
+import { detectFeedType } from "@/server/feed/parser";
 import { processMarkdown } from "@/server/markdown";
 import { usageLimitsConfig } from "@/server/config/env";
 import { absolutizeUrls } from "@/server/feed/content-cleaner";
@@ -508,6 +515,39 @@ async function fetchPrivateGoogleDocWithAuth(
   }
 }
 
+/**
+ * Content types that are unambiguously a feed. When a page fetch is rejected
+ * with one of these, we can route to Subscribe without a second fetch.
+ */
+const UNAMBIGUOUS_FEED_CONTENT_TYPES = [
+  "application/rss+xml",
+  "application/atom+xml",
+  "application/feed+json",
+];
+
+/**
+ * Decide whether a URL that failed a page fetch on its content type is actually
+ * a feed (so the caller can route the user to Subscribe instead of failing the
+ * save). Unambiguous feed content types short-circuit; ambiguous XML/JSON
+ * (`text/xml`, `application/xml`, `application/json`, which also covers sitemaps
+ * and plain APIs) is confirmed with a single feed-sniffing fetch. Only reached
+ * on the rare feed-share path, so the common article save stays a single fetch.
+ */
+async function urlIsDirectFeed(url: string, contentType: string): Promise<boolean> {
+  const normalized = contentType.toLowerCase();
+  if (UNAMBIGUOUS_FEED_CONTENT_TYPES.some((type) => normalized.includes(type))) {
+    return true;
+  }
+  try {
+    const { text } = await fetchRawUrl(url);
+    return detectFeedType(text) !== "unknown";
+  } catch {
+    // If we can't fetch/parse it, treat it as not-a-feed and let the original
+    // fetch error surface.
+    return false;
+  }
+}
+
 /** True for errors created by errors.contentTooLarge. */
 function isContentTooLargeError(error: unknown): boolean {
   return (
@@ -699,6 +739,14 @@ async function acquireArticleContent(
       }
       if (error.isBlocked()) {
         throw errors.siteBlocked(fetchUrl, error.status);
+      }
+    }
+    // A feed shared to the PWA lands here (feeds are served as XML/JSON, which
+    // the page fetch rejects). If it's really a feed, signal the caller to route
+    // to Subscribe instead of failing the save.
+    if (error instanceof InvalidContentTypeError) {
+      if (await urlIsDirectFeed(fetchUrl, error.contentType)) {
+        throw errors.urlIsFeed(fetchUrl);
       }
     }
     throw errors.savedArticleFetchError(

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -20,7 +20,7 @@ import {
   ContentTooLargeError,
   InvalidContentTypeError,
 } from "@/server/http/fetch";
-import { detectFeedType } from "@/server/feed/parser";
+import { parseFeed } from "@/server/feed/parser";
 import { processMarkdown } from "@/server/markdown";
 import { usageLimitsConfig } from "@/server/config/env";
 import { absolutizeUrls } from "@/server/feed/content-cleaner";
@@ -529,9 +529,11 @@ const UNAMBIGUOUS_FEED_CONTENT_TYPES = [
  * Decide whether a URL that failed a page fetch on its content type is actually
  * a feed (so the caller can route the user to Subscribe instead of failing the
  * save). Unambiguous feed content types short-circuit; ambiguous XML/JSON
- * (`text/xml`, `application/xml`, `application/json`, which also covers sitemaps
- * and plain APIs) is confirmed with a single feed-sniffing fetch. Only reached
- * on the rare feed-share path, so the common article save stays a single fetch.
+ * (`text/xml`, `application/xml`, `application/json`) is confirmed by fetching
+ * and actually parsing it as a feed — so a sitemap (`<urlset>`) or a plain JSON
+ * API (no JSON Feed `version`/`items`) is correctly rejected rather than
+ * misrouted to Subscribe. Only reached on the rare feed-rejection path, so the
+ * common article save stays a single fetch.
  */
 async function urlIsDirectFeed(url: string, contentType: string): Promise<boolean> {
   const normalized = contentType.toLowerCase();
@@ -540,9 +542,12 @@ async function urlIsDirectFeed(url: string, contentType: string): Promise<boolea
   }
   try {
     const { text } = await fetchRawUrl(url);
-    return detectFeedType(text) !== "unknown";
+    // parseFeed throws for unknown formats and for structurally-invalid feeds
+    // (a sitemap, a plain JSON object, etc.) — exactly what we want to exclude.
+    parseFeed(text);
+    return true;
   } catch {
-    // If we can't fetch/parse it, treat it as not-a-feed and let the original
+    // Not fetchable or not a real feed: treat as not-a-feed and let the original
     // fetch error surface.
     return false;
   }

--- a/src/server/trpc/errors.ts
+++ b/src/server/trpc/errors.ts
@@ -37,6 +37,7 @@ const ErrorCodes = {
 
   // Validation errors (400)
   VALIDATION_ERROR: "VALIDATION_ERROR",
+  URL_IS_FEED: "URL_IS_FEED",
   INVALID_EMAIL: "INVALID_EMAIL",
   WEAK_PASSWORD: "WEAK_PASSWORD",
   EMAIL_ALREADY_EXISTS: "EMAIL_ALREADY_EXISTS",
@@ -109,6 +110,7 @@ const errorCodeToTRPCCode: Record<
   BLOCKED_SENDER_NOT_FOUND: "NOT_FOUND",
   TOKEN_NOT_FOUND: "NOT_FOUND",
   VALIDATION_ERROR: "BAD_REQUEST",
+  URL_IS_FEED: "BAD_REQUEST",
   INVALID_EMAIL: "BAD_REQUEST",
   WEAK_PASSWORD: "BAD_REQUEST",
   EMAIL_ALREADY_EXISTS: "BAD_REQUEST",
@@ -214,6 +216,15 @@ export const errors = {
 
   validation: (message: string, details?: Record<string, unknown>) =>
     createError(ErrorCodes.VALIDATION_ERROR, message, details),
+
+  /**
+   * The URL a caller tried to save is actually a feed, not an article. The
+   * message is the machine-readable token `URL_IS_FEED` (tRPC does not ship the
+   * `cause` to clients, so the web share/save UI matches on the message — same
+   * pattern as the NEEDS_GOOGLE_* codes) so the PWA can route the user to the
+   * Subscribe page instead of failing the save.
+   */
+  urlIsFeed: (url: string) => createError(ErrorCodes.URL_IS_FEED, "URL_IS_FEED", { url }),
 
   emailExists: () =>
     createError(ErrorCodes.EMAIL_ALREADY_EXISTS, "An account with this email already exists"),

--- a/tests/integration/saved-feed-detection.test.ts
+++ b/tests/integration/saved-feed-detection.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Integration tests for feed detection on the save path.
+ *
+ * When a user shares/saves a URL that is actually a feed (not an article), the
+ * PWA should route them to Subscribe instead of saving garbage. The server
+ * signals this by throwing the machine-readable `URL_IS_FEED` error from
+ * `saveArticle` (see `src/server/services/saved.ts`), which the /save page turns
+ * into a redirect to `/subscribe?url=...`.
+ *
+ * These drive real HTTP requests against a loopback server so the actual fetch +
+ * content-type handling is covered (`.env.test` sets ALLOW_PRIVATE_NETWORK_FETCH).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+import { type AddressInfo } from "node:net";
+import { TRPCError } from "@trpc/server";
+import { db } from "../../src/server/db";
+import { users } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { saveArticle } from "../../src/server/services/saved";
+import { getAppErrorCode } from "../../src/server/trpc/errors";
+
+const RSS_BODY = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel><title>Example Feed</title>
+<item><title>First post</title></item></channel></rss>`;
+
+// Non-feed XML (a sitemap) served with an ambiguous content type — must NOT be
+// treated as a feed even though the content type alone doesn't rule it out.
+const SITEMAP_BODY = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://example.com/</loc></url></urlset>`;
+
+const HTML_BODY = `<!doctype html><html><head><title>An Article</title></head>
+<body><article><h1>An Article</h1><p>${"Some real body text. ".repeat(40)}</p></article></body></html>`;
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const path = req.url ?? "/";
+    if (path === "/feed.xml") {
+      // Unambiguous feed content type — routed to Subscribe without a 2nd fetch.
+      res.writeHead(200, { "Content-Type": "application/rss+xml; charset=utf-8" });
+      res.end(RSS_BODY);
+    } else if (path === "/ambiguous-feed") {
+      // Ambiguous content type but the body sniffs as a feed → still Subscribe.
+      res.writeHead(200, { "Content-Type": "application/xml" });
+      res.end(RSS_BODY);
+    } else if (path === "/sitemap.xml") {
+      // Ambiguous content type, non-feed body → normal save-fetch error, not a feed.
+      res.writeHead(200, { "Content-Type": "application/xml" });
+      res.end(SITEMAP_BODY);
+    } else if (path === "/article") {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(HTML_BODY);
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+async function createTestUser(): Promise<string> {
+  const userId = generateUuidv7();
+  await db.insert(users).values({
+    id: userId,
+    email: `feed-detect-${userId}@test.com`,
+    passwordHash: "test-hash",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  return userId;
+}
+
+describe("saveArticle feed detection", () => {
+  it("throws URL_IS_FEED for a URL served as a feed content type", async () => {
+    const userId = await createTestUser();
+    const promise = saveArticle(db, userId, { url: `${baseUrl}/feed.xml` });
+    await expect(promise).rejects.toBeInstanceOf(TRPCError);
+    await promise.catch((error) => {
+      expect(error.message).toBe("URL_IS_FEED");
+      expect(getAppErrorCode(error)).toBe("URL_IS_FEED");
+    });
+  });
+
+  it("throws URL_IS_FEED for an ambiguous content type whose body is a feed", async () => {
+    const userId = await createTestUser();
+    await expect(saveArticle(db, userId, { url: `${baseUrl}/ambiguous-feed` })).rejects.toThrow(
+      "URL_IS_FEED"
+    );
+  });
+
+  it("does not treat a non-feed XML document (sitemap) as a feed", async () => {
+    const userId = await createTestUser();
+    const promise = saveArticle(db, userId, { url: `${baseUrl}/sitemap.xml` });
+    // Not a feed → the original fetch failure surfaces, not URL_IS_FEED.
+    await expect(promise).rejects.toThrow();
+    await promise.catch((error) => {
+      expect(error.message).not.toBe("URL_IS_FEED");
+      expect(getAppErrorCode(error)).toBe("SAVED_ARTICLE_FETCH_ERROR");
+    });
+  });
+
+  it("saves a normal HTML article without triggering feed detection", async () => {
+    const userId = await createTestUser();
+    const result = await saveArticle(db, userId, { url: `${baseUrl}/article` });
+    expect(result.outcome).toBe("created");
+    expect(result.title).toBe("An Article");
+  });
+});

--- a/tests/integration/saved-feed-detection.test.ts
+++ b/tests/integration/saved-feed-detection.test.ts
@@ -34,6 +34,16 @@ const SITEMAP_BODY = `<?xml version="1.0" encoding="UTF-8"?>
 const HTML_BODY = `<!doctype html><html><head><title>An Article</title></head>
 <body><article><h1>An Article</h1><p>${"Some real body text. ".repeat(40)}</p></article></body></html>`;
 
+// A valid JSON Feed vs. a plain JSON API response, both served as
+// application/json (the ambiguous branch): the feed must route to Subscribe, the
+// API must not.
+const JSON_FEED_BODY = JSON.stringify({
+  version: "https://jsonfeed.org/version/1.1",
+  title: "Example JSON Feed",
+  items: [{ id: "1", title: "First post" }],
+});
+const JSON_API_BODY = JSON.stringify({ data: [1, 2, 3], ok: true });
+
 let server: Server;
 let baseUrl: string;
 
@@ -52,6 +62,12 @@ beforeAll(async () => {
       // Ambiguous content type, non-feed body → normal save-fetch error, not a feed.
       res.writeHead(200, { "Content-Type": "application/xml" });
       res.end(SITEMAP_BODY);
+    } else if (path === "/json-feed") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON_FEED_BODY);
+    } else if (path === "/json-api") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON_API_BODY);
     } else if (path === "/article") {
       res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
       res.end(HTML_BODY);
@@ -102,6 +118,23 @@ describe("saveArticle feed detection", () => {
     const userId = await createTestUser();
     const promise = saveArticle(db, userId, { url: `${baseUrl}/sitemap.xml` });
     // Not a feed → the original fetch failure surfaces, not URL_IS_FEED.
+    await expect(promise).rejects.toThrow();
+    await promise.catch((error) => {
+      expect(error.message).not.toBe("URL_IS_FEED");
+      expect(getAppErrorCode(error)).toBe("SAVED_ARTICLE_FETCH_ERROR");
+    });
+  });
+
+  it("throws URL_IS_FEED for a valid JSON Feed served as application/json", async () => {
+    const userId = await createTestUser();
+    await expect(saveArticle(db, userId, { url: `${baseUrl}/json-feed` })).rejects.toThrow(
+      "URL_IS_FEED"
+    );
+  });
+
+  it("does not treat a plain JSON API response as a feed", async () => {
+    const userId = await createTestUser();
+    const promise = saveArticle(db, userId, { url: `${baseUrl}/json-api` });
     await expect(promise).rejects.toThrow();
     await promise.catch((error) => {
       expect(error.message).not.toBe("URL_IS_FEED");


### PR DESCRIPTION
## Summary

When you share a **feed** URL to the PWA (or hit the bookmarklet/save flow with one), we now open the **Subscribe** page pre-filled instead of trying to save it as an article.

This isn't just a nicety — the previous behavior was broken. Feeds are served as XML/JSON, which the article fetch (`fetchHtmlPage`) rejects with an "Invalid content type" error, so sharing a feed to the PWA produced an error toast (or, for the rare feed served as `text/html`, saved Readability garbage).

## How it works

1. The `/save` flow calls `saved.save` → `saveArticle()` as before (single fetch on the common article path — no added latency).
2. If the fetch is rejected on its content type, we check whether the URL is **actually a feed**. If so, `saveArticle` throws the machine-readable `URL_IS_FEED` error.
3. The `/save` page catches it and redirects to `/subscribe?url=…`, which pre-fills the field and auto-runs the preview.

Per discussion, detection is deliberately **scoped to direct feeds only**: sharing an article page always **saves the article**, even if the site has a discoverable feed — that matches intent and avoids hijacking the common save case. The extra "is this a feed" sniff fetch only runs on the feed-rejection path, and only for *ambiguous* content types (`application/xml`, `text/xml`, `application/json`); unambiguous `application/rss+xml` / `application/atom+xml` skip even that.

## Changes

- `http/fetch.ts`: promote the content-type rejection to a typed `InvalidContentTypeError` carrying the content type (still an `Error`; existing callers unaffected).
- `trpc/errors.ts`: new `URL_IS_FEED` (400). Message is the machine token, since tRPC doesn't ship the error `cause` to clients — same pattern as the existing `NEEDS_GOOGLE_*` codes.
- `services/saved.ts`: `urlIsDirectFeed()` + detection in `acquireArticleContent`'s fetch catch.
- `app/save/page.tsx`: redirect to Subscribe on `URL_IS_FEED`, showing a spinner ("This is a feed — opening Subscribe…") instead of an error card.
- `components/subscribe/SubscribeContent.tsx`: read `?url=`, pre-fill, auto-preview once.

## Testing

New integration test `tests/integration/saved-feed-detection.test.ts` drives real HTTP against a loopback server:
- feed served as `application/rss+xml` → `URL_IS_FEED` (no second fetch)
- ambiguous `application/xml` whose body sniffs as a feed → `URL_IS_FEED`
- ambiguous `application/xml` sitemap (not a feed) → normal save-fetch error, **not** `URL_IS_FEED`
- normal HTML article → saves as before

`pnpm typecheck` + `eslint` clean; full integration suite (666 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)