### PR TITLE
Hotfix: guard feed/readability/sanitize metrics to stop crash loop

### DIFF
--- a/src/server/metrics/metrics.ts
+++ b/src/server/metrics/metrics.ts
@@ -262,40 +262,31 @@ const CONTENT_PROCESSING_BUCKETS = [
  * Histogram for feed parsing (RSS/Atom/JSON) duration in seconds.
  * Measures only the parse step, not the surrounding fetch or processing.
  */
-const feedParseDurationSeconds = metricsEnabled
-  ? new Histogram({
-      name: "feed_parse_duration_seconds",
-      help: "Feed parsing (RSS/Atom/JSON) duration in seconds",
-      buckets: CONTENT_PROCESSING_BUCKETS,
-      registers: [registry],
-    })
-  : null;
+const feedParseDurationSeconds = getOrCreateHistogram({
+  name: "feed_parse_duration_seconds",
+  help: "Feed parsing (RSS/Atom/JSON) duration in seconds",
+  buckets: CONTENT_PROCESSING_BUCKETS,
+});
 
 /**
  * Histogram for readability (article extraction) duration in seconds.
  * Measures only the native extraction step.
  */
-const readabilityDurationSeconds = metricsEnabled
-  ? new Histogram({
-      name: "readability_duration_seconds",
-      help: "Readability article extraction duration in seconds",
-      buckets: CONTENT_PROCESSING_BUCKETS,
-      registers: [registry],
-    })
-  : null;
+const readabilityDurationSeconds = getOrCreateHistogram({
+  name: "readability_duration_seconds",
+  help: "Readability article extraction duration in seconds",
+  buckets: CONTENT_PROCESSING_BUCKETS,
+});
 
 /**
  * Histogram for HTML sanitization duration in seconds.
  * Measures only the native sanitizer pass.
  */
-const sanitizeDurationSeconds = metricsEnabled
-  ? new Histogram({
-      name: "sanitize_duration_seconds",
-      help: "HTML sanitization duration in seconds",
-      buckets: CONTENT_PROCESSING_BUCKETS,
-      registers: [registry],
-    })
-  : null;
+const sanitizeDurationSeconds = getOrCreateHistogram({
+  name: "sanitize_duration_seconds",
+  help: "HTML sanitization duration in seconds",
+  buckets: CONTENT_PROCESSING_BUCKETS,
+});
 
 /**
  * Creates a timer for tracking feed parse duration.


### PR DESCRIPTION
## 🔴 Active production outage — site-wide 500s

The app is crash-looping in production:

```
⨯ unhandledRejection: Error: A metric with the name feed_parse_duration_seconds has already been registered.
... reboot: Restarting system
```

## Cause: interaction between two concurrently-merged PRs

- **#1296** made the metrics registry a `globalThis` singleton shared across the app process's multiple module graphs, and converted `metrics.ts`'s definitions to idempotent `getOrCreate*` helpers so a second module-graph evaluation **reuses** the existing metric objects instead of re-registering.
- **#1293** ("Add duration metrics for feed parsing, readability, and sanitization") merged concurrently and added `feed_parse_duration_seconds`, `readability_duration_seconds`, and `sanitize_duration_seconds` using the **old** `metricsEnabled ? new Histogram({ registers: [registry] }) : null` pattern.

#1296 branched *before* #1293, so those three histograms were never converted. On the now-shared registry, the second module graph re-registering them throws → unhandledRejection → the app process crashes → Fly reboots it → site-wide 500s.

Neither PR is wrong in isolation; the merge order created an unguarded registration against a shared registry.

## Fix

Convert the three histograms to `getOrCreateHistogram` so their registration is idempotent like every other metric in the file.

## Verification

Reproduced the exact failure in-process (two module-graph evaluations sharing the registry) and confirmed the fix:

```
second eval did NOT throw on duplicate registration: OK
same registry: true
feed_parse_duration_seconds present: true
http_requests_total present: true
RESULT: PASS — no double-registration crash, metrics converge
```

(Before this change, the second eval threw the exact production error.)

**Merge and deploy ASAP to restore service.** `pnpm typecheck` is clean for `metrics.ts`; the only local tsc errors are the unrelated `@lion-reader/feed-parser` native module not being built in the review sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)