### PR TITLE
Add announcement banner and maintenance mode (admin-controlled)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -420,6 +420,10 @@ Practically, this means using the expand/contract pattern:
 - **Expand** (safe in one release): add nullable columns or columns with defaults, add tables, add indexes, create views alongside old ones
 - **Contract** (requires two releases): to drop or rename a column/table, first ship a release whose code no longer references it; only then ship the migration that removes it. A rename is an add + dual-write/backfill + drop across releases, never a single `ALTER ... RENAME`.
 
+### Maintenance Mode
+
+For a heavier migration that can't be made backward-compatible (a data backfill, a non-expand/contract change), an admin can flip **maintenance mode** from `/admin` → Status. It is a **Redis** flag (not Postgres — the DB may be the thing being migrated) read by every process group. The custom server (`scripts/server.ts`) then serves a self-contained 503 maintenance page/JSON for all traffic except the demo (no DB), the admin panel, and the health check; the worker stops claiming jobs and the Discord bot stops responding. Turning it off resumes everything with no redeploy. A `MAINTENANCE_MODE` env var is an additional force-on fallback. There's also a Redis-backed, closeable **announcement banner** (info/warning) shown site-wide for known-issue notices. See "Site Status" in `src/server/CLAUDE.md`.
+
 ### Local Development
 
 Docker Compose provides Postgres and Redis for local development. See README for setup instructions (and "Local Services" in the root CLAUDE.md for the no-Docker path).

--- a/scripts/raw-color-baseline.json
+++ b/scripts/raw-color-baseline.json
@@ -22,6 +22,7 @@
   "src/components/admin/AdminApp.tsx\thover:border-zinc-300",
   "src/components/admin/AdminFeedsContent.tsx\tdark:bg-zinc-800",
   "src/components/admin/AdminInvitesContent.tsx\tdark:bg-zinc-800/60",
+  "src/components/admin/AdminStatusContent.tsx\tdark:bg-zinc-800",
   "src/components/auth/OAuthSignInButton.tsx\tdark:hover:bg-zinc-200",
   "src/components/auth/OAuthSignInButton.tsx\thover:bg-zinc-800",
   "src/components/entries/EntryArticle.tsx\tactive:text-zinc-800",

--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -69,7 +69,7 @@ app.prepare().then(() => {
     const maintenance = getCurrentMaintenance();
     if (maintenance.enabled) {
       const pathname = (req.url || "/").split("?")[0];
-      const decision = evaluateRequest(pathname, req.headers.cookie);
+      const decision = evaluateRequest(pathname, req.headers.cookie, req.headers.authorization);
       if (decision !== "allow") {
         res.statusCode = 503;
         res.setHeader("Retry-After", "3600");

--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -17,6 +17,13 @@ import { createServer } from "node:http";
 import { maybeCompressResponse } from "../src/server/http/compression";
 import { stripOauthSurfaceTrailingSlash } from "../src/server/http/trailing-slash";
 import { startMetricsServer, stopMetricsServer } from "../src/server/metrics/server";
+import {
+  startMaintenancePoller,
+  getCurrentMaintenance,
+  evaluateRequest,
+  renderMaintenanceHtml,
+  maintenanceJsonBody,
+} from "../src/server/maintenance/server-gate";
 import { getResourceCleanup } from "../src/server/shutdown";
 import { logger } from "../src/lib/logger";
 
@@ -42,6 +49,10 @@ app.prepare().then(() => {
   const handle = app.getRequestHandler();
   const upgrade = app.getUpgradeHandler();
 
+  // Poll Redis for the maintenance flag so the per-request check below stays
+  // synchronous (no await on the hot path).
+  startMaintenancePoller();
+
   const server = createServer((req, res) => {
     // OAuth/MCP endpoints must answer trailing-slash URLs in place instead of
     // Next's default 308 (server-to-server OAuth clients don't follow
@@ -51,6 +62,29 @@ app.prepare().then(() => {
     if (req.url) {
       req.url = stripOauthSurfaceTrailingSlash(req.url);
     }
+
+    // Maintenance mode: short-circuit everything except the exempt surfaces
+    // (demo, admin, health, static). Demo stays up because it never touches the
+    // database, which is the whole point during a DB migration.
+    const maintenance = getCurrentMaintenance();
+    if (maintenance.enabled) {
+      const pathname = (req.url || "/").split("?")[0];
+      const decision = evaluateRequest(pathname, req.headers.cookie);
+      if (decision !== "allow") {
+        res.statusCode = 503;
+        res.setHeader("Retry-After", "3600");
+        res.setHeader("Cache-Control", "no-store");
+        if (decision === "block-api") {
+          res.setHeader("Content-Type", "application/json; charset=utf-8");
+          res.end(maintenanceJsonBody(maintenance.message));
+        } else {
+          res.setHeader("Content-Type", "text/html; charset=utf-8");
+          res.end(renderMaintenanceHtml(maintenance.message));
+        }
+        return;
+      }
+    }
+
     maybeCompressResponse(req, res);
     handle(req, res);
   });

--- a/scripts/theme-token-baseline.json
+++ b/scripts/theme-token-baseline.json
@@ -1,5 +1,7 @@
 [
   "accent-height",
+  "border-box",
+  "border-color",
   "border-radius",
   "fill-opacity",
   "fill-rule",

--- a/src/app/admin/status/page.tsx
+++ b/src/app/admin/status/page.tsx
@@ -1,0 +1,8 @@
+/**
+ * Admin Status Page
+ *
+ * Route marker for /admin/status. Content is rendered by AdminApp.
+ */
+export default function AdminStatusPage() {
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono, Merriweather, Literata, Inter, Source_Sans_3 } from 
 import { defaultOpenGraph } from "@/lib/metadata";
 import { appUrl } from "@/server/config/env";
 import { ThemeProvider } from "@/lib/theme/ThemeProvider";
+import { AnnouncementBanner } from "@/components/layout/AnnouncementBanner";
+import { getAnnouncement } from "@/server/services/site-status";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -140,11 +142,15 @@ if ('serviceWorker' in navigator) {
 }
 `;
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Global announcement banner (admin-controlled, Redis-backed). Fetched here so
+  // it renders on every route including the demo and logged-out surfaces.
+  const announcement = await getAnnouncement();
+
   return (
     // Font variables live on <html> (not <body>) so the entry text-appearance
     // custom properties, which are set on documentElement by the head script
@@ -162,7 +168,10 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: swScript }} />
       </head>
       <body className="antialiased">
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          <AnnouncementBanner announcement={announcement} />
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/admin/AdminApp.tsx
+++ b/src/components/admin/AdminApp.tsx
@@ -24,12 +24,14 @@ import AdminOverviewContent from "@/components/admin/AdminOverviewContent";
 import AdminInvitesContent from "@/components/admin/AdminInvitesContent";
 import AdminFeedsContent from "@/components/admin/AdminFeedsContent";
 import AdminUsersContent from "@/components/admin/AdminUsersContent";
+import AdminStatusContent from "@/components/admin/AdminStatusContent";
 
 const adminTabs = [
   { href: "/admin/overview", label: "Overview" },
   { href: "/admin/invites", label: "Invites" },
   { href: "/admin/feeds", label: "Feed Health" },
   { href: "/admin/users", label: "Users" },
+  { href: "/admin/status", label: "Status" },
 ];
 
 /**
@@ -169,6 +171,8 @@ function AdminContentRouter() {
       return <AdminFeedsContent />;
     case "/admin/users":
       return <AdminUsersContent />;
+    case "/admin/status":
+      return <AdminStatusContent />;
     default:
       return <AdminOverviewContent />;
   }

--- a/src/components/admin/AdminStatusContent.tsx
+++ b/src/components/admin/AdminStatusContent.tsx
@@ -1,0 +1,258 @@
+/**
+ * Admin Status Content
+ *
+ * Controls the site-wide announcement banner and maintenance mode. Both flags
+ * are stored in Redis (DB-independent) so maintenance mode works during a
+ * database migration. See src/server/services/site-status.ts.
+ */
+
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { trpc } from "@/lib/trpc/client";
+import { Button } from "@/components/ui/button";
+import { Card, StatusCard } from "@/components/ui/card";
+import { SpinnerIcon } from "@/components/ui/icon-button";
+import { AnnouncementBannerView } from "@/components/layout/AnnouncementBanner";
+import type { AnnouncementLevel } from "@/server/services/site-status";
+
+const MESSAGE_MAX = 1000;
+
+const textareaClass =
+  "ui-text-sm bg-surface text-body border-edge-input focus:border-focus focus:ring-focus block w-full rounded-md border px-3 py-2 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+const selectClass =
+  "ui-text-sm bg-surface text-body border-edge-input focus:border-focus focus:ring-focus block rounded-md border px-3 py-2 focus:ring-2 focus:ring-offset-2 focus:outline-none";
+const checkboxClass =
+  "text-accent focus:ring-focus border-edge-input h-4 w-4 rounded dark:bg-zinc-800";
+
+interface SiteStatus {
+  maintenance: { enabled: boolean; message: string };
+  announcement: { enabled: boolean; message: string; level: AnnouncementLevel };
+}
+
+/**
+ * The form, seeded once from the initial query result. Split out so the seeding
+ * happens via useState initializers (not a setState-in-effect). After a save the
+ * query re-invalidates, but the operator's typed values are the source of truth,
+ * so we deliberately don't re-seed.
+ */
+function StatusForm({ initial }: { initial: SiteStatus }) {
+  const utils = trpc.useUtils();
+
+  const [annEnabled, setAnnEnabled] = useState(initial.announcement.enabled);
+  const [annMessage, setAnnMessage] = useState(initial.announcement.message);
+  const [annLevel, setAnnLevel] = useState<AnnouncementLevel>(initial.announcement.level);
+
+  const [maintEnabled, setMaintEnabled] = useState(initial.maintenance.enabled);
+  const [maintMessage, setMaintMessage] = useState(initial.maintenance.message);
+
+  const setAnnouncement = trpc.admin.setAnnouncement.useMutation({
+    onSuccess: () => {
+      void utils.admin.getSiteStatus.invalidate();
+      toast.success("Announcement saved");
+    },
+    onError: (error) => toast.error(error.message || "Failed to save announcement"),
+  });
+
+  const setMaintenance = trpc.admin.setMaintenance.useMutation({
+    onSuccess: (_data, variables) => {
+      setMaintEnabled(variables.enabled);
+      void utils.admin.getSiteStatus.invalidate();
+      toast.success(variables.enabled ? "Maintenance mode enabled" : "Maintenance mode disabled");
+    },
+    onError: (error) => toast.error(error.message || "Failed to update maintenance mode"),
+  });
+
+  return (
+    <div className="space-y-6">
+      {/* Announcement banner ------------------------------------------------ */}
+      <section>
+        <h2 className="ui-text-base text-body mb-1 font-semibold">Announcement banner</h2>
+        <p className="text-muted ui-text-sm mb-3">
+          Shown at the top of every page (including the demo and logged-out visitors). Users can
+          dismiss it; changing the message re-shows it to everyone.
+        </p>
+        <Card>
+          <div className="space-y-4">
+            <div>
+              <label
+                htmlFor="ann-message"
+                className="ui-text-sm text-body mb-1.5 block font-medium"
+              >
+                Message
+              </label>
+              <textarea
+                id="ann-message"
+                rows={3}
+                maxLength={MESSAGE_MAX}
+                placeholder="e.g. Known issue: feed refresh is delayed. We're on it."
+                value={annMessage}
+                onChange={(e) => setAnnMessage(e.target.value)}
+                disabled={setAnnouncement.isPending}
+                className={textareaClass}
+              />
+            </div>
+
+            <div className="flex flex-wrap items-center gap-4">
+              <div>
+                <label
+                  htmlFor="ann-level"
+                  className="ui-text-sm text-body mb-1.5 block font-medium"
+                >
+                  Level
+                </label>
+                <select
+                  id="ann-level"
+                  value={annLevel}
+                  onChange={(e) => setAnnLevel(e.target.value as AnnouncementLevel)}
+                  disabled={setAnnouncement.isPending}
+                  className={selectClass}
+                >
+                  <option value="info">Info (blue)</option>
+                  <option value="warning">Warning (amber)</option>
+                </select>
+              </div>
+
+              <label className="ui-text-sm text-body mt-6 flex cursor-pointer items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={annEnabled}
+                  onChange={(e) => setAnnEnabled(e.target.checked)}
+                  disabled={setAnnouncement.isPending}
+                  className={checkboxClass}
+                />
+                Enabled
+              </label>
+            </div>
+
+            {/* Live preview */}
+            {annMessage.trim() !== "" && (
+              <div>
+                <p className="text-muted ui-text-xs mb-1.5 font-medium">Preview</p>
+                <div className="border-edge overflow-hidden rounded-md border">
+                  <AnnouncementBannerView message={annMessage} level={annLevel} />
+                </div>
+              </div>
+            )}
+
+            <div className="flex gap-2">
+              <Button
+                onClick={() =>
+                  setAnnouncement.mutate({
+                    enabled: annEnabled,
+                    message: annMessage,
+                    level: annLevel,
+                  })
+                }
+                loading={setAnnouncement.isPending}
+              >
+                Save announcement
+              </Button>
+              <Button
+                variant="secondary"
+                disabled={setAnnouncement.isPending}
+                onClick={() => {
+                  setAnnEnabled(false);
+                  setAnnMessage("");
+                  setAnnLevel("info");
+                  setAnnouncement.mutate({ enabled: false, message: "", level: "info" });
+                }}
+              >
+                Clear
+              </Button>
+            </div>
+          </div>
+        </Card>
+      </section>
+
+      {/* Maintenance mode --------------------------------------------------- */}
+      <section>
+        <h2 className="ui-text-base text-body mb-1 font-semibold">Maintenance mode</h2>
+        <p className="text-muted ui-text-sm mb-3">
+          Takes the whole site and API down behind a maintenance page, and pauses the worker and
+          Discord bot. The demo and this admin panel stay up. Use this for database migrations.
+        </p>
+        <Card>
+          <div className="space-y-4">
+            <StatusCard variant={maintEnabled ? "error" : "warning"}>
+              {maintEnabled ? (
+                <span>
+                  <strong>Maintenance mode is ON.</strong> The site and API are down for everyone
+                  except the demo and admin panel.
+                </span>
+              ) : (
+                <span>
+                  Enabling this makes the site and API return a maintenance page for all users
+                  (except the demo and admin), and pauses the worker and Discord bot.
+                </span>
+              )}
+            </StatusCard>
+
+            <div>
+              <label
+                htmlFor="maint-message"
+                className="ui-text-sm text-body mb-1.5 block font-medium"
+              >
+                Maintenance message <span className="text-faint font-normal">(optional)</span>
+              </label>
+              <textarea
+                id="maint-message"
+                rows={2}
+                maxLength={MESSAGE_MAX}
+                placeholder="Lion Reader is temporarily down for scheduled maintenance. We'll be back shortly."
+                value={maintMessage}
+                onChange={(e) => setMaintMessage(e.target.value)}
+                disabled={setMaintenance.isPending}
+                className={textareaClass}
+              />
+            </div>
+
+            <div className="flex gap-2">
+              {maintEnabled ? (
+                <Button
+                  variant="secondary"
+                  loading={setMaintenance.isPending}
+                  onClick={() => setMaintenance.mutate({ enabled: false, message: maintMessage })}
+                >
+                  Disable maintenance mode
+                </Button>
+              ) : (
+                <Button
+                  variant="danger"
+                  loading={setMaintenance.isPending}
+                  onClick={() => setMaintenance.mutate({ enabled: true, message: maintMessage })}
+                >
+                  Enable maintenance mode
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                disabled={setMaintenance.isPending}
+                onClick={() =>
+                  setMaintenance.mutate({ enabled: maintEnabled, message: maintMessage })
+                }
+              >
+                Save message
+              </Button>
+            </div>
+          </div>
+        </Card>
+      </section>
+    </div>
+  );
+}
+
+export default function AdminStatusContent() {
+  const statusQuery = trpc.admin.getSiteStatus.useQuery();
+
+  if (statusQuery.isLoading || !statusQuery.data) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <SpinnerIcon className="text-faint h-6 w-6" />
+      </div>
+    );
+  }
+
+  return <StatusForm initial={statusQuery.data} />;
+}

--- a/src/components/layout/AnnouncementBanner.tsx
+++ b/src/components/layout/AnnouncementBanner.tsx
@@ -1,0 +1,95 @@
+/**
+ * Announcement Banner
+ *
+ * A closeable bar rendered at the very top of every page (from the root layout).
+ * The announcement is fetched server-side and passed in as a prop, so this needs
+ * no client API call. Dismissal is stored in localStorage keyed by the
+ * announcement's message-derived id: dismissing sticks for that exact message,
+ * but a new/changed announcement gets a new id and re-appears.
+ */
+
+"use client";
+
+import { useCallback, useState } from "react";
+import { CloseIcon } from "@/components/ui/icon-button";
+import type { AnnouncementLevel } from "@/server/services/site-status";
+
+const STORAGE_KEY = "lion-reader:announcement-dismissed";
+
+const LEVEL_STYLES: Record<AnnouncementLevel, string> = {
+  info: "bg-info-subtle text-info-subtle-foreground border-info-border",
+  warning: "bg-warning-banner text-warning-banner-foreground border-transparent",
+};
+
+/**
+ * Presentational banner. Shared with the admin preview so the operator sees
+ * exactly what users will see. `onDismiss` is omitted in preview mode.
+ */
+export function AnnouncementBannerView({
+  message,
+  level,
+  onDismiss,
+}: {
+  message: string;
+  level: AnnouncementLevel;
+  onDismiss?: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      className={`flex items-start gap-3 border-b px-4 py-2.5 ${LEVEL_STYLES[level]}`}
+    >
+      <p className="ui-text-sm mx-auto max-w-4xl flex-1 text-center font-medium break-words whitespace-pre-wrap">
+        {message}
+      </p>
+      {onDismiss && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss announcement"
+          className="focus:ring-focus -mr-1 shrink-0 rounded p-1 opacity-80 hover:opacity-100 focus:ring-2 focus:outline-none"
+        >
+          <CloseIcon className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+export interface AnnouncementBannerProps {
+  announcement: { id: string; message: string; level: AnnouncementLevel } | null;
+}
+
+export function AnnouncementBanner({ announcement }: AnnouncementBannerProps) {
+  // Lazy init (SSR-safe): read the dismissed id once. Matches the localStorage
+  // pattern in useKeyboardShortcutsEnabled.ts.
+  const [dismissedId, setDismissedId] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  });
+
+  const dismiss = useCallback(() => {
+    if (!announcement) return;
+    setDismissedId(announcement.id);
+    try {
+      localStorage.setItem(STORAGE_KEY, announcement.id);
+    } catch {
+      // localStorage unavailable (private browsing) — banner stays hidden for
+      // this session via the state update above.
+    }
+  }, [announcement]);
+
+  if (!announcement || dismissedId === announcement.id) return null;
+
+  return (
+    <AnnouncementBannerView
+      message={announcement.message}
+      level={announcement.level}
+      onDismiss={dismiss}
+    />
+  );
+}

--- a/src/server/CLAUDE.md
+++ b/src/server/CLAUDE.md
@@ -10,6 +10,14 @@ Business logic lives in pure service functions in `src/server/services/` — fun
 
 Entry content served by `getEntry`/`getEntries`/`toFullEntry` is **sanitized in the services layer** (see `src/server/html/CLAUDE.md`), so every consumer gets the same guarantee.
 
+## Site Status (announcement banner + maintenance mode)
+
+Two admin-controlled global flags live in **Redis, not Postgres** (`src/server/services/site-status.ts`): a site-wide **announcement banner** and a **maintenance mode** kill switch. Redis is deliberate — maintenance mode is meant to be turned on _while Postgres is being migrated/locked_, so the code that reads it must not depend on the DB. Both reads are fail-safe (Redis down ⇒ no banner, maintenance = the `MAINTENANCE_MODE` env override only) and cached in-process for a few seconds so the hot paths issue no per-request Redis round-trip.
+
+- **Maintenance gate** (`src/server/maintenance/server-gate.ts`) runs in the **custom HTTP server** (`scripts/server.ts`) — the single choke point every request passes through before Next.js. A background poller keeps the flag in a module variable so the per-request `evaluateRequest(pathname, cookie)` check is synchronous. When on, everything returns a 503 (HTML page / JSON body) **except** the demo (`/demo`, no DB), the admin panel + its session route (`/admin`, `/api/admin`), the health check, legal pages, `/`, and static assets; `/api/trpc` stays open only to a valid `admin_session` cookie so the admin can toggle it back off. `evaluateRequest` is pure and unit-tested (`tests/unit/maintenance-gate.test.ts`).
+- The **worker** (`src/server/jobs/worker.ts`) wraps its `claimJob` to return null while maintenance is on (no Postgres access; the loop just sleeps and resumes automatically), and the **Discord bot** (`src/server/discord/bot.ts`) short-circuits its DB-touching handlers. All three process groups (app/worker/discord) read the same Redis flag.
+- Admin control is the `getSiteStatus` / `setAnnouncement` / `setMaintenance` endpoints on `adminRouter`; the banner is rendered SSR from the root layout via `getAnnouncement()` (see `src/components/layout/AnnouncementBanner.tsx`).
+
 ## Subscription Views
 
 Use the database views for frontend queries instead of manual joins:

--- a/src/server/auth/bearer.ts
+++ b/src/server/auth/bearer.ts
@@ -1,0 +1,22 @@
+/**
+ * Parse an `Authorization: Bearer <token>` header.
+ *
+ * Parsed with a single left-to-right whitespace scan rather than a regex like
+ * `/^Bearer\s+(.+)$/i`. That regex is ambiguous — both `\s+` and `.+` can match
+ * a space — so a crafted header (`Bearer` + many spaces + a char `.` can't
+ * match, e.g. a newline) makes the backtracking engine run in quadratic time
+ * (ReDoS, CWE-1333). This scan is linear.
+ *
+ * Semantics: the scheme is matched case-insensitively (per RFC 7235) and the
+ * returned token is trimmed of surrounding whitespace. Returns null if the
+ * header is absent, has no whitespace separator, the scheme isn't `Bearer`, or
+ * the token is empty.
+ */
+export function extractBearerToken(authHeader: string | null | undefined): string | null {
+  if (!authHeader) return null;
+  // A single `\s` with no quantifier can't backtrack, so this is O(n).
+  const wsIdx = authHeader.search(/\s/);
+  if (wsIdx === -1) return null;
+  if (authHeader.slice(0, wsIdx).toLowerCase() !== "bearer") return null;
+  return authHeader.slice(wsIdx + 1).trim() || null;
+}

--- a/src/server/discord/bot.ts
+++ b/src/server/discord/bot.ts
@@ -33,6 +33,7 @@ import { db } from "@/server/db";
 import { oauthAccounts } from "@/server/db/schema";
 import { saveArticle } from "@/server/services/saved";
 import { validateApiToken } from "@/server/auth/api-token";
+import { getMaintenance } from "@/server/services/site-status";
 import { getRedisClient } from "@/server/redis";
 import { logger } from "@/lib/logger";
 import {
@@ -45,6 +46,20 @@ import {
 
 // Redis key prefix for storing Discord user -> API token mappings
 const REDIS_KEY_PREFIX = "discord:token:";
+
+/** Shown to users when the bot is paused for maintenance. */
+const MAINTENANCE_REPLY =
+  "🛠️ Lion Reader is temporarily down for maintenance — please try again shortly.";
+
+/**
+ * Whether maintenance mode is active. Every DB-touching handler consults this
+ * before doing any work, so during a database migration the bot stays connected
+ * but does nothing that would hit Postgres. The read is cached in-process, so
+ * this adds no per-event Redis load.
+ */
+async function isUnderMaintenance(): Promise<boolean> {
+  return (await getMaintenance()).enabled;
+}
 
 // How long after login() to wait for the gateway `clientReady` event before
 // warning that the bot connected but isn't receiving events.
@@ -264,6 +279,10 @@ export async function startDiscordBot(): Promise<void> {
     const { commandName, user } = interaction;
 
     try {
+      if (await isUnderMaintenance()) {
+        await interaction.reply({ content: MAINTENANCE_REPLY, flags: MessageFlags.Ephemeral });
+        return;
+      }
       if (commandName === "link") {
         await handleLinkCommand(interaction, user);
       } else if (commandName === "unlink") {
@@ -543,6 +562,13 @@ async function handleSaveReaction(
   partialMessage: Message | { partial: true; fetch: () => Promise<Message> },
   user: User | PartialUser
 ): Promise<void> {
+  // Paused for maintenance — don't touch the database. Reactions are a
+  // low-signal surface, so skip silently rather than DMing the user.
+  if (await isUnderMaintenance()) {
+    logger.info("Ignoring save reaction: maintenance mode active", { discordId: user.id });
+    return;
+  }
+
   // Look up Lion Reader user
   const resolved = await resolveUser(user.id);
   if (!resolved) {
@@ -588,6 +614,20 @@ async function handleDirectMessage(message: Message): Promise<void> {
       messageId: message.id,
       contentLength: message.content?.length ?? 0,
     });
+    return;
+  }
+
+  // Paused for maintenance — they sent a link, so tell them to retry instead of
+  // touching the database.
+  if (await isUnderMaintenance()) {
+    logger.info("Ignoring direct message: maintenance mode active", {
+      discordId: message.author.id,
+    });
+    try {
+      await message.reply(MAINTENANCE_REPLY);
+    } catch (error) {
+      logger.warn("Failed to reply to DM during maintenance", { error });
+    }
     return;
   }
 

--- a/src/server/google-reader/auth.ts
+++ b/src/server/google-reader/auth.ts
@@ -15,6 +15,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/server/db";
 import { users } from "@/server/db/schema";
 import { createSession, validateSession, type SessionData } from "@/server/auth/session";
+import { extractBearerToken } from "@/server/auth/bearer";
 import { isSignupConfirmed } from "@/server/auth/confirmation";
 import { OAUTH_SCOPES } from "@/server/oauth/utils";
 
@@ -87,9 +88,9 @@ export function extractAuthToken(request: Request): string | null {
   }
 
   // Bearer {token}
-  const bearerMatch = authHeader.match(/^Bearer\s+(.+)$/i);
-  if (bearerMatch) {
-    return bearerMatch[1];
+  const bearerToken = extractBearerToken(authHeader);
+  if (bearerToken) {
+    return bearerToken;
   }
 
   return null;

--- a/src/server/jobs/worker.ts
+++ b/src/server/jobs/worker.ts
@@ -37,6 +37,7 @@ import type { Job } from "../db/schema";
 import { logger as appLogger } from "@/lib/logger";
 import * as Sentry from "@sentry/nextjs";
 import { trackJobProcessed } from "../metrics/metrics";
+import { getMaintenance } from "../services/site-status";
 import { createWorkerCore, type WorkerLogger, type Worker } from "./worker-core";
 
 // Re-export types for backwards compatibility
@@ -372,6 +373,28 @@ function createWorker(config: WorkerConfig = {}): Worker {
     claimSingleton: claimSingletonJob,
   });
 
+  // Maintenance-mode guard: while maintenance is on, claim nothing so the worker
+  // never touches Postgres (maintenance is used during DB migrations). Returning
+  // null makes the core loop simply sleep(pollIntervalMs) and poll again; the
+  // process stays alive and resumes automatically when the flag clears. The
+  // maintenance read is cached in-process, so this adds no per-claim Redis load.
+  let maintenancePaused = false;
+  const guardedClaimJob = async (options?: { types?: JobType[] }): Promise<Job | null> => {
+    const { enabled } = await getMaintenance();
+    if (enabled) {
+      if (!maintenancePaused) {
+        maintenancePaused = true;
+        logger.warn("Maintenance mode active — worker paused, not claiming jobs");
+      }
+      return null;
+    }
+    if (maintenancePaused) {
+      maintenancePaused = false;
+      logger.info("Maintenance mode cleared — worker resumed");
+    }
+    return claimJob(options);
+  };
+
   /**
    * Processes a single job using the real handlers.
    */
@@ -566,7 +589,7 @@ function createWorker(config: WorkerConfig = {}): Worker {
     jobTimeoutMs,
     jobTypes,
     logger,
-    claimJob,
+    claimJob: guardedClaimJob,
     processJob,
     onJobError: (job, error) => {
       Sentry.captureException(error, {

--- a/src/server/maintenance/server-gate.ts
+++ b/src/server/maintenance/server-gate.ts
@@ -19,6 +19,7 @@ import {
   validateAdminSessionToken,
   validateAdminSecret,
 } from "@/server/auth/admin-session";
+import { extractBearerToken } from "@/server/auth/bearer";
 import { logger } from "@/lib/logger";
 
 export type GateDecision = "allow" | "block-page" | "block-api";
@@ -55,19 +56,6 @@ const EXEMPT_EXACT = new Set([
 /** A path is treated as a static asset when it ends in a common file extension. */
 const STATIC_EXT =
   /\.(?:ico|png|jpg|jpeg|gif|svg|webp|avif|css|js|mjs|map|woff2?|ttf|otf|eot|json|txt|xml|wasm)$/i;
-
-/**
- * Extract the token from an `Authorization: Bearer <token>` header. Parsed
- * without a backtracking regex — `/^Bearer\s+(.+)$/` is ambiguous (both `\s+`
- * and `.+` match spaces) and can go quadratic on a crafted header (ReDoS). A
- * single left-to-right scan for the first whitespace is linear and safe.
- */
-function extractBearerToken(authHeader: string): string | null {
-  const wsIdx = authHeader.search(/\s/); // single \s, no quantifier → no backtracking
-  if (wsIdx === -1) return null;
-  if (authHeader.slice(0, wsIdx).toLowerCase() !== "bearer") return null;
-  return authHeader.slice(wsIdx + 1).trim() || null;
-}
 
 /**
  * Whether the request carries a valid admin credential. Mirrors `adminMiddleware`

--- a/src/server/maintenance/server-gate.ts
+++ b/src/server/maintenance/server-gate.ts
@@ -57,6 +57,19 @@ const STATIC_EXT =
   /\.(?:ico|png|jpg|jpeg|gif|svg|webp|avif|css|js|mjs|map|woff2?|ttf|otf|eot|json|txt|xml|wasm)$/i;
 
 /**
+ * Extract the token from an `Authorization: Bearer <token>` header. Parsed
+ * without a backtracking regex — `/^Bearer\s+(.+)$/` is ambiguous (both `\s+`
+ * and `.+` match spaces) and can go quadratic on a crafted header (ReDoS). A
+ * single left-to-right scan for the first whitespace is linear and safe.
+ */
+function extractBearerToken(authHeader: string): string | null {
+  const wsIdx = authHeader.search(/\s/); // single \s, no quantifier → no backtracking
+  if (wsIdx === -1) return null;
+  if (authHeader.slice(0, wsIdx).toLowerCase() !== "bearer") return null;
+  return authHeader.slice(wsIdx + 1).trim() || null;
+}
+
+/**
  * Whether the request carries a valid admin credential. Mirrors `adminMiddleware`
  * (src/server/trpc/trpc.ts): either the `admin_session` cookie or a
  * `Bearer <ALLOWLIST_SECRET>` header, so programmatic admins aren't locked out.
@@ -72,8 +85,8 @@ function hasValidAdminAuth(cookieHeader?: string, authHeader?: string): boolean 
     }
   }
   if (authHeader) {
-    const match = authHeader.match(/^Bearer\s+(.+)$/i);
-    if (match?.[1] && validateAdminSecret(match[1])) return true;
+    const token = extractBearerToken(authHeader);
+    if (token && validateAdminSecret(token)) return true;
   }
   return false;
 }

--- a/src/server/maintenance/server-gate.ts
+++ b/src/server/maintenance/server-gate.ts
@@ -14,7 +14,11 @@
  */
 
 import { getMaintenance, type MaintenanceState } from "@/server/services/site-status";
-import { ADMIN_COOKIE_NAME, validateAdminSessionToken } from "@/server/auth/admin-session";
+import {
+  ADMIN_COOKIE_NAME,
+  validateAdminSessionToken,
+  validateAdminSecret,
+} from "@/server/auth/admin-session";
 import { logger } from "@/lib/logger";
 
 export type GateDecision = "allow" | "block-page" | "block-api";
@@ -52,37 +56,56 @@ const EXEMPT_EXACT = new Set([
 const STATIC_EXT =
   /\.(?:ico|png|jpg|jpeg|gif|svg|webp|avif|css|js|mjs|map|woff2?|ttf|otf|eot|json|txt|xml|wasm)$/i;
 
-function hasValidAdminCookie(cookieHeader: string | undefined): boolean {
-  if (!cookieHeader) return false;
-  for (const part of cookieHeader.split(/;\s*/)) {
-    const eq = part.indexOf("=");
-    if (eq === -1) continue;
-    const name = part.slice(0, eq);
-    if (name !== ADMIN_COOKIE_NAME) continue;
-    const value = part.slice(eq + 1);
-    if (value && validateAdminSessionToken(value)) return true;
+/**
+ * Whether the request carries a valid admin credential. Mirrors `adminMiddleware`
+ * (src/server/trpc/trpc.ts): either the `admin_session` cookie or a
+ * `Bearer <ALLOWLIST_SECRET>` header, so programmatic admins aren't locked out.
+ */
+function hasValidAdminAuth(cookieHeader?: string, authHeader?: string): boolean {
+  if (cookieHeader) {
+    for (const part of cookieHeader.split(/;\s*/)) {
+      const eq = part.indexOf("=");
+      if (eq === -1) continue;
+      if (part.slice(0, eq) !== ADMIN_COOKIE_NAME) continue;
+      const value = part.slice(eq + 1);
+      if (value && validateAdminSessionToken(value)) return true;
+    }
+  }
+  if (authHeader) {
+    const match = authHeader.match(/^Bearer\s+(.+)$/i);
+    if (match?.[1] && validateAdminSecret(match[1])) return true;
   }
   return false;
 }
 
 /**
  * Decide what to do with a request while maintenance is active. Pure — takes the
- * pathname and raw Cookie header, returns the decision. Unit-tested.
+ * pathname and the raw Cookie/Authorization headers, returns the decision.
+ * Unit-tested.
  */
-export function evaluateRequest(pathname: string, cookieHeader?: string): GateDecision {
+export function evaluateRequest(
+  pathname: string,
+  cookieHeader?: string,
+  authHeader?: string
+): GateDecision {
   if (EXEMPT_EXACT.has(pathname)) return "allow";
   if (EXEMPT_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))) {
     return "allow";
   }
-  if (STATIC_EXT.test(pathname)) return "allow";
 
   const isApi = pathname === "/api" || pathname.startsWith("/api/");
 
-  // The main tRPC endpoint stays open ONLY to a valid admin session, so the
+  // The main tRPC endpoint stays open ONLY to a valid admin credential, so the
   // admin panel can read status and toggle maintenance back off.
   if (pathname === "/api/trpc" || pathname.startsWith("/api/trpc/")) {
-    return hasValidAdminCookie(cookieHeader) ? "allow" : "block-api";
+    return hasValidAdminAuth(cookieHeader, authHeader) ? "allow" : "block-api";
   }
+
+  // Static assets stay up — but ONLY off the API surface. Several authenticated
+  // API routes end in a static-looking suffix (the Wallabag compat API uses
+  // `.json`), and those must be blocked, so this check runs after the API
+  // decisions and never applies under `/api/`.
+  if (!isApi && STATIC_EXT.test(pathname)) return "allow";
 
   return isApi ? "block-api" : "block-page";
 }

--- a/src/server/maintenance/server-gate.ts
+++ b/src/server/maintenance/server-gate.ts
@@ -1,0 +1,187 @@
+/**
+ * Maintenance gate for the custom HTTP server (scripts/server.ts).
+ *
+ * When maintenance mode is on, every request is checked here before Next.js
+ * sees it. Pages get a self-contained 503 HTML page; API routes get a 503 JSON
+ * body. A short list of surfaces stays up: the demo (no DB), the admin panel and
+ * its session endpoint (so you can turn maintenance back off), the health check,
+ * legal pages, and static assets. The main tRPC endpoint is blocked unless the
+ * request carries a valid admin session cookie, so the admin panel keeps working
+ * while everything else is down.
+ *
+ * The per-request check is synchronous: a background poller refreshes the flag
+ * from Redis into a module variable so we never `await` Redis in the hot path.
+ */
+
+import { getMaintenance, type MaintenanceState } from "@/server/services/site-status";
+import { ADMIN_COOKIE_NAME, validateAdminSessionToken } from "@/server/auth/admin-session";
+import { logger } from "@/lib/logger";
+
+export type GateDecision = "allow" | "block-page" | "block-api";
+
+/**
+ * Path prefixes that stay reachable during maintenance. The demo is the public
+ * face (it never touches Postgres); /admin + /api/admin let an operator toggle
+ * maintenance off; /api/health keeps Fly's health checks green; the legal pages
+ * and "/" (a lightweight redirector) stay up per the "keep the landing page up"
+ * decision.
+ */
+const EXEMPT_PREFIXES = [
+  "/demo",
+  "/admin",
+  "/api/admin",
+  "/api/health",
+  "/_next",
+  "/privacy",
+  "/terms",
+  "/onnx",
+  "/icons",
+];
+
+/** Individual exact static paths that must stay reachable. */
+const EXEMPT_EXACT = new Set([
+  "/",
+  "/favicon.ico",
+  "/robots.txt",
+  "/sitemap.xml",
+  "/manifest.webmanifest",
+  "/sw.js",
+]);
+
+/** A path is treated as a static asset when it ends in a common file extension. */
+const STATIC_EXT =
+  /\.(?:ico|png|jpg|jpeg|gif|svg|webp|avif|css|js|mjs|map|woff2?|ttf|otf|eot|json|txt|xml|wasm)$/i;
+
+function hasValidAdminCookie(cookieHeader: string | undefined): boolean {
+  if (!cookieHeader) return false;
+  for (const part of cookieHeader.split(/;\s*/)) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    const name = part.slice(0, eq);
+    if (name !== ADMIN_COOKIE_NAME) continue;
+    const value = part.slice(eq + 1);
+    if (value && validateAdminSessionToken(value)) return true;
+  }
+  return false;
+}
+
+/**
+ * Decide what to do with a request while maintenance is active. Pure — takes the
+ * pathname and raw Cookie header, returns the decision. Unit-tested.
+ */
+export function evaluateRequest(pathname: string, cookieHeader?: string): GateDecision {
+  if (EXEMPT_EXACT.has(pathname)) return "allow";
+  if (EXEMPT_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))) {
+    return "allow";
+  }
+  if (STATIC_EXT.test(pathname)) return "allow";
+
+  const isApi = pathname === "/api" || pathname.startsWith("/api/");
+
+  // The main tRPC endpoint stays open ONLY to a valid admin session, so the
+  // admin panel can read status and toggle maintenance back off.
+  if (pathname === "/api/trpc" || pathname.startsWith("/api/trpc/")) {
+    return hasValidAdminCookie(cookieHeader) ? "allow" : "block-api";
+  }
+
+  return isApi ? "block-api" : "block-page";
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+const DEFAULT_MAINTENANCE_MESSAGE =
+  "Lion Reader is temporarily down for scheduled maintenance. We'll be back shortly.";
+
+/**
+ * Self-contained maintenance HTML — inline CSS, no app/DB/Next dependency, so it
+ * renders even if the rest of the app is broken. Honors light/dark via
+ * prefers-color-scheme.
+ */
+export function renderMaintenanceHtml(message?: string): string {
+  const text = escapeHtml(message?.trim() || DEFAULT_MAINTENANCE_MESSAGE);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>Down for maintenance · Lion Reader</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
+    padding: 1.5rem; background: #fafafa; color: #27272a;
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  .card {
+    max-width: 32rem; width: 100%; text-align: center;
+    background: #ffffff; border: 1px solid #e4e4e7; border-radius: 0.75rem;
+    padding: 2.5rem 2rem; box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  }
+  .logo { font-size: 2.5rem; line-height: 1; margin-bottom: 1rem; }
+  h1 { font-size: 1.375rem; margin: 0 0 0.75rem; }
+  p { margin: 0; font-size: 1rem; line-height: 1.6; color: #52525b; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #09090b; color: #e4e4e7; }
+    .card { background: #18181b; border-color: #27272a; box-shadow: none; }
+    p { color: #a1a1aa; }
+  }
+</style>
+</head>
+<body>
+  <main class="card">
+    <div class="logo" role="img" aria-label="Lion">🦁</div>
+    <h1>Down for maintenance</h1>
+    <p>${text}</p>
+  </main>
+</body>
+</html>`;
+}
+
+export function maintenanceJsonBody(message?: string): string {
+  return JSON.stringify({
+    error: "maintenance",
+    message: message?.trim() || DEFAULT_MAINTENANCE_MESSAGE,
+  });
+}
+
+// --- Background poller (custom-server hot path stays synchronous) -----------
+
+let current: MaintenanceState = { enabled: false, message: "" };
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+/** Synchronous read of the last-polled maintenance state. */
+export function getCurrentMaintenance(): MaintenanceState {
+  return current;
+}
+
+async function refresh(): Promise<void> {
+  try {
+    current = await getMaintenance();
+  } catch (error) {
+    // getMaintenance is already fail-safe, but never let a refresh throw.
+    logger.error("Maintenance poll failed", {
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+}
+
+/**
+ * Start polling Redis for the maintenance flag. Called once from the custom
+ * server after Next is prepared. Idempotent. `.unref()` so it never keeps the
+ * process alive during shutdown.
+ */
+export function startMaintenancePoller(intervalMs = 3_000): void {
+  if (pollTimer) return;
+  void refresh();
+  pollTimer = setInterval(() => void refresh(), intervalMs);
+  pollTimer.unref?.();
+}

--- a/src/server/services/site-status.ts
+++ b/src/server/services/site-status.ts
@@ -1,0 +1,189 @@
+/**
+ * Site Status Service — global announcement banner + maintenance mode.
+ *
+ * Both flags live in **Redis**, deliberately NOT Postgres: maintenance mode is
+ * meant to be turned on *while the database is being migrated / locked*, so the
+ * gate that reads it must not depend on the DB being available. Redis is already
+ * used for caching/SSE and is shared by every process group (app, worker,
+ * discord — see fly.toml), so a single write is visible everywhere.
+ *
+ * Everything here is **fail-safe**: if Redis is unconfigured/unavailable or a
+ * read throws, maintenance falls back to the `MAINTENANCE_MODE` env var only
+ * (default off) and the announcement falls back to null. A Redis outage must
+ * never accidentally take the site down or surface a stale banner.
+ *
+ * Reads are cached in-process for a few seconds so the hot paths (the custom
+ * server's poller, the worker's claim loop, the Discord handlers) never issue a
+ * Redis round-trip per request/job/message.
+ */
+
+import { createHash } from "node:crypto";
+import { getRedisClient } from "@/server/redis";
+import { logger } from "@/lib/logger";
+
+const MAINTENANCE_KEY = "lion-reader:site-status:maintenance";
+const ANNOUNCEMENT_KEY = "lion-reader:site-status:announcement";
+
+/** How long a read is cached in-process before it's refreshed from Redis. */
+const CACHE_TTL_MS = 5_000;
+
+export const ANNOUNCEMENT_LEVELS = ["info", "warning"] as const;
+export type AnnouncementLevel = (typeof ANNOUNCEMENT_LEVELS)[number];
+
+/** Stored maintenance flag. */
+export interface MaintenanceState {
+  enabled: boolean;
+  /** Optional message shown on the maintenance page. */
+  message: string;
+}
+
+/** Stored announcement flag (as configured by the admin). */
+export interface AnnouncementState {
+  enabled: boolean;
+  message: string;
+  level: AnnouncementLevel;
+}
+
+/** Announcement as delivered to the banner, with a message-derived id. */
+export interface Announcement {
+  /**
+   * Deterministic id derived from `message` + `level`. The banner stores the
+   * dismissed id in localStorage, so the same text keeps the same id (a dismiss
+   * sticks across no-op saves) while a changed message yields a new id and the
+   * banner re-appears.
+   */
+  id: string;
+  message: string;
+  level: AnnouncementLevel;
+}
+
+const DEFAULT_MAINTENANCE: MaintenanceState = { enabled: false, message: "" };
+const DEFAULT_ANNOUNCEMENT: AnnouncementState = { enabled: false, message: "", level: "info" };
+
+/** `MAINTENANCE_MODE` env var as an always-on override (belt and suspenders). */
+function envMaintenanceEnabled(): boolean {
+  const raw = process.env.MAINTENANCE_MODE?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+function announcementId(message: string, level: AnnouncementLevel): string {
+  return createHash("sha256").update(`${level}:${message}`).digest("hex").slice(0, 16);
+}
+
+// --- Tiny in-process TTL caches (one per key) -------------------------------
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+let maintenanceCache: CacheEntry<MaintenanceState> | null = null;
+let announcementCache: CacheEntry<AnnouncementState> | null = null;
+
+function invalidateCache(): void {
+  maintenanceCache = null;
+  announcementCache = null;
+}
+
+async function readJson<T>(key: string, fallback: T): Promise<T> {
+  const redis = getRedisClient();
+  if (!redis) return fallback;
+  try {
+    const raw = await redis.get(key);
+    if (!raw) return fallback;
+    return { ...fallback, ...(JSON.parse(raw) as Partial<T>) };
+  } catch (error) {
+    logger.error("Failed to read site-status key from Redis", {
+      key,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    return fallback;
+  }
+}
+
+async function writeJson(key: string, value: unknown): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis) {
+    logger.warn("Redis not configured; site-status change not persisted", { key });
+    return;
+  }
+  await redis.set(key, JSON.stringify(value));
+}
+
+// --- Maintenance ------------------------------------------------------------
+
+/** Reads the stored maintenance flag (uncached; includes disabled state). */
+export async function getMaintenanceRaw(): Promise<MaintenanceState> {
+  return readJson(MAINTENANCE_KEY, DEFAULT_MAINTENANCE);
+}
+
+/**
+ * Effective maintenance state (env override OR Redis flag), cached in-process.
+ * This is what the server gate / worker / bot consult.
+ */
+export async function getMaintenance(): Promise<MaintenanceState> {
+  const now = Date.now();
+  if (!maintenanceCache || maintenanceCache.expiresAt <= now) {
+    const stored = await getMaintenanceRaw();
+    const value: MaintenanceState = {
+      enabled: stored.enabled || envMaintenanceEnabled(),
+      message: stored.message,
+    };
+    maintenanceCache = { value, expiresAt: now + CACHE_TTL_MS };
+  }
+  return maintenanceCache.value;
+}
+
+export async function setMaintenance(input: { enabled: boolean; message?: string }): Promise<void> {
+  await writeJson(MAINTENANCE_KEY, {
+    enabled: input.enabled,
+    message: input.message ?? "",
+  } satisfies MaintenanceState);
+  invalidateCache();
+}
+
+// --- Announcement -----------------------------------------------------------
+
+/** Reads the stored announcement config (uncached; includes disabled state). */
+export async function getAnnouncementRaw(): Promise<AnnouncementState> {
+  const stored = await readJson(ANNOUNCEMENT_KEY, DEFAULT_ANNOUNCEMENT);
+  // Guard against an unexpected level value from a hand-edited key.
+  const level = ANNOUNCEMENT_LEVELS.includes(stored.level) ? stored.level : "info";
+  return { ...stored, level };
+}
+
+/**
+ * The active announcement to render, or null when disabled/empty. Cached
+ * in-process (the root layout reads this on every SSR page render).
+ */
+export async function getAnnouncement(): Promise<Announcement | null> {
+  const now = Date.now();
+  if (!announcementCache || announcementCache.expiresAt <= now) {
+    announcementCache = { value: await getAnnouncementRaw(), expiresAt: now + CACHE_TTL_MS };
+  }
+  const stored = announcementCache.value;
+  if (!stored.enabled || stored.message.trim() === "") return null;
+  return {
+    id: announcementId(stored.message, stored.level),
+    message: stored.message,
+    level: stored.level,
+  };
+}
+
+export async function setAnnouncement(input: {
+  enabled: boolean;
+  message: string;
+  level: AnnouncementLevel;
+}): Promise<void> {
+  await writeJson(ANNOUNCEMENT_KEY, {
+    enabled: input.enabled,
+    message: input.message,
+    level: input.level,
+  } satisfies AnnouncementState);
+  invalidateCache();
+}
+
+/** Test-only: clear the in-process caches so a fresh Redis read happens. */
+export function __resetSiteStatusCacheForTests(): void {
+  invalidateCache();
+}

--- a/src/server/trpc/context.ts
+++ b/src/server/trpc/context.ts
@@ -9,6 +9,7 @@ import { type FetchCreateContextFnOptions } from "@trpc/server/adapters/fetch";
 import { db, type Database } from "@/server/db";
 import { validateSession, type SessionData } from "@/server/auth/session";
 import { validateApiToken, type ApiTokenData, type ApiTokenScope } from "@/server/auth/api-token";
+import { extractBearerToken } from "@/server/auth/bearer";
 
 // Re-export types for use in other modules
 /**
@@ -69,9 +70,9 @@ export interface Context {
  */
 function getToken(headers: Headers): string | null {
   // Check Authorization header first (for API clients and extensions)
-  const authHeader = headers.get("authorization");
-  if (authHeader?.startsWith("Bearer ")) {
-    return authHeader.slice(7);
+  const bearerToken = extractBearerToken(headers.get("authorization"));
+  if (bearerToken) {
+    return bearerToken;
   }
 
   // Check cookie (for browser clients)

--- a/src/server/trpc/routers/admin.ts
+++ b/src/server/trpc/routers/admin.ts
@@ -23,6 +23,13 @@ import {
   userEntries,
 } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
+import {
+  getMaintenanceRaw,
+  getAnnouncementRaw,
+  setMaintenance,
+  setAnnouncement,
+  ANNOUNCEMENT_LEVELS,
+} from "@/server/services/site-status";
 
 // ============================================================================
 // CONSTANTS
@@ -807,6 +814,103 @@ const overviewEndpoints = {
 } as const;
 
 // ============================================================================
+// SITE STATUS ENDPOINTS (announcement banner + maintenance mode)
+// ============================================================================
+
+/** Max length for admin-entered banner / maintenance messages. */
+const SITE_STATUS_MESSAGE_MAX = 1000;
+
+const siteStatusEndpoints = {
+  /**
+   * Read the current announcement + maintenance configuration (raw stored
+   * values, including disabled state) so the admin form can prefill.
+   */
+  getSiteStatus: adminProcedure
+    .meta({
+      openapi: {
+        method: "GET",
+        path: "/admin/site-status",
+        tags: ["Admin"],
+        summary: "Get announcement banner and maintenance mode status",
+      },
+    })
+    .input(z.object({}).optional())
+    .output(
+      z.object({
+        maintenance: z.object({
+          enabled: z.boolean(),
+          message: z.string(),
+        }),
+        announcement: z.object({
+          enabled: z.boolean(),
+          message: z.string(),
+          level: z.enum(ANNOUNCEMENT_LEVELS),
+        }),
+      })
+    )
+    .query(async () => {
+      const [maintenance, announcement] = await Promise.all([
+        getMaintenanceRaw(),
+        getAnnouncementRaw(),
+      ]);
+      return { maintenance, announcement };
+    }),
+
+  /**
+   * Set the site-wide announcement banner. `enabled=false` (or an empty
+   * message) hides it. The message is what determines the banner id, so
+   * changing the text re-shows the banner to users who dismissed the old one.
+   */
+  setAnnouncement: adminProcedure
+    .meta({
+      openapi: {
+        method: "POST",
+        path: "/admin/site-status/announcement",
+        tags: ["Admin"],
+        summary: "Set the announcement banner",
+      },
+    })
+    .input(
+      z.object({
+        enabled: z.boolean(),
+        message: z.string().max(SITE_STATUS_MESSAGE_MAX),
+        level: z.enum(ANNOUNCEMENT_LEVELS),
+      })
+    )
+    .output(z.object({ success: z.boolean() }))
+    .mutation(async ({ input }) => {
+      await setAnnouncement(input);
+      return { success: true };
+    }),
+
+  /**
+   * Enable or disable maintenance mode. When enabled, the custom server serves
+   * a maintenance page for everything except the demo + admin panel + health
+   * check, and the worker and Discord bot pause. Intended for DB migrations.
+   */
+  setMaintenance: adminProcedure
+    .meta({
+      openapi: {
+        method: "POST",
+        path: "/admin/site-status/maintenance",
+        tags: ["Admin"],
+        summary: "Enable or disable maintenance mode",
+      },
+    })
+    .input(
+      z.object({
+        enabled: z.boolean(),
+        message: z.string().max(SITE_STATUS_MESSAGE_MAX).optional(),
+      })
+    )
+    .output(z.object({ success: z.boolean() }))
+    .mutation(async ({ input }) => {
+      await setMaintenance(input);
+      return { success: true };
+    }),
+} as const;
+
+// ============================================================================
 // ROUTER
 // ============================================================================
 
@@ -819,4 +923,6 @@ export const adminRouter = createTRPCRouter({
   ...feedHealthEndpoints,
   // Users
   ...userEndpoints,
+  // Site status (announcement banner + maintenance mode)
+  ...siteStatusEndpoints,
 });

--- a/src/server/trpc/trpc.ts
+++ b/src/server/trpc/trpc.ts
@@ -25,6 +25,7 @@ import {
   validateAdminSessionToken,
   validateAdminSecret,
 } from "@/server/auth/admin-session";
+import { extractBearerToken } from "@/server/auth/bearer";
 import { logger } from "@/lib/logger";
 import * as Sentry from "@sentry/nextjs";
 
@@ -424,12 +425,9 @@ const adminMiddleware = t.middleware(({ ctx, next }) => {
   }
 
   // Fallback: check Bearer token (for programmatic access)
-  const authHeader = ctx.headers.get("authorization");
-  if (authHeader) {
-    const match = authHeader.match(/^Bearer\s+(.+)$/i);
-    if (match?.[1] && validateAdminSecret(match[1])) {
-      return next({ ctx });
-    }
+  const bearerToken = extractBearerToken(ctx.headers.get("authorization"));
+  if (bearerToken && validateAdminSecret(bearerToken)) {
+    return next({ ctx });
   }
 
   throw errors.adminUnauthorized();

--- a/src/server/wallabag/auth.ts
+++ b/src/server/wallabag/auth.ts
@@ -18,6 +18,7 @@ import * as argon2 from "argon2";
 import { eq } from "drizzle-orm";
 import { db } from "@/server/db";
 import { users } from "@/server/db/schema";
+import { extractBearerToken } from "@/server/auth/bearer";
 import { validateAccessToken, createTokens, rotateRefreshToken } from "@/server/oauth/service";
 import { OAUTH_SCOPES } from "@/server/oauth/utils";
 import { isSignupConfirmed } from "@/server/auth/confirmation";
@@ -155,12 +156,11 @@ export async function refreshTokenGrant(
 async function authenticateRequest(
   request: Request
 ): Promise<{ userId: string; email: string; scopes: string[]; user: User } | null> {
-  const authHeader = request.headers.get("authorization");
-  if (!authHeader?.startsWith("Bearer ")) {
+  const token = extractBearerToken(request.headers.get("authorization"));
+  if (!token) {
     return null;
   }
 
-  const token = authHeader.slice(7);
   const tokenData = await validateAccessToken(token);
   if (!tokenData) {
     return null;
@@ -198,7 +198,7 @@ export async function requireAuth(
     // that sent a token we rejected (expired — normal churn as clients lazily
     // refresh — or revoked, e.g. by reuse detection). Logged at info because an
     // expired-token 401 is expected traffic, not an error.
-    const hasBearer = request.headers.get("authorization")?.startsWith("Bearer ") ?? false;
+    const hasBearer = extractBearerToken(request.headers.get("authorization")) !== null;
     logger.info("Wallabag request unauthenticated", {
       component: "wallabag",
       reason: hasBearer ? "invalid_token" : "missing_bearer",

--- a/tests/integration/site-status.test.ts
+++ b/tests/integration/site-status.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Integration tests for the Redis-backed site-status service (announcement
+ * banner + maintenance mode). Runs against a real Redis.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import Redis from "ioredis";
+import {
+  getMaintenance,
+  getMaintenanceRaw,
+  setMaintenance,
+  getAnnouncement,
+  getAnnouncementRaw,
+  setAnnouncement,
+  __resetSiteStatusCacheForTests,
+} from "../../src/server/services/site-status";
+
+const MAINTENANCE_KEY = "lion-reader:site-status:maintenance";
+const ANNOUNCEMENT_KEY = "lion-reader:site-status:announcement";
+
+let redis: Redis;
+
+beforeAll(() => {
+  const redisUrl = process.env.REDIS_URL;
+  if (!redisUrl) {
+    throw new Error("REDIS_URL must be set for site-status integration tests");
+  }
+  redis = new Redis(redisUrl);
+});
+
+afterAll(async () => {
+  await redis.del(MAINTENANCE_KEY, ANNOUNCEMENT_KEY);
+  await redis.quit();
+});
+
+beforeEach(async () => {
+  await redis.del(MAINTENANCE_KEY, ANNOUNCEMENT_KEY);
+  delete process.env.MAINTENANCE_MODE;
+  __resetSiteStatusCacheForTests();
+});
+
+describe("maintenance mode", () => {
+  it("defaults to disabled when no key exists", async () => {
+    expect(await getMaintenanceRaw()).toEqual({ enabled: false, message: "" });
+    expect((await getMaintenance()).enabled).toBe(false);
+  });
+
+  it("round-trips enabled + message", async () => {
+    await setMaintenance({ enabled: true, message: "Migrating the database" });
+    const raw = await getMaintenanceRaw();
+    expect(raw).toEqual({ enabled: true, message: "Migrating the database" });
+    expect(await getMaintenance()).toEqual({ enabled: true, message: "Migrating the database" });
+  });
+
+  it("MAINTENANCE_MODE env var forces maintenance on even when Redis says off", async () => {
+    await setMaintenance({ enabled: false });
+    __resetSiteStatusCacheForTests();
+    process.env.MAINTENANCE_MODE = "true";
+    expect((await getMaintenance()).enabled).toBe(true);
+    // getMaintenanceRaw reflects only the stored flag (no env override).
+    expect((await getMaintenanceRaw()).enabled).toBe(false);
+  });
+});
+
+describe("announcement banner", () => {
+  it("returns null when no announcement is set", async () => {
+    expect(await getAnnouncement()).toBeNull();
+  });
+
+  it("returns null when disabled or empty, even with a message", async () => {
+    await setAnnouncement({ enabled: false, message: "Heads up", level: "info" });
+    expect(await getAnnouncement()).toBeNull();
+
+    await setAnnouncement({ enabled: true, message: "   ", level: "warning" });
+    expect(await getAnnouncement()).toBeNull();
+    // ...but the raw config is preserved for the admin form.
+    expect(await getAnnouncementRaw()).toEqual({ enabled: true, message: "   ", level: "warning" });
+  });
+
+  it("returns the announcement with a stable, message-derived id", async () => {
+    await setAnnouncement({ enabled: true, message: "Known issue", level: "warning" });
+    const first = await getAnnouncement();
+    expect(first).not.toBeNull();
+    expect(first?.message).toBe("Known issue");
+    expect(first?.level).toBe("warning");
+
+    // Re-saving the same text keeps the same id (a dismiss sticks).
+    await setAnnouncement({ enabled: true, message: "Known issue", level: "warning" });
+    const second = await getAnnouncement();
+    expect(second?.id).toBe(first?.id);
+  });
+
+  it("changes the id when the message or level changes (re-shows the banner)", async () => {
+    await setAnnouncement({ enabled: true, message: "First", level: "info" });
+    const a = await getAnnouncement();
+
+    await setAnnouncement({ enabled: true, message: "Second", level: "info" });
+    const b = await getAnnouncement();
+    expect(b?.id).not.toBe(a?.id);
+
+    await setAnnouncement({ enabled: true, message: "Second", level: "warning" });
+    const c = await getAnnouncement();
+    expect(c?.id).not.toBe(b?.id);
+  });
+});

--- a/tests/unit/bearer.test.ts
+++ b/tests/unit/bearer.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for the shared Authorization: Bearer header parser.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractBearerToken } from "../../src/server/auth/bearer";
+
+describe("extractBearerToken", () => {
+  it("extracts the token from a well-formed header", () => {
+    expect(extractBearerToken("Bearer abc123")).toBe("abc123");
+  });
+
+  it("is case-insensitive on the scheme (RFC 7235)", () => {
+    expect(extractBearerToken("bearer abc123")).toBe("abc123");
+    expect(extractBearerToken("BEARER abc123")).toBe("abc123");
+  });
+
+  it("tolerates extra whitespace and tabs around the token", () => {
+    expect(extractBearerToken("Bearer   abc123")).toBe("abc123");
+    expect(extractBearerToken("Bearer\tabc123")).toBe("abc123");
+    expect(extractBearerToken("Bearer abc123   ")).toBe("abc123");
+  });
+
+  it("returns null for missing, empty, or non-Bearer headers", () => {
+    expect(extractBearerToken(null)).toBeNull();
+    expect(extractBearerToken(undefined)).toBeNull();
+    expect(extractBearerToken("")).toBeNull();
+    expect(extractBearerToken("Basic dXNlcjpwYXNz")).toBeNull();
+    expect(extractBearerToken("Bearer")).toBeNull(); // no separator
+    expect(extractBearerToken("Bearer    ")).toBeNull(); // no token
+    expect(extractBearerToken(" Bearer abc")).toBeNull(); // leading space => scheme mismatch
+  });
+
+  it("does not include the GoogleLogin scheme", () => {
+    expect(extractBearerToken("GoogleLogin auth=token")).toBeNull();
+  });
+
+  it("resolves a crafted whitespace-heavy header quickly (no ReDoS)", () => {
+    const evil = `Bearer ${" ".repeat(200_000)}\n`;
+    const start = Date.now();
+    expect(extractBearerToken(evil)).toBeNull();
+    expect(Date.now() - start).toBeLessThan(100);
+  });
+});

--- a/tests/unit/maintenance-gate.test.ts
+++ b/tests/unit/maintenance-gate.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the maintenance gate's pure request-evaluation logic and the
+ * self-contained maintenance responses (custom-server hot path).
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  evaluateRequest,
+  renderMaintenanceHtml,
+  maintenanceJsonBody,
+} from "../../src/server/maintenance/server-gate";
+import { createAdminSessionToken, ADMIN_COOKIE_NAME } from "../../src/server/auth/admin-session";
+
+describe("evaluateRequest", () => {
+  it("allows the demo, admin, health, legal, and root surfaces", () => {
+    for (const path of [
+      "/",
+      "/demo",
+      "/demo/all",
+      "/admin",
+      "/admin/status",
+      "/api/admin/session",
+      "/api/health",
+      "/privacy",
+      "/terms",
+    ]) {
+      expect(evaluateRequest(path)).toBe("allow");
+    }
+  });
+
+  it("allows Next internals and static assets", () => {
+    for (const path of [
+      "/_next/static/chunk.js",
+      "/favicon.ico",
+      "/robots.txt",
+      "/sitemap.xml",
+      "/sw.js",
+      "/icons/icon-192.png",
+      "/apple-touch-icon.png",
+      "/some/thing.css",
+    ]) {
+      expect(evaluateRequest(path)).toBe("allow");
+    }
+  });
+
+  it("blocks app pages with the HTML page response", () => {
+    for (const path of ["/all", "/login", "/save", "/complete-signup", "/settings"]) {
+      expect(evaluateRequest(path)).toBe("block-page");
+    }
+  });
+
+  it("blocks non-admin API routes with the JSON response", () => {
+    for (const path of [
+      "/api/v1/entries",
+      "/api/mcp",
+      "/api/wallabag/api/entries",
+      "/api/greader.php",
+    ]) {
+      expect(evaluateRequest(path)).toBe("block-api");
+    }
+  });
+
+  it("does not treat a page path that merely contains /demo as exempt", () => {
+    expect(evaluateRequest("/not-demo")).toBe("block-page");
+    expect(evaluateRequest("/admins")).toBe("block-page");
+  });
+
+  describe("/api/trpc admin exception", () => {
+    beforeAll(() => {
+      process.env.ADMIN_SECRET = "test-admin-secret-for-gate";
+    });
+
+    it("blocks /api/trpc without a cookie", () => {
+      expect(evaluateRequest("/api/trpc/admin.getSiteStatus")).toBe("block-api");
+    });
+
+    it("blocks /api/trpc with an invalid admin cookie", () => {
+      expect(evaluateRequest("/api/trpc/admin.getSiteStatus", `${ADMIN_COOKIE_NAME}=garbage`)).toBe(
+        "block-api"
+      );
+    });
+
+    it("allows /api/trpc with a valid admin session cookie", () => {
+      const token = createAdminSessionToken();
+      const cookie = `foo=bar; ${ADMIN_COOKIE_NAME}=${token}; other=1`;
+      expect(evaluateRequest("/api/trpc/admin.getSiteStatus", cookie)).toBe("allow");
+    });
+  });
+});
+
+describe("renderMaintenanceHtml", () => {
+  it("includes the message and escapes HTML", () => {
+    const html = renderMaintenanceHtml('<script>alert("x")</script> & more');
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&amp; more");
+    expect(html).not.toContain("<script>alert");
+  });
+
+  it("falls back to a default message when empty", () => {
+    const html = renderMaintenanceHtml("   ");
+    expect(html).toContain("maintenance");
+    expect(html).toContain("<!doctype html>");
+  });
+});
+
+describe("maintenanceJsonBody", () => {
+  it("returns a JSON error body with the message", () => {
+    const parsed = JSON.parse(maintenanceJsonBody("Down for DB migration"));
+    expect(parsed.error).toBe("maintenance");
+    expect(parsed.message).toBe("Down for DB migration");
+  });
+
+  it("uses the default message when none is provided", () => {
+    const parsed = JSON.parse(maintenanceJsonBody());
+    expect(parsed.error).toBe("maintenance");
+    expect(typeof parsed.message).toBe("string");
+    expect(parsed.message.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/maintenance-gate.test.ts
+++ b/tests/unit/maintenance-gate.test.ts
@@ -60,6 +60,21 @@ describe("evaluateRequest", () => {
     }
   });
 
+  it("blocks API routes even when they end in a static-looking suffix", () => {
+    // The Wallabag compat API and others hit Postgres but end in .json/.xml/etc.
+    // These must NOT be treated as static assets during maintenance.
+    for (const path of [
+      "/api/wallabag/api/entries.json",
+      "/api/wallabag/api/tags.json",
+      "/api/wallabag/api/user.json",
+      "/api/entries.json",
+      "/api/search.json",
+      "/api/version.json",
+    ]) {
+      expect(evaluateRequest(path)).toBe("block-api");
+    }
+  });
+
   it("does not treat a page path that merely contains /demo as exempt", () => {
     expect(evaluateRequest("/not-demo")).toBe("block-page");
     expect(evaluateRequest("/admins")).toBe("block-page");
@@ -84,6 +99,22 @@ describe("evaluateRequest", () => {
       const token = createAdminSessionToken();
       const cookie = `foo=bar; ${ADMIN_COOKIE_NAME}=${token}; other=1`;
       expect(evaluateRequest("/api/trpc/admin.getSiteStatus", cookie)).toBe("allow");
+    });
+
+    it("allows /api/trpc with a valid Bearer admin secret", () => {
+      expect(
+        evaluateRequest(
+          "/api/trpc/admin.getSiteStatus",
+          undefined,
+          "Bearer test-admin-secret-for-gate"
+        )
+      ).toBe("allow");
+    });
+
+    it("blocks /api/trpc with an invalid Bearer secret", () => {
+      expect(
+        evaluateRequest("/api/trpc/admin.getSiteStatus", undefined, "Bearer wrong-secret")
+      ).toBe("block-api");
     });
   });
 });

--- a/tests/unit/maintenance-gate.test.ts
+++ b/tests/unit/maintenance-gate.test.ts
@@ -116,6 +116,23 @@ describe("evaluateRequest", () => {
         evaluateRequest("/api/trpc/admin.getSiteStatus", undefined, "Bearer wrong-secret")
       ).toBe("block-api");
     });
+
+    it("tolerates extra whitespace / tab between Bearer and the secret", () => {
+      for (const auth of [
+        "Bearer   test-admin-secret-for-gate",
+        "Bearer\ttest-admin-secret-for-gate",
+        "bearer test-admin-secret-for-gate  ",
+      ]) {
+        expect(evaluateRequest("/api/trpc/admin.getSiteStatus", undefined, auth)).toBe("allow");
+      }
+    });
+
+    it("resolves a crafted whitespace-heavy Authorization header quickly (no ReDoS)", () => {
+      const evil = `Bearer ${" ".repeat(100_000)}\n`;
+      const start = Date.now();
+      expect(evaluateRequest("/api/trpc/admin.getSiteStatus", undefined, evil)).toBe("block-api");
+      expect(Date.now() - start).toBeLessThan(100);
+    });
   });
 });
 


### PR DESCRIPTION
Adds two operator tools for downtime/incidents, both driven from **/admin → Status** and backed by **Redis** (DB-independent, so maintenance mode works during a database migration).

## Announcement banner
A closeable bar at the top of **every** page (info/warning). Rendered SSR from the root layout via `getAnnouncement()`, so it shows on the app, the demo, and logged-out pages. Dismissal is stored in localStorage keyed by a **message-derived id**, so changing the announcement re-shows it to everyone who dismissed the old one.

![Announcement banner on the demo](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/maintenance-announcement-1252/banner-demo-light.png)

## Maintenance mode
A global kill switch for use during a heavier/non-backward-compatible DB migration. The **custom HTTP server** (`scripts/server.ts`) is the single choke point every request passes through, so the gate lives there (`src/server/maintenance/server-gate.ts`). When on, everything returns a self-contained **503** (HTML page for pages, JSON for API) **except**:

- `/demo` (never touches Postgres — stays fully usable)
- `/admin` + `/api/admin` (so you can turn it back off)
- `/api/health`, legal pages, `/`, and static assets
- `/api/trpc` **only** when carrying a valid `admin_session` cookie

The **worker** stops claiming jobs (no Postgres access; loop just sleeps) and the **Discord bot** stops responding while it's on — all three process groups read the same Redis flag and resume automatically when it clears. A `MAINTENANCE_MODE` env var is an additional force-on fallback.

![Maintenance page](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/maintenance-announcement-1252/maintenance-page-light.png)

## Admin UI
New **Status** tab with a live-preview announcement editor and the maintenance toggle.

![Admin Status tab](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/maintenance-announcement-1252/admin-status-light.png)

## Design notes
- **Redis, not Postgres**: maintenance mode is meant to run *while Postgres is being migrated/locked*, so the code that reads the flag must not depend on the DB.
- **Fail-safe**: Redis down ⇒ no banner and maintenance = the env override only; never accidentally takes the site down or shows a stale banner.
- **No per-request Redis**: the server gate reads a background-polled module variable; reads elsewhere are cached in-process for a few seconds.
- No schema migration required.

## Testing
- **Unit** (`tests/unit/maintenance-gate.test.ts`): pure `evaluateRequest` truth table (demo/admin/health/legal/static/`/` allow; `/api/trpc` with/without a valid admin cookie; other `/api/*` → block-api; pages → block-page), HTML escaping, JSON body.
- **Integration** (`tests/integration/site-status.test.ts`, real Redis): flag round-trips, `MAINTENANCE_MODE` env fallback, fail-safe defaults, and the message-specific announcement id.
- **Manual** (Playwright + curl against a local dev server): verified the banner renders on demo/login, maintenance 503s the app/API while exempting demo/admin/health/legal + admin-cookie tRPC, and the worker logs paused→resumed. `pnpm typecheck`, `pnpm test:unit`, `pnpm lint`, `check:colors`/`check:theme-tokens`, and all three esbuild bundles pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)