### PR TITLE
Wallabag: save a labeled placeholder instead of a 4xx on save failure (#1254)

### DIFF
--- a/src/app/api/wallabag/api/entries/route.ts
+++ b/src/app/api/wallabag/api/entries/route.ts
@@ -173,9 +173,9 @@ export async function POST(request: Request): Promise<Response> {
   } catch (error) {
     // The Wallabag Android app's offline save queue only advances an item on a
     // 2xx response; any error keeps it queued, retried forever, AND halts every
-    // newer queued save behind it (a poison item — #1254). So for a *permanent*
-    // client-side failure (oversized page, 404, blocked site, feed URL, private
-    // doc needing auth) we can't return the 4xx — we save a labeled placeholder
+    // newer queued save behind it (a poison item — #1254). So for a client-side
+    // save failure (oversized page, 404, blocked site, feed URL, private doc
+    // needing auth) we can't return the 4xx — we save a labeled placeholder
     // entry (URL as title, reason as body) and return it with 200, which drains
     // the queue and tells the user in-app why the save failed.
     //
@@ -183,7 +183,10 @@ export async function POST(request: Request): Promise<Response> {
     // client/upstream failure, not our bug" signal (a 4xx, or an expected
     // upstream 5xx like SITE_BLOCKED). A genuine server bug returns null and
     // still throws → 500, so the app legitimately retries it once we've fixed
-    // the cause.
+    // the cause. Note this also placeholders the *transient* client-coded
+    // failures (UPSTREAM_RATE_LIMITED, SITE_BLOCKED); a plain app re-share won't
+    // then heal them (see the trade-off note on savePlaceholderArticle) — but
+    // draining the queue beats leaving it jammed for every other save.
     if (clientErrorResponse(error) !== null) {
       const placeholder = await savedService.savePlaceholderArticle(db, auth.userId, {
         url: articleUrl,

--- a/src/app/api/wallabag/api/entries/route.ts
+++ b/src/app/api/wallabag/api/entries/route.ts
@@ -29,6 +29,7 @@
  * - content: string - optional content override
  */
 
+import { TRPCError } from "@trpc/server";
 import { requireAuth } from "@/server/wallabag/auth";
 import {
   jsonResponse,
@@ -37,6 +38,7 @@ import {
   parseEntryListParams,
   parseBody,
 } from "@/server/wallabag/parse";
+import { getAppErrorCode } from "@/server/trpc/errors";
 import {
   formatEntryFull,
   formatEntryListItem,
@@ -169,12 +171,43 @@ export async function POST(request: Request): Promise<Response> {
 
     return jsonResponse(formatSavedArticle(article, wallabagId));
   } catch (error) {
-    // saveArticle throws a TRPCError when the user-provided URL can't be fetched
-    // (e.g. a 404 from a mistyped/markdown-artifact URL). Return that as a clean
-    // Wallabag error envelope instead of an unhandled 500 that hits Sentry;
-    // genuine server errors (null) still propagate.
-    const clientError = clientErrorResponse(error);
-    if (clientError) return clientError;
+    // The Wallabag Android app's offline save queue only advances an item on a
+    // 2xx response; any error keeps it queued, retried forever, AND halts every
+    // newer queued save behind it (a poison item — #1254). So for a *permanent*
+    // client-side failure (oversized page, 404, blocked site, feed URL, private
+    // doc needing auth) we can't return the 4xx — we save a labeled placeholder
+    // entry (URL as title, reason as body) and return it with 200, which drains
+    // the queue and tells the user in-app why the save failed.
+    //
+    // `clientErrorResponse` returning non-null is exactly the "expected
+    // client/upstream failure, not our bug" signal (a 4xx, or an expected
+    // upstream 5xx like SITE_BLOCKED). A genuine server bug returns null and
+    // still throws → 500, so the app legitimately retries it once we've fixed
+    // the cause.
+    if (clientErrorResponse(error) !== null) {
+      const placeholder = await savedService.savePlaceholderArticle(db, auth.userId, {
+        url: articleUrl,
+        reason: describeSaveFailure(error),
+      });
+      const wallabagId = await entryIdToWallabagId(db, placeholder.id);
+      if (wallabagId === null) {
+        return errorResponse("not_found", "Entry not found", 404);
+      }
+      return jsonResponse(formatSavedArticle(placeholder, wallabagId));
+    }
     throw error;
   }
+}
+
+/**
+ * Human-readable reason for a failed save, used as the placeholder entry body.
+ * Most service errors already carry a user-facing message; `URL_IS_FEED` is a
+ * bare machine code, so translate it into advice.
+ */
+function describeSaveFailure(error: unknown): string {
+  if (getAppErrorCode(error) === "URL_IS_FEED") {
+    return "This looks like a feed URL. Subscribe to it in Lion Reader instead of saving it.";
+  }
+  if (error instanceof TRPCError) return error.message;
+  return "The page could not be fetched.";
 }

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -27,6 +27,7 @@ import { absolutizeUrls } from "@/server/feed/content-cleaner";
 import { cleanContentInWorker, sanitizeEntryHtmlInWorker } from "@/server/worker-thread/pool";
 import { getOrCreateSavedFeed, getSavedFeedId, SAVED_FEED_TITLE } from "@/server/feed/saved-feed";
 import { generateSummary, stripHtml } from "@/server/html/strip-html";
+import { escapeHtml } from "@/server/http/html";
 import { withSanitizedEntryContentAsync } from "@/server/html/sanitize-entry";
 import { logger } from "@/lib/logger";
 import { publishNewEntry, publishEntryUpdatedFromEntry } from "@/server/redis/pubsub";
@@ -1161,6 +1162,67 @@ export async function saveArticle(
   });
 
   return { ...saved, outcome: "created" };
+}
+
+/**
+ * Save a placeholder entry recording that a URL could **not** be fetched/saved.
+ *
+ * This exists only for the Wallabag POST surface. The Wallabag Android app's
+ * offline save queue advances an item only on a 2xx response; any error keeps
+ * the item queued and retried forever AND halts every newer queued save behind
+ * it (a poison item — see #1254). So when a save fails for a *permanent*
+ * client-side reason (oversized page, 404, blocked site, feed URL, …) the
+ * Wallabag route can't just return the 4xx — it saves this labeled placeholder
+ * and returns 200, which drains the queue and tells the user in-app why the save
+ * failed. Genuine 5xx server bugs are deliberately NOT turned into placeholders
+ * (the caller still throws), so the app legitimately retries them once the bug
+ * is fixed.
+ *
+ * The entry keeps the original URL (so it stays clickable and the save is
+ * idempotent by URL), uses the URL as its title, and the failure reason as its
+ * body. Interactive callers (tRPC/MCP) must keep surfacing the real error
+ * instead of calling this.
+ */
+export async function savePlaceholderArticle(
+  db: typeof dbType,
+  userId: string,
+  params: { url: string; reason: string }
+): Promise<SaveArticleResult> {
+  const normalizedUrl = normalizeSavedUrl(params.url);
+  const savedFeedId = await getOrCreateSavedFeed(db, userId);
+
+  // The placeholder body is our own short, trusted text; escape the reason (it
+  // embeds the failing URL / upstream message) so it can't inject markup. It's
+  // sanitized again at write time by insertSavedEntry regardless.
+  const body = `<p>Lion Reader couldn't save this page.</p><p>${escapeHtml(params.reason)}</p>`;
+  const contentHash = generateContentHash(params.url, body);
+
+  const saved = await insertSavedEntry(db, userId, savedFeedId, {
+    guid: normalizedUrl,
+    url: normalizedUrl,
+    title: params.url,
+    author: null,
+    contentOriginal: body,
+    contentCleaned: body,
+    summary: params.reason,
+    siteName: null,
+    imageUrl: null,
+    contentHash,
+  });
+
+  if (saved) {
+    logger.info("Saved placeholder for failed article save", {
+      entryId: saved.id,
+      url: normalizedUrl,
+    });
+    return { ...saved, outcome: "created" };
+  }
+
+  // The (feed_id, guid) already exists: this URL was previously saved (a real
+  // article or an earlier placeholder), or two queued retries raced. Return the
+  // existing entry idempotently instead of a unique-violation. The no-refetch
+  // saveArticle path re-selects and version-heals it exactly as we need.
+  return saveArticle(db, userId, { url: params.url });
 }
 
 /**

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -1182,6 +1182,18 @@ export async function saveArticle(
  * idempotent by URL), uses the URL as its title, and the failure reason as its
  * body. Interactive callers (tRPC/MCP) must keep surfacing the real error
  * instead of calling this.
+ *
+ * Trade-off (accepted): because the placeholder is stored under `guid =
+ * normalized URL`, a later *no-refetch* save of the same URL — a plain re-share
+ * to the Wallabag app, or MCP `save_article` — matches it and returns the
+ * placeholder rather than re-fetching, so it does NOT auto-heal into the real
+ * article. This mainly bites the transient failure codes we still treat as
+ * client errors (`UPSTREAM_RATE_LIMITED`, `SITE_BLOCKED`): a save that failed
+ * only momentarily leaves a placeholder that a plain re-share won't replace. It
+ * is recoverable — the web `saved.save` path defaults `refetch: true` and heals
+ * it, and deleting the placeholder then re-sharing fetches fresh — but a bare
+ * app re-share won't. We accept this because the alternative (a jammed queue
+ * that blocks *every* newer save) is worse. See #1254.
  */
 export async function savePlaceholderArticle(
   db: typeof dbType,

--- a/tests/e2e/wallabag-api.spec.ts
+++ b/tests/e2e/wallabag-api.spec.ts
@@ -251,27 +251,48 @@ test.describe("Wallabag API happy path", () => {
     }
   });
 
-  test("saving an unfetchable URL returns a clean 4xx, not a 500", async ({ request }) => {
+  test("saving an unfetchable URL saves a labeled placeholder with 200 (#1254)", async ({
+    request,
+  }) => {
     const { access_token } = await getTokens(request);
     const auth = { Authorization: `Bearer ${access_token}` };
 
     // A reachable server that 404s every path — mirrors the real report where a
-    // user saved a mistyped URL (a markdown link with a trailing `)`), which the
-    // remote returned 404 for. This must surface as a client error, not an
-    // unhandled 500 that gets reported to Sentry.
+    // user saved a mistyped URL. The Wallabag Android app's offline queue only
+    // advances on a 2xx and otherwise retries the failed item forever, halting
+    // every newer queued save behind it. So a permanent client-side failure must
+    // NOT return the 4xx (which poisons the queue): it saves a labeled
+    // placeholder entry and returns 200 so the queue drains and the user sees
+    // why the save failed.
     const { url, close } = await start404Server();
     try {
       const res = await request.post("/api/wallabag/api/entries", {
         headers: auth,
         form: { url },
       });
-      // A 404 fetch of a user-provided URL is a client error, not a server bug:
-      // exactly 400, not a 500 (which would be reported to Sentry).
-      expect(res.status()).toBe(400);
-      // Wallabag error envelope, so clients can display why the save failed.
-      const body = await res.json();
-      expect(body.error).toBe("BAD_REQUEST");
-      expect(typeof body.error_description).toBe("string");
+      // 200 with a real, labeled placeholder entry — not a 4xx.
+      expect(res.status()).toBe(200);
+      const saved = await res.json();
+      expect(typeof saved.id).toBe("number");
+      expect(saved.url).toBe(url);
+      // URL as the title; the reason lives in the body.
+      expect(saved.title).toBe(url);
+      expect(saved.content).toContain("save this page");
+
+      // It's a real entry: it shows up in the list and can be deleted.
+      const listRes = await request.get("/api/wallabag/api/entries", { headers: auth });
+      const ids = (await listRes.json())._embedded.items.map((e: { id: number }) => e.id);
+      expect(ids).toContain(saved.id);
+
+      // Re-saving the same failing URL is idempotent (no duplicate entry).
+      const again = await request.post("/api/wallabag/api/entries", {
+        headers: auth,
+        form: { url },
+      });
+      expect(again.status()).toBe(200);
+      expect((await again.json()).id).toBe(saved.id);
+
+      await request.delete(`/api/wallabag/api/entries/${saved.id}`, { headers: auth });
     } finally {
       await close();
     }


### PR DESCRIPTION
## Problem

Saving via the Wallabag Android app (share-to-save) hangs with no feedback and nothing shows up in the feed; the app can also drop into a "finish setup / fix configuration" state even though re-testing the login works.

**Root cause** (traced through the app + apiwrapper source — see #1254): the Wallabag Android app's offline save queue (`OfflineChangesSynchronizer`) advances an item **only on a 2xx response**. Any non-2xx:
- keeps the item queued and **retries it forever**,
- **halts every newer queued save behind it** (a poison item), and
- a `400`/`401` flips the app into `INCORRECT_CREDENTIALS` → the "fix configuration" notification and disables auto-sync.

There is **no** status/body that signals "permanent failure, drop it" — real Wallabag almost never errors on `POST /api/entries` (it creates an entry even when extraction fails), so the app treats every error as transient.

The user's trigger was saving a **5.27 MB** page (`transformer-circuits.pub/.../crosscoders/`) that exceeds our 5 MB `maxSavedArticleSizeBytes` limit, so `POST /api/entries` returned `400 CONTENT_TOO_LARGE` on every retry, jamming the queue behind it — small URLs shared afterward never uploaded.

## Fix

For the **Wallabag POST surface only**, on a *permanent client-side* failure — the existing `clientErrorResponse` signal (a 4xx, plus expected upstream conditions like `SITE_BLOCKED`) — instead of returning the 4xx we save a **labeled placeholder entry** (URL as title, failure reason as body) and return **200**. This drains the app's queue and tells the user in-app why the save failed.

Genuine 5xx server bugs still `throw` → 500, so the app legitimately retries them once fixed. The tRPC/MCP save paths are unchanged and keep returning their clean 4xx errors.

## Changes

- **`savePlaceholderArticle`** service (`saved.ts`): idempotent by URL, creates a real, deletable entry via the shared `insertSavedEntry` path (no fetch, no Readability).
- **Wallabag POST route**: catch client errors → save placeholder → 200 with the formatted entry; `describeSaveFailure` maps the error to a human-readable body (`URL_IS_FEED` → subscribe advice; others use the service message).
- **e2e test** rewritten: the old test asserted the 4xx; now asserts the 200 placeholder, that it appears in the list, and that re-saving the same failing URL is idempotent.

## Testing

- `pnpm typecheck` ✅
- Wallabag e2e suite (16 tests) ✅
- Integration suite (675 passed) ✅

## Notes / follow-ups (in #1254)

- The app **persists** the returned entry locally and its default FAST (`?since=`) sync deletes nothing, so a *non-persisted* synthetic 200 would leave a permanent orphan — hence the placeholder is a real, deletable entry.
- Because the placeholder is stored with `guid = normalized URL`, a later successful save of the same URL (via the no-refetch Wallabag POST) returns the placeholder until it's deleted. Acceptable for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)