### PR TITLE
Narration: context-aware number-suffix expansion

### DIFF
--- a/src/server/services/narration.ts
+++ b/src/server/services/narration.ts
@@ -59,6 +59,10 @@ RULES:
   - Standalone acronyms: "tl;dr" → "TL;DR", "api" → "API", "html" → "HTML"
   - Product versions: "iPhone 15 Pro" stays as-is, "Pixel 8" stays as-is
   - Model names that look like abbreviations: "iPhone SE" stays as-is
+- Expand number suffixes ONLY when context makes the meaning unambiguous - use judgement, don't guess:
+  - "6'" → "6 feet", "6\"" → "6 inches" when describing height/length; "$6B" → "6 billion dollars", "6M users" → "6 million users"; "4x faster" → "4 times faster"
+  - Leave it literal when the suffix is part of a name or its meaning is unclear: "5900X" (AMD chip) stays as-is (the X is read as a letter), "Model X" stays as-is
+  - If you can't tell from context what a suffix means, leave it unchanged so TTS reads it literally rather than inventing a meaning
 - Image alt text is already speakable - clean up if needed, don't rephrase
 - Skip garbage content (ellipsis, ads, junk) using empty string: "text": ""
 - Keep content faithful - do NOT summarize or editorialize
@@ -71,7 +75,9 @@ INPUT:
     { "id": 1, "text": "Dr. Smith said hello." },
     { "id": 2, "text": "The margin is 10 px." },
     { "id": 3, "text": "tl;dr: it works great" },
-    { "id": 4, "text": "..." }
+    { "id": 4, "text": "The rocket is 6' tall and 4x faster." },
+    { "id": 5, "text": "The Ryzen 5900X is fast." },
+    { "id": 6, "text": "..." }
   ]
 }
 
@@ -82,7 +88,9 @@ OUTPUT:
     { "id": 1, "text": "Doctor Smith said hello." },
     { "id": 2, "text": "The margin is 10 pixels." },
     { "id": 3, "text": "TL;DR: it works great." },
-    { "id": 4, "text": "" }
+    { "id": 4, "text": "The rocket is 6 feet tall and 4 times faster." },
+    { "id": 5, "text": "The Ryzen 5900X is fast." },
+    { "id": 6, "text": "" }
   ]
 }
 


### PR DESCRIPTION
## What

Extends the narration cleanup prompt (`NARRATION_SYSTEM_PROMPT` in `src/server/services/narration.ts`) to expand number suffixes with context, per the request:

- `6'` → `6 feet`, `6"` → `6 inches` (height/length)
- `$6B` → `6 billion dollars`, `6M users` → `6 million users`
- `4x faster` → `4 times faster`

## Non-prescriptive by design

The guidance leans on the model's judgement rather than hard rules:

- Suffixes that are part of a name or whose meaning is unclear stay **literal** — e.g. AMD `5900X` (the X is read as a letter), `Model X`.
- If the model can't tell from context what a suffix means, it leaves it **unchanged** so TTS reads it literally rather than inventing a meaning.

Added a matching example pair to the prompt's INPUT/OUTPUT (`6' tall and 4x lighter` → expanded; `Ryzen 5900X` → unchanged).

## Testing

Prompt-text-only change. Existing narration tests cover the fallback and cache paths (not prompt output), so no test changes were needed. `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)