### PR TITLE
Disable horizontal overscroll actions (swipe-back marks wrong article read)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -487,6 +487,20 @@
   }
 }
 
+/* Disable the browser's horizontal-overscroll actions: Chrome Android's
+   overscroll history navigation (a rightward drag anywhere on the page shows
+   a back arrow and navigates on release — it competes with our in-app
+   swipe-to-previous-article and can double-navigate, #1260) and the
+   horizontal rubber-band/stretch bounce. OS-level edge-swipe back gestures
+   (iOS Safari/PWA, Android gesture nav) are system gestures unaffected by
+   this, so swipe-back-to-list still works there. Set on both html and body:
+   the spec propagates the root's value to the viewport, falling back to
+   body, and browsers have historically disagreed on which one they read. */
+html,
+body {
+  overscroll-behavior-x: none;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);


### PR DESCRIPTION
Fixes #1260.

## Problem

Swiping back from an article to the list marked the article *above* it as read, while the back-arrow button worked correctly.

In the article view, a rightward swipe maps to "open the previous article". Chrome Android's **overscroll history navigation** triggers on a rightward drag *anywhere* on the page (not just the screen edge) when the page can't scroll horizontally — it shows a back arrow and navigates back on release, while still delivering the touch events to the page. So a swipe-back did two things at once:

1. Our swipe handler opened the previous article (`clientReplace` to `?entry=<prev>`), whose mount effect auto-marks it read.
2. The browser's own history-back then completed, landing on the list.

Net effect: the user ends up on the list with the article above wrongly marked read.

## Fix

`overscroll-behavior-x: none` on `html, body`. This disables the browser's horizontal-overscroll actions: the overscroll history-swipe navigation and the horizontal stretch/rubber-band bounce during article swipes. It's set on both `html` and `body` because the spec propagates the root's value to the viewport with a body fallback, and browsers have historically disagreed on which they read.

Notes:

- OS-level edge gestures (iOS Safari/PWA edge-swipe, Android gesture nav) are system gestures unaffected by this CSS, so swipe-back-to-list keeps working there. If the bug reproduces via those paths (they can also deliver touch events in installed PWAs), a complementary gesture-level fix — ignoring swipes starting in the physical screen-edge strip — is parked on the [`claude/swipe-edge-gesture-zone`](https://github.com/brendanlong/lion-reader/tree/claude/swipe-edge-gesture-zone) branch, tested and ready to layer on top.
- Known tradeoff: desktop trackpad two-finger history-swipe is also disabled while in the app (same overscroll mechanism). Could be scoped to `@media (pointer: coarse)` if that's missed.

## Testing

- CSS-only change; `pnpm typecheck` and the unit suite are unaffected (branch is master + this one commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)