### PR TITLE
Security: add CSP, frame-ancestors, HSTS, nosniff, Referrer-Policy headers (#1264)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,14 @@ Entry bodies, saved articles, and AI summaries are rendered with
 - The allowlist deliberately excludes `script`/`style`/`on*`/`form`/`base`/`meta`,
   restricts URL schemes, forces `rel=noopener`, and treats SVG/MathML as mXSS-prone.
   Changes here need a security review.
+- **Defense-in-depth headers** (`securityHeaders` in `next.config.ts`, mirrored on
+  the maintenance short-circuit in `scripts/server.ts`) add a CSP
+  (`frame-ancestors 'none'; object-src 'none'; base-uri 'self'`), `X-Frame-Options`,
+  `X-Content-Type-Options: nosniff`, `Referrer-Policy`, and (prod) HSTS. The CSP
+  does **not** yet lock down `script-src`/`default-src` — that needs a per-request
+  nonce/hash for the two inline `<script>`s in `layout.tsx` — so the sanitizer is
+  still the sole gate against injected `<script>`; the CSP only backstops
+  clickjacking, plugin/object injection, and `<base>` hijacking.
 
 ## 2. SSRF-safe outbound fetching
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -75,6 +75,37 @@ const withPWAConfig = withPWA({
   },
 });
 
+// Security response headers applied to every route (defense-in-depth). Entry
+// bodies render via `dangerouslySetInnerHTML`, so the server-side sanitizer is
+// the sole XSS gate; these headers make a future sanitizer regression a
+// non-event (CSP blocks plugins/base-tag injection) and stop the app from being
+// framed (clickjacking).
+//
+// The CSP intentionally omits `default-src`/`script-src`: locking those down
+// requires a per-request nonce/hash for the two inline <script>s in layout.tsx,
+// which the static `headers()` config can't emit. We still ship the directives
+// that are safe without a nonce. `frame-ancestors` has no X-Frame-Options
+// equivalent for allow-lists, but we send both so older browsers are covered.
+const securityHeaders: { key: string; value: string }[] = [
+  {
+    key: "Content-Security-Policy",
+    value: ["frame-ancestors 'none'", "object-src 'none'", "base-uri 'self'"].join("; "),
+  },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  // HSTS only in production: sending it over plaintext dev/HTTP would pin
+  // localhost to HTTPS. Fly.io terminates TLS and serves everything over HTTPS.
+  ...(process.env.NODE_ENV === "production"
+    ? [
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains",
+        },
+      ]
+    : []),
+];
+
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["127.0.0.1", "localhost"],
   // Disable Next.js's built-in gzip compression. Our custom server applies
@@ -88,6 +119,11 @@ const nextConfig: NextConfig = {
   // Cache static assets for 1 day to reduce unnecessary requests
   async headers() {
     return [
+      {
+        // Security headers on every response (defense-in-depth).
+        source: "/:path*",
+        headers: securityHeaders,
+      },
       {
         // Match common static assets in public/
         source: "/:path*.(ico|png|svg|jpg|jpeg|gif|webp|woff|woff2|ttf|otf|eot)",

--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -74,6 +74,15 @@ app.prepare().then(() => {
         res.statusCode = 503;
         res.setHeader("Retry-After", "3600");
         res.setHeader("Cache-Control", "no-store");
+        // These responses short-circuit before Next's handler, so they miss the
+        // security headers configured in next.config.ts. Set the framing/sniffing
+        // protections here too so maintenance-mode pages aren't a coverage gap.
+        res.setHeader("X-Frame-Options", "DENY");
+        res.setHeader("X-Content-Type-Options", "nosniff");
+        res.setHeader(
+          "Content-Security-Policy",
+          "frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
+        );
         if (decision === "block-api") {
           res.setHeader("Content-Type", "application/json; charset=utf-8");
           res.end(maintenanceJsonBody(maintenance.message));


### PR DESCRIPTION
Fixes #1264.

## Problem
`next.config.ts` `headers()` and `scripts/server.ts` set only caching/maintenance headers — no CSP, `X-Frame-Options`/`frame-ancestors`, HSTS, `X-Content-Type-Options`, or `Referrer-Policy`. Since entry bodies render via `dangerouslySetInnerHTML`, the server-side sanitizer is the sole XSS gate with no CSP backstop, and nothing prevents clickjacking.

## Fix
Added defense-in-depth response headers on every route (`securityHeaders` in `next.config.ts`):

- **CSP**: `frame-ancestors 'none'; object-src 'none'; base-uri 'self'`
  - `script-src`/`default-src` are intentionally left open for now — locking them down requires a per-request nonce/hash for the two inline `<script>`s in `layout.tsx`, which the static `headers()` config can't emit. The directives shipped are safe without a nonce.
- **X-Frame-Options**: `DENY` (older-browser companion to `frame-ancestors`)
- **X-Content-Type-Options**: `nosniff`
- **Referrer-Policy**: `strict-origin-when-cross-origin`
- **Strict-Transport-Security**: production only (`max-age=63072000; includeSubDomains`). Omitted in dev so plaintext HTTP doesn't pin localhost to HTTPS.

The maintenance 503 short-circuit in `scripts/server.ts` bypasses Next's handler, so the framing/sniffing/CSP headers are mirrored there too to avoid a coverage gap.

`SECURITY.md` documents the new backstop under the sanitization section, noting the CSP does not yet cover `script-src`.

## Verification
Ran `pnpm dev:local` + curl:
- App routes and static assets both emit the CSP, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy` headers.
- Static assets keep their existing `Cache-Control` alongside the security headers (Next merges matching rules).
- HSTS correctly absent in development.
- `pnpm typecheck` and eslint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)