### PR TITLE
Fix Docker build: run pnpm prune with CI=true

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,9 +95,11 @@ RUN pnpm build:discord-bot
 # Build migration bundle (single optimized JS file)
 RUN pnpm build:migrate
 
-# Prune dev dependencies after build
+# Prune dev dependencies after build. CI=true lets pnpm remove/recreate the
+# modules directory without a confirmation prompt (there's no TTY in the
+# builder; without it prune fails with ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY).
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
-    pnpm prune --prod --ignore-scripts
+    CI=true pnpm prune --prod --ignore-scripts
 
 # =============================================================================
 # Stage 4: Production runner (minimal image, no pnpm needed)


### PR DESCRIPTION
## Summary

The Fly.io deploy has been failing since the Rust sanitizer landed ([failed run](https://github.com/brendanlong/lion-reader/actions/runs/29530285558/job/87728689217)):

```
#23 [builder 13/13] RUN ... pnpm prune --prod --ignore-scripts
ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY  Aborted removal of modules directory due to no TTY
If you are running pnpm in CI, set the CI environment variable to "true".
```

With `native/sanitizer` now a workspace package, `pnpm prune` in the builder stage decides it must remove and recreate `node_modules`. That's a destructive operation, so pnpm asks for confirmation — and since Docker builds have no TTY, it aborts instead. Setting `CI=true` on the prune step makes pnpm proceed non-interactively, exactly as its error message suggests.

## Testing

- No Docker available in this sandbox, so the image build itself couldn't be re-run locally — the deploy workflow on merge is the real verification. The change is scoped to the single failing `RUN` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)