### PR TITLE
sync: mark_all_read carries the max marked entry id so a same-instant entry isn't skipped (#1102)

### DIFF
--- a/src/lib/events/cursors.ts
+++ b/src/lib/events/cursors.ts
@@ -110,8 +110,14 @@ function entryEventAfterId(event: SyncEvent): string {
       // MAX_UUID sentinel — keeps the cursor *inside* the tied-timestamp
       // group: an unrelated entry written in the same millisecond has a
       // UUIDv7 id above every earlier-created marked entry, so a catch-up can
-      // still deliver it when its live event was missed (#1102). Events from
-      // servers predating the field fall back to skipping the whole group.
+      // still deliver it when its live event was missed (#1102). That ordering
+      // comes from the UUIDv7 millisecond timestamp prefix (our generator has
+      // no intra-ms counter — sub-timestamp bits are random), so a marked
+      // entry *created in the same millisecond* as the mark-all-read can
+      // still randomly out-sort the newcomer; that residual, like the
+      // fallback below, is covered by the entries.list invalidation the event
+      // also triggers. Events from servers predating the field fall back to
+      // skipping the whole group.
       return event.entryId ?? MAX_UUID;
     default:
       // Unreachable: only the entries-cursor events above are passed here.

--- a/src/lib/events/cursors.ts
+++ b/src/lib/events/cursors.ts
@@ -32,18 +32,20 @@ function compareTimestamps(a: string, b: string): number {
 }
 
 /**
- * Largest possible UUID. Used as the entries id tiebreaker for `mark_all_read`,
- * which carries no single entry id: advancing past `(T, MAX_UUID)` skips every
- * entry tied at timestamp T (they were all just marked read), so a catch-up
- * doesn't re-deliver them one by one.
+ * Largest possible UUID. Fallback id tiebreaker for `mark_all_read` events
+ * that don't carry `entryId` (published by servers predating the field):
+ * advancing past `(T, MAX_UUID)` skips every entry tied at timestamp T, so a
+ * catch-up doesn't re-deliver the marked entries one by one.
  *
- * Known limitation (pre-existing, not introduced by the keyset): if an unrelated
- * new entry is inserted at the *exact* same microsecond timestamp T as the
- * mark-all-read and its live `new_entry` is missed, this sentinel makes a
- * later catch-up skip it (`GREATEST = T AND id > MAX_UUID` is false). The old
- * timestamp-only strict-`>` cursor had the identical blind spot. Collisions at
- * µs precision are vanishingly rare, and `mark_all_read` already invalidates the
- * entry lists, so the entry reappears on the next list refresh regardless.
+ * Known limitation of this fallback (#1102): if an unrelated new entry lands
+ * on the same timestamp T as the mark-all-read (both stamps come from JS
+ * `new Date()`, so a collision needs only the same *millisecond*) and its live
+ * `new_entry` is missed, the sentinel makes a later catch-up skip it too
+ * (`GREATEST = T AND id > MAX_UUID` is always false). Current servers instead
+ * send the largest marked entry id, which excludes exactly the marked rows
+ * while still admitting the tied newcomer (see entryEventAfterId). Either way
+ * `mark_all_read` also invalidates the entry lists, so a skipped entry
+ * reappears on the next list refetch.
  */
 const MAX_UUID = "ffffffff-ffff-ffff-ffff-ffffffffffff";
 
@@ -93,7 +95,8 @@ export function cursorTypeForEvent(event: SyncEvent): keyof SyncCursors | null {
 
 /**
  * The entries-cursor id tiebreaker an event advances to. Per-entry events carry
- * their own id; mark_all_read has none and advances past the whole tied group.
+ * their own id; mark_all_read carries the LARGEST id among the entries it
+ * marked read.
  */
 function entryEventAfterId(event: SyncEvent): string {
   switch (event.type) {
@@ -101,8 +104,17 @@ function entryEventAfterId(event: SyncEvent): string {
     case "entry_updated":
     case "entry_state_changed":
       return event.entryId;
+    case "mark_all_read":
+      // Advancing to the largest marked id skips every row the mark-all-read
+      // stamped at this timestamp (no catch-up re-delivery), but — unlike the
+      // MAX_UUID sentinel — keeps the cursor *inside* the tied-timestamp
+      // group: an unrelated entry written in the same millisecond has a
+      // UUIDv7 id above every earlier-created marked entry, so a catch-up can
+      // still deliver it when its live event was missed (#1102). Events from
+      // servers predating the field fall back to skipping the whole group.
+      return event.entryId ?? MAX_UUID;
     default:
-      // mark_all_read (the only other event mapped to the entries cursor).
+      // Unreachable: only the entries-cursor events above are passed here.
       return MAX_UUID;
   }
 }

--- a/src/lib/events/schemas.ts
+++ b/src/lib/events/schemas.ts
@@ -223,6 +223,12 @@ const markAllReadEventSchema = z.object({
   // mark-all-read timestamp, used to advance the entries cursor.
   timestamp: timestampWithDefault,
   updatedAt: z.string(),
+  // The largest entry id among the marked rows: the entries keyset cursor
+  // advances to (updatedAt, entryId), which skips every marked row in a
+  // catch-up while still admitting an unrelated entry written in the same
+  // millisecond (#1102). Absent on events from servers predating the field;
+  // the client then falls back to skipping the whole tied-timestamp group.
+  entryId: z.string().optional(),
 });
 
 const subscriptionCreatedEventSchema = z.object({

--- a/src/server/redis/pubsub.ts
+++ b/src/server/redis/pubsub.ts
@@ -138,6 +138,14 @@ const userEventSchema = z.discriminatedUnion("type", [
     userId: z.string(),
     timestamp: z.string(),
     updatedAt: z.string(),
+    // The largest entry id among the marked rows. The client advances its
+    // entries keyset cursor to (updatedAt, entryId): every marked row sorts at
+    // or below it (no catch-up re-delivery), while an unrelated entry written
+    // in the same millisecond — whose UUIDv7 id sorts above every
+    // earlier-created marked entry — stays past the cursor, so a catch-up can
+    // still deliver it (#1102). Optional so events published by a previous
+    // release still parse during a rolling deploy.
+    entryId: z.string().optional(),
   }),
   z.object({
     type: z.literal("tag_created"),
@@ -625,9 +633,17 @@ export async function publishEntryStateChanged(
  * @param userId - The ID of the user whose entries were marked read
  * @param updatedAt - The mark-all-read timestamp, used to advance the entries
  *   sync cursor so a reconnect catch-up doesn't re-deliver every marked entry
+ * @param maxEntryId - The largest entry id among the marked rows; together with
+ *   `updatedAt` it forms the exact keyset position past the marked rows, so the
+ *   cursor doesn't also skip an unrelated entry written in the same
+ *   millisecond (#1102)
  * @returns The number of subscribers that received the message (0 if Redis unavailable)
  */
-export async function publishMarkAllRead(userId: string, updatedAt: Date): Promise<number> {
+export async function publishMarkAllRead(
+  userId: string,
+  updatedAt: Date,
+  maxEntryId: string
+): Promise<number> {
   const client = getPublisherClient();
   if (!client) {
     return 0;
@@ -637,6 +653,7 @@ export async function publishMarkAllRead(userId: string, updatedAt: Date): Promi
     userId,
     timestamp: new Date().toISOString(),
     updatedAt: updatedAt.toISOString(),
+    entryId: maxEntryId,
   };
   const channel = getUserEventsChannel(userId);
   return client.publish(channel, JSON.stringify(event));

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -1309,7 +1309,15 @@ export async function markAllEntriesRead(
   // caller runs this inside a transaction, move the publish to after the commit
   // so a rolled-back mark-all-read can't emit a phantom event.
   if (entryIds.length > 0) {
-    void publishMarkAllRead(params.userId, updatedAt).catch(() => {
+    // The largest marked entry id rides along so the client's entries keyset
+    // cursor lands exactly past the marked rows rather than past the whole
+    // tied-timestamp group: an unrelated entry written in the same millisecond
+    // as `updatedAt` has a UUIDv7 id above every earlier-created marked entry,
+    // so a catch-up sync can still deliver it if its live event was missed
+    // (#1102). UUIDs are lowercase, so string comparison matches Postgres uuid
+    // ordering.
+    const maxEntryId = entryIds.reduce((max, id) => (id > max ? id : max));
+    void publishMarkAllRead(params.userId, updatedAt, maxEntryId).catch(() => {
       // Ignore publish errors - SSE is best-effort
     });
   }

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -1312,10 +1312,11 @@ export async function markAllEntriesRead(
     // The largest marked entry id rides along so the client's entries keyset
     // cursor lands exactly past the marked rows rather than past the whole
     // tied-timestamp group: an unrelated entry written in the same millisecond
-    // as `updatedAt` has a UUIDv7 id above every earlier-created marked entry,
-    // so a catch-up sync can still deliver it if its live event was missed
-    // (#1102). UUIDs are lowercase, so string comparison matches Postgres uuid
-    // ordering.
+    // as `updatedAt` has a UUIDv7 id above every earlier-created marked entry
+    // (the ordering comes from the UUIDv7 ms-timestamp prefix; marked entries
+    // exist before the mark-all-read), so a catch-up sync can still deliver it
+    // if its live event was missed (#1102). UUIDs are lowercase, so string
+    // comparison matches Postgres uuid ordering.
     const maxEntryId = entryIds.reduce((max, id) => (id > max ? id : max));
     void publishMarkAllRead(params.userId, updatedAt, maxEntryId).catch(() => {
       // Ignore publish errors - SSE is best-effort

--- a/tests/integration/mark-all-read-events.test.ts
+++ b/tests/integration/mark-all-read-events.test.ts
@@ -169,7 +169,7 @@ function waitForMessage(channel: string, timeoutMs = 5000): Promise<string> {
 }
 
 describe("entries.markAllRead SSE publishing", () => {
-  it("publishes a mark_all_read signal carrying a cursor timestamp", async () => {
+  it("publishes a mark_all_read signal carrying a cursor timestamp and the max marked id", async () => {
     const userId = generateUuidv7();
     await db.insert(users).values({
       id: userId,
@@ -178,7 +178,7 @@ describe("entries.markAllRead SSE publishing", () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     });
-    await seedUnreadEntries(userId, 3);
+    const entryIds = await seedUnreadEntries(userId, 3);
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
@@ -193,6 +193,10 @@ describe("entries.markAllRead SSE publishing", () => {
     // updatedAt is the mark-all-read timestamp used to advance the entries cursor.
     expect(typeof event.updatedAt).toBe("string");
     expect(Number.isNaN(Date.parse(event.updatedAt))).toBe(false);
+    // entryId is the LARGEST marked entry id: the client's keyset cursor lands
+    // exactly past the marked rows, so a catch-up skips them without also
+    // skipping an unrelated entry written in the same millisecond (#1102).
+    expect(event.entryId).toBe([...entryIds].sort().at(-1));
   });
 
   it("publishes no event when nothing was unread", async () => {

--- a/tests/integration/sync-events.test.ts
+++ b/tests/integration/sync-events.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
+import { parseTimestamptz } from "../../src/server/db/temporal";
 import { advanceCursors, type SyncCursors } from "../../src/lib/events/cursors";
 import type { SyncEvent } from "../../src/lib/events/schemas";
 import type { Context } from "../../src/server/trpc/context";
@@ -975,6 +976,88 @@ describe("sync.events", () => {
       expect(deliveredIds.length).toBe(total);
       expect([...deliveredIds].every((id) => allIds.has(id))).toBe(true);
     }, 30000);
+
+    // #1102: the mark_all_read event advances the client's keyset to
+    // (T, maxMarkedId) — exactly past the marked rows — instead of the old
+    // (T, MAX_UUID) sentinel that skipped the WHOLE tied-timestamp group. An
+    // unrelated entry written in the same millisecond as the mark-all-read
+    // (whose live new_entry was missed) must still be delivered by catch-up,
+    // while none of the marked rows re-deliver.
+    it("delivers an unrelated entry written in the same instant as a mark-all-read (#1102)", async () => {
+      const userId = await createTestUser();
+      const feedId = await createTestFeed("https://example.com/mark-all-tied.xml");
+      await createTestSubscription(userId, feedId);
+
+      // Three unread entries; mark-all-read stamps them all with one
+      // millisecond-precision timestamp T (markAllEntriesRead's `new Date()`).
+      const markedIds: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const id = await createTestEntry(feedId);
+        await createUserEntry(userId, id);
+        markedIds.push(id);
+      }
+      markedIds.sort();
+      const maxMarkedId = markedIds[markedIds.length - 1];
+
+      const caller = createCaller(createAuthContext(userId));
+      const result = await caller.entries.markAllRead({});
+      expect(result.count).toBe(3);
+
+      // Read T back at full precision — the GREATEST value the marked rows now share.
+      const tRows = await db
+        .select({ t: sql`${userEntries.updatedAt}`.mapWith(parseTimestamptz) })
+        .from(userEntries)
+        .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, maxMarkedId)));
+      const t = tRows[0].t;
+      const tiedDate = new Date(t.epochMilliseconds);
+
+      // An unrelated new entry lands at exactly T. Generated after the marked
+      // entries, its UUIDv7 id sorts above all of them.
+      const newcomerId = await createTestEntry(feedId, {
+        createdAt: tiedDate,
+        updatedAt: tiedDate,
+      });
+      await createUserEntry(userId, newcomerId, { updatedAt: tiedDate });
+      expect(newcomerId > maxMarkedId).toBe(true);
+
+      // Advance the entries keyset exactly as the client does from the
+      // mark_all_read event, which carries T and the max marked id.
+      const cursors = advanceCursors(
+        { entries: null, entriesAfterId: null, subscriptions: null, tags: null },
+        {
+          type: "mark_all_read",
+          timestamp: t.toString(),
+          updatedAt: t.toString(),
+          entryId: maxMarkedId,
+        }
+      );
+      const catchUp = await caller.sync.events({
+        cursors: {
+          entries: cursors.entries ?? undefined,
+          entriesAfterId: cursors.entriesAfterId ?? undefined,
+        },
+      });
+
+      // The tied newcomer is delivered (as new_entry, plus the accompanying
+      // entry_state_changed for its fresh user_entries row); none of the
+      // marked rows re-deliver.
+      const entryEvents = catchUp.events.filter((e) => ENTRY_EVENT_TYPES.has(e.type));
+      expect(entryEvents.length).toBeGreaterThan(0);
+      for (const event of entryEvents) {
+        expect("entryId" in event ? event.entryId : null).toBe(newcomerId);
+      }
+      expect(entryEvents.some((e) => e.type === "new_entry")).toBe(true);
+
+      // Contrast: the pre-#1102 MAX_UUID sentinel skipped the whole tied group,
+      // permanently hiding the newcomer from catch-up.
+      const sentinelCatchUp = await caller.sync.events({
+        cursors: {
+          entries: cursors.entries ?? undefined,
+          entriesAfterId: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        },
+      });
+      expect(sentinelCatchUp.events.filter((e) => ENTRY_EVENT_TYPES.has(e.type))).toHaveLength(0);
+    });
   });
 
   // ==========================================================================

--- a/tests/integration/sync-events.test.ts
+++ b/tests/integration/sync-events.test.ts
@@ -998,6 +998,7 @@ describe("sync.events", () => {
       }
       markedIds.sort();
       const maxMarkedId = markedIds[markedIds.length - 1];
+      const seededAtMs = Date.now();
 
       const caller = createCaller(createAuthContext(userId));
       const result = await caller.entries.markAllRead({});
@@ -1011,8 +1012,13 @@ describe("sync.events", () => {
       const t = tRows[0].t;
       const tiedDate = new Date(t.epochMilliseconds);
 
-      // An unrelated new entry lands at exactly T. Generated after the marked
-      // entries, its UUIDv7 id sorts above all of them.
+      // An unrelated new entry lands at exactly T. Its id must sort above the
+      // marked ids, which UUIDv7's ms-timestamp prefix guarantees only when it
+      // is generated in a strictly LATER millisecond than the marked entries —
+      // wait one out so the test can't flake if the prologue ran within 1ms.
+      while (Date.now() <= seededAtMs) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+      }
       const newcomerId = await createTestEntry(feedId, {
         createdAt: tiedDate,
         updatedAt: tiedDate,

--- a/tests/unit/frontend/events/cursors.test.ts
+++ b/tests/unit/frontend/events/cursors.test.ts
@@ -43,11 +43,12 @@ function tagEvent(updatedAt: string): SyncEvent {
   };
 }
 
-function markAllReadEvent(updatedAt: string): SyncEvent {
+function markAllReadEvent(updatedAt: string, entryId?: string): SyncEvent {
   return {
     type: "mark_all_read",
     timestamp: updatedAt,
     updatedAt,
+    ...(entryId !== undefined ? { entryId } : {}),
   };
 }
 
@@ -189,7 +190,24 @@ describe("advanceCursors", () => {
       expect(advanceCursors(cursors, entryEvent(T, "a"))).toBe(cursors);
     });
 
-    it("advances past the whole tied group for mark_all_read (max id sentinel)", () => {
+    // #1102: mark_all_read carries the LARGEST marked entry id, so the cursor
+    // lands exactly past the marked rows instead of past the whole tied group.
+    // A same-millisecond unrelated entry (UUIDv7 id above every earlier-created
+    // marked entry) stays after the cursor and is still delivered by catch-up.
+    it("advances to the max marked id for mark_all_read, keeping later tied ids syncable", () => {
+      const cursors = advanceCursors(EMPTY_CURSORS, entryEvent(T, "b"));
+      const next = advanceCursors(cursors, markAllReadEvent(T, "d"));
+      expect(next.entries).toBe(T);
+      expect(next.entriesAfterId).toBe("d");
+    });
+
+    it("does not move the tiebreaker backward for a mark_all_read with a smaller max id", () => {
+      const cursors = advanceCursors(EMPTY_CURSORS, entryEvent(T, "e"));
+      expect(advanceCursors(cursors, markAllReadEvent(T, "c"))).toBe(cursors);
+    });
+
+    it("falls back to skipping the whole tied group when mark_all_read has no entryId", () => {
+      // Events from servers predating the entryId field (#1102).
       const cursors = advanceCursors(EMPTY_CURSORS, entryEvent(T, "b"));
       const next = advanceCursors(cursors, markAllReadEvent(T));
       expect(next.entries).toBe(T);


### PR DESCRIPTION
Fixes #1102.

## Problem

`mark_all_read` carries no entry id, so the client advanced its entries keyset cursor to `(T, MAX_UUID)` — skipping the **whole** tied-timestamp group in a later `sync.events` catch-up. An unrelated entry whose `GREATEST(entries.updated_at, user_entries.updated_at)` landed on the same millisecond `T` as the mark-all-read (both stamps come from JS `new Date()`, so a collision needs only the same millisecond) was then permanently excluded from catch-up if its live SSE event was missed: the tie branch `GREATEST = T AND id > MAX_UUID` is always false.

## Fix

The `mark_all_read` event now carries the **largest entry id among the marked rows**, and the client advances the keyset to `(T, maxMarkedId)` instead:

- Every marked row sorts at or below `maxMarkedId`, so a catch-up still doesn't re-deliver the marked entries one by one (the reason the sentinel existed).
- A genuinely-new entry written in the colliding millisecond has a UUIDv7 id generated at ~`T`, which sorts **above** every earlier-created marked entry — so it stays past the cursor and catch-up delivers it.

Events without the field (published by servers predating it, during a rolling deploy) fall back to the old `MAX_UUID` whole-group skip, which remains backstopped by the `entries.list` invalidation that `mark_all_read` already triggers.

Residual (documented in `cursors.ts`): an *old* entry updated in the exact same millisecond, or a marked entry created in that same millisecond whose random UUIDv7 bits out-sort the newcomer, can still be skipped — both are compounded rarities covered by the same invalidation backstop.

## Changes

- `src/server/services/entries.ts` — `markAllEntriesRead` computes the max marked id and passes it to the publisher.
- `src/server/redis/pubsub.ts` — `mark_all_read` event schema + `publishMarkAllRead` gain the (optional-on-parse) `entryId` field.
- `src/lib/events/schemas.ts` — client event schema gains optional `entryId`.
- `src/lib/events/cursors.ts` — `entryEventAfterId` uses `event.entryId ?? MAX_UUID`; docs updated.

## Tests

- Unit (`cursors.test.ts`): keyset advances to the max marked id; doesn't move backward; `MAX_UUID` fallback when the field is absent.
- Integration (`mark-all-read-events.test.ts`): the published event carries the max marked id.
- Integration (`sync-events.test.ts`): end-to-end issue scenario — real `markAllRead`, an unrelated entry inserted at exactly `T`, cursor advanced through the real `advanceCursors`; the newcomer is delivered and no marked row re-delivers, with a contrast assertion showing the old sentinel hid it.

`pnpm typecheck`, `pnpm test:unit` (2383 passed), and the full integration suite (673 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)