### PR TITLE
Mark saved-article placeholders and always refetch them on re-save (#1256)

### DIFF
--- a/migrations/0101_entries_is_placeholder.sql
+++ b/migrations/0101_entries_is_placeholder.sql
@@ -1,0 +1,21 @@
+-- Mark saved-article placeholder entries so a re-save can always refetch them
+-- (issue #1256).
+--
+-- The Wallabag POST surface saves a labeled *placeholder* entry (URL as title,
+-- failure reason as body, 200) when an article can't be fetched, so the app's
+-- offline queue drains instead of jamming on a poison item (#1254/#1255). A
+-- placeholder is keyed by `guid = normalized URL`, so a later no-refetch save of
+-- the same URL (a plain Wallabag re-share or MCP save_article) matched it and
+-- returned it without re-fetching — so a transiently-failed URL never healed.
+--
+-- This boolean lets saveArticle tell a placeholder from a real saved article, so
+-- it can always refetch a placeholder on re-save (healing it into real content)
+-- while a real article keeps returning instantly. savePlaceholderArticle sets it
+-- true; any successful real save clears it.
+--
+-- Additive, NOT NULL DEFAULT false → expand/contract-compatible: the previous
+-- release ignores the column, and release_command runs before the canary, so
+-- old code runs against the new schema during rollout and on rollback. No
+-- backfill needed — existing placeholders (if any) simply stay unmarked, which
+-- only means they don't get the new always-refetch treatment (acceptable).
+ALTER TABLE entries ADD COLUMN is_placeholder boolean NOT NULL DEFAULT false;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -701,6 +701,13 @@
       "when": 1782953300000,
       "tag": "0100_lazy_full_content_original_sanitized",
       "breakpoints": true
+    },
+    {
+      "idx": 100,
+      "version": "7",
+      "when": 1782953400000,
+      "tag": "0101_entries_is_placeholder",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -222,6 +222,7 @@ CREATE TABLE public.entries (
     full_content_cleaned_sanitized text,
     full_content_sanitized_version smallint,
     greader_item_id bigint NOT NULL,
+    is_placeholder boolean DEFAULT false NOT NULL,
     CONSTRAINT entries_last_seen_only_fetched CHECK (((type = 'web'::public.feed_type) = (last_seen_at IS NOT NULL))),
     CONSTRAINT entries_saved_metadata_only_saved CHECK (((type = 'saved'::public.feed_type) OR ((site_name IS NULL) AND (image_url IS NULL)))),
     CONSTRAINT entries_spam_only_email CHECK (((type = 'email'::public.feed_type) OR ((spam_score IS NULL) AND (is_spam = false)))),

--- a/src/app/api/wallabag/api/entries/route.ts
+++ b/src/app/api/wallabag/api/entries/route.ts
@@ -183,10 +183,10 @@ export async function POST(request: Request): Promise<Response> {
     // client/upstream failure, not our bug" signal (a 4xx, or an expected
     // upstream 5xx like SITE_BLOCKED). A genuine server bug returns null and
     // still throws → 500, so the app legitimately retries it once we've fixed
-    // the cause. Note this also placeholders the *transient* client-coded
-    // failures (UPSTREAM_RATE_LIMITED, SITE_BLOCKED); a plain app re-share won't
-    // then heal them (see the trade-off note on savePlaceholderArticle) — but
-    // draining the queue beats leaving it jammed for every other save.
+    // the cause. The placeholder is flagged is_placeholder, so a later re-share
+    // of the same URL always refetches it (see savePlaceholderArticle / #1256) —
+    // a transient failure (UPSTREAM_RATE_LIMITED, SITE_BLOCKED) heals on the next
+    // re-share instead of being stuck behind the placeholder.
     if (clientErrorResponse(error) !== null) {
       const placeholder = await savedService.savePlaceholderArticle(db, auth.userId, {
         url: articleUrl,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -525,6 +525,14 @@ export const entries = pgTable(
     greaderItemId: bigint("greader_item_id", { mode: "bigint" })
       .notNull()
       .default(sql`nextval('entries_greader_item_id_seq'::regclass)`),
+
+    // True for a saved-article *placeholder*: a stand-in entry (URL as title,
+    // failure reason as body) the Wallabag POST surface writes when an article
+    // can't be fetched (#1254). Lets saveArticle always refetch a placeholder on
+    // re-save so a transiently-failed URL self-heals into real content, while a
+    // real saved article keeps returning instantly (#1256). Cleared by any
+    // successful real save.
+    isPlaceholder: boolean("is_placeholder").notNull().default(false),
   },
   (table) => [
     // Unique constraint on feed + guid

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -256,6 +256,8 @@ interface InsertSavedEntryParams {
   siteName: string | null;
   imageUrl: string | null;
   contentHash: string;
+  /** True for a failed-save placeholder entry (see savePlaceholderArticle). */
+  isPlaceholder?: boolean;
 }
 
 /**
@@ -306,6 +308,7 @@ async function insertSavedEntry(
       summary: params.summary,
       siteName: params.siteName,
       imageUrl: params.imageUrl,
+      isPlaceholder: params.isPlaceholder ?? false,
       publishedAt: null,
       fetchedAt: now,
       contentHash: params.contentHash,
@@ -838,6 +841,63 @@ export async function savedArticleExistsByUrl(
   return existing[0]?.id ?? null;
 }
 
+/**
+ * Re-select an already-saved article for this (user, normalized URL) and shape
+ * it into a {@link SaveArticleResult} with outcome `"existing"`, version-healing
+ * the sanitized body off the event loop (raw content must not leave the service
+ * layer). Returns null if no such row exists.
+ *
+ * Shared by {@link saveArticle}'s post-conflict idempotent return and
+ * {@link savePlaceholderArticle}'s conflict fallback — both of which need the
+ * existing row **without** triggering a refetch (savePlaceholderArticle must
+ * not, since a placeholder now always refetches on the normal saveArticle path).
+ */
+async function selectExistingSavedArticle(
+  db: typeof dbType,
+  userId: string,
+  savedFeedId: string,
+  normalizedUrl: string
+): Promise<SaveArticleResult | null> {
+  const [row] = await db
+    .select({ entry: entries, userState: userEntries })
+    .from(entries)
+    .innerJoin(userEntries, eq(userEntries.entryId, entries.id))
+    .where(
+      and(
+        eq(entries.feedId, savedFeedId),
+        eq(entries.guid, normalizedUrl),
+        eq(userEntries.userId, userId)
+      )
+    )
+    .limit(1);
+  if (!row) {
+    return null;
+  }
+  const { entry, userState } = row;
+  // Version-check + worker-offload + self-heal rather than a synchronous
+  // re-sanitize of a possibly-stale body (matches the no-refetch path).
+  const { cleaned } = await resolveSanitizedFamily(db, entry.id, "content", {
+    originalSanitized: entry.contentOriginalSanitized,
+    cleanedSanitized: entry.contentCleanedSanitized,
+    version: entry.contentSanitizedVersion,
+    hasRaw: entry.contentOriginal !== null || entry.contentCleaned !== null,
+  });
+  return {
+    id: entry.id,
+    url: entry.url!,
+    title: entry.title,
+    siteName: entry.siteName,
+    author: entry.author,
+    imageUrl: entry.imageUrl,
+    contentCleaned: cleaned,
+    excerpt: entry.summary,
+    read: userState.read,
+    starred: userState.starred,
+    savedAt: entry.fetchedAt,
+    outcome: "existing",
+  };
+}
+
 export async function saveArticle(
   db: typeof dbType,
   userId: string,
@@ -869,7 +929,13 @@ export async function saveArticle(
   let existingEntry: (typeof existing)[0] | null = null;
 
   if (existing.length > 0) {
-    if (!params.refetch) {
+    // A placeholder (a failed-save stand-in, see savePlaceholderArticle) always
+    // refetches on re-save so a transiently-failed URL self-heals into the real
+    // article — even for the no-refetch callers (a plain Wallabag re-share, MCP
+    // save_article). A real saved article still returns instantly unless the
+    // caller opted into refetch. See #1256.
+    const isPlaceholder = existing[0].entry.isPlaceholder;
+    if (!params.refetch && !isPlaceholder) {
       const { entry, userState } = existing[0];
       // Serve the stored sanitized body, healing it off the event loop if the
       // stored SANITIZER_VERSION is behind (raw content must not leave the
@@ -896,7 +962,7 @@ export async function saveArticle(
         outcome: "existing",
       };
     }
-    // refetch=true: continue to fetch new content and compare
+    // refetch=true (or a placeholder): continue to fetch new content and compare
     existingEntry = existing[0];
   }
 
@@ -977,9 +1043,15 @@ export async function saveArticle(
     const { entry: oldEntry, userState } = existingEntry;
     const now = new Date();
 
+    // A placeholder body is intentionally tiny (URL + failure reason), so the
+    // "reject if new content is worse" guard would reject nearly every real
+    // article that replaces it. Replacing a placeholder with any real content
+    // should always win — treat it as force-equivalent (#1256).
+    const skipQualityGuard = params.force || oldEntry.isPlaceholder;
+
     // Compare content quality to avoid overwriting good content with bad
     // (e.g., private Google Doc fetched with auth, refetched without)
-    if (!params.force) {
+    if (!skipQualityGuard) {
       const oldTextLength = oldEntry.contentCleaned ? stripHtml(oldEntry.contentCleaned).length : 0;
 
       const newTextLength = pluginContent
@@ -1029,6 +1101,9 @@ export async function saveArticle(
         imageUrl: metadata.imageUrl,
         contentHash,
         updatedAt: now,
+        // A successful real save clears the placeholder mark (no-op when the
+        // entry was already a real article). See #1256.
+        isPlaceholder: false,
       },
       presanitizedCleaned
     );
@@ -1114,45 +1189,12 @@ export async function saveArticle(
   // guid) between our existence check above and the insert. Return the existing
   // article idempotently instead of surfacing a unique-violation 500 (#952).
   if (!saved) {
-    const [row] = await db
-      .select({ entry: entries, userState: userEntries })
-      .from(entries)
-      .innerJoin(userEntries, eq(userEntries.entryId, entries.id))
-      .where(
-        and(
-          eq(entries.feedId, savedFeedId),
-          eq(entries.guid, normalizedUrl),
-          eq(userEntries.userId, userId)
-        )
-      )
-      .limit(1);
-    if (!row) {
+    const existingResult = await selectExistingSavedArticle(db, userId, savedFeedId, normalizedUrl);
+    if (!existingResult) {
       // Should not happen: the insert only aborts on an existing row.
       throw new Error(`Saved article vanished after conflict: ${normalizedUrl}`);
     }
-    const { entry, userState } = row;
-    // See the no-refetch path above: version-check + worker-offload + self-heal
-    // rather than a synchronous re-sanitize of a possibly-stale body.
-    const { cleaned } = await resolveSanitizedFamily(db, entry.id, "content", {
-      originalSanitized: entry.contentOriginalSanitized,
-      cleanedSanitized: entry.contentCleanedSanitized,
-      version: entry.contentSanitizedVersion,
-      hasRaw: entry.contentOriginal !== null || entry.contentCleaned !== null,
-    });
-    return {
-      id: entry.id,
-      url: entry.url!,
-      title: entry.title,
-      siteName: entry.siteName,
-      author: entry.author,
-      imageUrl: entry.imageUrl,
-      contentCleaned: cleaned,
-      excerpt: entry.summary,
-      read: userState.read,
-      starred: userState.starred,
-      savedAt: entry.fetchedAt,
-      outcome: "existing",
-    };
+    return existingResult;
   }
 
   logger.info("Saved article", {
@@ -1180,20 +1222,19 @@ export async function saveArticle(
  *
  * The entry keeps the original URL (so it stays clickable and the save is
  * idempotent by URL), uses the URL as its title, and the failure reason as its
- * body. Interactive callers (tRPC/MCP) must keep surfacing the real error
- * instead of calling this.
+ * body. It is flagged `is_placeholder = true` (see below). Interactive callers
+ * (tRPC/MCP) must keep surfacing the real error instead of calling this.
  *
- * Trade-off (accepted): because the placeholder is stored under `guid =
- * normalized URL`, a later *no-refetch* save of the same URL — a plain re-share
- * to the Wallabag app, or MCP `save_article` — matches it and returns the
- * placeholder rather than re-fetching, so it does NOT auto-heal into the real
- * article. This mainly bites the transient failure codes we still treat as
- * client errors (`UPSTREAM_RATE_LIMITED`, `SITE_BLOCKED`): a save that failed
- * only momentarily leaves a placeholder that a plain re-share won't replace. It
- * is recoverable — the web `saved.save` path defaults `refetch: true` and heals
- * it, and deleting the placeholder then re-sharing fetches fresh — but a bare
- * app re-share won't. We accept this because the alternative (a jammed queue
- * that blocks *every* newer save) is worse. See #1254.
+ * Self-heal (#1256): the placeholder is stored under `guid = normalized URL`, so
+ * a later save of the same URL matches it. Because it's flagged, {@link
+ * saveArticle} always **refetches** a placeholder on re-save (even for the
+ * no-refetch callers — a plain Wallabag re-share, MCP `save_article`) and, on
+ * success, replaces it with the real article. So a transiently-failed URL
+ * (`UPSTREAM_RATE_LIMITED`, `SITE_BLOCKED`) heals on the next re-share instead of
+ * being stuck behind the placeholder. Only *this* function's own conflict
+ * fallback (below) returns the existing placeholder without refetching, so a
+ * re-fetch that fails *again* still drains the Wallabag queue with a 200 rather
+ * than looping.
  */
 export async function savePlaceholderArticle(
   db: typeof dbType,
@@ -1220,6 +1261,7 @@ export async function savePlaceholderArticle(
     siteName: null,
     imageUrl: null,
     contentHash,
+    isPlaceholder: true,
   });
 
   if (saved) {
@@ -1232,9 +1274,20 @@ export async function savePlaceholderArticle(
 
   // The (feed_id, guid) already exists: this URL was previously saved (a real
   // article or an earlier placeholder), or two queued retries raced. Return the
-  // existing entry idempotently instead of a unique-violation. The no-refetch
-  // saveArticle path re-selects and version-heals it exactly as we need.
-  return saveArticle(db, userId, { url: params.url });
+  // existing entry idempotently instead of a unique-violation.
+  //
+  // Deliberately re-select directly rather than calling saveArticle: a
+  // placeholder now always *refetches* on the saveArticle path, and a refetch
+  // that fails again would throw here — breaking this surface's contract of
+  // draining the Wallabag queue with a 200. (This is reached only after our own
+  // insert lost a race with an existing row, so a fresh fetch here would be
+  // wasted work anyway.)
+  const existingResult = await selectExistingSavedArticle(db, userId, savedFeedId, normalizedUrl);
+  if (!existingResult) {
+    // Should not happen: the insert only aborts on an existing row.
+    throw new Error(`Saved placeholder vanished after conflict: ${normalizedUrl}`);
+  }
+  return existingResult;
 }
 
 /**

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -19,7 +19,11 @@ import { users, entries, userEntries, feeds } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
-import { saveArticle, savedArticleExistsByUrl } from "../../src/server/services/saved";
+import {
+  saveArticle,
+  savePlaceholderArticle,
+  savedArticleExistsByUrl,
+} from "../../src/server/services/saved";
 import { markEntriesRead } from "../../src/server/services/entries";
 
 // ============================================================================
@@ -1341,6 +1345,138 @@ describe("Saved Articles API", () => {
         .from(feeds)
         .where(and(eq(feeds.type, "saved"), eq(feeds.userId, userId)));
       expect(savedFeeds).toHaveLength(0);
+    });
+  });
+
+  describe("savePlaceholderArticle self-heal (#1256)", () => {
+    const realHtml = `
+      <!DOCTYPE html>
+      <html>
+        <head><title>Real Article Title</title></head>
+        <body>
+          <article>
+            <p>This is the real article content, fetched successfully on re-save.</p>
+            <p>It has plenty of text so it comfortably passes any quality checks.</p>
+            <p>This paragraph exists only to push the body well past 500 characters
+            so the "reject if worse" guard would normally have something to compare
+            against — though for a placeholder that guard is skipped entirely.</p>
+          </article>
+        </body>
+      </html>
+    `;
+
+    async function isPlaceholderFlag(entryId: string): Promise<boolean> {
+      const [row] = await db
+        .select({ isPlaceholder: entries.isPlaceholder })
+        .from(entries)
+        .where(eq(entries.id, entryId))
+        .limit(1);
+      return row.isPlaceholder;
+    }
+
+    it("marks the placeholder entry with is_placeholder = true", async () => {
+      const userId = await createTestUser();
+      const url = "https://example.com/placeholder-marked";
+
+      const placeholder = await savePlaceholderArticle(db, userId, {
+        url,
+        reason: "The site blocked us.",
+      });
+
+      expect(placeholder.outcome).toBe("created");
+      expect(await isPlaceholderFlag(placeholder.id)).toBe(true);
+    });
+
+    it("always refetches a placeholder on a no-refetch re-save, replacing it with real content", async () => {
+      const userId = await createTestUser();
+      const url = "https://example.com/placeholder-heals";
+
+      // A transient failure leaves a placeholder.
+      const placeholder = await savePlaceholderArticle(db, userId, {
+        url,
+        reason: "Rate limited.",
+      });
+      expect(await isPlaceholderFlag(placeholder.id)).toBe(true);
+
+      // A plain re-share (no refetch) must NOT short-circuit on the placeholder —
+      // it refetches and replaces it with the real article.
+      const healed = await saveArticle(db, userId, { url, html: realHtml });
+
+      expect(healed.outcome).toBe("updated");
+      expect(healed.id).toBe(placeholder.id); // same entry, healed in place
+      expect(healed.title).toBe("Real Article Title");
+      expect(await isPlaceholderFlag(healed.id)).toBe(false);
+
+      // The served body is now the real content, not the placeholder text.
+      const ctx = createAuthContext(userId);
+      const caller = createCaller(ctx);
+      const fetched = await caller.entries.get({ id: healed.id });
+      expect(fetched.entry.contentCleaned).toContain("real article content");
+      expect(fetched.entry.contentCleaned).not.toContain("couldn't save");
+    });
+
+    it("skips the quality guard when replacing a placeholder (any real content wins)", async () => {
+      const userId = await createTestUser();
+      const url = "https://example.com/placeholder-short-content";
+
+      await savePlaceholderArticle(db, userId, { url, reason: "Blocked." });
+
+      // Short real content that would trip the "reject if worse" guard on a real
+      // article. Because the existing row is a placeholder, the guard is skipped
+      // and this must succeed rather than throw REFETCH_CONTENT_WORSE.
+      const shortHtml =
+        "<html><head><title>Short But Real</title></head><body><p>Tiny real body.</p></body></html>";
+      const healed = await saveArticle(db, userId, { url, html: shortHtml });
+
+      expect(healed.outcome).toBe("updated");
+      expect(healed.title).toBe("Short But Real");
+      expect(await isPlaceholderFlag(healed.id)).toBe(false);
+    });
+
+    it("returns a real saved article instantly on re-save (no refetch, not a placeholder)", async () => {
+      const userId = await createTestUser();
+      const url = "https://example.com/real-not-refetched";
+
+      // A genuinely saved article (not a placeholder).
+      const first = await saveArticle(db, userId, { url, html: realHtml });
+      expect(first.outcome).toBe("created");
+      expect(await isPlaceholderFlag(first.id)).toBe(false);
+
+      // A no-refetch re-save returns it as-is without refetching (outcome
+      // "existing"), even though we pass different HTML — proving the common
+      // re-share path is unaffected by the placeholder always-refetch change.
+      const again = await saveArticle(db, userId, {
+        url,
+        html: "<html><head><title>Should Be Ignored</title></head><body>x</body></html>",
+      });
+      expect(again.outcome).toBe("existing");
+      expect(again.title).toBe("Real Article Title");
+    });
+
+    it("does not loop when a placeholder re-save fails again (savePlaceholderArticle stays idempotent)", async () => {
+      const userId = await createTestUser();
+      const url = "https://example.com/placeholder-refail";
+
+      const first = await savePlaceholderArticle(db, userId, {
+        url,
+        reason: "First failure.",
+      });
+
+      // A second placeholder save of the same URL (e.g. the re-fetch failed
+      // again) must return the existing placeholder idempotently, not throw or
+      // recurse into a refetch.
+      const second = await savePlaceholderArticle(db, userId, {
+        url,
+        reason: "Second failure.",
+      });
+
+      expect(second.id).toBe(first.id);
+      expect(second.outcome).toBe("existing");
+      expect(await isPlaceholderFlag(second.id)).toBe(true);
+
+      // Exactly one entry row exists for this URL.
+      const rows = await db.select({ id: entries.id }).from(entries).where(eq(entries.guid, url));
+      expect(rows).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
Fixes #1256.

## Background

#1254/#1255 made the Wallabag `POST /api/entries` surface save a **placeholder entry** (URL as title, failure reason as body, 200) when an article can't be fetched, so the Wallabag app's offline queue drains instead of jamming on a poison item. A placeholder is keyed by `guid = normalized URL`, so a later **no-refetch** save of the same URL — a plain Wallabag re-share or MCP `save_article` — matched it and returned the placeholder **without re-fetching**, so a transiently-failed URL (`UPSTREAM_RATE_LIMITED`, `SITE_BLOCKED`) never healed into the real article.

## Changes

1. **Mark placeholders in the DB.** New `entries.is_placeholder` boolean (`NOT NULL DEFAULT false`; additive, expand/contract-compatible, no backfill). `savePlaceholderArticle` sets it `true`; any successful real save clears it.
2. **Always refetch a placeholder on re-save.** In `saveArticle`'s existence check, when the matched row is a placeholder it no longer short-circuits — it fetches fresh even for the no-refetch callers and, on success, replaces the placeholder with real content. A real saved article still returns instantly (the common re-share path is unaffected).
3. **Skip the quality guard for placeholders.** The "reject if new content is worse" comparison is skipped when the existing row is a placeholder (its body is intentionally tiny), so any real content wins — force-equivalent.
4. **No refetch loop.** `savePlaceholderArticle`'s conflict fallback now re-selects the existing row directly (shared `selectExistingSavedArticle` helper) instead of calling `saveArticle`, so a re-fetch that fails *again* still drains the Wallabag queue with a 200 rather than looping.

Primarily benefits the Wallabag POST and MCP `save_article` (the no-refetch callers); the web `saved.save` path already healed via its `refetch: true` default. A distinct UI affordance for placeholders is a separate follow-up (noted in the issue).

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (2403 pass) all green.
- New integration tests in `tests/integration/saved-articles.test.ts` (run against local Postgres, 55 pass): placeholder is flagged; a no-refetch re-save heals it into real content; the quality guard is skipped; a real article still returns instantly on re-save; and a repeated placeholder save stays idempotent (no loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)