### PR TITLE
Fix orphaned HTTP metrics (http_request_duration_seconds missing from Grafana)

### DIFF
--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -16,7 +16,6 @@ import next from "next";
 import { createServer } from "node:http";
 import { maybeCompressResponse } from "../src/server/http/compression";
 import { stripOauthSurfaceTrailingSlash } from "../src/server/http/trailing-slash";
-import { startMetricsServer, stopMetricsServer } from "../src/server/metrics/server";
 import {
   startMaintenancePoller,
   getCurrentMaintenance,
@@ -115,9 +114,6 @@ app.prepare().then(() => {
     });
   });
 
-  // Start internal metrics server for Prometheus scraping (port 9091)
-  startMetricsServer(9091);
-
   // Graceful shutdown: stop accepting connections, let in-flight requests
   // drain, sever long-lived connections (SSE streams never end on their own —
   // destroying their sockets aborts the requests, which unsubscribes them
@@ -141,15 +137,15 @@ app.prepare().then(() => {
     server.close(() => {
       void (async () => {
         try {
-          // Close DB pool / Redis / metrics registered by instrumentation.ts
-          // (the Next.js runtime's module graph — a separate copy from this
-          // bundle's modules in production).
+          // Close DB pool / Redis / metrics server, all registered by
+          // instrumentation.ts in the Next.js runtime module graph (a separate
+          // copy from this bundle's modules in production). The metrics server
+          // (port 9091) is started AND stopped there so it shares the registry
+          // the route handlers write to — see src/instrumentation.ts.
           const cleanup = getResourceCleanup();
           if (cleanup) {
             await cleanup();
           }
-          // Stop this bundle's metrics server copy, whichever bound the port.
-          await stopMetricsServer();
           logger.info("Graceful shutdown complete");
           process.exit(0);
         } catch (error) {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -26,10 +26,20 @@ export async function register() {
 
     const { logger } = await import("./lib/logger");
 
-    // The internal Prometheus metrics server (port 9091) is started by the
-    // custom server (scripts/server.ts), NOT here: in production this module
-    // and the custom server bundle are separate module graphs, so starting it
-    // in both places would try to bind the port twice.
+    // Start the internal Prometheus metrics server (port 9091) HERE, in the
+    // Next.js runtime module graph — NOT in the custom server (scripts/server.ts).
+    // The HTTP request metrics (http_requests_total / http_request_duration_seconds)
+    // are observed by the tRPC and REST route handlers, which run in THIS module
+    // graph. In production the custom server bundle is a separate module graph
+    // with its own copy of the metrics registry, so starting the metrics server
+    // there scraped an orphaned registry: the HTTP metrics (recorded into this
+    // graph's registry) never appeared, while business/default metrics happened
+    // to work because they're collected inside the scrape handler itself.
+    // Colocating the server with the route handlers means one registry holds
+    // everything the app process emits. The worker/discord processes are single
+    // bundles and keep starting their own metrics servers in their scripts.
+    const { startMetricsServer, stopMetricsServer } = await import("./server/metrics/server");
+    startMetricsServer(9091);
 
     // Register resource cleanup for graceful shutdown. The custom server
     // (scripts/server.ts) owns the signal handlers and the HTTP server; it
@@ -39,6 +49,10 @@ export async function register() {
     const { registerResourceCleanup } = await import("./server/shutdown");
     registerResourceCleanup(async () => {
       logger.info("Closing shared resources...");
+
+      // Stop serving metrics scrapes first — a scrape runs DB queries
+      // (collectAllMetrics), so it must stop before the pool below closes.
+      await stopMetricsServer();
 
       // Flush buffered Sentry events first (errors captured during the
       // connection drain are the ones most worth keeping). No-op without a


### PR DESCRIPTION
## Problem

`http_request_duration_seconds` (and `http_requests_total`) never show up in Grafana, even though the app has traffic and `METRICS_ENABLED=true`.

## Root cause

The **app** process runs two separate module graphs in production:

1. The **custom server bundle** (`dist/server.js`, built from `scripts/server.ts`).
2. The **Next.js runtime module graph**, where the tRPC/REST route handlers run.

Each has its own copy of `src/server/metrics/metrics.ts`, and therefore its own prom-client `registry`. The metrics HTTP server (port 9091) was started from `scripts/server.ts`, so `/metrics` served the **custom-server-bundle** registry. But the HTTP request metrics are observed by the **route handlers**, which run in the **Next runtime** and write to *that* graph's registry. The two registries never meet, so those series were recorded into an orphaned registry and never scraped.

Business/default metrics (`users_total`, `nodejs_*`, `db_pool_*`, …) happened to work because they're collected *inside* the scrape handler (`collectAllMetrics()`), which runs in the scraped registry. That's the fingerprint of the bug: on the app machine those series exist but `http_request_*` don't.

The split is documented in the code itself (`src/instrumentation.ts` and `scripts/server.ts` shutdown comments); the metrics server was simply on the wrong side of it.

## Fix

Move `startMetricsServer(9091)` into `src/instrumentation.ts` (the Next runtime), colocating the scraped registry with the route handlers so a single registry holds everything the app process emits. The server's graceful shutdown now runs via the `registerResourceCleanup` callback already registered there (stopped before the DB pool closes, since a scrape runs DB queries). `scripts/server.ts` no longer starts or stops it.

Worker and Discord are single-bundle processes and are unaffected — they keep starting their own metrics servers (ports 9092/9093) in their scripts.

## Verification

Typecheck passes. Full app run wasn't possible in the agent sandbox (no Rust toolchain to build the native sanitizer/readability modules), so this needs a post-deploy check on an app machine (`curl` isn't on the image, but `node` is):

```
fly ssh console -a lion-reader -s   # pick an "app" machine
node -e "fetch('http://localhost:9091/metrics').then(r=>r.text()).then(t=>console.log(t.split('\n').filter(l=>l.startsWith('http_request')).length))"
```

Expect a non-zero count after the fix (it was `0` before). Then the `http_request_duration_seconds` histogram should populate in Grafana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)