### PR TITLE
Security: explicitly reject non-http(s) schemes in SSRF guard (#1273)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,9 @@ Entry bodies, saved articles, and AI summaries are rendered with
   Do not call `fetch`/`undici` directly on a URL that a user or feed can influence.
 - The guard pins DNS to defeat rebinding, re-validates every redirect hop, blocks
   private/loopback/link-local/cloud-metadata ranges and all literal-IP encodings,
-  rejects non-http schemes, and enforces size + timeout limits.
+  rejects non-http(s) schemes via an explicit allowlist enforced on the initial URL
+  and every redirect hop (not left to the underlying fetch), and enforces size +
+  timeout limits.
 - Applies to: feed polling/discovery, WebSub hub subscribe, full-content/save
   fetches, and content-source plugins. The content-source plugins that fetch
   hardcoded public hosts (`plugins/github.ts`, `plugins/bluesky.ts`,

--- a/src/server/http/CLAUDE.md
+++ b/src/server/http/CLAUDE.md
@@ -8,6 +8,7 @@ Every outgoing request must send our custom User-Agent (`USER_AGENT`/`buildUserA
 
 All server-side fetches that target user-influenced URLs (feed preview/discover, feed fetching, full-content fetching, WebSub hub callbacks) are guarded against Server-Side Request Forgery to private/internal networks. The shared helper `fetchWithSsrfProtection(url, init)` in `src/server/http/ssrf.ts` performs the fetch and:
 
+0. Rejects any URL whose scheme is not `http:`/`https:` via an explicit allowlist (`assertAllowedScheme`), so `file:`/`ftp:`/`gopher:`/`data:` etc. are blocked by the guard itself rather than left to whatever the underlying fetch happens to accept. Enforced on the initial URL **and every redirect hop**, in both the dispatcher path and the `ALLOW_PRIVATE_NETWORK_FETCH` path.
 1. Rejects literal private/reserved IP hosts up front (e.g. `http://169.254.169.254/`, `http://127.0.0.1/`, IPv4-mapped IPv6 literals, decimal-encoded IPs which WHATWG `URL` normalizes to dotted form). undici skips the custom DNS lookup for IP literals, so they must be checked here.
 2. Attaches a custom undici dispatcher whose DNS `lookup` resolves the hostname, blocks if **any** resolved address is private, and connects only to the vetted address — closing the DNS-rebinding TOCTOU gap.
 

--- a/src/server/http/ssrf.ts
+++ b/src/server/http/ssrf.ts
@@ -111,6 +111,54 @@ class SsrfBlockedError extends Error {
 }
 
 /**
+ * Error thrown when a request targets a URL whose scheme is not http(s).
+ *
+ * Shares the `SsrfBlockedError` name so callers/error handlers that classify
+ * SSRF rejections by `err.name` treat a blocked scheme the same as a blocked
+ * address.
+ */
+class SsrfBlockedSchemeError extends Error {
+  constructor(
+    public readonly url: string,
+    public readonly scheme: string
+  ) {
+    super(`Blocked request to non-http(s) scheme "${scheme}" (${url})`);
+    this.name = "SsrfBlockedError";
+  }
+}
+
+/**
+ * Schemes the SSRF guard permits. Everything else (file:, ftp:, gopher:, data:,
+ * etc.) is rejected up front so the guarantee holds regardless of what the
+ * underlying fetch implementation happens to accept.
+ */
+const ALLOWED_PROTOCOLS: ReadonlySet<string> = new Set(["http:", "https:"]);
+
+/**
+ * Rejects any URL whose scheme is not http(s), fail-closed.
+ *
+ * SECURITY.md §2 promises the guard "rejects non-http schemes". The IP-range and
+ * DNS-pinning checks assume an http(s) host, and today non-http schemes are only
+ * rejected *implicitly* by the underlying `fetch`. Enforcing an explicit allowlist
+ * here — on the initial URL and every redirect hop — makes that guarantee real and
+ * independent of the fetch transport. An unparseable URL is treated as disallowed.
+ *
+ * @throws SsrfBlockedError if the URL's scheme is not http: or https:
+ */
+export function assertAllowedScheme(url: string): void {
+  let protocol: string;
+  try {
+    protocol = new URL(url).protocol;
+  } catch {
+    // Unparseable URL — fail closed rather than hand it to the fetch impl.
+    throw new SsrfBlockedSchemeError(url, "unparseable");
+  }
+  if (!ALLOWED_PROTOCOLS.has(protocol)) {
+    throw new SsrfBlockedSchemeError(url, protocol);
+  }
+}
+
+/**
  * Custom DNS lookup that validates every resolved address against the block list.
  *
  * Follows the Node `dns.lookup` callback contract for both the single-address and
@@ -202,6 +250,15 @@ export function assertNotPrivateIpLiteral(url: string): void {
 }
 
 /**
+ * Full per-hop validator for the DNS-pinning path: rejects non-http(s) schemes and
+ * literal private/internal IP hosts. Runs on the initial URL and every redirect hop.
+ */
+export function assertAllowedUrl(url: string): void {
+  assertAllowedScheme(url);
+  assertNotPrivateIpLiteral(url);
+}
+
+/**
  * Maximum redirects to follow before giving up. Matches undici/browser defaults.
  */
 const MAX_REDIRECTS = 20;
@@ -245,9 +302,10 @@ function originOf(url: string): string {
  * and method-downgrade behavior can be unit-tested without a live server.
  *
  * `validateHop` runs on the initial URL and on every redirect target *before*
- * connecting — this is where the literal-IP check lives, closing the bypass where
- * undici follows a redirect to an IP literal (e.g. `http://169.254.169.254/`)
- * without running its custom DNS lookup.
+ * connecting — this is where the scheme allowlist and literal-IP check live,
+ * closing the bypass where undici follows a redirect to an IP literal (e.g.
+ * `http://169.254.169.254/`) without running its custom DNS lookup, and rejecting
+ * non-http(s) schemes regardless of what the fetch impl would accept.
  */
 export async function followRedirects(
   url: string,
@@ -332,7 +390,10 @@ export async function followRedirects(
  * Performs a fetch with SSRF protection. Use this instead of `fetch` for any
  * request whose URL is user-influenced.
  *
- * Two layers of protection, applied to the initial request and every redirect hop:
+ * Layers of protection, applied to the initial request and every redirect hop:
+ * 0. Non-http(s) schemes (file:, ftp:, gopher:, data:, …) are rejected up front by
+ *    an explicit allowlist, in both the protected and ALLOW_PRIVATE_NETWORK_FETCH
+ *    paths, so the guarantee doesn't depend on the underlying fetch implementation.
  * 1. Literal IP hosts (e.g. http://169.254.169.254/) are checked up front and
  *    rejected here — undici bypasses the custom DNS lookup for IP literals.
  * 2. Hostnames are validated at connection time by the attached undici dispatcher,
@@ -357,8 +418,8 @@ export async function followRedirects(
  * (dev/test), the literal/DNS checks are skipped and Node's global fetch is used,
  * but redirects are still followed by the same loop.
  *
- * @throws SsrfBlockedError if the URL (or any redirect hop) targets a literal
- *   private/internal IP
+ * @throws SsrfBlockedError if the URL (or any redirect hop) uses a non-http(s)
+ *   scheme or targets a literal private/internal IP
  * @example
  * const res = await fetchWithSsrfProtection(url, { headers, signal });
  */
@@ -376,14 +437,17 @@ export async function fetchWithSsrfProtection(url: string, init: RequestInit): P
       // one; cast so callers keep using standard Response types.
       (hopUrl, hopInit) =>
         undiciFetch(hopUrl, { ...hopInit, dispatcher }) as unknown as Promise<Response>,
-      assertNotPrivateIpLiteral
+      assertAllowedUrl
     );
   }
 
+  // Private-network fetching is allowed (dev/test), so the literal/DNS checks are
+  // skipped — but the scheme allowlist is not: a non-http(s) scheme is rejected in
+  // both modes so the guarantee is independent of the underlying fetch.
   return followRedirects(
     url,
     init,
     (hopUrl, hopInit) => fetch(hopUrl, hopInit as RequestInit),
-    () => {}
+    assertAllowedScheme
   );
 }

--- a/tests/unit/ssrf-redirects.test.ts
+++ b/tests/unit/ssrf-redirects.test.ts
@@ -17,6 +17,8 @@ import { describe, it, expect } from "vitest";
 import {
   followRedirects,
   assertNotPrivateIpLiteral,
+  assertAllowedScheme,
+  assertAllowedUrl,
   type FetchImpl,
 } from "../../src/server/http/ssrf";
 
@@ -111,6 +113,67 @@ describe("followRedirects — per-hop SSRF validation", () => {
       "http://a.example.com/1",
       "http://b.example.com/2",
     ]);
+  });
+});
+
+describe("assertAllowedScheme — non-http(s) scheme rejection", () => {
+  it("allows http and https URLs", () => {
+    expect(() => assertAllowedScheme("http://public.example.com/a")).not.toThrow();
+    expect(() => assertAllowedScheme("https://public.example.com/a")).not.toThrow();
+  });
+
+  it.each([
+    "file:///etc/passwd",
+    "ftp://example.com/x",
+    "gopher://example.com/",
+    "data:text/plain,hi",
+  ])("rejects non-http(s) scheme: %s", (url) => {
+    expect(() => assertAllowedScheme(url)).toThrowError(
+      expect.objectContaining({ name: "SsrfBlockedError" })
+    );
+  });
+
+  it("rejects an unparseable URL (fail closed)", () => {
+    expect(() => assertAllowedScheme("not a url")).toThrowError(
+      expect.objectContaining({ name: "SsrfBlockedError" })
+    );
+  });
+});
+
+describe("followRedirects — per-hop scheme validation", () => {
+  it("blocks an initial non-http(s) URL (dispatcher path validator)", async () => {
+    const { impl, requests } = fakeFetch({});
+    await expect(
+      followRedirects("file:///etc/passwd", {}, impl, assertAllowedUrl)
+    ).rejects.toMatchObject({ name: "SsrfBlockedError" });
+    // Rejected before ever hitting the fetch impl.
+    expect(requests).toHaveLength(0);
+  });
+
+  it("blocks an initial non-http(s) URL (allow-private path validator)", async () => {
+    const { impl, requests } = fakeFetch({});
+    await expect(
+      followRedirects("file:///etc/passwd", {}, impl, assertAllowedScheme)
+    ).rejects.toMatchObject({ name: "SsrfBlockedError" });
+    expect(requests).toHaveLength(0);
+  });
+
+  it("blocks a redirect to a non-http(s) scheme (dispatcher path validator)", async () => {
+    const { impl } = fakeFetch({
+      "http://public.example.com/a": { status: 302, location: "file:///etc/passwd" },
+    });
+    await expect(
+      followRedirects("http://public.example.com/a", {}, impl, assertAllowedUrl)
+    ).rejects.toMatchObject({ name: "SsrfBlockedError" });
+  });
+
+  it("blocks a redirect to a non-http(s) scheme (allow-private path validator)", async () => {
+    const { impl } = fakeFetch({
+      "http://public.example.com/a": { status: 302, location: "gopher://public.example.com/" },
+    });
+    await expect(
+      followRedirects("http://public.example.com/a", {}, impl, assertAllowedScheme)
+    ).rejects.toMatchObject({ name: "SsrfBlockedError" });
   });
 });
 


### PR DESCRIPTION
Fixes #1273.

## Problem

`SECURITY.md` §2 claimed the SSRF guard "rejects non-http schemes", but `src/server/http/ssrf.ts` performed **no explicit scheme check**. Non-http schemes (`file:`, `ftp:`, `gopher:`, `data:`) were only rejected *implicitly* by the underlying fetch impl. In particular, a redirect `Location` was re-validated for private IPs but its **scheme was never checked** — a future/swapped transport that tolerated a non-http scheme could bypass the intent.

Severity: Low (defense-in-depth; not exploitable today), but this is a security chokepoint where fail-closed enforcement belongs in our code, not the transport.

## Fix

- Add `assertAllowedScheme(url)` — an explicit `http:`/`https:` allowlist that fails closed on unparseable URLs, throwing a `SsrfBlockedError`-named error.
- Add `assertAllowedUrl` = scheme check + literal-IP check, used as the per-hop validator on the dispatcher path.
- Run scheme validation on the **initial URL and every redirect hop** in **both** the dispatcher path and the `ALLOW_PRIVATE_NETWORK_FETCH` path, so the guarantee holds regardless of the underlying fetch.
- Update `SECURITY.md` §2 and `src/server/http/CLAUDE.md` to document the now-explicit enforcement.

## Tests

New unit tests in `tests/unit/ssrf-redirects.test.ts`:
- `assertAllowedScheme` allows http/https, rejects `file:`/`ftp:`/`gopher:`/`data:`, and fails closed on an unparseable URL.
- `followRedirects` rejects an initial non-http URL and a redirect to a non-http scheme — on **both** validation paths (dispatcher `assertAllowedUrl` and allow-private `assertAllowedScheme`), asserting the request never reaches the fetch impl.

`pnpm test:unit`, `pnpm typecheck`, and eslint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)