### PR TITLE
docs: runbook for migrating MPG → unmanaged Fly Postgres (shared-cpu-8x)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -91,31 +91,44 @@ You should see your new app listed.
 
 ## Database Provisioning (Postgres)
 
-Lion Reader uses PostgreSQL for all persistent data.
+Lion Reader uses PostgreSQL for all persistent data. Production runs **unmanaged
+Fly Postgres (flex), single node** — chosen over Fly Managed Postgres in July 2026
+for performance-per-dollar (see `docs/runbooks/migrate-mpg-to-unmanaged-postgres.md`
+for the rationale, the migration procedure, and the operational duties this implies:
+Fly does not support or upgrade unmanaged clusters).
 
 ### 1. Create a Postgres Cluster
 
 ```bash
 flyctl postgres create \
-  --name lion-reader-db \
+  --name lion-reader-pg \
   --region lax \
-  --vm-size shared-cpu-1x \
+  --flex \
+  --vm-size shared-cpu-8x \
+  --vm-memory 4096 \
   --initial-cluster-size 1 \
-  --volume-size 10
+  --volume-size 10 \
+  --enable-backups
 ```
 
 **Options explained:**
 
 - `--name`: Name for your Postgres app (must be unique)
 - `--region`: Should match your app's `primary_region` in `fly.toml`
-- `--vm-size`: `shared-cpu-1x` is sufficient for MVP (~$7/month)
-- `--initial-cluster-size`: 1 for MVP, increase for HA
-- `--volume-size`: 10GB is plenty for MVP
+- `--vm-size`/`--vm-memory`: shared CPU quotas are pooled per machine, so
+  `shared-cpu-8x` gives Postgres a 50%-of-a-core sustained floor with burst to 8
+  cores (~$27/month at 4GB) — better burst behavior than a dedicated
+  `performance-1x` core at ~$32/month. Save the superuser password it prints.
+- `--initial-cluster-size`: 1 (deliberate — flex multi-node uses repmgr, which has
+  a poor failure-mode track record; WAL backups are the safety net)
+- `--volume-size`: 10GB is plenty
+- `--enable-backups`: WAL-based backups to a Tigris bucket (PITR via
+  `fly postgres backup restore`), on top of daily volume snapshots
 
 ### 2. Attach Postgres to Your App
 
 ```bash
-flyctl postgres attach lion-reader-db --app lion-reader
+flyctl postgres attach lion-reader-pg --app lion-reader
 ```
 
 This automatically:
@@ -128,7 +141,7 @@ This automatically:
 
 ```bash
 # Connect to the database
-flyctl postgres connect -a lion-reader-db
+flyctl postgres connect -a lion-reader-pg
 
 # Run a quick test
 \conninfo
@@ -387,19 +400,19 @@ flyctl scale count 3 --process-group app
 **Connect to database:**
 
 ```bash
-flyctl postgres connect -a lion-reader-db
+flyctl postgres connect -a lion-reader-pg
 ```
 
 **Manual backup:**
 
 ```bash
-flyctl postgres backup create -a lion-reader-db
+flyctl postgres backup create -a lion-reader-pg
 ```
 
 **List backups:**
 
 ```bash
-flyctl postgres backup list -a lion-reader-db
+flyctl postgres backup list -a lion-reader-pg
 ```
 
 ### Viewing Logs
@@ -457,7 +470,7 @@ This usually means database migrations failed.
 flyctl logs | grep -i migration
 
 # Connect to database and check state
-flyctl postgres connect -a lion-reader-db
+flyctl postgres connect -a lion-reader-pg
 ```
 
 **"Health check failed"**
@@ -484,7 +497,7 @@ flyctl secrets list
 # Should show DATABASE_URL
 
 # Re-attach if needed
-flyctl postgres attach lion-reader-db
+flyctl postgres attach lion-reader-pg
 ```
 
 **"Authentication failed"**
@@ -492,8 +505,8 @@ flyctl postgres attach lion-reader-db
 The database user credentials may be wrong. Detach and reattach:
 
 ```bash
-flyctl postgres detach lion-reader-db
-flyctl postgres attach lion-reader-db
+flyctl postgres detach lion-reader-pg
+flyctl postgres attach lion-reader-pg
 ```
 
 ### Redis Connection Issues
@@ -593,14 +606,16 @@ bot). Only `app` is behind the HTTP load balancer; all three share Postgres and 
        +-------------+     +-------------+
 ```
 
-## Cost Estimate (MVP)
+## Cost Estimate (current production shape, July 2026)
 
-| Resource        | Size                 | Estimated Cost    |
-| --------------- | -------------------- | ----------------- |
-| App VM          | shared-cpu-1x, 512MB | ~$5/month         |
-| Postgres        | shared-cpu-1x, 10GB  | ~$7/month         |
-| Redis (Upstash) | Pay-as-you-go        | ~$0-5/month       |
-| **Total**       |                      | **~$12-17/month** |
+| Resource        | Size                            | Estimated Cost    |
+| --------------- | ------------------------------- | ----------------- |
+| App VMs         | 2× shared-cpu-2x, 512MB         | ~$8/month         |
+| Worker VM       | shared-cpu-1x, 512MB            | ~$3.50/month      |
+| Discord VM      | shared-cpu-1x, 256MB            | ~$2/month         |
+| Postgres        | shared-cpu-8x, 4GB, 10GB volume | ~$28/month        |
+| Redis (Upstash) | Pay-as-you-go                   | ~$0-5/month       |
+| **Total**       |                                 | **~$42-47/month** |
 
 Costs vary by usage. Check [fly.io/docs/about/pricing](https://fly.io/docs/about/pricing/) for current rates.
 

--- a/docs/runbooks/migrate-mpg-to-unmanaged-postgres.md
+++ b/docs/runbooks/migrate-mpg-to-unmanaged-postgres.md
@@ -1,0 +1,181 @@
+# Runbook: Migrate from Managed Postgres (MPG) to unmanaged Fly Postgres
+
+**Written 2026-07-14.** Moves production from the Fly Managed Postgres "Basic" plan
+(cluster `k1v53olme1nr8q6p`, `lion-reader-db`, ~$41/mo, shared-cpu-2x/1GB, 2-node HA)
+to a **single-node unmanaged Fly Postgres (flex)** on `shared-cpu-8x` / 4GB
+(~$28/mo incl. volume).
+
+**Why this shape:** Fly shared-CPU quotas are pooled per machine (5ms × vCPUs per
+80ms period — [CPU performance docs](https://fly.io/docs/machines/cpu-performance/)),
+so shared-8x gives Postgres a 50%-of-a-core sustained floor (vs 12.5% on MPG Basic),
+burst to 8 cores while the 500 CPU-second burst balance lasts, and 4× the RAM for
+cache — at ~70% of the MPG price. Single node is deliberate: flex multi-node uses
+repmgr, which has a poor failure-mode track record; WAL backups + volume snapshots
+are the safety net instead. Trade-offs: no Fly support for unmanaged Postgres, we
+own upgrades, and a host failure means restoring from backup instead of failover.
+
+**Downtime:** the app is stopped during the dump/restore — minutes for a <10GB DB.
+
+**Prerequisites:** local `flyctl` authenticated with full org access (deploy tokens
+can't open the WireGuard tunnels that `fly mpg proxy` / `fly proxy` need), and local
+Postgres client tools (`pg_dump`/`psql`) at a major version ≥ the server's.
+
+---
+
+## 1. Pre-flight
+
+```bash
+# Current state / the MPG cluster id
+fly mpg list -o personal
+fly machine list -a lion-reader
+
+# Grab the current MPG connection string (this is also the rollback value)
+fly ssh console -a lion-reader --machine <app-machine-id> -C "printenv DATABASE_URL"
+# Save it somewhere safe. Note the user, password, and database name.
+
+# Safety backup on the MPG side
+fly mpg backup create k1v53olme1nr8q6p
+
+# Check the source Postgres major version (pg_dump client must be >= this)
+fly mpg proxy k1v53olme1nr8q6p --local-port 16543 &
+psql "<MPG url with host replaced by 127.0.0.1:16543>" -c "select version()"
+```
+
+## 2. Create the new cluster
+
+```bash
+fly postgres create \
+  --name lion-reader-pg \
+  --org personal \
+  --region lax \
+  --flex \
+  --initial-cluster-size 1 \
+  --vm-size shared-cpu-8x \
+  --vm-memory 4096 \
+  --volume-size 10 \
+  --enable-backups
+```
+
+- `--enable-backups` provisions a Tigris bucket and turns on WAL-based backups
+  (real PITR; restore with `fly postgres backup restore`).
+- **Save the superuser password it prints** — it is shown once.
+- Sanity-check the memory-derived tuning; flex sizes `shared_buffers` etc. from VM
+  memory at init:
+
+```bash
+fly postgres config view -a lion-reader-pg
+# If shared_buffers looks sized for 2GB rather than 4GB:
+# fly postgres config update -a lion-reader-pg --shared-buffers 1024MB
+```
+
+Optional rehearsal (no downtime): run the §4 dump/restore now against the live DB
+just to time it, then drop/recreate the target database before the real cutover.
+The worker writes continuously, so a rehearsal copy is _not_ a valid final copy.
+
+## 3. Cutover — stop the app (downtime starts)
+
+```bash
+fly machine list -a lion-reader   # note the app, worker, and discord machine ids
+fly machine stop <app-id> <worker-id> <discord-id> -a lion-reader
+
+# attach (next step) fails if DATABASE_URL already exists; machines are stopped,
+# so --stage avoids any deploy/restart churn
+fly secrets unset DATABASE_URL -a lion-reader --stage
+```
+
+## 4. Provision the app user and copy the data
+
+```bash
+# Creates role + database on the new cluster and sets DATABASE_URL on the app.
+# SAVE the connection string it prints (password is shown once).
+fly postgres attach lion-reader-pg -a lion-reader --database-name lion_reader
+
+# Two tunnels: old MPG on 16543 (may still be running from §1), new flex on 16544
+fly mpg proxy k1v53olme1nr8q6p --local-port 16543 &
+fly proxy 16544:5432 -a lion-reader-pg &
+
+# Copy. Use the creds from the MPG URL (§1) on the left, and the user/password/db
+# from the attach output on the right — only the hosts are replaced.
+pg_dump "postgres://<mpg-user>:<mpg-pass>@127.0.0.1:16543/<mpg-db>" \
+    --no-owner --no-privileges \
+  | psql "postgres://lion_reader:<attach-pass>@127.0.0.1:16544/lion_reader" \
+    -v ON_ERROR_STOP=1 --single-transaction
+```
+
+Notes:
+
+- `--no-owner --no-privileges` because the source roles don't exist on the target;
+  objects end up owned by the connecting `lion_reader` user, which is what the app
+  uses. The dump includes `CREATE EXTENSION citext` (the attach user is superuser
+  by default, so this succeeds).
+- The drizzle migration bookkeeping is part of the dump, so the next deploy's
+  `release_command` migration run is a no-op.
+
+Spot-check row counts on both sides before proceeding:
+
+```bash
+for url in "postgres://...16543/<mpg-db>" "postgres://...16544/lion_reader"; do
+  psql "$url" -c "select (select count(*) from entries) as entries,
+                         (select count(*) from subscriptions) as subs,
+                         (select count(*) from users) as users"
+done
+```
+
+## 5. Restart and verify (downtime ends)
+
+```bash
+fly machine start <app-id> <worker-id> <discord-id> -a lion-reader
+
+curl -s https://lionreader.com/api/health   # expect database + redis healthy
+fly logs -a lion-reader --no-tail | tail -50
+```
+
+Then check the UI: entries load, mark-read works, new entries appear (worker is
+fetching), Discord bot responds.
+
+## Rollback
+
+The MPG cluster is untouched until §6. To roll back:
+
+```bash
+fly secrets set DATABASE_URL="<original MPG url from §1>" -a lion-reader
+fly machine restart <app-id> <worker-id> <discord-id> -a lion-reader
+```
+
+Any writes made to the new cluster after cutover are lost on rollback (acceptable
+for a short observation window; entries re-fetch from feeds).
+
+## 6. Post-cutover (after a few days of confidence)
+
+```bash
+# Verify backups are flowing
+fly postgres backup list -a lion-reader-pg
+fly volumes list -a lion-reader-pg   # daily snapshots, default 5-day retention
+
+# Take a final local archive of the old DB, then destroy MPG (ends the $38/mo plan)
+pg_dump "<MPG url via proxy>" -Fc -f lion-reader-mpg-final.dump
+fly mpg destroy k1v53olme1nr8q6p
+```
+
+Also restore the second app machine (drift found 2026-07-14: only one `app` machine
+was running despite `min_machines_running = 2`, which breaks zero-downtime canary
+deploys):
+
+```bash
+fly scale count app=2 -a lion-reader
+```
+
+## Ongoing operations you now own
+
+- **Watch throttling:** on [fly-metrics.net](https://fly-metrics.net), the
+  `lion-reader-pg` app's CPU dashboard shows the burst balance
+  (`fly_instance_cpu_balance`) and throttle/steal time. If the balance pins at 0
+  outside of backups, upgrade: `fly machine update <id> --vm-size performance-1x -a
+lion-reader-pg` (dedicated core, ~$32/mo, seconds of restart).
+- **Minor version updates:** `fly image update -a lion-reader-pg` (restarts the node).
+- **Major version upgrades:** dump/restore into a fresh cluster (repeat this runbook
+  shape) — Fly does not upgrade unmanaged clusters.
+- **Disk:** 10GB volume; `fly volumes extend` when needed. A full volume is an
+  outage you have to notice — check the fly-metrics disk panel occasionally.
+- **Restore drill:** once, soon after migrating, run `fly postgres backup restore`
+  into a scratch cluster to prove the WAL backups actually restore.

--- a/docs/runbooks/migrate-mpg-to-unmanaged-postgres.md
+++ b/docs/runbooks/migrate-mpg-to-unmanaged-postgres.md
@@ -76,12 +76,24 @@ The worker writes continuously, so a rehearsal copy is _not_ a valid final copy.
 
 ```bash
 fly machine list -a lion-reader   # note the app, worker, and discord machine ids
+
+# The app group has auto_start_machines = true, so the Fly proxy will WAKE a
+# stopped app machine as soon as a request arrives — mid-copy, pointed at
+# whichever DATABASE_URL is current. Disable autostart for the window:
+fly machine update <app-id> --autostart=false -y -a lion-reader
+
 fly machine stop <app-id> <worker-id> <discord-id> -a lion-reader
+
+# Confirm all three actually show "stopped" before dumping — a machine still
+# draining writes to MPG after the dump snapshot starts means lost writes:
+fly machine list -a lion-reader
 
 # attach (next step) fails if DATABASE_URL already exists; machines are stopped,
 # so --stage avoids any deploy/restart churn
 fly secrets unset DATABASE_URL -a lion-reader --stage
 ```
+
+(worker/discord have no HTTP service, so a plain stop is enough for them.)
 
 ## 4. Provision the app user and copy the data
 
@@ -93,6 +105,10 @@ fly postgres attach lion-reader-pg -a lion-reader --database-name lion_reader
 # Two tunnels: old MPG on 16543 (may still be running from §1), new flex on 16544
 fly mpg proxy k1v53olme1nr8q6p --local-port 16543 &
 fly proxy 16544:5432 -a lion-reader-pg &
+
+# Gate on both tunnels being up — a backgrounded proxy that isn't ready yet (or a
+# port collision) would fail the pipe mid-stream:
+pg_isready -h 127.0.0.1 -p 16543 && pg_isready -h 127.0.0.1 -p 16544
 
 # Copy. Use the creds from the MPG URL (§1) on the left, and the user/password/db
 # from the attach output on the right — only the hosts are replaced.
@@ -124,6 +140,10 @@ done
 ## 5. Restart and verify (downtime ends)
 
 ```bash
+# Re-enable proxy autostart on the app machine (the next `fly deploy` would also
+# reset this from fly.toml, but don't leave it to chance)
+fly machine update <app-id> --autostart -y -a lion-reader
+
 fly machine start <app-id> <worker-id> <discord-id> -a lion-reader
 
 curl -s https://lionreader.com/api/health   # expect database + redis healthy


### PR DESCRIPTION
## Summary

Production Postgres is moving from **Fly Managed Postgres Basic** (~$41/mo, shared-cpu-2x/1GB — throttled to a 12.5%-of-a-core sustained baseline) to a **single-node unmanaged flex cluster on shared-cpu-8x/4GB** (~$28/mo incl. volume).

Rationale (researched 2026-07-14): Fly shared-CPU quotas are pooled per machine ("Quotas are shared between a Machine's vCPUs" — [CPU performance docs](https://fly.io/docs/machines/cpu-performance/)), so shared-8x gives Postgres a 50%-of-a-core sustained floor, burst to 8 cores on the 500 CPU-second balance, and 4× the RAM for cache — cheaper than both MPG Basic and a dedicated performance-1x/2GB ($32/mo). The first dedicated-CPU MPG tier is $282/mo. Single node is deliberate (flex multi-node repmgr has a poor failure-mode track record); `--enable-backups` WAL archiving to Tigris + daily volume snapshots are the safety net.

## Changes

- **New: `docs/runbooks/migrate-mpg-to-unmanaged-postgres.md`** — step-by-step cutover: create cluster → stop machines → `fly postgres attach` → `pg_dump | psql` over proxies → verify → destroy MPG. Includes rollback, post-cutover checks (incl. restoring the second app machine — currently only one is running despite `min_machines_running = 2`), and the ongoing ops we take on (throttle monitoring via `fly_instance_cpu_balance`, upgrades, restore drill). All flyctl flags verified against the current CLI.
- **`docs/DEPLOYMENT.md`** — provisioning section and cost table updated to the real production shape (they still described the original $7/mo MVP sizing and the old `lion-reader-db` name).

Docs only — no code changes. The actual migration is run manually per the runbook (needs WireGuard-capable credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)