### PR TITLE
Narration: migrate cleanup LLM to gpt-oss-20b

### DIFF
--- a/src/app/demo/articles/text-to-speech.ts
+++ b/src/app/demo/articles/text-to-speech.ts
@@ -14,13 +14,13 @@ const article: DemoArticle = {
   heroImage: "/demo/text-to-speech.png",
   heroImageAlt:
     "The Lion Reader lion wearing headphones and reading a newspaper as an article is read aloud, with sound waves rising from the page.",
-  summaryHtml: `<p>Lion Reader converts articles to audio using a two-stage process: an <strong>AI preprocessor</strong> (Llama 3.1) transforms HTML into narration-friendly text by expanding abbreviations and formatting complex elements, then either Web Speech API or local <strong>Piper TTS</strong> synthesizes speech. Features include synchronized paragraph highlighting, playback controls, and offline capability.</p>`,
+  summaryHtml: `<p>Lion Reader converts articles to audio using a two-stage process: an <strong>AI preprocessor</strong> (GPT-OSS) transforms HTML into narration-friendly text by expanding abbreviations and formatting complex elements, then either Web Speech API or local <strong>Piper TTS</strong> synthesizes speech. Features include synchronized paragraph highlighting, playback controls, and offline capability.</p>`,
   contentHtml: `
     <p>Sometimes you want to listen instead of read &mdash; while cooking, commuting, or just giving your eyes a rest. Lion Reader&rsquo;s narration feature transforms articles into natural-sounding audio using a two-stage pipeline that combines AI preprocessing with on-device speech synthesis.</p>
 
     <h3>Stage 1: AI Text Preprocessing</h3>
 
-    <p>Raw article HTML isn&rsquo;t ready for text-to-speech. Abbreviations like &ldquo;Dr.&rdquo; get mispronounced, URLs sound terrible when read aloud, and technical notation confuses speech engines. To solve this, Lion Reader first sends article content through an LLM (<a href="https://www.llama.com/" target="_blank" rel="noopener noreferrer">Llama 3.1</a> via <a href="https://groq.com/" target="_blank" rel="noopener noreferrer">Groq</a>) that transforms the text for natural narration.</p>
+    <p>Raw article HTML isn&rsquo;t ready for text-to-speech. Abbreviations like &ldquo;Dr.&rdquo; get mispronounced, URLs sound terrible when read aloud, and technical notation confuses speech engines. To solve this, Lion Reader first sends article content through an LLM (<a href="https://openai.com/index/introducing-gpt-oss/" target="_blank" rel="noopener noreferrer">GPT-OSS</a> via <a href="https://groq.com/" target="_blank" rel="noopener noreferrer">Groq</a>) that transforms the text for natural narration.</p>
 
     <p>The AI expands abbreviations (&ldquo;Dr.&rdquo; becomes &ldquo;Doctor&rdquo;), converts URLs to readable phrases, formats lists and tables as natural language, and handles code blocks with clear verbal markers. Crucially, it maintains paragraph-level mapping so the app can synchronize highlighting as the audio plays. This preprocessing is cached by content hash, so the same article is only processed once &mdash; even if multiple users narrate it.</p>
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -155,7 +155,7 @@ export default function PrivacyPolicyPage() {
               <LegalParagraph>
                 <strong>This feature is optional and disabled by default.</strong> When you enable
                 AI text processing in narration settings, article content is sent to Groq (using
-                their Llama 3.1 8B model) to convert it into speakable text. This preprocessing
+                their GPT-OSS 20B model) to convert it into speakable text. This preprocessing
                 expands abbreviations, formats numbers for speech, and improves pronunciation. The
                 processed text is cached on our servers to avoid repeated processing.
               </LegalParagraph>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -154,10 +154,11 @@ export default function PrivacyPolicyPage() {
             <LegalSubsection title="Audio Narration (Groq) — Optional">
               <LegalParagraph>
                 <strong>This feature is optional and disabled by default.</strong> When you enable
-                AI text processing in narration settings, article content is sent to Groq (using
-                their GPT-OSS 20B model) to convert it into speakable text. This preprocessing
-                expands abbreviations, formats numbers for speech, and improves pronunciation. The
-                processed text is cached on our servers to avoid repeated processing.
+                AI text processing in narration settings, article content is sent to Groq (running
+                the open-weights GPT-OSS 20B model) to convert it into speakable text. This
+                preprocessing expands abbreviations, formats numbers for speech, and improves
+                pronunciation. The processed text is cached on our servers to avoid repeated
+                processing.
               </LegalParagraph>
               <LegalParagraph>
                 When AI processing is disabled, we use simple HTML-to-text conversion that happens

--- a/src/server/services/narration.ts
+++ b/src/server/services/narration.ts
@@ -209,7 +209,12 @@ export async function generateNarration(
       ],
       response_format: { type: "json_object" }, // Request JSON output
       temperature: 0.1, // Low temperature for consistency
-      max_tokens: 8000,
+      // Output must echo back every rewritten paragraph for the whole article,
+      // and (unlike the old non-reasoning llama-3.1-8b) gpt-oss spends some of
+      // this budget on reasoning tokens even at "low" effort. Keep the cap high
+      // so long articles don't truncate into the (uncached, repeatedly-retried)
+      // fallback path. We only pay for tokens actually generated.
+      max_completion_tokens: 16000,
     });
 
     const rawOutput = response.choices[0]?.message?.content;

--- a/src/server/services/narration.ts
+++ b/src/server/services/narration.ts
@@ -192,7 +192,7 @@ export async function generateNarration(
 
     const response = await client.chat.completions.create({
       model: "openai/gpt-oss-20b",
-      // Mechanical text-normalization task — minimal reasoning keeps latency and
+      // Mechanical text normalization task — minimal reasoning keeps latency and
       // token cost close to the old llama-3.1-8b-instant model. gpt-oss emits any
       // reasoning in a separate `reasoning` field, so `message.content` is still
       // the clean JSON we parse below.

--- a/src/server/services/narration.ts
+++ b/src/server/services/narration.ts
@@ -1,7 +1,7 @@
 /**
  * Narration service for LLM-based text preprocessing.
  *
- * Uses Groq (Llama 3.1 8B) to convert article HTML to narration-ready text
+ * Uses Groq (GPT-OSS 20B) to convert article HTML to narration-ready text
  * for text-to-speech. Falls back to simple HTML stripping when Groq is unavailable.
  */
 
@@ -191,7 +191,12 @@ export async function generateNarration(
     const userPrompt = JSON.stringify({ paragraphs: inputParagraphs });
 
     const response = await client.chat.completions.create({
-      model: "llama-3.1-8b-instant",
+      model: "openai/gpt-oss-20b",
+      // Mechanical text-normalization task — minimal reasoning keeps latency and
+      // token cost close to the old llama-3.1-8b-instant model. gpt-oss emits any
+      // reasoning in a separate `reasoning` field, so `message.content` is still
+      // the clean JSON we parse below.
+      reasoning_effort: "low",
       messages: [
         {
           role: "system",


### PR DESCRIPTION
## What

`llama-3.1-8b-instant` — the model the narration text-cleanup pipeline uses to convert article HTML into TTS-friendly text — is **deprecated on Groq** (retirement announced 2026-06-17). Groq's recommended replacement is `openai/gpt-oss-20b`. This PR migrates the cleanup model.

## Changes

- `src/server/services/narration.ts`: model → `openai/gpt-oss-20b`, plus `reasoning_effort: "low"`.
  - gpt-oss is a reasoning model that defaults to `medium` effort. This cleanup task is mechanical text normalization (expand abbreviations, rewrite URLs, preserve JSON structure), so `low` keeps latency/cost close to the old 8B model.
  - gpt-oss emits reasoning in a separate `reasoning` field, so the existing JSON-mode `message.content` parsing is unaffected.
- Updated the user-facing model name in the privacy policy and the text-to-speech demo article.

## Notes

- Narration output is cached by content hash, so only newly-generated narration uses the new model — no backfill/invalidation needed.
- No tests hardcode the model ID; `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)