### PR TITLE
Pin onnxruntime-web to CPU-only build to fix CSP eval violation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -169,6 +169,21 @@ const nextConfig: NextConfig = {
         fs: false,
         path: false,
       };
+      // Redirect onnxruntime-web (pulled in only by piper-tts-web for TTS
+      // narration) to its CPU-only `./wasm` build. The default entry loads the
+      // WebGPU/WebNN "JSEP" glue, which calls `new Function(...)` in its
+      // Emscripten/Embind init — both in the bundled `ort.bundle.min.mjs` and
+      // in the runtime-fetched `ort-wasm-simd-threaded.jsep.mjs` from
+      // public/onnx/. CSP treats `new Function` as `eval` and blocks it in prod
+      // (script-src has `wasm-unsafe-eval` but deliberately not `unsafe-eval`).
+      // Piper runs pure CPU inference and requests no `executionProviders`, so
+      // the JSEP build is dead weight whose init trips a CSP violation. The
+      // `$` limits the alias to the bare specifier so runtime wasm-file loads
+      // (served from public/onnx/) are untouched. See src/server/http/csp.ts.
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        "onnxruntime-web$": "onnxruntime-web/wasm",
+      };
     }
     // isomorphic-dompurify pulls in jsdom during SSR of `"use client"` components
     // (e.g. EntryContentBody). jsdom reads browser/default-stylesheet.css via
@@ -216,6 +231,9 @@ const nextConfig: NextConfig = {
     resolveAlias: {
       fs: { browser: "./src/lib/stubs/empty.js" },
       path: { browser: "./src/lib/stubs/empty.js" },
+      // See the webpack `onnxruntime-web$` alias above: use the CPU-only build
+      // so the JSEP glue's `new Function` (CSP eval) never loads.
+      "onnxruntime-web": { browser: "onnxruntime-web/wasm" },
     },
   },
 };

--- a/src/server/http/csp.ts
+++ b/src/server/http/csp.ts
@@ -26,7 +26,12 @@ import { embedCanonicalHostnames } from "@lion-reader/sanitizer";
  *   (Next.js chunk loading, dynamic `import()` of the ONNX runtime). `'self'`
  *   is a fallback for pre-CSP3 browsers, which ignore `'strict-dynamic'`.
  *   `'wasm-unsafe-eval'` is required to compile WebAssembly (ONNX runtime and
- *   Piper phonemizer for TTS narration). Dev additionally needs
+ *   Piper phonemizer for TTS narration) but deliberately NOT `'unsafe-eval'`:
+ *   runtime `eval`/`new Function` stays blocked. onnxruntime-web is pinned to
+ *   its CPU-only `./wasm` build (a bundler alias in `next.config.ts`) precisely
+ *   because the default WebGPU/WebNN "JSEP" build's Embind init calls
+ *   `new Function`, which would trip this policy; do not "fix" a resulting CSP
+ *   eval warning by adding `'unsafe-eval'`. Dev additionally needs
  *   `'unsafe-eval'` for React Refresh / HMR.
  * - `style-src 'unsafe-inline'`: inline styles are pervasive (React `style`
  *   props, next-themes, sonner, `NarrationHighlightStyles`, sanitized entry


### PR DESCRIPTION
## Problem

Loading the app produced a CSP violation in the browser console:

> blocked a JavaScript eval (script-src) … `script-src 'self' 'nonce-…' 'strict-dynamic' 'wasm-unsafe-eval'` (Missing 'unsafe-eval') … `decode-data-html.js:4`

The `decode-data-html.js` filename is a **source-map red herring** (that `entities` module has no eval). The real cause: **Piper TTS narration** dynamically imports `onnxruntime-web`, whose default entry loads the **WebGPU/WebNN "JSEP"** WASM glue. That glue's Emscripten/Embind init calls `new Function(...)`, which CSP treats as `eval`. The production `script-src` grants `wasm-unsafe-eval` but **deliberately not** `unsafe-eval` (#1275), so it's blocked.

Piper runs **pure CPU inference** and passes no `executionProviders`, so the JSEP build was never actually used — its init just tripped the CSP. (Narration kept working because the blocked call is on the unused WebGPU init path.)

## Fix

Redirect the bare `onnxruntime-web` specifier to its CPU-only **`./wasm`** build via webpack + Turbopack resolve aliases. That build loads the plain, eval-free `ort-wasm-simd-threaded.mjs`, so:

- the `new Function`/eval attempt **never loads** (not caught-and-fallen-back — simply gone), and
- WebGPU/WebNN kernels drop out of the client bundle (smaller download).

`onnxruntime-web` isn't imported anywhere in our own `src` (only transitively via piper-tts-web), so a package-wide redirect has no other blast radius. The plain glue + `.wasm` are already copied to `public/onnx/` by the postinstall, so `CUSTOM_WASM_PATHS` is unaffected.

Also documents the constraint in `csp.ts` so the eval warning isn't later "fixed" by adding `unsafe-eval`.

## Testing

- `pnpm typecheck` passes.
- **Functional:** enhanced (Piper) narration verified working end-to-end on a dev server (voice download + playback). OPFS requires a secure context, so this was tested over HTTPS.
- **Production build (webpack) — deterministic bundle check:** the emitted client build contains `ort.wasm.bundle.min.*.mjs` (CPU-only) with **0** `new Function` / **0** emval-codegen occurrences, emits only the plain `ort-wasm-simd-threaded.wasm` (no jsep/jspi/asyncify), and **no client chunk references the JSEP glue**. So under the strict prod CSP there is no `eval`/`new Function` left to block — the violation is eliminated at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)