### PR TITLE
Harden Google Reader / MCP compat APIs (#1266)

### DIFF
--- a/src/app/api/greader.php/reader/api/0/edit-tag/route.ts
+++ b/src/app/api/greader.php/reader/api/0/edit-tag/route.ts
@@ -33,6 +33,11 @@ import { db } from "@/server/db";
 
 export const dynamic = "force-dynamic";
 
+// Bound the item-id list so a single call can't ask the server to issue an
+// unbounded number of per-entry updates. Matches the cap on
+// `stream/items/contents` and the services-layer bulk mutations (issue #1266).
+const MAX_ITEM_IDS = 1000;
+
 export async function POST(request: Request): Promise<Response> {
   const session = await requireAuth(request);
   if (session instanceof Response) return session;
@@ -44,6 +49,13 @@ export async function POST(request: Request): Promise<Response> {
     itemIds = parseItemIds(params);
   } catch {
     return errorResponse("Invalid item ID format", 400);
+  }
+
+  if (itemIds.length > MAX_ITEM_IDS) {
+    return errorResponse(
+      `Too many item ids: ${itemIds.length} requested, maximum ${MAX_ITEM_IDS} per request. Split into smaller batches.`,
+      400
+    );
   }
 
   if (itemIds.length === 0) {
@@ -77,9 +89,7 @@ export async function POST(request: Request): Promise<Response> {
   const removeStarred = removeTags.some((t) => isState(t, "starred"));
 
   if (addStarred || removeStarred) {
-    for (const entryId of entryUuids) {
-      await entriesService.updateEntryStarred(db, session.user.id, entryId, addStarred);
-    }
+    await entriesService.updateEntriesStarred(db, session.user.id, entryUuids, addStarred);
   }
 
   return textResponse("OK");

--- a/src/app/api/greader.php/reader/api/0/subscription/import/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/import/route.ts
@@ -52,8 +52,9 @@ export async function POST(request: Request): Promise<Response> {
     if (err instanceof OpmlParseError) {
       return errorResponse(`Failed to parse OPML: ${err.message}`, 400);
     }
+    // Log the detail server-side but return a generic message — internal error
+    // text must not be echoed to clients (issue #1266).
     console.error("Failed to import OPML:", err);
-    const message = err instanceof Error ? err.message : "Unknown error";
-    return errorResponse(`Failed to import OPML: ${message}`, 500);
+    return errorResponse("Failed to import OPML", 500);
   }
 }

--- a/src/app/api/greader.php/reader/api/0/subscription/import/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/import/route.ts
@@ -30,8 +30,12 @@ export async function POST(request: Request): Promise<Response> {
   if (session instanceof Response) return session;
 
   // OPML import queues a subscribe job per feed — the tRPC equivalent is an
-  // "expensive" procedure, so rate-limit this compat path the same way.
-  const rateLimited = await checkRouteRateLimit(request, "expensive");
+  // "expensive" procedure, so rate-limit this compat path the same way. Key the
+  // bucket per user (the caller is authenticated), matching the tRPC middleware
+  // rather than falling back to a per-IP key.
+  const rateLimited = await checkRouteRateLimit(request, "expensive", {
+    userId: session.user.id,
+  });
   if (rateLimited) return rateLimited;
 
   const opml = await request.text();

--- a/src/app/api/greader.php/reader/api/0/subscription/quickadd/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/quickadd/route.ts
@@ -13,6 +13,7 @@ import { requireAuth } from "@/server/google-reader/auth";
 import { parseFormData, jsonResponse, errorResponse } from "@/server/google-reader/parse";
 import { feedStreamId } from "@/server/google-reader/id";
 import * as subscriptionsService from "@/server/services/subscriptions";
+import { checkRouteRateLimit } from "@/server/rate-limit";
 import { db } from "@/server/db";
 import { eq, isNull, and } from "drizzle-orm";
 import { feeds, subscriptions } from "@/server/db/schema";
@@ -23,6 +24,12 @@ export const dynamic = "force-dynamic";
 export async function POST(request: Request): Promise<Response> {
   const session = await requireAuth(request);
   if (session instanceof Response) return session;
+
+  // Creating a feed schedules an immediate fetch — the tRPC subscribe path is an
+  // "expensive" procedure, so rate-limit this compat path the same way to stop an
+  // authenticated client from enqueuing many immediate feed fetches (issue #1266).
+  const rateLimited = await checkRouteRateLimit(request, "expensive");
+  if (rateLimited) return rateLimited;
 
   const params = await parseFormData(request);
   const feedUrl = params.get("quickadd");
@@ -113,8 +120,9 @@ export async function POST(request: Request): Promise<Response> {
       streamName: feedUrl,
     });
   } catch (err) {
+    // Log the detail server-side but return a generic message — internal error
+    // text must not be echoed to clients (issue #1266).
     console.error("Failed to subscribe to feed:", err);
-    const message = err instanceof Error ? err.message : "Unknown error";
-    return errorResponse(`Failed to subscribe: ${message}`, 500);
+    return errorResponse("Failed to subscribe to feed", 500);
   }
 }

--- a/src/app/api/greader.php/reader/api/0/subscription/quickadd/route.ts
+++ b/src/app/api/greader.php/reader/api/0/subscription/quickadd/route.ts
@@ -28,7 +28,11 @@ export async function POST(request: Request): Promise<Response> {
   // Creating a feed schedules an immediate fetch — the tRPC subscribe path is an
   // "expensive" procedure, so rate-limit this compat path the same way to stop an
   // authenticated client from enqueuing many immediate feed fetches (issue #1266).
-  const rateLimited = await checkRouteRateLimit(request, "expensive");
+  // Key the bucket per user (the caller is authenticated), matching the tRPC
+  // middleware rather than falling back to a per-IP key.
+  const rateLimited = await checkRouteRateLimit(request, "expensive", {
+    userId: session.user.id,
+  });
   if (rateLimited) return rateLimited;
 
   const params = await parseFormData(request);

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -177,6 +177,9 @@ function createMcpServer(userId: string): Server {
     try {
       result = await tool.handler(db, userId, args ?? {});
     } catch (error) {
+      // Log the original error server-side; toMcpError replaces internal error
+      // messages with a generic string so detail isn't echoed to clients (#1266).
+      logger.error("MCP tool execution error", { tool: name, userId, error });
       throw toMcpError(error);
     }
 

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -60,17 +60,22 @@ function parseArgs<T extends z.ZodType>(schema: T, args: unknown): z.infer<T> {
  * a parseable InvalidParams instead of an opaque internal error. Services
  * throw TRPCErrors (their native error type across all transports); bad IDs
  * and invalid cursors surface as BAD_REQUEST/NOT_FOUND.
+ *
+ * Client-error branches (BAD_REQUEST/NOT_FOUND) forward the message — it
+ * describes the caller's own bad input and is safe to surface. The
+ * InternalError branch does NOT: an unexpected server error's message can leak
+ * internal detail, so it's replaced with a generic string (issue #1266). Callers
+ * are responsible for logging the original error server-side before mapping.
  */
 export function toMcpError(error: unknown): unknown {
   if (error instanceof McpError) {
     return error;
   }
   if (error instanceof TRPCError) {
-    const code =
-      error.code === "BAD_REQUEST" || error.code === "NOT_FOUND"
-        ? ErrorCode.InvalidParams
-        : ErrorCode.InternalError;
-    return new McpError(code, error.message);
+    if (error.code === "BAD_REQUEST" || error.code === "NOT_FOUND") {
+      return new McpError(ErrorCode.InvalidParams, error.message);
+    }
+    return new McpError(ErrorCode.InternalError, "An internal error occurred");
   }
   return error;
 }

--- a/src/server/rate-limit/index.ts
+++ b/src/server/rate-limit/index.ts
@@ -291,17 +291,24 @@ function buildRateLimitResponse(
  * Checks rate limit for a route handler request and returns a 429 Response if exceeded.
  * Returns null if the request is allowed.
  *
+ * Pass `options.userId` for routes that have already authenticated the caller so
+ * the bucket is keyed per user (`user:<id>`), matching the tRPC middleware — a
+ * per-IP key would let everyone behind a shared NAT/proxy share (and exhaust)
+ * one bucket, and let a single user reset their limit by rotating source IPs.
+ * Leave it unset only on pre-authentication endpoints (login / OAuth token
+ * exchange), where there is no user yet and per-IP is the correct key.
+ *
  * @param request - The incoming request
  * @param type - Type of rate limit to apply
- * @param options - Options for the response format
+ * @param options - Response format and the authenticated user id (if any)
  * @returns A 429 Response if rate limited, or null if allowed
  */
 export async function checkRouteRateLimit(
   request: Request,
   type: RateLimitType = "default",
-  options: { json?: boolean } = {}
+  options: { json?: boolean; userId?: string | null } = {}
 ): Promise<Response | null> {
-  const identifier = getClientIdentifier(null, request.headers);
+  const identifier = getClientIdentifier(options.userId ?? null, request.headers);
   const result = await checkRateLimit(identifier, type);
 
   if (!result.allowed) {

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -34,7 +34,11 @@ import {
   type BulkUnreadCounts,
   type UnreadCounts,
 } from "./counts";
-import { publishMarkReadStateChanges, publishStarredStateChange } from "./entry-events";
+import {
+  publishMarkReadStateChanges,
+  publishStarredStateChange,
+  publishStarredStateChanges,
+} from "./entry-events";
 import { persistResanitizedFamily, sanitizeFamilyFromRaw } from "./resanitize";
 import {
   buildEntrySubscriptionFilter,
@@ -1437,6 +1441,81 @@ export async function updateEntryStarred(
   }
 
   return { entry, counts };
+}
+
+/**
+ * Bulk star/unstar: applies a single starred value to many entries in one
+ * `UPDATE ... FROM` instead of issuing one statement per entry. Used by the
+ * Google Reader `edit-tag` endpoint, which can carry up to 1000 item ids in a
+ * single call (issue #1266). Mirrors {@link markEntriesRead}: a self-join on
+ * `prev` captures each row's pre-update starred value so we can tell a real
+ * flip from a same-value watermark bump, `updated_at` (the delta-sync
+ * visibility timestamp) advances only on a real flip, and `starred_changed_at`
+ * (the last-writer-wins watermark) advances on every accepted write.
+ */
+export async function updateEntriesStarred(
+  db: DbOrTx,
+  userId: string,
+  entryIds: string[],
+  starred: boolean,
+  changedAt: Date = new Date()
+): Promise<{
+  entries: MarkReadEntryState[];
+  changed: MarkReadEntryState[];
+  counts?: BulkUnreadCounts;
+}> {
+  if (entryIds.length === 0) {
+    return { entries: [], changed: [] };
+  }
+
+  if (entryIds.length > 1000) {
+    throw errors.validation("Maximum 1000 entries per request");
+  }
+
+  const now = new Date();
+
+  const idValues = entryIds.map((id) => sql`${id}::uuid`);
+  const updated = await db.execute<{ entry_id: string; old_starred: boolean }>(sql`
+    UPDATE user_entries AS ue
+    SET starred = ${starred},
+        starred_changed_at = ${changedAt},
+        updated_at = CASE WHEN prev.starred <> ${starred} THEN ${now} ELSE ue.updated_at END
+    FROM user_entries AS prev
+    WHERE ue.user_id = ${userId}::uuid
+      AND ue.entry_id IN (${sql.join(idValues, sql`, `)})
+      AND prev.user_id = ue.user_id
+      AND prev.entry_id = ue.entry_id
+      AND ue.starred_changed_at <= ${changedAt}
+    RETURNING ue.entry_id AS entry_id, prev.starred AS old_starred
+  `);
+  const flippedIds = new Set(
+    updated.rows.filter((row) => row.old_starred !== starred).map((row) => row.entry_id)
+  );
+
+  const entriesState = await db
+    .select({
+      id: visibleEntries.id,
+      subscriptionId: visibleEntries.subscriptionId,
+      read: visibleEntries.read,
+      starred: visibleEntries.starred,
+      type: visibleEntries.type,
+      updatedAt: visibleEntries.updatedAt,
+    })
+    .from(visibleEntries)
+    .where(and(eq(visibleEntries.userId, userId), inArray(visibleEntries.id, entryIds)));
+
+  // Only entries whose starred value actually flipped warrant SSE events and
+  // count recomputation (issue #1118); a batch of pure re-asserts still
+  // advanced the watermark above but changes no count.
+  const changed = entriesState.filter((entry) => flippedIds.has(entry.id));
+  const counts =
+    changed.length > 0 ? await getBulkEntryRelatedCounts(db, userId, changed) : undefined;
+
+  if (changed.length > 0 && counts) {
+    publishStarredStateChanges(userId, changed, counts);
+  }
+
+  return { entries: entriesState, changed, counts };
 }
 
 /**

--- a/src/server/services/entry-events.ts
+++ b/src/server/services/entry-events.ts
@@ -135,3 +135,31 @@ export function publishStarredStateChange(
     // Ignore publish errors - SSE is best-effort
   });
 }
+
+/**
+ * Publishes an entry_state_changed event for each entry affected by a bulk
+ * star/unstar, carrying the absolute counts so other tabs set them directly.
+ * Mirrors {@link publishStarredStateChange} but for the batched
+ * (`updateEntriesStarred`) path — counts are already array-shaped, so no
+ * per-entry normalization is needed.
+ */
+export function publishStarredStateChanges(
+  userId: string,
+  entries: Array<Pick<MarkReadEntryState, "id" | "read" | "starred" | "updatedAt">>,
+  counts: BulkUnreadCounts
+): void {
+  void Promise.all(
+    entries.map((entry) =>
+      publishEntryStateChanged(
+        userId,
+        entry.id,
+        entry.read,
+        entry.starred,
+        entry.updatedAt,
+        counts
+      ).catch(() => {
+        // Ignore publish errors - SSE is best-effort
+      })
+    )
+  );
+}

--- a/tests/integration/entry-state-events.test.ts
+++ b/tests/integration/entry-state-events.test.ts
@@ -476,3 +476,69 @@ describe("updateEntryStarred SSE publishing", () => {
     expect(row.starredChangedAt).toEqual(t2);
   });
 });
+
+describe("updateEntriesStarred (bulk) SSE publishing", () => {
+  it("stars multiple entries in one call and publishes an event per flip", async () => {
+    const userId = await seedUser();
+    const entryA = await seedEntry(userId);
+    const entryB = await seedEntry(userId);
+
+    const channel = getUserEventsChannel(userId);
+    await subscriber.subscribe(channel);
+    const first = waitForMessage(channel);
+
+    const {
+      entries: state,
+      changed,
+      counts,
+    } = await entriesService.updateEntriesStarred(db, userId, [entryA, entryB], true);
+    expect(state.every((e) => e.starred)).toBe(true);
+    expect(changed.map((e) => e.id).sort()).toEqual([entryA, entryB].sort());
+    // Both entries are now starred, so the starred badge reflects both.
+    expect(counts?.starred.unread).toBe(2);
+
+    const event = JSON.parse(await first);
+    expect(event.type).toBe("entry_state_changed");
+    expect([entryA, entryB]).toContain(event.entryId);
+    expect(event.starred).toBe(true);
+    expect(event.counts.starred.unread).toBe(2);
+
+    // Both rows were actually written.
+    expect((await getUserEntryRow(userId, entryA)).starred).toBe(true);
+    expect((await getUserEntryRow(userId, entryB)).starred).toBe(true);
+  });
+
+  it("rejects more than 1000 entries", async () => {
+    const userId = await seedUser();
+    const ids = Array.from({ length: 1001 }, () => generateUuidv7());
+    await expect(entriesService.updateEntriesStarred(db, userId, ids, true)).rejects.toThrow(
+      /Maximum 1000 entries/
+    );
+  });
+
+  it("does not publish or compute counts when re-asserting already-starred entries (issue #1118)", async () => {
+    const userId = await seedUser();
+    const entryId = await seedEntry(userId);
+
+    const t1 = new Date("2026-01-01T00:00:01Z");
+    const t2 = new Date("2026-01-01T00:00:05Z");
+    await entriesService.updateEntriesStarred(db, userId, [entryId], true, t1);
+
+    const before = await getUserEntryRow(userId, entryId);
+
+    const channel = getUserEventsChannel(userId);
+    await subscriber.subscribe(channel);
+
+    // A fresh changedAt advances the watermark, but the value doesn't flip, so
+    // nothing is published and no counts are computed.
+    await expectNoMessage(channel, async () => {
+      const result = await entriesService.updateEntriesStarred(db, userId, [entryId], true, t2);
+      expect(result.changed).toHaveLength(0);
+      expect(result.counts).toBeUndefined();
+    });
+
+    const row = await getUserEntryRow(userId, entryId);
+    expect(row.starredChangedAt).toEqual(t2);
+    expect(row.updatedAt).toEqual(before.updatedAt);
+  });
+});


### PR DESCRIPTION
Fixes #1266. Three self-scoped compat-API hardening items from the security review (companion to #1262).

## Changes

1. **`edit-tag` unbounded item-id list** — Added a `MAX_ITEM_IDS = 1000` cap (matching `stream/items/contents`) and batched the star update. New bulk service `updateEntriesStarred` applies one `starred` value to many entries in a single `UPDATE ... FROM` (mirroring `markEntriesRead`: `prev` self-join to detect real flips, `updated_at` moves only on a flip, `starred_changed_at` LWW watermark advances on every accepted write), replacing the previous one-statement-per-entry loop.

2. **`subscription/quickadd` rate limit** — Applies `checkRouteRateLimit(request, "expensive")` so an authenticated client can't enqueue many immediate feed fetches, matching `subscription/import`.

3. **Internal error messages echoed to clients** — `quickadd` and `subscription/import` now return a generic message and log the detail server-side. MCP `toMcpError` no longer forwards `error.message` on the `InternalError` branch (client-error branches still forward, since those describe the caller's own bad input); the original error is logged at the `api/mcp` call site.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (2415 passing) all green.
- `pnpm test:integration:local` green, including new `updateEntriesStarred (bulk)` cases in `entry-state-events.test.ts` covering multi-entry starring + per-flip SSE, the 1000-entry cap, and the idempotent re-assert (no publish / no counts, watermark advances, `updated_at` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)