### PR TITLE
Pass GIT_COMMIT_SHA as a runtime env var instead of a build arg

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,9 +47,12 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to Fly.io
-        # Pass the deployed commit SHA as a build arg: the alpine builder has no
-        # git, so next.config.ts's `git rev-parse` fallback can't resolve it.
-        # Short SHA to match the previous git-derived value baked into User-Agent.
-        run: flyctl deploy --remote-only --build-arg GIT_COMMIT_SHA="$(git rev-parse --short HEAD)"
+        # Pass the deployed commit SHA as a RUNTIME env var (read by
+        # src/server/config/env.ts for the outgoing User-Agent). A runtime var
+        # reaches every process group — including the esbuild-bundled worker and
+        # Discord bot, which a build-time inline never reached — and keeps the
+        # Docker image build independent of the SHA, so unchanged layers stay
+        # cached. Short SHA to match the previous git-derived value.
+        run: flyctl deploy --remote-only --env GIT_COMMIT_SHA="$(git rev-parse --short HEAD)"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,13 +84,10 @@ COPY --from=native-builder /app/native/feed-parser/feed-parser.node ./native/fee
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
 
-# Git commit SHA for the build. The alpine builder has no git, so next.config.ts's
-# `git rev-parse` fallback fails ("git: not found") and the SHA is baked in as
-# undefined — it's surfaced in the outgoing User-Agent. Pass it explicitly from CI
-# (fly deploy --build-arg GIT_COMMIT_SHA=...) so the value is correct and the noisy
-# "git: not found" line disappears. Empty locally, where the git fallback works.
-ARG GIT_COMMIT_SHA=""
-ENV GIT_COMMIT_SHA=$GIT_COMMIT_SHA
+# NOTE: GIT_COMMIT_SHA (surfaced in the outgoing User-Agent) is deliberately
+# NOT a build arg — it's a runtime env var set by CI at deploy time
+# (fly deploy --env GIT_COMMIT_SHA=..., see .github/workflows/deploy.yml).
+# Keeping the SHA out of the build keeps these layers cacheable across deploys.
 # Dummy URLs for build - modules check these exist but don't connect
 ENV DATABASE_URL="postgresql://build:build@localhost:5432/build"
 ENV REDIS_URL="redis://localhost:6379"

--- a/fly.toml
+++ b/fly.toml
@@ -37,6 +37,11 @@ kill_timeout = 30
   discord = "node dist/discord-bot.js"
 
 [env]
+  # GIT_COMMIT_SHA (surfaced in the outgoing User-Agent) is not listed here —
+  # CI passes it per-deploy via `flyctl deploy --env GIT_COMMIT_SHA=...`
+  # (.github/workflows/deploy.yml). A manual deploy without that flag leaves it
+  # unset, which only means the User-Agent omits the SHA suffix.
+
   # apple/google are open to the public; email is allowed only with a valid invite.
   ALLOWED_SIGNUP_PROVIDERS = "apple,google,email"
   ALLOWED_PUBLIC_SIGNUP_PROVIDERS = "apple,google"

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,21 +1,6 @@
-import { execSync } from "child_process";
 import type { NextConfig } from "next";
 import withPWA from "@ducanh2912/next-pwa";
 import { withSentryConfig } from "@sentry/nextjs";
-
-// Get git commit SHA at build time
-function getGitCommitSha(): string | undefined {
-  // First check environment variable (set by CI/CD systems like Vercel, Fly.io)
-  if (process.env.GIT_COMMIT_SHA) {
-    return process.env.GIT_COMMIT_SHA;
-  }
-  // Fall back to git command
-  try {
-    return execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim();
-  } catch {
-    return undefined;
-  }
-}
 
 // PWA configuration - wraps the Next.js config to enable service worker precaching
 const withPWAConfig = withPWA({
@@ -107,10 +92,6 @@ const nextConfig: NextConfig = {
   // zstd/brotli/gzip/deflate compression to streaming SSR responses, and
   // Fly.io's edge handles non-streaming responses.
   compress: false,
-  env: {
-    // Inject git commit SHA at build time
-    GIT_COMMIT_SHA: getGitCommitSha(),
-  },
   // Cache static assets for 1 day to reduce unnecessary requests
   async headers() {
     return [

--- a/src/server/config/env.ts
+++ b/src/server/config/env.ts
@@ -110,7 +110,13 @@ export const securityConfig = {
 export const fetcherConfig = {
   /** Optional contact email to include in User-Agent header. */
   contactEmail: process.env.FETCHER_CONTACT_EMAIL,
-  /** Git commit SHA, injected at build time via next.config.ts. */
+  /**
+   * Git commit SHA, set at deploy time as a runtime env var
+   * (flyctl deploy --env, see .github/workflows/deploy.yml). A runtime var —
+   * not a build-time inline — so the esbuild-bundled worker/Discord/server
+   * processes see it too, and the Docker build stays SHA-independent.
+   * Unset in local dev.
+   */
   commitSha: process.env.GIT_COMMIT_SHA,
 };
 


### PR DESCRIPTION
Follow-up to #1304, from the deploy-speed discussion.

## The bug this fixes

The SHA (surfaced in the outgoing feed-fetch User-Agent) was inlined at build time via `next.config.ts`'s `env:` key — which only reaches code compiled by Next's webpack. The esbuild bundles read `process.env.GIT_COMMIT_SHA` at **runtime**, where nothing set it: the builder stage's `ENV` doesn't carry into the runner stage, and fly.toml doesn't define it. So **`worker.js` — which does most of the actual feed fetching — has been sending a User-Agent without the commit SHA in production** (likewise the Discord bot and the custom server wrapper's own code).

## The fix

Deploy with `flyctl deploy --env GIT_COMMIT_SHA=$(git rev-parse --short HEAD)`, which sets a plain runtime env var on all machines in every process group (including the release-command machine). Then:

- `next.config.ts`: drop the `env:` inlining and the `execSync` git fallback — nothing client-side uses the SHA (the only consumer is server-only `user-agent.ts`), and server code reads `process.env` at runtime fine.
- `Dockerfile`: delete the `ARG`/`ENV GIT_COMMIT_SHA` block. The image build is now fully SHA-independent, so redeploys/rollbacks of unchanged source are ~100% layer-cache hits (a normal deploy still rebuilds from the source diff, of course).
- `fly.toml`: comment explaining why GIT_COMMIT_SHA isn't in `[env]`.

## Trade-offs

- A manual `fly deploy` without the `--env` flag leaves the SHA unset — the User-Agent just omits the SHA suffix (noted in fly.toml).
- Local dev no longer gets a SHA (previously the git fallback provided one to the Next app only). Dev User-Agents are `LionReader/1.0 (...)` without a suffix.

## Verification

`pnpm typecheck` passes. The runtime read path is unchanged (`fetcherConfig.commitSha` → `process.env.GIT_COMMIT_SHA`); after the first deploy with this change, worker feed-fetch User-Agents should show the SHA suffix — easy to spot in any feed's access logs, or via `fly ssh console -C "printenv GIT_COMMIT_SHA"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)