### PR TITLE
Add duration metrics for feed parsing, readability, and sanitization (#1293)

### DIFF
--- a/src/server/feed/content-cleaner.ts
+++ b/src/server/feed/content-cleaner.ts
@@ -13,6 +13,7 @@ import type { ExtractedArticle, ExtractOptions } from "@lion-reader/readability"
 import { HTMLRewriter } from "html-rewriter-wasm";
 import { logger } from "@/lib/logger";
 import { sanitizeEntryHtmlAsync } from "@/server/html/sanitize";
+import { startReadabilityTimer } from "@/server/metrics/metrics";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -328,7 +329,14 @@ export function cleanContent(
   if (!passesMinContentLength(html, options)) return null;
 
   try {
-    return finishCleaned(extractArticle(html, EXTRACT_OPTIONS), html, options);
+    const stopTimer = startReadabilityTimer();
+    let article: ExtractedArticle | null;
+    try {
+      article = extractArticle(html, EXTRACT_OPTIONS);
+    } finally {
+      stopTimer();
+    }
+    return finishCleaned(article, html, options);
   } catch (error) {
     // Log the error but don't throw - return null to indicate failure
     logger.warn("Readability parsing error", {
@@ -356,12 +364,20 @@ export async function cleanContentAsync(
   options: CleanContentOptions = {}
 ): Promise<CleanedContent | null> {
   if (!passesMinContentLength(html, options)) return null;
+  // Small inputs run through the sync path, which records its own timing.
   if (html.length <= CLEAN_INLINE_MAX_CHARS) {
     return cleanContent(html, options);
   }
 
   try {
-    return finishCleaned(await extractArticleAsync(html, EXTRACT_OPTIONS), html, options);
+    const stopTimer = startReadabilityTimer();
+    let article: ExtractedArticle | null;
+    try {
+      article = await extractArticleAsync(html, EXTRACT_OPTIONS);
+    } finally {
+      stopTimer();
+    }
+    return finishCleaned(article, html, options);
   } catch (error) {
     logger.warn("Readability parsing error", {
       url: options.url,

--- a/src/server/feed/parser.ts
+++ b/src/server/feed/parser.ts
@@ -15,6 +15,7 @@ import {
   UnknownFeedFormatError,
 } from "./streaming/parser";
 import { usageLimitsConfig } from "../config/env";
+import { startFeedParseTimer } from "../metrics/metrics";
 
 // Re-export for backwards compatibility
 export { UnknownFeedFormatError };
@@ -58,8 +59,13 @@ export function detectFeedType(content: string): "rss" | "atom" | "json" | "unkn
  * @throws Error if the feed is invalid (missing required elements)
  */
 export function parseFeed(content: string): ParsedFeed {
-  const result = parseFeedInternal(content);
-  return resultToParsedFeed(result);
+  const stopTimer = startFeedParseTimer();
+  try {
+    const result = parseFeedInternal(content);
+    return resultToParsedFeed(result);
+  } finally {
+    stopTimer();
+  }
 }
 
 /**
@@ -77,8 +83,13 @@ export function parseFeed(content: string): ParsedFeed {
  * @throws Error if the feed is invalid (missing required elements)
  */
 export async function parseFeedAsync(content: string): Promise<ParsedFeed> {
-  const result = await parseFeedAsyncInternal(content);
-  return resultToParsedFeed(result);
+  const stopTimer = startFeedParseTimer();
+  try {
+    const result = await parseFeedAsyncInternal(content);
+    return resultToParsedFeed(result);
+  } finally {
+    stopTimer();
+  }
 }
 
 /**
@@ -91,6 +102,11 @@ export async function parseFeedAsync(content: string): Promise<ParsedFeed> {
  * @throws Error if the feed is invalid
  */
 export function parseFeedWithFormat(content: string, format: "rss" | "atom" | "json"): ParsedFeed {
-  const result = parseFeedWithFormatInternal(content, format);
-  return resultToParsedFeed(result);
+  const stopTimer = startFeedParseTimer();
+  try {
+    const result = parseFeedWithFormatInternal(content, format);
+    return resultToParsedFeed(result);
+  } finally {
+    stopTimer();
+  }
 }

--- a/src/server/html/sanitize.ts
+++ b/src/server/html/sanitize.ts
@@ -33,6 +33,7 @@ import {
 } from "@lion-reader/sanitizer";
 
 import { logger } from "@/lib/logger";
+import { startSanitizeTimer } from "@/server/metrics/metrics";
 
 /**
  * Version of the sanitization rules, re-exported from the native module —
@@ -67,9 +68,14 @@ function logWarnings(warnings: string[]): void {
  */
 export function sanitizeEntryHtml(html: string | null | undefined): string | null {
   if (!html) return null;
-  const result = nativeSanitizeEntryHtml(html);
-  logWarnings(result.warnings);
-  return result.html;
+  const stopTimer = startSanitizeTimer();
+  try {
+    const result = nativeSanitizeEntryHtml(html);
+    logWarnings(result.warnings);
+    return result.html;
+  } finally {
+    stopTimer();
+  }
 }
 
 /**
@@ -96,10 +102,16 @@ export async function sanitizeEntryHtmlAsync(
   html: string | null | undefined
 ): Promise<string | null> {
   if (!html) return null;
+  // Small bodies run through the sync path, which records its own timing.
   if (html.length <= SANITIZE_INLINE_MAX_CHARS) {
     return sanitizeEntryHtml(html);
   }
-  const result = await nativeSanitizeEntryHtmlAsync(html);
-  logWarnings(result.warnings);
-  return result.html;
+  const stopTimer = startSanitizeTimer();
+  try {
+    const result = await nativeSanitizeEntryHtmlAsync(html);
+    logWarnings(result.warnings);
+    return result.html;
+  } finally {
+    stopTimer();
+  }
 }

--- a/src/server/metrics/metrics.ts
+++ b/src/server/metrics/metrics.ts
@@ -199,6 +199,103 @@ export function startFeedFetchTimer(): (status: FeedFetchStatus) => void {
 }
 
 // ============================================================================
+// Content Processing Metrics
+// ============================================================================
+
+/**
+ * Buckets for the content-processing steps (feed parsing, readability
+ * extraction, HTML sanitization). These run an order of magnitude faster than
+ * a feed fetch — sanitization is ~1ms/100KB — so the buckets start well below
+ * a millisecond and stretch to a few seconds to catch pathologically large
+ * bodies, giving useful p50/p90/p99 resolution across the fast common case.
+ */
+const CONTENT_PROCESSING_BUCKETS = [
+  0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
+];
+
+/**
+ * Histogram for feed parsing (RSS/Atom/JSON) duration in seconds.
+ * Measures only the parse step, not the surrounding fetch or processing.
+ */
+const feedParseDurationSeconds = metricsEnabled
+  ? new Histogram({
+      name: "feed_parse_duration_seconds",
+      help: "Feed parsing (RSS/Atom/JSON) duration in seconds",
+      buckets: CONTENT_PROCESSING_BUCKETS,
+      registers: [registry],
+    })
+  : null;
+
+/**
+ * Histogram for readability (article extraction) duration in seconds.
+ * Measures only the native extraction step.
+ */
+const readabilityDurationSeconds = metricsEnabled
+  ? new Histogram({
+      name: "readability_duration_seconds",
+      help: "Readability article extraction duration in seconds",
+      buckets: CONTENT_PROCESSING_BUCKETS,
+      registers: [registry],
+    })
+  : null;
+
+/**
+ * Histogram for HTML sanitization duration in seconds.
+ * Measures only the native sanitizer pass.
+ */
+const sanitizeDurationSeconds = metricsEnabled
+  ? new Histogram({
+      name: "sanitize_duration_seconds",
+      help: "HTML sanitization duration in seconds",
+      buckets: CONTENT_PROCESSING_BUCKETS,
+      registers: [registry],
+    })
+  : null;
+
+/**
+ * Creates a timer for tracking feed parse duration.
+ * Returns a function to call when parsing completes.
+ * Returns a no-op function when metrics are disabled.
+ */
+export function startFeedParseTimer(): () => void {
+  return startContentProcessingTimer(feedParseDurationSeconds);
+}
+
+/**
+ * Creates a timer for tracking readability extraction duration.
+ * Returns a function to call when extraction completes.
+ * Returns a no-op function when metrics are disabled.
+ */
+export function startReadabilityTimer(): () => void {
+  return startContentProcessingTimer(readabilityDurationSeconds);
+}
+
+/**
+ * Creates a timer for tracking HTML sanitization duration.
+ * Returns a function to call when sanitization completes.
+ * Returns a no-op function when metrics are disabled.
+ */
+export function startSanitizeTimer(): () => void {
+  return startContentProcessingTimer(sanitizeDurationSeconds);
+}
+
+/**
+ * Shared implementation for the content-processing timers. Returns a no-op
+ * when metrics are disabled so callers have zero overhead.
+ */
+function startContentProcessingTimer(histogram: Histogram | null): () => void {
+  if (!metricsEnabled || !histogram) {
+    return () => {};
+  }
+
+  const startTime = performance.now();
+
+  return () => {
+    histogram.observe((performance.now() - startTime) / 1000);
+  };
+}
+
+// ============================================================================
 // Job Processing Metrics
 // ============================================================================
 

--- a/tests/unit/metrics-content-processing.test.ts
+++ b/tests/unit/metrics-content-processing.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for the content-processing duration metrics (feed parsing,
+ * readability extraction, HTML sanitization).
+ *
+ * `metricsEnabled` is read from the environment at module load, so we set
+ * METRICS_ENABLED before dynamically importing the metrics module.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+
+let metrics: typeof import("@/server/metrics/metrics");
+
+beforeAll(async () => {
+  process.env.METRICS_ENABLED = "true";
+  metrics = await import("@/server/metrics/metrics");
+});
+
+async function exportedMetrics(): Promise<string> {
+  return metrics.registry.metrics();
+}
+
+describe("content-processing duration metrics", () => {
+  it("records feed parse duration when the timer completes", async () => {
+    const stop = metrics.startFeedParseTimer();
+    stop();
+
+    const output = await exportedMetrics();
+    expect(output).toContain("feed_parse_duration_seconds_bucket");
+    expect(output).toMatch(/feed_parse_duration_seconds_count \d+/);
+  });
+
+  it("records readability duration when the timer completes", async () => {
+    const stop = metrics.startReadabilityTimer();
+    stop();
+
+    const output = await exportedMetrics();
+    expect(output).toContain("readability_duration_seconds_bucket");
+    expect(output).toMatch(/readability_duration_seconds_count \d+/);
+  });
+
+  it("records sanitize duration when the timer completes", async () => {
+    const stop = metrics.startSanitizeTimer();
+    stop();
+
+    const output = await exportedMetrics();
+    expect(output).toContain("sanitize_duration_seconds_bucket");
+    expect(output).toMatch(/sanitize_duration_seconds_count \d+/);
+  });
+
+  it("uses the same buckets across all three histograms", async () => {
+    metrics.startFeedParseTimer()();
+
+    const output = await exportedMetrics();
+    // A representative bucket from CONTENT_PROCESSING_BUCKETS should be present.
+    expect(output).toContain('feed_parse_duration_seconds_bucket{le="0.001"}');
+    expect(output).toContain('readability_duration_seconds_bucket{le="0.001"}');
+    expect(output).toContain('sanitize_duration_seconds_bucket{le="0.001"}');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1293. Adds three Prometheus histograms so we can compare p50/p90/p99 for the content-processing steps, bucketed like `feed_fetch_duration_seconds`:

- `feed_parse_duration_seconds` — RSS/Atom/JSON parsing
- `readability_duration_seconds` — native article extraction
- `sanitize_duration_seconds` — native HTML sanitization

## Implementation

Each metric is observed at its single chokepoint:

- **Feed parsing** — the `parseFeed` / `parseFeedAsync` / `parseFeedWithFormat` wrappers in `src/server/feed/parser.ts` (the only public entry points; nothing calls the streaming parsers directly).
- **Readability** — around the `extractArticle` / `extractArticleAsync` native calls in `content-cleaner.ts`, so the timing reflects just the extraction step, not URL absolutization.
- **Sanitization** — around the native calls in `sanitize.ts`.

The async paths delegate small bodies to the sync path (which records its own timing), so there is **no double counting**.

Buckets (`CONTENT_PROCESSING_BUCKETS`) start below a millisecond and stretch to a few seconds, since these steps run an order of magnitude faster than a feed fetch (sanitization is ~1ms/100KB). Timers are zero-overhead no-ops when `METRICS_ENABLED` is off, matching the existing metric helpers.

## Testing

- New unit test `tests/unit/metrics-content-processing.test.ts` verifies each timer records an observation in the registry and that all three share the same buckets.
- `pnpm typecheck`, `pnpm test:unit`, and eslint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)