### PR TITLE
Security: lock down CSP script-src/default-src with a per-request nonce (#1275)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,14 +44,22 @@ Entry bodies, saved articles, and AI summaries are rendered with
 - The allowlist deliberately excludes `script`/`style`/`on*`/`form`/`base`/`meta`,
   restricts URL schemes, forces `rel=noopener`, and treats SVG/MathML as mXSS-prone.
   Changes here need a security review.
-- **Defense-in-depth headers** (`securityHeaders` in `next.config.ts`, mirrored on
-  the maintenance short-circuit in `scripts/server.ts`) add a CSP
-  (`frame-ancestors 'none'; object-src 'none'; base-uri 'self'`), `X-Frame-Options`,
-  `X-Content-Type-Options: nosniff`, `Referrer-Policy`, and (prod) HSTS. The CSP
-  does **not** yet lock down `script-src`/`default-src` — that needs a per-request
-  nonce/hash for the two inline `<script>`s in `layout.tsx` — so the sanitizer is
-  still the sole gate against injected `<script>`; the CSP only backstops
-  clickjacking, plugin/object injection, and `<base>` hijacking.
+- **Defense-in-depth headers**: `securityHeaders` in `next.config.ts` sets
+  `X-Frame-Options`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, and
+  (prod) HSTS. The **Content-Security-Policy** is set per-request in
+  `src/proxy.ts` with the policy built in `src/server/http/csp.ts`: it locks
+  `script-src` down to a random per-request nonce (`'strict-dynamic'`), sets
+  `default-src 'self'`, restricts `frame-src` to the sanitizer's allow-listed
+  embed hosts, and keeps `frame-ancestors 'none'` / `object-src 'none'` /
+  `base-uri 'self'`. The nonce is threaded to the inline `<script>`s in
+  `layout.tsx` (and next-themes) via the `x-nonce` request header, so an
+  injected `<script>` (or inline event handler) that survives a sanitizer
+  regression is blocked by the browser instead of executing — the sanitizer is
+  the primary XSS gate, the CSP is the backstop. Directive rationale lives in
+  `csp.ts`; the maintenance short-circuit in `scripts/server.ts` carries its own
+  static, script-less CSP (it bypasses Next and has no scripts). `/sw.js` is
+  deliberately CSP-exempt (the service worker's own fetches for runtime caching
+  of cross-origin images would be broken by the app's `connect-src`).
 
 ## 2. SSRF-safe outbound fetching
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -77,20 +77,15 @@ const withPWAConfig = withPWA({
 
 // Security response headers applied to every route (defense-in-depth). Entry
 // bodies render via `dangerouslySetInnerHTML`, so the server-side sanitizer is
-// the sole XSS gate; these headers make a future sanitizer regression a
-// non-event (CSP blocks plugins/base-tag injection) and stop the app from being
-// framed (clickjacking).
+// the primary XSS gate; these headers make a future sanitizer regression a
+// non-event and stop the app from being framed (clickjacking).
 //
-// The CSP intentionally omits `default-src`/`script-src`: locking those down
-// requires a per-request nonce/hash for the two inline <script>s in layout.tsx,
-// which the static `headers()` config can't emit. We still ship the directives
-// that are safe without a nonce. `frame-ancestors` has no X-Frame-Options
-// equivalent for allow-lists, but we send both so older browsers are covered.
+// The Content-Security-Policy is NOT set here: it carries a per-request nonce
+// for the inline <script>s in layout.tsx, which a static `headers()` value
+// can't emit, so it is set in `src/proxy.ts` (policy in `src/server/http/csp.ts`).
+// `X-Frame-Options` duplicates the CSP's `frame-ancestors 'none'` for browsers
+// that predate it.
 const securityHeaders: { key: string; value: string }[] = [
-  {
-    key: "Content-Security-Policy",
-    value: ["frame-ancestors 'none'", "object-src 'none'", "base-uri 'self'"].join("; "),
-  },
   { key: "X-Frame-Options", value: "DENY" },
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },

--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -75,13 +75,17 @@ app.prepare().then(() => {
         res.setHeader("Retry-After", "3600");
         res.setHeader("Cache-Control", "no-store");
         // These responses short-circuit before Next's handler, so they miss the
-        // security headers configured in next.config.ts. Set the framing/sniffing
-        // protections here too so maintenance-mode pages aren't a coverage gap.
+        // security headers from next.config.ts and the nonce'd CSP from
+        // src/proxy.ts. Set the framing/sniffing protections here too so
+        // maintenance-mode pages aren't a coverage gap. The maintenance HTML
+        // has no scripts at all (inline <style> only), so this static policy
+        // can be stricter than the app's (`script-src 'none'`); keep it
+        // conceptually in sync with src/server/http/csp.ts.
         res.setHeader("X-Frame-Options", "DENY");
         res.setHeader("X-Content-Type-Options", "nosniff");
         res.setHeader(
           "Content-Security-Policy",
-          "frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
+          "script-src 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
         );
         if (decision === "block-api") {
           res.setHeader("Content-Type", "application/json; charset=utf-8");

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { Geist, Geist_Mono, Merriweather, Literata, Inter, Source_Sans_3 } from "next/font/google";
 import { defaultOpenGraph } from "@/lib/metadata";
 import { appUrl } from "@/server/config/env";
@@ -153,8 +153,17 @@ export default async function RootLayout({
   // it renders on every route including the demo and logged-out surfaces. The
   // dismissed id is read from a cookie (not localStorage) so the server can hide
   // an already-dismissed banner and it never flashes back on reload.
-  const [announcement, cookieStore] = await Promise.all([getAnnouncement(), cookies()]);
+  const [announcement, cookieStore, headerStore] = await Promise.all([
+    getAnnouncement(),
+    cookies(),
+    headers(),
+  ]);
   const dismissedId = cookieStore.get(ANNOUNCEMENT_DISMISSED_COOKIE)?.value ?? null;
+  // Per-request CSP nonce, generated in src/proxy.ts (issue #1275). Every
+  // inline <script> must carry it or the CSP blocks the script — that includes
+  // next-themes' theme script, which gets it via ThemeProvider below. Absent
+  // only if the proxy didn't run, in which case the response has no CSP either.
+  const nonce = headerStore.get("x-nonce") ?? undefined;
 
   return (
     // Font variables live on <html> (not <body>) so the entry text-appearance
@@ -169,11 +178,22 @@ export default async function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} ${merriweather.variable} ${literata.variable} ${inter.variable} ${sourceSans.variable}`}
     >
       <head>
-        <script dangerouslySetInnerHTML={{ __html: textAppearanceScript }} />
-        <script dangerouslySetInnerHTML={{ __html: swScript }} />
+        {/* suppressHydrationWarning: browsers blank the nonce content attribute
+            after parsing (nonce hiding), so hydration would see nonce="" and
+            warn on every load. The scripts have executed by then either way. */}
+        <script
+          nonce={nonce}
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: textAppearanceScript }}
+        />
+        <script
+          nonce={nonce}
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: swScript }}
+        />
       </head>
       <body className="antialiased">
-        <ThemeProvider>
+        <ThemeProvider nonce={nonce}>
           <AnnouncementBanner announcement={announcement} initialDismissedId={dismissedId} />
           {children}
         </ThemeProvider>

--- a/src/lib/theme/ThemeProvider.tsx
+++ b/src/lib/theme/ThemeProvider.tsx
@@ -13,6 +13,13 @@ import { useIsEInkDisplay } from "./eink";
 
 interface ThemeProviderProps {
   children: ReactNode;
+  /**
+   * CSP nonce for next-themes' inline theme script (it runs blocking in
+   * <head> to apply the theme class before first paint). Without it the
+   * nonce-based `script-src` set in src/proxy.ts blocks the script and the
+   * theme flashes/breaks. Passed from the root layout.
+   */
+  nonce?: string;
 }
 
 /**
@@ -110,7 +117,7 @@ function ThemeColorMeta() {
  * - disableTransitionOnChange: Prevents flash by disabling CSS transitions during theme change
  * - storageKey: Uses our existing localStorage key for backwards compatibility
  */
-export function ThemeProvider({ children }: ThemeProviderProps) {
+export function ThemeProvider({ children, nonce }: ThemeProviderProps) {
   return (
     <NextThemesProvider
       attribute="class"
@@ -119,6 +126,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       themes={["light", "dark", "epaper"]}
       disableTransitionOnChange
       storageKey="lion-reader-theme"
+      nonce={nonce}
     >
       <EInkSystemThemeOverride />
       <ThemeColorMeta />

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,12 +1,21 @@
 /**
  * Next.js Proxy (middleware)
  *
- * Two jobs:
+ * Three jobs:
  *
- * 1. The claude.ai OAuth workaround: rewriting POST/OPTIONS `/register` to the
+ * 1. The per-request Content-Security-Policy nonce (issue #1275): a locked-down
+ *    `script-src` needs a fresh nonce on every response, which the static
+ *    `headers()` config in `next.config.ts` can't produce. This is Next's
+ *    documented CSP pattern: generate the nonce here and put the policy on the
+ *    *request* headers — Next.js extracts the nonce from the forwarded
+ *    `Content-Security-Policy` request header and stamps it onto its own
+ *    framework/chunk `<script>` tags, and `src/app/layout.tsx` reads `x-nonce`
+ *    for the app's inline scripts — then set the same policy on the *response*.
+ *    Policy contents and directive rationale live in `src/server/http/csp.ts`.
+ * 2. The claude.ai OAuth workaround: rewriting POST/OPTIONS `/register` to the
  *    Dynamic Client Registration handler at `/oauth/register` (see the big
  *    comment in `proxy()`).
- * 2. Optional request logging for debugging remote MCP connectors: when
+ * 3. Optional request logging for debugging remote MCP connectors: when
  *    `LOG_MCP_REQUESTS=true`, one structured line per request — host, method,
  *    path, redacted query, user-agent, whether an Authorization header was
  *    present. This is how we see exactly what claude.ai sends — most importantly
@@ -14,7 +23,7 @@
  *    #986 / the connector header-drop bug), AND whether it hits any path we don't
  *    expect (the "wrong URL" / origin-root-fallback failure modes).
  *
- * The matcher runs on all requests (minus static assets) so job 2 can see
+ * The matcher runs on all requests (minus static assets) so job 3 can see
  * unexpected paths, but logging is gated: nothing is logged unless
  * `LOG_MCP_REQUESTS=true`, and even then only for (a) **every** request to the
  * dedicated MCP host (`MCP_HOST`) — full visibility on the debug host — and
@@ -34,6 +43,7 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { mcpConfig } from "@/server/config/env";
+import { buildContentSecurityPolicy, generateCspNonce } from "@/server/http/csp";
 
 /**
  * Query params that are safe to log (client_id, PKCE code_challenge, state,
@@ -127,6 +137,25 @@ export function proxy(request: NextRequest) {
     logRequest(request);
   }
 
+  // The service worker script deliberately gets NO CSP. A service worker's
+  // fetches are governed by the CSP served on the worker script itself, and
+  // the runtime-caching config in next.config.ts fetches cross-origin entry
+  // images (and Google Fonts) from *inside* the worker — the app policy's
+  // `connect-src` would silently break that caching. Pages control what the
+  // SW can be asked to fetch via their own CSP.
+  if (request.nextUrl.pathname === "/sw.js") {
+    return NextResponse.next();
+  }
+
+  // Per-request CSP nonce (issue #1275). `set` overwrites any client-supplied
+  // `x-nonce`/`Content-Security-Policy` request header, so the values Next.js
+  // and the layout read are always ours.
+  const nonce = generateCspNonce();
+  const csp = buildContentSecurityPolicy(nonce);
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("Content-Security-Policy", csp);
+
   // ==========================================================================
   // HACK: claude.ai OAuth "root path" workaround — `/register` is METHOD-SPLIT.
   //
@@ -157,25 +186,30 @@ export function proxy(request: NextRequest) {
   //   https://github.com/anthropics/claude-ai-mcp/issues/341  (tracking bug)
   //   https://github.com/anthropics/claude-ai-mcp/issues/82   (root-path synthesis)
   // ==========================================================================
+  let response: NextResponse;
   if (
     request.nextUrl.pathname === "/register" &&
     (request.method === "POST" || request.method === "OPTIONS")
   ) {
     const dcrUrl = request.nextUrl.clone();
     dcrUrl.pathname = "/oauth/register";
-    return NextResponse.rewrite(dcrUrl);
+    response = NextResponse.rewrite(dcrUrl, { request: { headers: requestHeaders } });
+  } else {
+    // GET /register (and anything else) falls through to the normal route.
+    response = NextResponse.next({ request: { headers: requestHeaders } });
   }
-
-  // GET /register (and anything else) falls through to the normal route.
-  return NextResponse.next();
+  response.headers.set("Content-Security-Policy", csp);
+  return response;
 }
 
 /**
- * Run the proxy on all requests except static assets. The broad matcher is what
- * lets `LOG_MCP_REQUESTS` capture requests to unexpected paths on the MCP host
- * (the "wrong URL" failure mode); `shouldLog` keeps ordinary app traffic out of
- * the logs, and the proxy is otherwise a pass-through save for the `/register`
- * rewrite. Static assets are excluded so middleware doesn't run per-asset.
+ * Run the proxy on all requests except Next's build assets. The broad matcher
+ * is what lets `LOG_MCP_REQUESTS` capture requests to unexpected paths on the
+ * MCP host (the "wrong URL" failure mode), and it also puts the nonce'd CSP on
+ * every response — including API/JSON responses, where a CSP is inert but
+ * hardens any content-type-confusion angle. `_next/static`/`_next/image` are
+ * excluded so middleware doesn't run per-asset (a CSP on those subresources is
+ * meaningless); `/sw.js` is matched but bypassed inside `proxy()` (see there).
  */
 export const config = {
   matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],

--- a/src/server/http/CLAUDE.md
+++ b/src/server/http/CLAUDE.md
@@ -1,6 +1,6 @@
 # Outbound HTTP & SSRF Protection (`src/server/http/`)
 
-This file governs the outbound-HTTP helpers: SSRF-protected fetching (`ssrf.ts`), user agent (`user-agent.ts`), CORS, compression, client IP, and the OAuth-surface trailing-slash handling (`trailing-slash.ts` — see `src/server/oauth/CLAUDE.md` for why it exists).
+This file governs the outbound-HTTP helpers: SSRF-protected fetching (`ssrf.ts`), user agent (`user-agent.ts`), CORS, compression, client IP, and the OAuth-surface trailing-slash handling (`trailing-slash.ts` — see `src/server/oauth/CLAUDE.md` for why it exists). One inbound-response concern also lives here: the Content-Security-Policy builder (`csp.ts`, security-critical — the XSS backstop behind the sanitizer). The policy is applied per-request with a fresh `script-src` nonce by `src/proxy.ts`; directive rationale is documented in `csp.ts` itself, the header wiring in SECURITY.md.
 
 Every outgoing request must send our custom User-Agent (`USER_AGENT`/`buildUserAgent` from `@/server/http/user-agent`).
 

--- a/src/server/http/csp.ts
+++ b/src/server/http/csp.ts
@@ -39,10 +39,14 @@ import { EMBED_CANONICAL_HOSTNAMES } from "@/server/html/embed-providers";
  *   audio unlock. `http:` also covers plain-HTTP local dev.
  * - `connect-src`: same-origin covers tRPC, SSE, and the Sentry `/monitoring`
  *   tunnel. The external hosts are the TTS narration downloads: Piper voice
- *   models from Hugging Face (`huggingface.co` redirects to `cdn-lfs*.huggingface.co`
- *   / `*.hf.co` CDNs, and CSP checks every hop of a redirect chain) and the
- *   Piper phonemizer wasm/data from jsdelivr (`CUSTOM_WASM_PATHS` in
- *   `src/lib/narration/piper-tts-provider.ts`). Dev needs `ws:` for HMR.
+ *   models from Hugging Face and the Piper phonemizer wasm/data from jsdelivr
+ *   (`CUSTOM_WASM_PATHS` in `src/lib/narration/piper-tts-provider.ts`). CSP
+ *   checks every hop of a redirect chain, and `huggingface.co/…/resolve/…`
+ *   302s to its storage CDNs — `cdn-lfs*.huggingface.co` historically, Xet
+ *   hosts like `cas-bridge.xethub.hf.co` today. A CSP host wildcard
+ *   suffix-matches subdomains at ANY depth (unlike TLS certs), so
+ *   `https://*.hf.co` covers the multi-label Xet hosts. Dev needs `ws:` for
+ *   HMR.
  * - `worker-src`: the service worker is same-origin; the ONNX runtime spawns
  *   its threading helper workers from `blob:` URLs.
  * - `frame-src`: exactly the sanitizer's allow-listed embed providers — every
@@ -52,7 +56,11 @@ import { EMBED_CANONICAL_HOSTNAMES } from "@/server/html/embed-providers";
  *   pre-existing baseline (plugins, `<base>` hijacking, clickjacking).
  * - `form-action` is deliberately absent: Chrome checks post-submit redirects
  *   against it, which would break the OAuth consent flow (form POST to self,
- *   then 302 to the client's external `redirect_uri`).
+ *   then 302 to the client's external `redirect_uri`). Note `form-action`
+ *   does NOT fall back to `default-src` — omitted means form submissions are
+ *   unrestricted. That's acceptable here because the sanitizer strips
+ *   `<form>` from entry HTML, so an injected exfiltration form can't reach
+ *   the DOM in the first place.
  */
 export function buildContentSecurityPolicy(nonce: string): string {
   const isDev = process.env.NODE_ENV === "development";
@@ -78,10 +86,10 @@ export function buildContentSecurityPolicy(nonce: string): string {
 }
 
 /**
- * Generates the per-request CSP nonce: 128 bits of randomness, base64-encoded
- * (the header grammar requires base64url charset; standard base64 is a subset
- * browsers accept, and the value round-trips verbatim between the header and
- * the `nonce` attributes).
+ * Generates the per-request CSP nonce: 128 bits of randomness, base64-encoded.
+ * The header grammar (`base64-value`) accepts both standard base64 and
+ * base64url characters, and the value round-trips verbatim between the header
+ * and the `nonce` attributes.
  */
 export function generateCspNonce(): string {
   const bytes = new Uint8Array(16);

--- a/src/server/http/csp.ts
+++ b/src/server/http/csp.ts
@@ -1,0 +1,90 @@
+/**
+ * Content-Security-Policy construction (issue #1275).
+ *
+ * The policy is built per-request in `src/proxy.ts` around a random nonce, so
+ * `script-src` can be locked down while still allowing the app's own inline
+ * scripts (the text-appearance and service-worker-registration scripts in
+ * `src/app/layout.tsx`, plus next-themes' theme script). Entry bodies render
+ * untrusted-but-sanitized HTML via `dangerouslySetInnerHTML`, so this CSP is
+ * the backstop that turns a sanitizer regression from an XSS into a blocked
+ * script — see SECURITY.md.
+ *
+ * The maintenance short-circuit in `scripts/server.ts` bypasses Next.js (and
+ * therefore the proxy), so it carries its own static, script-less CSP — keep
+ * the two conceptually in sync when changing directives here.
+ */
+
+import { EMBED_CANONICAL_HOSTNAMES } from "@/server/html/embed-providers";
+
+/**
+ * Builds the Content-Security-Policy header value for a request.
+ *
+ * Directive rationale:
+ *
+ * - `script-src`: the nonce + `'strict-dynamic'` is the modern CSP3 pattern —
+ *   only nonce'd scripts run, and trust propagates to scripts they load
+ *   (Next.js chunk loading, dynamic `import()` of the ONNX runtime). `'self'`
+ *   is a fallback for pre-CSP3 browsers, which ignore `'strict-dynamic'`.
+ *   `'wasm-unsafe-eval'` is required to compile WebAssembly (ONNX runtime and
+ *   Piper phonemizer for TTS narration). Dev additionally needs
+ *   `'unsafe-eval'` for React Refresh / HMR.
+ * - `style-src 'unsafe-inline'`: inline styles are pervasive (React `style`
+ *   props, next-themes, sonner, `NarrationHighlightStyles`, sanitized entry
+ *   `style` attributes) and inline-style injection is far lower risk than
+ *   script injection. Do NOT add a nonce or hash here — any nonce/hash in a
+ *   directive makes browsers ignore its `'unsafe-inline'`.
+ * - `img-src`/`media-src`: sanitized entry HTML allows `<img>`/`<audio>`/
+ *   `<video>` with http/https/data URLs from arbitrary feeds (see
+ *   `SANITIZE_OPTIONS.allowedSchemesByTag`), and TTS uses a `data:` silent
+ *   audio unlock. `http:` also covers plain-HTTP local dev.
+ * - `connect-src`: same-origin covers tRPC, SSE, and the Sentry `/monitoring`
+ *   tunnel. The external hosts are the TTS narration downloads: Piper voice
+ *   models from Hugging Face (`huggingface.co` redirects to `cdn-lfs*.huggingface.co`
+ *   / `*.hf.co` CDNs, and CSP checks every hop of a redirect chain) and the
+ *   Piper phonemizer wasm/data from jsdelivr (`CUSTOM_WASM_PATHS` in
+ *   `src/lib/narration/piper-tts-provider.ts`). Dev needs `ws:` for HMR.
+ * - `worker-src`: the service worker is same-origin; the ONNX runtime spawns
+ *   its threading helper workers from `blob:` URLs.
+ * - `frame-src`: exactly the sanitizer's allow-listed embed providers — every
+ *   iframe that survives sanitization is rewritten to one of these canonical
+ *   hosts (`EMBED_CANONICAL_HOSTNAMES`), so the CSP double-enforces that list.
+ * - `object-src 'none'`, `base-uri 'self'`, `frame-ancestors 'none'`: the
+ *   pre-existing baseline (plugins, `<base>` hijacking, clickjacking).
+ * - `form-action` is deliberately absent: Chrome checks post-submit redirects
+ *   against it, which would break the OAuth consent flow (form POST to self,
+ *   then 302 to the client's external `redirect_uri`).
+ */
+export function buildContentSecurityPolicy(nonce: string): string {
+  const isDev = process.env.NODE_ENV === "development";
+  const frameSrc = EMBED_CANONICAL_HOSTNAMES.map((host) => `https://${host}`).join(" ");
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'wasm-unsafe-eval'${
+      isDev ? " 'unsafe-eval'" : ""
+    }`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: http: https:",
+    "media-src 'self' data: blob: http: https:",
+    "font-src 'self' data:",
+    `connect-src 'self' https://huggingface.co https://*.huggingface.co https://*.hf.co https://cdn.jsdelivr.net${
+      isDev ? " ws:" : ""
+    }`,
+    "worker-src 'self' blob:",
+    `frame-src ${frameSrc}`,
+    "object-src 'none'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+  ].join("; ");
+}
+
+/**
+ * Generates the per-request CSP nonce: 128 bits of randomness, base64-encoded
+ * (the header grammar requires base64url charset; standard base64 is a subset
+ * browsers accept, and the value round-trips verbatim between the header and
+ * the `nonce` attributes).
+ */
+export function generateCspNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString("base64");
+}

--- a/tests/e2e/security-headers.spec.ts
+++ b/tests/e2e/security-headers.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * E2E tests for the security response headers, in particular the nonce-based
+ * Content-Security-Policy set by src/proxy.ts (issue #1275).
+ *
+ * The CSP is the XSS backstop behind the server-side sanitizer: a `<script>`
+ * or inline event handler that survives a sanitizer regression must be blocked
+ * by the browser. These tests pin:
+ *
+ * - the policy shape (nonce'd `script-src` with `'strict-dynamic'`,
+ *   `default-src 'self'`, the baseline directives), with a fresh nonce per
+ *   request that matches the inline scripts' `nonce` attributes;
+ * - that injected markup with an inline event handler does NOT execute (the
+ *   parser-inserted markup-injection vector CSP is here to stop);
+ * - that a normally loaded app page produces no CSP violations (the app's own
+ *   inline scripts, styles, and chunk loading all satisfy the policy).
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  getDb,
+  createConfirmedUser,
+  createSubscribedFeed,
+  createUnreadEntry,
+  loginAs,
+  closeTestConnections,
+} from "./helpers";
+
+test.afterAll(async () => {
+  await closeTestConnections();
+});
+
+/** Extracts the script-src nonce from a Content-Security-Policy header value. */
+function extractNonce(csp: string): string | null {
+  const match = csp.match(/script-src[^;]*'nonce-([A-Za-z0-9+/_=-]+)'/);
+  return match ? match[1] : null;
+}
+
+test("HTML responses carry a nonce'd CSP that matches the inline scripts", async ({ request }) => {
+  const response = await request.get("/login");
+  expect(response.status()).toBe(200);
+
+  const csp = response.headers()["content-security-policy"];
+  expect(csp).toBeTruthy();
+
+  // Policy shape: locked-down script-src plus the baseline directives.
+  expect(csp).toContain("default-src 'self'");
+  expect(csp).toContain("'strict-dynamic'");
+  expect(csp).toContain("object-src 'none'");
+  expect(csp).toContain("base-uri 'self'");
+  expect(csp).toContain("frame-ancestors 'none'");
+  // No blanket inline-script escape hatch in script-src.
+  expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
+
+  const nonce = extractNonce(csp);
+  expect(nonce).toBeTruthy();
+
+  // The app's inline scripts must carry the same nonce or the browser blocks
+  // them. Check the raw HTML (browsers hide the nonce content attribute from
+  // the DOM once parsed).
+  const html = await response.text();
+  expect(html).toContain(`nonce="${nonce}"`);
+});
+
+test("each request gets a fresh nonce", async ({ request }) => {
+  const first = await request.get("/login");
+  const second = await request.get("/login");
+  const firstNonce = extractNonce(first.headers()["content-security-policy"] ?? "");
+  const secondNonce = extractNonce(second.headers()["content-security-policy"] ?? "");
+  expect(firstNonce).toBeTruthy();
+  expect(secondNonce).toBeTruthy();
+  expect(firstNonce).not.toBe(secondNonce);
+});
+
+test("injected inline event handlers are blocked by the CSP", async ({ page }) => {
+  await page.goto("/login");
+
+  const result = await page.evaluate(async () => {
+    const violations: string[] = [];
+    document.addEventListener("securitypolicyviolation", (e) => {
+      violations.push(e.violatedDirective);
+    });
+
+    // Simulate a sanitizer bypass: markup with an inline event handler landing
+    // in the DOM (the dangerouslySetInnerHTML injection shape). The handler
+    // fires on error of a broken image; with a nonce-only script-src it must
+    // never run. (A plain <script> inserted via innerHTML never executes per
+    // the HTML spec regardless of CSP, so the handler is the testable vector.)
+    interface PwnedWindow extends Window {
+      __cspPwned?: boolean;
+    }
+    const container = document.createElement("div");
+    container.innerHTML = '<img src="/nonexistent-image-404.png" onerror="window.__cspPwned=true">';
+    document.body.appendChild(container);
+
+    // Give the image time to fail and the (blocked) handler time to fire.
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    return {
+      pwned: (window as PwnedWindow).__cspPwned === true,
+      violations,
+    };
+  });
+
+  expect(result.pwned).toBe(false);
+  expect(result.violations).toContain("script-src-attr");
+});
+
+test("a logged-in app page loads with zero CSP violations", async ({ page, baseURL }) => {
+  const db = getDb();
+  const user = await createConfirmedUser(db);
+  const feed = await createSubscribedFeed(db, user.id);
+  await createUnreadEntry(db, {
+    feedId: feed.feedId,
+    userId: user.id,
+    title: "CSP smoke-test entry",
+  });
+  await loginAs(page.context(), user, baseURL!);
+
+  const violations: string[] = [];
+  await page.exposeFunction("__reportCspViolation", (report: string) => {
+    violations.push(report);
+  });
+  await page.addInitScript(() => {
+    document.addEventListener("securitypolicyviolation", (e) => {
+      (
+        window as Window & {
+          __reportCspViolation?: (report: string) => void;
+        }
+      ).__reportCspViolation?.(
+        `${e.violatedDirective}: ${e.blockedURI} (source: ${e.sourceFile}:${e.lineNumber}, sample: ${e.sample})`
+      );
+    });
+  });
+
+  // The main app shell: SSR inline scripts, theme script, chunk loading, tRPC
+  // and SSE connections all have to satisfy the policy.
+  await page.goto("/all");
+  await expect(page.getByRole("main")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "CSP smoke-test entry" })).toBeVisible();
+  // Let hydration, the SSE connection, and lazy chunks settle. (Can't use
+  // waitForLoadState("networkidle") — the persistent SSE stream means the
+  // network never goes idle.)
+  await page.waitForTimeout(3000);
+
+  // Zod 4 probes for eval support with `new Function("")` in a try/catch
+  // (`allowsEval` in zod/v4/core/util.js) and cleanly falls back to its
+  // non-JIT validation path when the CSP blocks it — correct behavior for us,
+  // but the blocked probe still fires a one-time report-only violation event.
+  // Filter that known-benign probe; anything else is a real policy gap.
+  const unexpected = violations.filter((v) => !v.startsWith("script-src: eval ("));
+  expect(unexpected).toEqual([]);
+});

--- a/tests/e2e/security-headers.spec.ts
+++ b/tests/e2e/security-headers.spec.ts
@@ -13,6 +13,11 @@
  *   parser-inserted markup-injection vector CSP is here to stop);
  * - that a normally loaded app page produces no CSP violations (the app's own
  *   inline scripts, styles, and chunk loading all satisfy the policy).
+ *
+ * Known coverage gaps (policy allows these, but the e2e env never exercises
+ * them): Sentry Session Replay (prod-DSN only; needs `worker-src blob:` +
+ * the same-origin `/monitoring` tunnel) and the TTS narration downloads
+ * (Hugging Face voice models via `*.hf.co` redirect hops, jsdelivr wasm).
  */
 
 import { test, expect } from "@playwright/test";


### PR DESCRIPTION
Closes #1275.

Follow-up to #1264 / #1269: those shipped a baseline CSP that intentionally left `script-src`/`default-src` unset. This PR closes that gap, so an injected `<script>` or inline event handler that survives a sanitizer regression is blocked by the browser instead of executing.

## What changed

- **`src/proxy.ts`** now generates a random nonce per request and sets the full CSP on both the forwarded request headers (Next.js extracts the nonce from there and stamps it onto its own framework/chunk scripts) and the response — Next's documented CSP pattern. The static CSP entry is removed from `next.config.ts` (a static `headers()` value can't carry a per-request nonce).
- **`src/server/http/csp.ts`** (new) builds the policy, with rationale for every directive:
  - `script-src 'self' 'nonce-…' 'strict-dynamic' 'wasm-unsafe-eval'` (+ `'unsafe-eval'` in dev for HMR). `wasm-unsafe-eval` is for the TTS narration WebAssembly (ONNX runtime + Piper phonemizer).
  - `default-src 'self'`; `img-src`/`media-src` allow `http:/https:/data:/blob:` (sanitized entry HTML legitimately embeds arbitrary remote images/audio/video); `style-src 'self' 'unsafe-inline'` (React style props, next-themes, sanitized `style` attrs).
  - `connect-src` allows self (tRPC/SSE/Sentry tunnel) plus the TTS downloads: Hugging Face voice models (incl. its LFS CDNs — CSP checks every redirect hop) and the Piper wasm/data on jsdelivr.
  - `frame-src` is derived from the sanitizer's `EMBED_CANONICAL_HOSTNAMES`, so the CSP double-enforces the embed-provider allow-list.
  - `worker-src 'self' blob:` (service worker + ONNX thread workers).
  - `form-action` deliberately omitted: Chrome checks post-submit redirects against it, which would break the OAuth consent flow's 302 to external `redirect_uri`s.
- **`layout.tsx`** reads the nonce from `x-nonce` and puts it on the two inline scripts (with `suppressHydrationWarning` — browsers blank the nonce attribute after parsing, which otherwise trips React hydration warnings); **`ThemeProvider`** gains a `nonce` prop for next-themes' inline theme script.
- **`/sw.js` is deliberately CSP-exempt**: a service worker's fetches are governed by the CSP on the worker script itself, and the runtime image caching fetches cross-origin entry images from *inside* the worker — the app's `connect-src` would silently break it.
- The maintenance short-circuit in `scripts/server.ts` keeps its own static CSP, tightened with `script-src 'none'` (that HTML has no scripts).
- SECURITY.md and `src/server/http/CLAUDE.md` updated.

## Verification

- New e2e spec (`tests/e2e/security-headers.spec.ts`), run against **both dev and the production build**: policy shape + nonce matches the inline scripts, fresh nonce per request, injected `<img onerror=…>` markup is **blocked** (`script-src-attr` violation fires, handler never runs), and a logged-in `/all` page load produces **zero CSP violations**.
- Full e2e suite passes (50 passed); typecheck/lint/unit green; production build succeeds (all HTML routes were already dynamic, so the nonce forces no rendering change).
- Manually verified in a browser against the prod build: demo page renders entries with zero violations and the service worker registers successfully.

## Notes / residual risk

- **Zod 4 probes eval support** with `new Function("")` in a try/catch and cleanly falls back to its non-JIT validation path when blocked; the caught probe still emits a one-time `securitypolicyviolation` event (filtered as known-benign in the e2e test). No functional impact.
- **TTS narration (Piper voice download + synthesis) couldn't be exercised headless** — the directives were sized from reading the actual load paths (`piper-tts-provider.ts`, `voice-download.ts`, the bundled piper-tts-web/ONNX code), but it's worth a quick manual narration run after deploy. If anything's blocked it'll show as a console CSP violation naming the host to add.
- I went straight to enforcing rather than a `Report-Only` rollout since there's no report collector wired up and the e2e suite + manual checks cover the main surfaces; happy to flip to Report-Only if you'd rather stage it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)