### PR TITLE
Add safeguards against metrics double-registration regressions

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -57,6 +57,16 @@ export default defineConfig({
       // from .env.test via inherited process env, which Next.js never
       // overrides).
       NODE_ENV: useProductionBuild ? "production" : "development",
+      // Exercise the Prometheus metric registration paths in the production
+      // build, where metrics.ts is split across multiple module graphs and a
+      // metric registered outside the idempotent getOrCreate* helpers crashes
+      // the app on the second module-graph evaluation (this is what took the
+      // site down when #1293 and #1296 landed together). With metrics disabled
+      // the whole registration path is skipped and such a regression sails
+      // through CI. Only in the production build: the dev server shares one
+      // module graph (so the crash can't occur) and would just contend for the
+      // metrics server's port 9091.
+      ...(useProductionBuild ? { METRICS_ENABLED: "true" } : {}),
     },
   },
 });

--- a/src/server/metrics/server.ts
+++ b/src/server/metrics/server.ts
@@ -91,6 +91,17 @@ export function startMetricsServer(port = 9091): Server | null {
     }
   });
 
+  // Without an 'error' listener a bind failure (e.g. EADDRINUSE) emits an
+  // unhandled 'error' event that crashes the whole process. The metrics server
+  // is non-essential — losing scrapes must never take down the app (or an e2e
+  // run) — so log and carry on instead.
+  server.on("error", (error) => {
+    logger.error("Internal metrics server error", {
+      port,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+
   server.listen(port, () => {
     logger.info("Internal metrics server started", { port });
   });

--- a/tests/unit/metrics-registration.test.ts
+++ b/tests/unit/metrics-registration.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression tests for the metrics-registry double-registration crash.
+ *
+ * In production the Next.js app process evaluates `src/server/metrics/metrics.ts`
+ * in MULTIPLE separate module graphs (custom-server bundle, instrumentation
+ * hook, and route-handler chunks). The registry is anchored on `globalThis` so
+ * all graphs converge on one object, and every metric is created via an
+ * idempotent `getOrCreate*` helper so a second module-graph evaluation REUSES
+ * the existing metric instead of re-registering it.
+ *
+ * If a metric is instead created with a raw `new Counter/Histogram/Gauge({
+ * registers: [registry] })` (as #1293 did — which, combined with the shared
+ * registry from #1296, crashed the whole app and took the site down), the second
+ * evaluation throws "A metric with the name X has already been registered".
+ *
+ * These two tests make that failure show up in CI instead of production:
+ * - the behavioral test reproduces the second module-graph evaluation, and
+ * - the source guard forbids the raw-constructor pattern outright (the crash
+ *   cause is non-obvious, so we stop it at the point of writing).
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect, beforeAll, vi } from "vitest";
+
+describe("metrics registry survives repeated module evaluation", () => {
+  beforeAll(() => {
+    // `metricsEnabled` is read at module load; the registration path (and thus
+    // the crash) is dead unless metrics are enabled.
+    process.env.METRICS_ENABLED = "true";
+  });
+
+  it("re-evaluating the metrics module does not throw on duplicate registration", async () => {
+    // First evaluation creates the shared (globalThis) registry and registers
+    // every metric on it.
+    const first = await import("@/server/metrics/metrics");
+
+    // Reset only vitest's module cache. The globalThis registry persists — which
+    // is exactly the production condition: a new module graph in the same
+    // process, sharing one registry via `Symbol.for`.
+    vi.resetModules();
+
+    // Second evaluation must reuse the existing metric objects. If any metric is
+    // registered outside the idempotent helpers, this import rejects with
+    // "A metric with the name X has already been registered".
+    const second = await import("@/server/metrics/metrics");
+
+    // Both evaluations resolve to the same underlying registry (globalThis
+    // singleton), and it still scrapes cleanly.
+    expect(second.registry).toBe(first.registry);
+    await expect(second.registry.metrics()).resolves.toContain("http_requests_total");
+  });
+});
+
+describe("metrics module constructs metrics only through the idempotent helpers", () => {
+  it("has no raw new Counter/Histogram/Gauge outside getOrCreate*", () => {
+    const source = readFileSync(
+      fileURLToPath(new URL("../../src/server/metrics/metrics.ts", import.meta.url)),
+      "utf8"
+    );
+
+    // The only legitimate constructions are inside the three getOrCreate*
+    // helpers, written as `new Counter<T>(...)` / `new Histogram<T>(...)` /
+    // `new Gauge<T>(...)`. Any `new Counter/Histogram/Gauge` NOT immediately
+    // followed by `<T>` is a raw registration that reintroduces the crash — use
+    // getOrCreateCounter / getOrCreateHistogram / getOrCreateGauge instead.
+    const rawConstructions = [...source.matchAll(/new\s+(Counter|Histogram|Gauge)\b(?!<T>)/g)].map(
+      (match) => match[0]
+    );
+
+    expect(
+      rawConstructions,
+      "Register metrics via getOrCreate<Counter|Histogram|Gauge>, not a raw prom-client constructor — " +
+        "a raw `new X({ registers: [registry] })` crashes the app on the second module-graph evaluation"
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/metrics-registration.test.ts
+++ b/tests/unit/metrics-registration.test.ts
@@ -20,13 +20,30 @@
  */
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { describe, it, expect, beforeAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+
+// Same key metrics.ts anchors the shared registry on (see getSharedRegistry).
+const REGISTRY_SYMBOL = Symbol.for("lion-reader.metrics.registry");
 
 describe("metrics registry survives repeated module evaluation", () => {
+  let prevMetricsEnabled: string | undefined;
+
   beforeAll(() => {
     // `metricsEnabled` is read at module load; the registration path (and thus
     // the crash) is dead unless metrics are enabled.
+    prevMetricsEnabled = process.env.METRICS_ENABLED;
     process.env.METRICS_ENABLED = "true";
+    // Start from a clean shared registry so this file reproduces a fresh process
+    // rather than inheriting one another test file left on globalThis (vitest
+    // isolates module caches per file but not globalThis within a worker).
+    Reflect.deleteProperty(globalThis, REGISTRY_SYMBOL);
+    vi.resetModules();
+  });
+
+  afterAll(() => {
+    // Don't leak the env mutation into other files sharing this worker.
+    if (prevMetricsEnabled === undefined) delete process.env.METRICS_ENABLED;
+    else process.env.METRICS_ENABLED = prevMetricsEnabled;
   });
 
   it("re-evaluating the metrics module does not throw on duplicate registration", async () => {
@@ -45,9 +62,18 @@ describe("metrics registry survives repeated module evaluation", () => {
     const second = await import("@/server/metrics/metrics");
 
     // Both evaluations resolve to the same underlying registry (globalThis
-    // singleton), and it still scrapes cleanly.
+    // singleton) and the same metric objects...
     expect(second.registry).toBe(first.registry);
-    await expect(second.registry.metrics()).resolves.toContain("http_requests_total");
+    expect(second.registry.getSingleMetric("http_requests_total")).toBe(
+      first.registry.getSingleMetric("http_requests_total")
+    );
+
+    // ...so an observation made through the RE-IMPORTED module lands on the
+    // registry the first import scrapes. This is the exact symptom that
+    // regressed: route handlers (a second module graph) mutating a different
+    // registry than the scrape reads.
+    second.startHttpTimer("GET", "/regression-probe")(200);
+    await expect(first.registry.metrics()).resolves.toContain('path="/regression-probe"');
   });
 });
 
@@ -63,9 +89,13 @@ describe("metrics module constructs metrics only through the idempotent helpers"
     // `new Gauge<T>(...)`. Any `new Counter/Histogram/Gauge` NOT immediately
     // followed by `<T>` is a raw registration that reintroduces the crash — use
     // getOrCreateCounter / getOrCreateHistogram / getOrCreateGauge instead.
-    const rawConstructions = [...source.matchAll(/new\s+(Counter|Histogram|Gauge)\b(?!<T>)/g)].map(
-      (match) => match[0]
-    );
+    // The `<\s*T\s*>` tolerance keeps this robust to generic-argument spacing.
+    // Scope note: this guard is intentionally file-local — every metric lives in
+    // metrics.ts. A raw registration in another file that imports `registry`
+    // would also crash and is not covered here.
+    const rawConstructions = [
+      ...source.matchAll(/new\s+(Counter|Histogram|Gauge)\b(?!<\s*T\s*>)/g),
+    ].map((match) => match[0]);
 
     expect(
       rawConstructions,


### PR DESCRIPTION
## Why

The #1293/#1296 interaction that took the site down — a metric registered with a raw `new Histogram({ registers: [registry] })` throwing `A metric with the name X has already been registered` on the second module-graph evaluation of the shared `globalThis` registry — was **invisible to CI**:

- **Integration tests** run in a single Node module graph (no `next build`), so they structurally cannot reproduce the multi-graph condition.
- **e2e tests** *do* run the production build (the real multi-graph environment), but `METRICS_ENABLED` was unset in the test env, so the entire registration path was dead code — the crash could never fire.

## Three safeguards

1. **Behavioral regression test** (`tests/unit/metrics-registration.test.ts`) — reproduces the second module-graph evaluation in milliseconds: `import` → `vi.resetModules()` → re-`import`. The `globalThis` registry persists across the reset (exactly the production condition), so a re-evaluation that re-registers a metric throws. Asserts it doesn't.

2. **Source guard** (same file) — forbids `new Counter/Histogram/Gauge` anywhere in `metrics.ts` except the three `getOrCreate*` helpers (matches any occurrence not written as `new X<T>`). The crash cause is non-obvious, so this stops the pattern at the point of writing, with an actionable failure message pointing to the helpers.

3. **e2e now exercises registration** (`playwright.config.ts`) — sets `METRICS_ENABLED=true` for the production-build e2e run, so a future unguarded registration crashes the e2e server (red CI) instead of prod. Gated on the production build only: the dev server shares one module graph (crash can't occur) and enabling it would just contend for the metrics server's port 9091.

## Verification

- All three pass on current code (`6 passed` including the existing content-processing tests).
- **Proved the tests actually catch the regression**: temporarily reintroduced a raw `new Histogram({ registers: [registry] })` and confirmed both tests fail — the behavioral test with the exact production error (`A metric with the name feed_parse_duration_seconds has already been registered`), the guard with `expected [ 'new Histogram' ] to deeply equal []`. Then reverted.

`pnpm typecheck` is clean for the touched files (the only local tsc errors are the unrelated `@lion-reader/feed-parser` native module not built in the sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)