### PR TITLE
Ignore screen-edge swipes that are OS/browser back-forward gestures

### DIFF
--- a/src/components/entries/EntryContentHelpers.ts
+++ b/src/components/entries/EntryContentHelpers.ts
@@ -57,6 +57,22 @@ export function detectSwipeDirection(
 const EDGE_GESTURE_ZONE_PX = 32;
 
 /**
+ * Convert a touch's layout-viewport clientX into its physical distance (screen
+ * CSS px) from the left edge of the screen.
+ *
+ * The OS back-forward gesture zone is a fixed *physical* strip, but touch
+ * clientX is in *layout* px: when pinch-zoomed it's offset by the pan and one
+ * layout px spans `scale` screen px, so a layout-px edge zone would grow with
+ * zoom (40% of the screen per side at 5x). Falls back to clientX when the
+ * visualViewport API is unavailable (scale 1, no pan — the two are identical).
+ */
+export function getScreenX(clientX: number): number {
+  const vv = typeof window !== "undefined" ? window.visualViewport : null;
+  if (!vv) return clientX;
+  return (clientX - vv.offsetLeft) * vv.scale;
+}
+
+/**
  * Whether a swipe is (likely) the OS/browser back-forward navigation gesture:
  * a rightward swipe starting against the left screen edge, or a leftward swipe
  * starting against the right edge. Some browsers (notably installed PWAs)
@@ -65,18 +81,20 @@ const EDGE_GESTURE_ZONE_PX = 32;
  * opening (and auto-marking read) the adjacent article before the browser's
  * history-back lands on the list (#1260).
  *
- * Returns false when the viewport width is unknown (<= 0) so navigation is
- * never blocked outright.
+ * Both coordinates are physical screen CSS px: `startScreenX` from
+ * getScreenX(), `screenWidth` from window.innerWidth (the layout viewport
+ * width, which pinch-zoom doesn't change). Returns false when the width is
+ * unknown (<= 0) so navigation is never blocked outright.
  */
 export function isEdgeGestureSwipe(
   direction: "left" | "right",
-  startX: number,
-  viewportWidth: number
+  startScreenX: number,
+  screenWidth: number
 ): boolean {
-  if (viewportWidth <= 0) return false;
+  if (screenWidth <= 0) return false;
   return direction === "right"
-    ? startX <= EDGE_GESTURE_ZONE_PX
-    : startX >= viewportWidth - EDGE_GESTURE_ZONE_PX;
+    ? startScreenX <= EDGE_GESTURE_ZONE_PX
+    : startScreenX >= screenWidth - EDGE_GESTURE_ZONE_PX;
 }
 
 /**

--- a/src/components/entries/EntryContentHelpers.ts
+++ b/src/components/entries/EntryContentHelpers.ts
@@ -49,6 +49,37 @@ export function detectSwipeDirection(
 }
 
 /**
+ * Width (CSS px) of the strip along each screen edge reserved for the
+ * OS/browser back-forward navigation gesture (iOS edge swipe, Android gesture
+ * nav). Covers the system zones on both platforms: ~20pt on iOS, 24-32dp on
+ * Android.
+ */
+const EDGE_GESTURE_ZONE_PX = 32;
+
+/**
+ * Whether a swipe is (likely) the OS/browser back-forward navigation gesture:
+ * a rightward swipe starting against the left screen edge, or a leftward swipe
+ * starting against the right edge. Some browsers (notably installed PWAs)
+ * deliver the full touch sequence for these gestures *and* perform history
+ * navigation, so also treating them as an article swipe navigates twice —
+ * opening (and auto-marking read) the adjacent article before the browser's
+ * history-back lands on the list (#1260).
+ *
+ * Returns false when the viewport width is unknown (<= 0) so navigation is
+ * never blocked outright.
+ */
+export function isEdgeGestureSwipe(
+  direction: "left" | "right",
+  startX: number,
+  viewportWidth: number
+): boolean {
+  if (viewportWidth <= 0) return false;
+  return direction === "right"
+    ? startX <= EDGE_GESTURE_ZONE_PX
+    : startX >= viewportWidth - EDGE_GESTURE_ZONE_PX;
+}
+
+/**
  * Tolerance (CSS px) for treating the visual viewport as flush against a layout
  * viewport edge; absorbs sub-pixel rounding from pinch-zoom.
  */

--- a/src/lib/hooks/useSwipeGesture.ts
+++ b/src/lib/hooks/useSwipeGesture.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef } from "react";
 import {
   detectSwipeDirection,
   getViewportEdges,
+  isEdgeGestureSwipe,
   isSwipeNavigationAllowed,
   type ViewportEdges,
 } from "@/components/entries/EntryContentHelpers";
@@ -66,6 +67,13 @@ export function useSwipeGesture({
         y: touch.clientY,
       });
       if (!direction) return;
+
+      // A swipe that begins against a screen edge is the OS/browser
+      // back-forward gesture. The browser handles it via history navigation
+      // (some browsers deliver the touch events anyway), so also treating it
+      // as an article swipe would navigate twice — opening and auto-marking
+      // read the adjacent article before the history-back lands (#1260).
+      if (isEdgeGestureSwipe(direction, start.x, window.innerWidth)) return;
 
       // When the article is pinch-zoomed, only navigate if the swipe started
       // against the edge it moves toward; otherwise the user is panning around

--- a/src/lib/hooks/useSwipeGesture.ts
+++ b/src/lib/hooks/useSwipeGesture.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from "react";
 import {
   detectSwipeDirection,
+  getScreenX,
   getViewportEdges,
   isEdgeGestureSwipe,
   isSwipeNavigationAllowed,
@@ -19,6 +20,8 @@ export function useSwipeGesture({
   const touchStartRef = useRef<{
     x: number;
     y: number;
+    /** Physical distance from the left screen edge; see getScreenX. */
+    screenX: number;
     edges: ViewportEdges;
   } | null>(null);
   // Set once a gesture ever involves more than one finger (pinch-to-zoom, etc.).
@@ -41,6 +44,9 @@ export function useSwipeGesture({
       touchStartRef.current = {
         x: touch.clientX,
         y: touch.clientY,
+        // Captured at gesture start: a one-finger drag pans a zoomed viewport,
+        // shifting visualViewport.offsetLeft mid-gesture.
+        screenX: getScreenX(touch.clientX),
         // Capture the pan position at the start of the gesture so a swipe that
         // begins mid-pan of a zoomed article scrolls instead of navigating.
         edges: getViewportEdges(),
@@ -73,7 +79,7 @@ export function useSwipeGesture({
       // (some browsers deliver the touch events anyway), so also treating it
       // as an article swipe would navigate twice — opening and auto-marking
       // read the adjacent article before the history-back lands (#1260).
-      if (isEdgeGestureSwipe(direction, start.x, window.innerWidth)) return;
+      if (isEdgeGestureSwipe(direction, start.screenX, window.innerWidth)) return;
 
       // When the article is pinch-zoomed, only navigate if the swipe started
       // against the edge it moves toward; otherwise the user is panning around

--- a/tests/unit/frontend/components/entry-swipe-navigation.test.ts
+++ b/tests/unit/frontend/components/entry-swipe-navigation.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   detectSwipeDirection,
+  getScreenX,
   getViewportEdges,
   isEdgeGestureSwipe,
   isSwipeNavigationAllowed,
@@ -54,6 +55,47 @@ describe("isEdgeGestureSwipe", () => {
   it("never blocks when the viewport width is unknown", () => {
     expect(isEdgeGestureSwipe("right", 0, 0)).toBe(false);
     expect(isEdgeGestureSwipe("left", 0, 0)).toBe(false);
+  });
+});
+
+describe("getScreenX", () => {
+  const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
+
+  function setVisualViewport(vv: Partial<VisualViewport> | null) {
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: vv,
+    });
+  }
+
+  afterEach(() => {
+    if (originalVisualViewport) {
+      Object.defineProperty(window, "visualViewport", originalVisualViewport);
+    }
+  });
+
+  it("returns clientX unchanged when the visualViewport API is unavailable", () => {
+    setVisualViewport(null);
+    expect(getScreenX(100)).toBe(100);
+  });
+
+  it("returns clientX unchanged when not zoomed", () => {
+    setVisualViewport({ offsetLeft: 0, scale: 1 });
+    expect(getScreenX(100)).toBe(100);
+  });
+
+  it("magnifies layout distance by the zoom scale when panned to the left edge", () => {
+    // Zoomed 2x, panned fully left: 10 layout px from the edge spans 20
+    // physical px on screen.
+    setVisualViewport({ offsetLeft: 0, scale: 2 });
+    expect(getScreenX(10)).toBe(20);
+  });
+
+  it("subtracts the pan offset when zoomed and panned into the page", () => {
+    // Zoomed 2x, panned to layout x=100: a touch at clientX=110 is 10 layout
+    // px into the visual viewport = 20 physical px from the screen edge.
+    setVisualViewport({ offsetLeft: 100, scale: 2 });
+    expect(getScreenX(110)).toBe(20);
   });
 });
 

--- a/tests/unit/frontend/components/entry-swipe-navigation.test.ts
+++ b/tests/unit/frontend/components/entry-swipe-navigation.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   detectSwipeDirection,
   getViewportEdges,
+  isEdgeGestureSwipe,
   isSwipeNavigationAllowed,
   type ViewportEdges,
 } from "@/components/entries/EntryContentHelpers";
@@ -22,6 +23,37 @@ describe("detectSwipeDirection", () => {
 
   it("ignores mostly-vertical movement (scrolling)", () => {
     expect(detectSwipeDirection({ x: 100, y: 0 }, { x: 160, y: 100 })).toBeNull();
+  });
+});
+
+describe("isEdgeGestureSwipe", () => {
+  const WIDTH = 400;
+
+  it("flags a rightward swipe starting against the left screen edge (browser back gesture)", () => {
+    expect(isEdgeGestureSwipe("right", 0, WIDTH)).toBe(true);
+    expect(isEdgeGestureSwipe("right", 32, WIDTH)).toBe(true);
+  });
+
+  it("flags a leftward swipe starting against the right screen edge (browser forward gesture)", () => {
+    expect(isEdgeGestureSwipe("left", WIDTH, WIDTH)).toBe(true);
+    expect(isEdgeGestureSwipe("left", WIDTH - 32, WIDTH)).toBe(true);
+  });
+
+  it("allows swipes starting away from the screen edges", () => {
+    expect(isEdgeGestureSwipe("right", 33, WIDTH)).toBe(false);
+    expect(isEdgeGestureSwipe("left", WIDTH - 33, WIDTH)).toBe(false);
+  });
+
+  it("allows a swipe moving away from the edge it started against", () => {
+    // Leftward swipe from the left edge / rightward from the right edge are
+    // not system gestures.
+    expect(isEdgeGestureSwipe("left", 10, WIDTH)).toBe(false);
+    expect(isEdgeGestureSwipe("right", WIDTH - 10, WIDTH)).toBe(false);
+  });
+
+  it("never blocks when the viewport width is unknown", () => {
+    expect(isEdgeGestureSwipe("right", 0, 0)).toBe(false);
+    expect(isEdgeGestureSwipe("left", 0, 0)).toBe(false);
   });
 });
 

--- a/tests/unit/frontend/hooks/useSwipeGesture.test.ts
+++ b/tests/unit/frontend/hooks/useSwipeGesture.test.ts
@@ -96,6 +96,28 @@ describe("useSwipeGesture", () => {
     expect(onSwipeLeft).toHaveBeenCalledOnce();
   });
 
+  it("ignores a rightward swipe starting at the left screen edge (browser back gesture)", () => {
+    const { onSwipeRight, handlers } = setup();
+    // jsdom's window.innerWidth defaults to 1024; x=10 is inside the edge zone.
+    handlers.onTouchStart(touchEvent([{ clientX: 10, clientY: 0 }]));
+    handlers.onTouchEnd(touchEvent([], [{ clientX: 150, clientY: 0 }]));
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it("ignores a leftward swipe starting at the right screen edge (browser forward gesture)", () => {
+    const { onSwipeLeft, handlers } = setup();
+    handlers.onTouchStart(touchEvent([{ clientX: window.innerWidth - 10, clientY: 0 }]));
+    handlers.onTouchEnd(touchEvent([], [{ clientX: window.innerWidth - 150, clientY: 0 }]));
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it("fires onSwipeRight for a rightward swipe starting away from the edge", () => {
+    const { onSwipeRight, handlers } = setup();
+    handlers.onTouchStart(touchEvent([{ clientX: RIGHT, clientY: 0 }]));
+    handlers.onTouchEnd(touchEvent([], [{ clientX: LEFT, clientY: 0 }]));
+    expect(onSwipeRight).toHaveBeenCalledOnce();
+  });
+
   it("keeps the flag set on touchcancel while a finger remains down", () => {
     const { onSwipeLeft, handlers } = setup();
     handlers.onTouchStart(touchEvent([{ clientX: LEFT, clientY: 0 }]));

--- a/tests/unit/frontend/hooks/useSwipeGesture.test.ts
+++ b/tests/unit/frontend/hooks/useSwipeGesture.test.ts
@@ -111,26 +111,48 @@ describe("useSwipeGesture", () => {
     expect(onSwipeLeft).not.toHaveBeenCalled();
   });
 
-  it("blocks an edge-zone swipe even when zoom edge-gating would allow it", () => {
-    // Zoomed 2x and panned fully left: isSwipeNavigationAllowed("right") is
-    // true, but a rightward swipe starting inside the 32px screen-edge strip
-    // is still treated as the OS back gesture and dropped — the edge-zone
-    // check deliberately takes precedence (#1260).
+  // The edge-gesture zone is physical: 32 *screen* px, however far that is in
+  // layout px under pinch-zoom. Both tests zoom 2x panned fully left, where
+  // zoom edge-gating (isSwipeNavigationAllowed) permits a rightward swipe.
+  function setupZoomed2xAtLeftEdge() {
     Object.defineProperty(document.documentElement, "clientWidth", {
       configurable: true,
       value: 400,
     });
     Object.defineProperty(window, "visualViewport", {
       configurable: true,
-      value: { offsetLeft: 0, width: 200 },
+      value: { offsetLeft: 0, width: 200, scale: 2 },
     });
+    return () => {
+      delete (document.documentElement as unknown as { clientWidth?: number }).clientWidth;
+    };
+  }
+
+  it("blocks a zoomed swipe starting inside the physical edge zone (OS back gesture)", () => {
+    const restore = setupZoomed2xAtLeftEdge();
     try {
       const { onSwipeRight, handlers } = setup();
+      // clientX=10 is 20 physical px from the screen edge — inside the zone.
       handlers.onTouchStart(touchEvent([{ clientX: 10, clientY: 0 }]));
       handlers.onTouchEnd(touchEvent([], [{ clientX: 150, clientY: 0 }]));
       expect(onSwipeRight).not.toHaveBeenCalled();
     } finally {
-      delete (document.documentElement as unknown as { clientWidth?: number }).clientWidth;
+      restore();
+    }
+  });
+
+  it("allows a zoomed swipe outside the physical zone even within 32 layout px", () => {
+    const restore = setupZoomed2xAtLeftEdge();
+    try {
+      const { onSwipeRight, handlers } = setup();
+      // clientX=20 is only 20 layout px from the edge, but 40 physical px —
+      // outside the OS gesture zone, so this legitimate zoomed "previous
+      // article" swipe must not be blocked.
+      handlers.onTouchStart(touchEvent([{ clientX: 20, clientY: 0 }]));
+      handlers.onTouchEnd(touchEvent([], [{ clientX: 150, clientY: 0 }]));
+      expect(onSwipeRight).toHaveBeenCalledOnce();
+    } finally {
+      restore();
     }
   });
 

--- a/tests/unit/frontend/hooks/useSwipeGesture.test.ts
+++ b/tests/unit/frontend/hooks/useSwipeGesture.test.ts
@@ -111,6 +111,29 @@ describe("useSwipeGesture", () => {
     expect(onSwipeLeft).not.toHaveBeenCalled();
   });
 
+  it("blocks an edge-zone swipe even when zoom edge-gating would allow it", () => {
+    // Zoomed 2x and panned fully left: isSwipeNavigationAllowed("right") is
+    // true, but a rightward swipe starting inside the 32px screen-edge strip
+    // is still treated as the OS back gesture and dropped — the edge-zone
+    // check deliberately takes precedence (#1260).
+    Object.defineProperty(document.documentElement, "clientWidth", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: { offsetLeft: 0, width: 200 },
+    });
+    try {
+      const { onSwipeRight, handlers } = setup();
+      handlers.onTouchStart(touchEvent([{ clientX: 10, clientY: 0 }]));
+      handlers.onTouchEnd(touchEvent([], [{ clientX: 150, clientY: 0 }]));
+      expect(onSwipeRight).not.toHaveBeenCalled();
+    } finally {
+      delete (document.documentElement as unknown as { clientWidth?: number }).clientWidth;
+    }
+  });
+
   it("fires onSwipeRight for a rightward swipe starting away from the edge", () => {
     const { onSwipeRight, handlers } = setup();
     handlers.onTouchStart(touchEvent([{ clientX: RIGHT, clientY: 0 }]));


### PR DESCRIPTION
Fixes #1260 (follow-up to #1261, whose `overscroll-behavior-x: none` change didn't resolve the report — pointing at an OS-level edge gesture rather than Chrome's overscroll navigation, which CSS can't disable).

## Problem

Swiping back from an article to the list marks the article *above* it as read, while the back-arrow button works correctly.

In the article view, a rightward swipe maps to "open the previous article". OS edge-swipe back gestures (iOS Safari/PWA edge swipe, Android gesture nav) can deliver the full touch sequence to the page *and* perform history navigation, so a swipe-back does two things at once:

1. Our swipe handler opens the previous article (`clientReplace` to `?entry=<prev>`), whose mount effect auto-marks it read.
2. The system's history-back then completes, landing on the list.

Net effect: the user ends up on the list with the article above wrongly marked read.

## Fix

`useSwipeGesture` now ignores swipes whose start point lies in the 32px strip along the screen edge matching the swipe direction — a rightward swipe from the left edge (system back gesture) or a leftward swipe from the right edge (system forward gesture). 32px covers the system gesture zones on both platforms (~20pt on iOS, 24–32dp on Android). Swipes starting anywhere else are unaffected, as are swipes moving *away* from the edge they started on.

The zone is measured in **physical screen px** (`getScreenX` converts touch clientX via `visualViewport` pan offset and zoom scale), since the OS gesture zone is a fixed physical strip. A naive layout-px check would be magnified by pinch-zoom (40% of the screen per side at 5x zoom), blocking legitimate zoomed article swipes; with the conversion the zone stays a constant 32 screen px at any zoom level.

The check lives in pure helpers (`getScreenX` / `isEdgeGestureSwipe` in `EntryContentHelpers.ts`) with unit tests, plus hook-level tests in `useSwipeGesture.test.ts` covering both edges, the zoom interaction (blocked inside the physical zone, allowed outside it even within 32 layout px), and the multi-touch lifecycle.

If reports persist after this ships, the likely cause is an OEM-widened Android gesture zone (>32px); next steps would be widening the strip or making prev/next swipes a setting.

## Testing

- `pnpm typecheck` clean
- `pnpm test:unit` — 2454 passed, 4 skipped (rebased on current master incl. the native Rust modules)
- An Opus-level review of this same diff earlier found no blocking defects; its suggestion (a test pinning the zoom-interaction behavior) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)