### PR TITLE
Remove unneeded mut on close_open_elements closure

### DIFF
--- a/native/feed-parser/core/src/xml.rs
+++ b/native/feed-parser/core/src/xml.rs
@@ -79,7 +79,7 @@ pub fn run_sax<H: SaxHandler>(
 
     // Open-element stack (top = end); see the dispatch rules above.
     let mut stack: Vec<String> = Vec::new();
-    let mut close_open_elements = |stack: &mut Vec<String>, handler: &mut H| {
+    let close_open_elements = |stack: &mut Vec<String>, handler: &mut H| {
         while let Some(open) = stack.pop() {
             handler.on_close(&open);
         }


### PR DESCRIPTION
## Summary

Silences an `unused_mut` warning that appeared during the Docker build:

```
warning: variable does not need to be mutable
  --> core/src/xml.rs:82:9
82 |     let mut close_open_elements = |stack: &mut Vec<String>, handler: &mut H| {
   |         ----^^^^^^^^^^^^^^^^^^^
```

The `close_open_elements` closure takes its `stack` and `handler` as parameters rather than capturing them, so the binding never mutates captured state and doesn't need `mut`.

## Testing

- `cargo build --release -p lion-reader-feed-parser-core` — compiles clean, warning gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)