### PR TITLE
Security: route content-source plugin fetches through fetchWithSsrfProtection (#1265)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,9 +56,12 @@ Entry bodies, saved articles, and AI summaries are rendered with
   private/loopback/link-local/cloud-metadata ranges and all literal-IP encodings,
   rejects non-http schemes, and enforces size + timeout limits.
 - Applies to: feed polling/discovery, WebSub hub subscribe, full-content/save
-  fetches, and content-source plugins. Plugin fetches to hardcoded public hosts
-  (`github.ts`, `arxiv.ts`, `lesswrong.ts`, Google Docs/Drive) currently use raw
-  `fetch`; keep their hosts hardcoded, or route them through the guard.
+  fetches, and content-source plugins. The content-source plugins that fetch
+  hardcoded public hosts (`plugins/github.ts`, `plugins/bluesky.ts`,
+  `feed/arxiv.ts`, `feed/lesswrong.ts`, Google Docs/Drive) route through the guard
+  too, so a future refactor that makes one of those hosts user-influenced can't
+  silently regress into SSRF (#1265). Keep it that way; don't call `fetch`/`undici`
+  directly on any content-source URL.
 
 ## 3. WebSub (feed push)
 

--- a/src/server/feed/arxiv.ts
+++ b/src/server/feed/arxiv.ts
@@ -12,6 +12,7 @@
 
 import { logger } from "@/lib/logger";
 import { FEED_FETCH_TIMEOUT_MS } from "@/server/http/fetch";
+import { fetchWithSsrfProtection } from "@/server/http/ssrf";
 import { USER_AGENT } from "@/server/http/user-agent";
 
 // ============================================================================
@@ -120,7 +121,7 @@ async function checkArxivHtmlExists(url: string): Promise<ArxivHtmlCheckResult |
 
   try {
     // Use HEAD request to check if HTML version exists without downloading it
-    const response = await fetch(htmlUrl, {
+    const response = await fetchWithSsrfProtection(htmlUrl, {
       method: "HEAD",
       headers: {
         "User-Agent": USER_AGENT,

--- a/src/server/feed/lesswrong.ts
+++ b/src/server/feed/lesswrong.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { logger } from "@/lib/logger";
 import { USER_AGENT } from "@/server/http/user-agent";
 import { HttpFetchError } from "@/server/http/fetch";
+import { fetchWithSsrfProtection } from "@/server/http/ssrf";
 
 // ============================================================================
 // Constants
@@ -307,7 +308,7 @@ const POST_QUERY = `
  */
 async function fetchLessWrongPost(postId: string): Promise<LessWrongPostContent | null> {
   try {
-    const response = await fetch(LESSWRONG_GRAPHQL_ENDPOINT, {
+    const response = await fetchWithSsrfProtection(LESSWRONG_GRAPHQL_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -444,7 +445,7 @@ const COMMENT_QUERY = `
  */
 async function fetchLessWrongComment(commentId: string): Promise<LessWrongCommentContent | null> {
   try {
-    const response = await fetch(LESSWRONG_GRAPHQL_ENDPOINT, {
+    const response = await fetchWithSsrfProtection(LESSWRONG_GRAPHQL_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -643,7 +644,7 @@ const USER_BY_SLUG_QUERY = `
  */
 export async function fetchLessWrongUserBySlug(slug: string): Promise<LessWrongUser | null> {
   try {
-    const response = await fetch(LESSWRONG_GRAPHQL_ENDPOINT, {
+    const response = await fetchWithSsrfProtection(LESSWRONG_GRAPHQL_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -806,7 +807,7 @@ const USER_BY_ID_QUERY = `
  */
 export async function fetchLessWrongUserById(userId: string): Promise<LessWrongUser | null> {
   try {
-    const response = await fetch(LESSWRONG_GRAPHQL_ENDPOINT, {
+    const response = await fetchWithSsrfProtection(LESSWRONG_GRAPHQL_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -942,7 +943,7 @@ export async function fetchLessWrongPostMetadata(
   postId: string
 ): Promise<LessWrongPostMetadata | null> {
   try {
-    const response = await fetch(LESSWRONG_GRAPHQL_ENDPOINT, {
+    const response = await fetchWithSsrfProtection(LESSWRONG_GRAPHQL_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/server/google/docs.ts
+++ b/src/server/google/docs.ts
@@ -27,6 +27,7 @@ import { logger } from "@/lib/logger";
 import { googleConfig } from "@/server/config/env";
 import { fetchAndUploadImage, isStorageAvailable } from "@/server/storage/s3";
 import { USER_AGENT } from "@/server/http/user-agent";
+import { fetchWithSsrfProtection } from "@/server/http/ssrf";
 import { escapeHtml } from "@/server/http/html";
 import { stripTitleHeader } from "@/server/html/strip-title-header";
 import {
@@ -1297,7 +1298,7 @@ async function fetchPublicGoogleDoc(
 
     logger.debug("Fetching public Google Doc via Docs API", { docId, tabId });
 
-    const response = await fetch(url, {
+    const response = await fetchWithSsrfProtection(url, {
       method: "GET",
       headers: {
         Accept: "application/json",
@@ -1436,7 +1437,7 @@ export async function fetchPrivateGoogleDoc(
 
     logger.debug("Fetching private Google Doc via Docs API", { docId, tabId });
 
-    const response = await fetch(url, {
+    const response = await fetchWithSsrfProtection(url, {
       method: "GET",
       headers: {
         Accept: "application/json",

--- a/src/server/google/drive.ts
+++ b/src/server/google/drive.ts
@@ -15,6 +15,7 @@ import { GoogleAuth } from "google-auth-library";
 import { logger } from "@/lib/logger";
 import { googleConfig } from "@/server/config/env";
 import { USER_AGENT } from "@/server/http/user-agent";
+import { fetchWithSsrfProtection } from "@/server/http/ssrf";
 
 // ============================================================================
 // Constants
@@ -156,7 +157,7 @@ async function getFileMetadata(
   try {
     const url = `${GOOGLE_DRIVE_API_ENDPOINT}/${fileId}?fields=id,name,mimeType`;
 
-    const response = await fetch(url, {
+    const response = await fetchWithSsrfProtection(url, {
       method: "GET",
       headers: {
         Accept: "application/json",
@@ -202,7 +203,7 @@ async function downloadFile(fileId: string, accessToken: string): Promise<ArrayB
   try {
     const url = `${GOOGLE_DRIVE_API_ENDPOINT}/${fileId}?alt=media`;
 
-    const response = await fetch(url, {
+    const response = await fetchWithSsrfProtection(url, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${accessToken}`,

--- a/src/server/plugins/bluesky.ts
+++ b/src/server/plugins/bluesky.ts
@@ -1,6 +1,7 @@
 import type { UrlPlugin, SavedArticleContent } from "./types";
 import { escapeHtml } from "@/server/http/html";
 import { readResponseWithSizeLimit } from "@/server/http/fetch";
+import { fetchWithSsrfProtection } from "@/server/http/ssrf";
 import { USER_AGENT } from "@/server/http/user-agent";
 import { logger } from "@/lib/logger";
 
@@ -379,7 +380,7 @@ export function blueskyPostTitle(post: PostView): string {
 // ============================================================================
 
 async function fetchJson<T>(url: string): Promise<T | null> {
-  const response = await fetch(url, {
+  const response = await fetchWithSsrfProtection(url, {
     headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
     signal: AbortSignal.timeout(BLUESKY_API_TIMEOUT_MS),
   });

--- a/src/server/plugins/github.ts
+++ b/src/server/plugins/github.ts
@@ -2,6 +2,7 @@ import type { UrlPlugin, SavedArticleContent } from "./types";
 import { logger } from "@/lib/logger";
 import { USER_AGENT } from "@/server/http/user-agent";
 import { readResponseWithSizeLimit } from "@/server/http/fetch";
+import { fetchWithSsrfProtection } from "@/server/http/ssrf";
 import { escapeHtml } from "@/server/http/html";
 import { githubConfig, usageLimitsConfig } from "@/server/config/env";
 import { marked } from "marked";
@@ -176,7 +177,7 @@ function getApiHeaders(): HeadersInit {
  * Fetch a gist by ID.
  */
 async function fetchGist(gistId: string): Promise<GistResponse | null> {
-  const response = await fetch(`https://api.github.com/gists/${gistId}`, {
+  const response = await fetchWithSsrfProtection(`https://api.github.com/gists/${gistId}`, {
     headers: getApiHeaders(),
   });
 
@@ -210,7 +211,7 @@ async function fetchRepoContents(
     url += `?ref=${encodeURIComponent(ref)}`;
   }
 
-  const response = await fetch(url, {
+  const response = await fetchWithSsrfProtection(url, {
     headers: getApiHeaders(),
   });
 
@@ -243,7 +244,7 @@ const RAW_FETCH_TIMEOUT_MS = 30000;
  */
 async function fetchRawContent(rawUrl: string): Promise<string | null> {
   try {
-    const response = await fetch(rawUrl, {
+    const response = await fetchWithSsrfProtection(rawUrl, {
       headers: {
         "User-Agent": USER_AGENT,
       },


### PR DESCRIPTION
Fixes #1265.

## Problem

Several plugin/feed content-source fetches used raw `fetch()` instead of `fetchWithSsrfProtection`. In every case the host is a hardcoded literal and only the path/query is user-influenced, so this is **not an SSRF vector today**. But this is defense-in-depth hardening:

- Some used `redirect: "follow"` with native undici, so a redirect off the fixed host would not be SSRF-re-validated per hop.
- A future refactor that made one of those hosts user-influenced would silently regress into SSRF.

## Fix

Routed each through the guarded helper (drop-in replacement — `fetchWithSsrfProtection(url, init)` has the same signature as `fetch`, defaults `redirect` to `"follow"`, follows redirects itself re-validating every hop, and returns a standard `Response`):

- `src/server/plugins/github.ts` — `api.github.com` gist/contents + `raw.githubusercontent.com`
- `src/server/plugins/bluesky.ts` — `public.api.bsky.app`
- `src/server/feed/arxiv.ts` — `arxiv.org` HTML-version HEAD check
- `src/server/feed/lesswrong.ts` — `www.lesswrong.com/graphql` (5 call sites)
- `src/server/google/drive.ts` — Drive API metadata + download
- `src/server/google/docs.ts` — Docs API fetch (public + private)

`src/server/plugins/arxiv.ts` was already covered — it only fetches via `fetchHtmlPage` (already guarded) and the now-guarded `feed/arxiv.ts` helper.

Also updated `SECURITY.md`'s SSRF section to record that these content-source plugins now go through the guard.

## Notes

- The guard is a no-op check when `ALLOW_PRIVATE_NETWORK_FETCH=true` (the default in `.env.test`), so it still follows redirects but skips the private-IP block in dev/test — behavior for these plugins is unchanged in tests.
- Credential headers (the Google `Authorization: Bearer` tokens) are stripped by the helper only on cross-origin redirect hops, matching undici's native redirect handling — no leakage regression.

## Testing

- `pnpm typecheck` passes.
- `pnpm test:unit` passes (2428 passed; the only failures were pre-existing integration tests that require a local Postgres this environment doesn't have).

🤖 Generated with [Claude Code](https://claude.com/claude-code)