### PR TITLE
Add per-tRPC-procedure latency histogram

### DIFF
--- a/src/server/metrics/metrics.ts
+++ b/src/server/metrics/metrics.ts
@@ -11,6 +11,7 @@ import type { CounterConfiguration, HistogramConfiguration, GaugeConfiguration }
  * - A shared registry for all metrics
  * - Conditional initialization of default collectors
  * - HTTP request metrics (counter and histogram)
+ * - tRPC per-procedure latency metrics
  * - Feed fetch metrics
  * - Job processing metrics
  * - SSE connection metrics
@@ -173,6 +174,55 @@ export function startHttpTimer(method: string, path: string): (status: number) =
     const durationMs = performance.now() - startTime;
     trackHttpRequest(method, path, status, durationMs);
   };
+}
+
+// ============================================================================
+// tRPC Procedure Metrics
+// ============================================================================
+
+/**
+ * tRPC procedure types (matches @trpc/server's ProcedureType).
+ */
+export type TrpcProcedureType = "query" | "mutation" | "subscription";
+
+/**
+ * Histogram for individual tRPC procedure duration in seconds.
+ *
+ * This is observed per procedure inside the tRPC timing middleware, so it is
+ * accurate even for BATCHED requests — unlike http_request_duration_seconds,
+ * which the fetch handler labels with only the first procedure in a batch. Use
+ * this for precise per-endpoint latency; use the HTTP histogram for transport
+ * overhead. Labels:
+ * - procedure: the tRPC path (e.g. "entries.list"); bounded by the router, so
+ *   cardinality is safe.
+ * - type: "query" | "mutation" | "subscription"
+ * - ok: "true" if the procedure resolved, "false" if it errored (so error
+ *   latency can be separated from success latency).
+ */
+const trpcProcedureDurationSeconds = getOrCreateHistogram({
+  name: "trpc_procedure_duration_seconds",
+  help: "tRPC procedure execution duration in seconds, labeled by procedure",
+  labelNames: ["procedure", "type", "ok"] as const,
+  buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+});
+
+/**
+ * Tracks a single tRPC procedure execution.
+ * This function has zero overhead when metrics are disabled.
+ *
+ * @param procedure - The tRPC procedure path (e.g. "entries.list")
+ * @param type - The procedure type (query, mutation, subscription)
+ * @param ok - Whether the procedure resolved successfully
+ * @param durationMs - Execution duration in milliseconds
+ */
+export function trackTrpcProcedure(
+  procedure: string,
+  type: TrpcProcedureType,
+  ok: boolean,
+  durationMs: number
+): void {
+  if (!metricsEnabled) return;
+  trpcProcedureDurationSeconds?.observe({ procedure, type, ok: String(ok) }, durationMs / 1000);
 }
 
 // ============================================================================

--- a/src/server/trpc/trpc.ts
+++ b/src/server/trpc/trpc.ts
@@ -27,6 +27,7 @@ import {
 } from "@/server/auth/admin-session";
 import { extractBearerToken } from "@/server/auth/bearer";
 import { logger } from "@/lib/logger";
+import { trackTrpcProcedure } from "@/server/metrics/metrics";
 import * as Sentry from "@sentry/nextjs";
 
 /**
@@ -71,6 +72,13 @@ const timingMiddleware = t.middleware(async ({ path, type, next, ctx }) => {
     const result = await next();
     const duration = Date.now() - start;
 
+    // Per-procedure latency metric. Accurate even for batched requests, unlike
+    // http_request_duration_seconds which only sees the first procedure in a
+    // batch. `result.ok` is authoritative here: tRPC returns a failed result
+    // object rather than always throwing, so read it directly (the catch below
+    // still covers errors thrown out of next()).
+    trackTrpcProcedure(path, type, result.ok, duration);
+
     // Log slow requests
     if (duration > 1000) {
       logger.warn("Slow tRPC request", {
@@ -84,6 +92,8 @@ const timingMiddleware = t.middleware(async ({ path, type, next, ctx }) => {
     return result;
   } catch (error) {
     const duration = Date.now() - start;
+
+    trackTrpcProcedure(path, type, false, duration);
 
     // Log the error
     const errorMessage = error instanceof Error ? error.message : "Unknown error";

--- a/tests/unit/metrics-trpc-procedure.test.ts
+++ b/tests/unit/metrics-trpc-procedure.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Unit tests for the per-procedure tRPC latency metric.
+ *
+ * `metricsEnabled` is read from the environment at module load, so we set
+ * METRICS_ENABLED before dynamically importing the metrics module.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+
+let metrics: typeof import("@/server/metrics/metrics");
+
+beforeAll(async () => {
+  process.env.METRICS_ENABLED = "true";
+  metrics = await import("@/server/metrics/metrics");
+});
+
+describe("trpc procedure duration metric", () => {
+  it("records a labeled observation per procedure", async () => {
+    metrics.trackTrpcProcedure("entries.list", "query", true, 12);
+
+    const output = await metrics.registry.metrics();
+    expect(output).toContain("trpc_procedure_duration_seconds_bucket");
+    expect(output).toMatch(
+      /trpc_procedure_duration_seconds_count\{[^}]*procedure="entries\.list"[^}]*type="query"[^}]*ok="true"[^}]*\} \d+/
+    );
+  });
+
+  it("separates errored calls via the ok label", async () => {
+    metrics.trackTrpcProcedure("subscriptions.create", "mutation", false, 34);
+
+    const output = await metrics.registry.metrics();
+    expect(output).toMatch(
+      /trpc_procedure_duration_seconds_count\{[^}]*procedure="subscriptions\.create"[^}]*ok="false"[^}]*\} \d+/
+    );
+  });
+});

--- a/tests/unit/metrics-trpc-procedure.test.ts
+++ b/tests/unit/metrics-trpc-procedure.test.ts
@@ -5,12 +5,15 @@
  * METRICS_ENABLED before dynamically importing the metrics module.
  */
 import { describe, it, expect, beforeAll } from "vitest";
+import type { Context } from "@/server/trpc/context";
 
 let metrics: typeof import("@/server/metrics/metrics");
+let trpc: typeof import("@/server/trpc/trpc");
 
 beforeAll(async () => {
   process.env.METRICS_ENABLED = "true";
   metrics = await import("@/server/metrics/metrics");
+  trpc = await import("@/server/trpc/trpc");
 });
 
 describe("trpc procedure duration metric", () => {
@@ -31,5 +34,37 @@ describe("trpc procedure duration metric", () => {
     expect(output).toMatch(
       /trpc_procedure_duration_seconds_count\{[^}]*procedure="subscriptions\.create"[^}]*ok="false"[^}]*\} \d+/
     );
+  });
+});
+
+describe("timingMiddleware records the procedure metric", () => {
+  it("observes ok=true on success and ok=false on error, exactly once each", async () => {
+    // A real router + real caller exercises the actual middleware wiring — the
+    // try/return-vs-catch path that decides the `ok` label (see the comment in
+    // trpc.ts). The procedures touch no DB, so a minimal cast context suffices
+    // (nothing internal is stubbed).
+    const router = trpc.createTRPCRouter({
+      metricsWiringOk: trpc.publicProcedure.query(() => "ok"),
+      metricsWiringErr: trpc.publicProcedure.query(() => {
+        throw new Error("boom");
+      }),
+    });
+    const caller = trpc.createCallerFactory(router)({
+      session: null,
+      apiToken: null,
+      authType: null,
+      scopes: [],
+      headers: new Headers(),
+      sessionToken: null,
+    } as unknown as Context);
+
+    await caller.metricsWiringOk();
+    await expect(caller.metricsWiringErr()).rejects.toThrow();
+
+    const output = await metrics.registry.metrics();
+    // Exactly one observation each — proves no double-count between the try and
+    // catch paths, and that a thrown procedure is recorded as ok="false".
+    expect(output).toMatch(/procedure="metricsWiringOk"[^}]*ok="true"[^}]*\} 1\b/);
+    expect(output).toMatch(/procedure="metricsWiringErr"[^}]*ok="false"[^}]*\} 1\b/);
   });
 });


### PR DESCRIPTION
## Why

`http_request_duration_seconds` labels a batched tRPC request with only the **first** procedure in the batch (`normalizeTrpcPath` in `src/app/api/trpc/[trpc]/route.ts`), so its per-endpoint latency is imprecise — a slow procedure riding behind a fast one in a batch is mis-attributed. That's fine for coarse transport monitoring but not for pinpointing which endpoint an optimization actually helped.

## What

Add `trpc_procedure_duration_seconds`, observed inside the existing tRPC `timingMiddleware` where each procedure is timed individually — so it's accurate regardless of batching. Labels:

- `procedure` — the tRPC path (e.g. `entries.list`); bounded by the router, so cardinality is safe.
- `type` — `query` | `mutation` | `subscription`.
- `ok` — `true`/`false`, so error latency can be separated from success latency.

The middleware already computes `duration` for its slow-request log; this reuses it (no extra timing cost). Success/error is read from `result.ok` — tRPC returns a failed result object rather than always throwing — with the existing `catch` still covering anything thrown out of `next()`.

Registered via the idempotent `getOrCreateHistogram` helper, so it's compatible with the shared-registry model (and the source guard in #1301).

## Example queries

```promql
# True p95 latency per procedure (unblurred by batching)
histogram_quantile(0.95,
  sum by (procedure, le) (rate(trpc_procedure_duration_seconds_bucket{ok="true"}[5m])))

# Slowest procedures right now
sort_desc(histogram_quantile(0.99,
  sum by (procedure, le) (rate(trpc_procedure_duration_seconds_bucket[5m]))))
```

## Tests

`tests/unit/metrics-trpc-procedure.test.ts` — asserts a labeled observation is recorded per procedure and that the `ok` label separates errored calls. `pnpm typecheck` clean for the touched files.

Depends on nothing beyond current master; complements #1301 (safeguards) and the metrics-registry fixes (#1290/#1296/#1300).

🤖 Generated with [Claude Code](https://claude.com/claude-code)