### PR TITLE
Narration: live pause/skip during chunk generation + cap chunk length

### DIFF
--- a/src/components/narration/NarrationControls.tsx
+++ b/src/components/narration/NarrationControls.tsx
@@ -115,16 +115,20 @@ export function NarrationControlsImpl({
   const { status, currentParagraph, totalParagraphs } = state;
   const isPlaying = status === "playing";
   const isPaused = status === "paused";
-  // Consider "loading" as active when we already have paragraphs (buffering mid-playback)
-  // vs initial generation (no paragraphs yet)
+  // "loading" once we already have paragraphs means we're generating the next
+  // chunk mid-playback. The controls stay live here so the user can pause or
+  // skip while a chunk generates. Before any paragraphs exist we're still doing
+  // the initial narration generation, where there's nothing yet to control.
   const isBufferingMidPlayback = status === "loading" && totalParagraphs > 0;
+  const isInitialLoading = (isLoading || status === "loading") && !isBufferingMidPlayback;
   const isActive = isPlaying || isPaused || isBufferingMidPlayback;
 
   /**
-   * Handle play/pause button click.
+   * Handle play/pause button click. Pausing works while a chunk is generating
+   * (buffering) as well as during normal playback.
    */
   const handlePlayPause = () => {
-    if (isPlaying) {
+    if (isPlaying || isBufferingMidPlayback) {
       pause();
     } else {
       play();
@@ -135,11 +139,13 @@ export function NarrationControlsImpl({
   let mainButtonLabel: string;
   let mainButtonIcon: React.ReactNode;
 
-  // Show loading state for both initial generation and mid-playback buffering
-  const showLoadingState = isLoading || isBufferingMidPlayback;
-
-  if (showLoadingState) {
+  if (isInitialLoading) {
     mainButtonLabel = "Generating...";
+    mainButtonIcon = <SpinnerIcon className="h-5 w-5" />;
+  } else if (isBufferingMidPlayback) {
+    // A chunk is generating, but playback is active — keep the spinner as an
+    // activity indicator while letting the button pause.
+    mainButtonLabel = "Pause";
     mainButtonIcon = <SpinnerIcon className="h-5 w-5" />;
   } else if (isPlaying) {
     mainButtonLabel = "Pause";
@@ -160,7 +166,7 @@ export function NarrationControlsImpl({
           variant="ghost"
           size="sm"
           onClick={skipBackward}
-          disabled={showLoadingState || currentParagraph === 0}
+          disabled={currentParagraph === 0}
           aria-label="Previous paragraph"
           className="min-w-[36px] px-2"
         >
@@ -173,7 +179,7 @@ export function NarrationControlsImpl({
         variant="secondary"
         size="sm"
         onClick={handlePlayPause}
-        disabled={showLoadingState}
+        disabled={isInitialLoading}
         aria-label={mainButtonLabel}
       >
         {mainButtonIcon}
@@ -186,7 +192,7 @@ export function NarrationControlsImpl({
           variant="ghost"
           size="sm"
           onClick={skipForward}
-          disabled={showLoadingState || currentParagraph >= totalParagraphs - 1}
+          disabled={currentParagraph >= totalParagraphs - 1}
           aria-label="Next paragraph"
           className="min-w-[36px] px-2"
         >

--- a/src/lib/hooks/useNarrationKeyboardShortcuts.ts
+++ b/src/lib/hooks/useNarrationKeyboardShortcuts.ts
@@ -98,6 +98,11 @@ export function useNarrationKeyboardShortcuts(options: UseNarrationKeyboardShort
 
   const isPlaying = status === "playing";
   const isPaused = status === "paused";
+  // "loading" with paragraphs already loaded means a chunk is generating
+  // mid-playback; controls stay live so the user can pause/skip while it does.
+  const isBufferingMidPlayback = status === "loading" && totalParagraphs > 0;
+  // The narration is controllable (not doing the initial pre-playback generation).
+  const isControllable = isPlaying || isPaused || isBufferingMidPlayback;
 
   // Base enabled condition: shortcuts enabled, modal not open, narration supported
   const baseEnabled = keyboardShortcutsEnabled && !isModalOpen && isSupported;
@@ -107,7 +112,7 @@ export function useNarrationKeyboardShortcuts(options: UseNarrationKeyboardShort
     "p",
     (e) => {
       e.preventDefault();
-      if (isPlaying) {
+      if (isPlaying || isBufferingMidPlayback) {
         pause();
       } else {
         play();
@@ -117,7 +122,7 @@ export function useNarrationKeyboardShortcuts(options: UseNarrationKeyboardShort
       enabled: baseEnabled && !isLoading,
       enableOnFormTags: false,
     },
-    [isPlaying, isLoading, play, pause, baseEnabled]
+    [isPlaying, isBufferingMidPlayback, isLoading, play, pause, baseEnabled]
   );
 
   // Shift+N - Skip to next paragraph
@@ -129,13 +134,10 @@ export function useNarrationKeyboardShortcuts(options: UseNarrationKeyboardShort
     },
     {
       enabled:
-        baseEnabled &&
-        !isLoading &&
-        (isPlaying || isPaused) &&
-        currentParagraph < totalParagraphs - 1,
+        baseEnabled && !isLoading && isControllable && currentParagraph < totalParagraphs - 1,
       enableOnFormTags: false,
     },
-    [skipForward, isLoading, isPlaying, isPaused, currentParagraph, totalParagraphs, baseEnabled]
+    [skipForward, isLoading, isControllable, currentParagraph, totalParagraphs, baseEnabled]
   );
 
   // Shift+P - Skip to previous paragraph
@@ -146,9 +148,9 @@ export function useNarrationKeyboardShortcuts(options: UseNarrationKeyboardShort
       skipBackward();
     },
     {
-      enabled: baseEnabled && !isLoading && (isPlaying || isPaused) && currentParagraph > 0,
+      enabled: baseEnabled && !isLoading && isControllable && currentParagraph > 0,
       enableOnFormTags: false,
     },
-    [skipBackward, isLoading, isPlaying, isPaused, currentParagraph, baseEnabled]
+    [skipBackward, isLoading, isControllable, currentParagraph, baseEnabled]
   );
 }

--- a/src/lib/narration/sentence-splitter.ts
+++ b/src/lib/narration/sentence-splitter.ts
@@ -13,10 +13,114 @@
 import { split, SentenceSplitterSyntax } from "sentence-splitter";
 
 /**
+ * Maximum number of characters in a single TTS synthesis chunk.
+ *
+ * Neural TTS (Piper) synthesizes one chunk in a single pass, and very long
+ * chunks get rushed and muddled (the model compresses too much speech into one
+ * breath). We therefore split sentences longer than this at clause boundaries
+ * so each chunk stays a comfortable, natural length. Chosen so ordinary
+ * sentences stay whole while run-on sentences (e.g. a 400-char sentence full of
+ * comma-separated clauses) break into clause-sized pieces.
+ */
+export const MAX_CHUNK_CHARS = 180;
+
+/**
+ * Split text at clause-level punctuation (commas, semicolons, colons, dashes)
+ * followed by whitespace. The punctuation stays with the preceding clause; the
+ * whitespace is dropped. Empty pieces are filtered out.
+ */
+function splitAtClauseBoundaries(text: string): string[] {
+  const parts: string[] = [];
+  // Each of these separators is a single UTF-16 code unit, so `index + 1`
+  // reliably keeps the punctuation attached to the clause before it.
+  const separator = /[,;:—–]\s+/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = separator.exec(text)) !== null) {
+    const end = match.index + 1;
+    const clause = text.slice(lastIndex, end).trim();
+    if (clause.length > 0) {
+      parts.push(clause);
+    }
+    lastIndex = match.index + match[0].length;
+  }
+  const tail = text.slice(lastIndex).trim();
+  if (tail.length > 0) {
+    parts.push(tail);
+  }
+  return parts;
+}
+
+/**
+ * Split text at word boundaries, greedily packing words up to `maxChars`.
+ * Used as a last resort for a single clause that still exceeds the limit.
+ */
+function splitAtWords(text: string, maxChars: number): string[] {
+  const chunks: string[] = [];
+  let current = "";
+  for (const word of text.split(/\s+/)) {
+    if (word.length === 0) continue;
+    if (current && current.length + 1 + word.length > maxChars) {
+      chunks.push(current);
+      current = word;
+    } else {
+      current = current ? `${current} ${word}` : word;
+    }
+  }
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+  return chunks;
+}
+
+/**
+ * Break a single sentence into chunks no longer than `maxChars`, preferring
+ * clause boundaries and falling back to word boundaries only when a lone clause
+ * is still too long. Sentences within the limit are returned unchanged.
+ */
+export function splitLongSentence(text: string, maxChars: number = MAX_CHUNK_CHARS): string[] {
+  if (text.length <= maxChars) {
+    return [text];
+  }
+
+  // Break into clauses, then further break any clause that is still too long.
+  const pieces: string[] = [];
+  for (const clause of splitAtClauseBoundaries(text)) {
+    if (clause.length > maxChars) {
+      pieces.push(...splitAtWords(clause, maxChars));
+    } else {
+      pieces.push(clause);
+    }
+  }
+
+  // Greedily recombine adjacent pieces so we don't over-split (e.g. two short
+  // clauses that comfortably fit together stay together).
+  const chunks: string[] = [];
+  let current = "";
+  for (const piece of pieces) {
+    if (current && current.length + 1 + piece.length > maxChars) {
+      chunks.push(current);
+      current = piece;
+    } else {
+      current = current ? `${current} ${piece}` : piece;
+    }
+  }
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+
+  // Defensive fallback: if we somehow produced nothing, keep the original text.
+  return chunks.length > 0 ? chunks : [text];
+}
+
+/**
  * Splits a paragraph into individual sentences.
  *
+ * Sentences longer than {@link MAX_CHUNK_CHARS} are further split at clause
+ * boundaries so neural TTS doesn't rush through them (see {@link splitLongSentence}).
+ *
  * @param text - The paragraph text to split
- * @returns Array of sentence strings, preserving original text
+ * @returns Array of sentence/chunk strings, preserving original text
  */
 export function splitIntoSentences(text: string): string[] {
   if (!text || text.trim().length === 0) {
@@ -36,13 +140,14 @@ export function splitIntoSentences(text: string): string[] {
     }
   }
 
-  // If no sentences were detected, return the original text as a single sentence
-  // This handles edge cases where the text has no sentence-ending punctuation
+  // If no sentences were detected, treat the original text as a single sentence.
+  // This handles edge cases where the text has no sentence-ending punctuation.
   if (sentences.length === 0 && text.trim().length > 0) {
-    return [text.trim()];
+    sentences.push(text.trim());
   }
 
-  return sentences;
+  // Split any over-long sentences so each synthesis chunk stays a natural length.
+  return sentences.flatMap((sentence) => splitLongSentence(sentence));
 }
 
 /**

--- a/src/lib/narration/streaming-audio-player.ts
+++ b/src/lib/narration/streaming-audio-player.ts
@@ -144,6 +144,10 @@ export class StreamingAudioPlayer {
 
   // Playback state
   private isPaused = false;
+  // True when the user paused while a chunk was still generating (no audio
+  // source to resume). Resume restarts playback from the current position
+  // instead of trying to resume a non-existent source.
+  private pausedWhileBuffering = false;
   private currentSentenceEndCallback: (() => void) | null = null;
 
   constructor(
@@ -200,8 +204,16 @@ export class StreamingAudioPlayer {
 
     if (this.status === "paused") {
       this.isPaused = false;
-      this.resumePlayback();
-      this.setStatus("playing");
+      if (this.pausedWhileBuffering) {
+        // We paused mid-generation, so there's no audio source to resume.
+        // Restart from the current position — this replays the cached chunk if
+        // generation finished while paused, or regenerates it otherwise.
+        this.pausedWhileBuffering = false;
+        await this.startPlaybackFrom(this.position);
+      } else {
+        this.resumePlayback();
+        this.setStatus("playing");
+      }
       return;
     }
 
@@ -215,13 +227,22 @@ export class StreamingAudioPlayer {
 
   /**
    * Pause playback.
+   *
+   * Works both while audio is playing and while a chunk is still generating
+   * (buffering). When buffering, we cancel the in-flight generation and
+   * remember the position so resume can restart from here.
    */
   pause(): void {
-    if (this.status !== "playing") return;
-
-    this.isPaused = true;
-    this.pausePlayback();
-    this.setStatus("paused");
+    if (this.status === "playing") {
+      this.isPaused = true;
+      this.pausePlayback();
+      this.setStatus("paused");
+    } else if (this.status === "buffering") {
+      this.isPaused = true;
+      this.pausedWhileBuffering = true;
+      this.cancelBuffering();
+      this.setStatus("paused");
+    }
   }
 
   /**
@@ -231,6 +252,7 @@ export class StreamingAudioPlayer {
     this.cancelBuffering();
     this.stopPlayback();
     this.isPaused = false;
+    this.pausedWhileBuffering = false;
     this.position = { paragraph: 0, sentence: 0 };
     this.setStatus("idle");
     this.notifyPositionChange();

--- a/src/lib/narration/streaming-audio-player.ts
+++ b/src/lib/narration/streaming-audio-player.ts
@@ -139,15 +139,24 @@ export class StreamingAudioPlayer {
   // Buffering state
   private isBuffering = false;
   private bufferingCancelled = false;
+  // Monotonic id bumped by cancelBuffering() every time in-flight generation is
+  // invalidated (pause/skip/stop). Each generation captures the current value
+  // and discards its result if the id has since changed. This is more robust
+  // than the shared `bufferingCancelled` boolean, which a newly-started
+  // generation resets to false — resurrecting an already-cancelled generation
+  // and causing double caching/playback on fast pause→resume or skip.
+  private bufferGeneration = 0;
   private currentGenerationParagraph: number | null = null;
   private currentGenerationSentence: number | null = null;
 
   // Playback state
   private isPaused = false;
-  // True when the user paused while a chunk was still generating (no audio
-  // source to resume). Resume restarts playback from the current position
-  // instead of trying to resume a non-existent source.
-  private pausedWhileBuffering = false;
+  // True when a resume must restart playback from the current position rather
+  // than resume a paused audio source, because there is no source to resume:
+  // either we paused mid-generation (buffering), or we skipped while paused
+  // (which stops and discards the paused buffer). Restarting replays the cached
+  // chunk if one exists, or regenerates it.
+  private resumeByRestart = false;
   private currentSentenceEndCallback: (() => void) | null = null;
 
   constructor(
@@ -204,11 +213,11 @@ export class StreamingAudioPlayer {
 
     if (this.status === "paused") {
       this.isPaused = false;
-      if (this.pausedWhileBuffering) {
-        // We paused mid-generation, so there's no audio source to resume.
-        // Restart from the current position — this replays the cached chunk if
-        // generation finished while paused, or regenerates it otherwise.
-        this.pausedWhileBuffering = false;
+      if (this.resumeByRestart) {
+        // No paused audio source to resume (we paused mid-generation or skipped
+        // while paused). Restart from the current position — replays the cached
+        // chunk if it exists, or regenerates it.
+        this.resumeByRestart = false;
         await this.startPlaybackFrom(this.position);
       } else {
         this.resumePlayback();
@@ -239,7 +248,7 @@ export class StreamingAudioPlayer {
       this.setStatus("paused");
     } else if (this.status === "buffering") {
       this.isPaused = true;
-      this.pausedWhileBuffering = true;
+      this.resumeByRestart = true;
       this.cancelBuffering();
       this.setStatus("paused");
     }
@@ -252,7 +261,7 @@ export class StreamingAudioPlayer {
     this.cancelBuffering();
     this.stopPlayback();
     this.isPaused = false;
-    this.pausedWhileBuffering = false;
+    this.resumeByRestart = false;
     this.position = { paragraph: 0, sentence: 0 };
     this.setStatus("idle");
     this.notifyPositionChange();
@@ -280,6 +289,11 @@ export class StreamingAudioPlayer {
     if (this.status === "playing" || this.status === "buffering") {
       await this.startPlaybackFrom(this.position);
     } else {
+      // Paused: stopPlayback() discarded the paused buffer, so resume must
+      // restart from the new position rather than resume a stale source.
+      if (this.status === "paused") {
+        this.resumeByRestart = true;
+      }
       this.notifyPositionChange();
     }
   }
@@ -299,6 +313,11 @@ export class StreamingAudioPlayer {
     if (this.status === "playing" || this.status === "buffering") {
       await this.startPlaybackFrom(this.position);
     } else {
+      // Paused: stopPlayback() discarded the paused buffer, so resume must
+      // restart from the new position rather than resume a stale source.
+      if (this.status === "paused") {
+        this.resumeByRestart = true;
+      }
       this.notifyPositionChange();
     }
   }
@@ -435,13 +454,16 @@ export class StreamingAudioPlayer {
     this.currentGenerationParagraph = paragraphIndex;
     this.currentGenerationSentence = sentenceIndex;
     this.bufferingCancelled = false;
+    const generation = this.bufferGeneration;
 
     try {
       const sentenceText = paragraphCache.sentences[sentenceIndex];
       const buffer = await this.generateAudio(sentenceText, this.config.voiceId);
 
-      // Check if we were cancelled
-      if (this.bufferingCancelled) {
+      // Discard the result if this generation was superseded (cancelled by a
+      // pause/skip/stop while it was in flight, even if a newer generation has
+      // since reset `bufferingCancelled`).
+      if (generation !== this.bufferGeneration) {
         return;
       }
 
@@ -460,7 +482,7 @@ export class StreamingAudioPlayer {
         this.startBuffering();
       }
     } catch (error) {
-      if (!this.bufferingCancelled) {
+      if (generation === this.bufferGeneration) {
         this.callbacks.onError?.(error instanceof Error ? error : new Error(String(error)));
         this.setStatus("idle");
       }
@@ -614,6 +636,9 @@ export class StreamingAudioPlayer {
   private cancelBuffering(): void {
     this.bufferingCancelled = true;
     this.isBuffering = false;
+    // Invalidate any in-flight generation so its result is discarded even if a
+    // subsequently-started generation resets `bufferingCancelled`.
+    this.bufferGeneration++;
   }
 
   /**
@@ -689,6 +714,7 @@ export class StreamingAudioPlayer {
     // Generate the sentence
     this.currentGenerationParagraph = targetParagraph;
     this.currentGenerationSentence = targetSentence;
+    const generation = this.bufferGeneration;
 
     try {
       const paragraphCache = this.getOrCreateParagraphCache(targetParagraph);
@@ -701,7 +727,10 @@ export class StreamingAudioPlayer {
 
       const buffer = await this.generateAudio(sentenceText, this.config.voiceId);
 
-      if (this.bufferingCancelled) {
+      // Discard if this generation was superseded (cancelled while in flight);
+      // a stale generation must not cache or continue the loop, or two buffer
+      // loops end up running at once after a skip.
+      if (generation !== this.bufferGeneration) {
         this.isBuffering = false;
         return;
       }
@@ -722,7 +751,9 @@ export class StreamingAudioPlayer {
       // Continue trying to buffer
       this.currentGenerationParagraph = null;
       this.currentGenerationSentence = null;
-      if (!this.bufferingCancelled) {
+      // Only retry if this generation is still current (not cancelled by a
+      // pause/skip/stop while it was in flight).
+      if (generation === this.bufferGeneration) {
         await this.sleep(500);
         this.bufferLoop();
       } else {

--- a/tests/unit/frontend/sentence-splitter.test.ts
+++ b/tests/unit/frontend/sentence-splitter.test.ts
@@ -5,7 +5,12 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { splitIntoSentences, splitIntoSentencesWithInfo } from "@/lib/narration/sentence-splitter";
+import {
+  splitIntoSentences,
+  splitIntoSentencesWithInfo,
+  splitLongSentence,
+  MAX_CHUNK_CHARS,
+} from "@/lib/narration/sentence-splitter";
 
 describe("splitIntoSentences", () => {
   describe("basic sentence splitting", () => {
@@ -133,6 +138,59 @@ describe("splitIntoSentences", () => {
       // Sentences should be trimmed but internal spacing preserved
       expect(sentences[0]).toContain("First  sentence");
     });
+  });
+});
+
+describe("long sentence chunking", () => {
+  // A real single-sentence paragraph that sounded rushed under Piper TTS
+  // (395 chars, comma-separated clauses) — see the "In this post I will show…"
+  // paragraph in the fork-around-and-find-out-part-2 post.
+  const LONG_SENTENCE =
+    "In this post I will show that controls rule out obvious alternative readings about block 5, that knight forks are mostly assembled compositionally (check plus queen attack) rather than holistically, and give causal evidence via ablations that tie the fork’s decodability to one specific attention head, ending on one potential confound that threatens to completely reshape what our results mean.";
+
+  it("leaves sentences within the limit unchanged", () => {
+    const short = "This is a perfectly reasonable length sentence.";
+    expect(short.length).toBeLessThanOrEqual(MAX_CHUNK_CHARS);
+    expect(splitLongSentence(short)).toEqual([short]);
+  });
+
+  it("splits an over-long sentence into multiple chunks under the limit", () => {
+    const chunks = splitLongSentence(LONG_SENTENCE);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(MAX_CHUNK_CHARS);
+    }
+  });
+
+  it("splits at clause boundaries, preserving all words in order", () => {
+    const chunks = splitLongSentence(LONG_SENTENCE);
+
+    // Every word from the original survives, in order, when rejoined.
+    const originalWords = LONG_SENTENCE.split(/\s+/);
+    const chunkedWords = chunks.join(" ").split(/\s+/);
+    expect(chunkedWords).toEqual(originalWords);
+  });
+
+  it("splits a very long run-on clause at word boundaries", () => {
+    // No clause punctuation at all, so it can only break on words.
+    const runOn = Array.from({ length: 60 }, (_, i) => `word${i}`).join(" ");
+    expect(runOn.length).toBeGreaterThan(MAX_CHUNK_CHARS);
+
+    const chunks = splitLongSentence(runOn);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(MAX_CHUNK_CHARS);
+    }
+    expect(chunks.join(" ")).toBe(runOn);
+  });
+
+  it("applies chunking through splitIntoSentences", () => {
+    const chunks = splitIntoSentences(LONG_SENTENCE);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(MAX_CHUNK_CHARS);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Two narration playback improvements requested from the [fork-around-and-find-out-part-2](https://www.lesswrong.com/posts/6reCnPYeopThEFQxN/fork-around-and-find-out-part-2-one-head-does-the-summing) post:

### 1. Skip forward/backward and pause while a chunk is generating

Previously play/pause and skip were disabled whenever a chunk was being synthesized (`showLoadingState = isLoading || isBufferingMidPlayback`), so mid-playback buffering locked the whole control bar.

Now only the **initial** pre-playback generation locks the controls. Once playback has started, pause and skip stay live while the next chunk generates:

- `NarrationControls` splits the old `showLoadingState` into `isInitialLoading` (locks controls, nothing to control yet) vs `isBufferingMidPlayback` (playback active, keep controls live — spinner still shows as an activity indicator but the button pauses).
- `StreamingAudioPlayer.pause()` now handles the `buffering` state: it cancels the in-flight generation and records `pausedWhileBuffering` so resume restarts from the current position (there's no audio source to resume mid-generation — it replays the cached chunk if generation finished while paused, else regenerates).
- Keyboard shortcuts (`p`, `Shift+N`, `Shift+P`) get the same treatment.

Browser voices are unaffected — `ArticleNarrator` never enters a `loading` status mid-playback, so `isBufferingMidPlayback` is Piper-only.

### 2. Cap synthesis chunk length

Neural TTS rushes/muddles very long sentences. `splitIntoSentences` now breaks any sentence over `MAX_CHUNK_CHARS` (180) at clause boundaries (commas/semicolons/colons/dashes), falling back to word boundaries only when a lone clause is still too long, and greedily recombines short clauses so it doesn't over-split. Sentences within the limit are untouched.

The reported 395-char single-sentence paragraph now reads as four clause-sized chunks (~90–106 chars each) instead of one rushed blob, while the shorter neighboring paragraphs (e.g. 133 chars) stay whole.

## Testing

- Added unit tests in `tests/unit/frontend/sentence-splitter.test.ts` covering the long-sentence chunking (clause split, word-boundary fallback, word-preservation, and the real 395-char example).
- `pnpm typecheck`, `pnpm test:unit`, and eslint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)