### PR TITLE
Fix entry-list keyboard/tab navigation

### DIFF
--- a/src/app/demo/DemoEntryList.tsx
+++ b/src/app/demo/DemoEntryList.tsx
@@ -28,9 +28,15 @@ interface DemoEntryListProps {
   entries: DemoEntry[];
   backHref: string;
   selectedEntryId?: string | null;
+  onEntryFocus?: (entryId: string) => void;
 }
 
-export function DemoEntryList({ entries, backHref, selectedEntryId }: DemoEntryListProps) {
+export function DemoEntryList({
+  entries,
+  backHref,
+  selectedEntryId,
+  onEntryFocus,
+}: DemoEntryListProps) {
   const demoState = useDemoState();
 
   const handleToggleRead = useCallback(
@@ -52,6 +58,7 @@ export function DemoEntryList({ entries, backHref, selectedEntryId }: DemoEntryL
       externalEntries={entries}
       externalQueryState={STATIC_QUERY_STATE}
       selectedEntryId={selectedEntryId}
+      onEntryFocus={onEntryFocus}
       onEntryClick={(id) => {
         clientPush(`${backHref}?entry=${id}`);
       }}

--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -190,7 +190,7 @@ function DemoRouterContent() {
   );
 
   // Keyboard shortcuts (j/k navigation, o/Enter to open, Escape to close, etc.)
-  const { selectedEntryId } = useKeyboardShortcuts({
+  const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
     entries,
     onOpenEntry: openEntry,
     onClose: closeEntry,
@@ -203,6 +203,15 @@ function DemoRouterContent() {
     onNavigateNext: goToNextEntry,
     onNavigatePrevious: goToPreviousEntry,
   });
+
+  // Sync selection with browser focus so Tabbing to a row makes m/s act on it,
+  // matching the real app.
+  const handleEntryFocus = useCallback(
+    (id: string) => {
+      setSelectedEntryId(id);
+    },
+    [setSelectedEntryId]
+  );
 
   const { onTouchStart: handleTouchStart, onTouchEnd: handleTouchEnd } = useSwipeGesture({
     onSwipeLeft: nextEntryId ? () => openEntry(nextEntryId) : undefined,
@@ -348,7 +357,12 @@ function DemoRouterContent() {
       </div>
 
       {/* Entry list */}
-      <DemoEntryList entries={entries} backHref={backHref} selectedEntryId={selectedEntryId} />
+      <DemoEntryList
+        entries={entries}
+        backHref={backHref}
+        selectedEntryId={selectedEntryId}
+        onEntryFocus={handleEntryFocus}
+      />
     </div>
   );
 }

--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -307,6 +307,19 @@ export function EntryContentBody({
     [onToggleRead]
   );
 
+  // Keyboard shortcut: s to toggle star (parity with `m`, and with the list view)
+  useHotkeys(
+    "s",
+    (e) => {
+      e.preventDefault();
+      onToggleStar();
+    },
+    {
+      enableOnFormTags: false,
+    },
+    [onToggleStar]
+  );
+
   return (
     <EntryArticle
       title={title}

--- a/src/components/entries/EntryList.tsx
+++ b/src/components/entries/EntryList.tsx
@@ -85,6 +85,12 @@ interface EntryListProps {
   selectedEntryId?: string | null;
 
   /**
+   * Callback when an entry row receives focus (Tab), used to sync the
+   * keyboard-shortcut selection with browser focus.
+   */
+  onEntryFocus?: (entryId: string) => void;
+
+  /**
    * Callback when the read status indicator is clicked.
    */
   onToggleRead?: (entryId: string, currentlyRead: boolean) => void;
@@ -121,6 +127,7 @@ export function EntryList({
   onEntryMouseDown,
   emptyMessage = "No entries to display",
   selectedEntryId,
+  onEntryFocus,
   onToggleRead,
   onToggleStar,
   externalEntries: allEntries,
@@ -210,6 +217,7 @@ export function EntryList({
             entry={entry}
             onClick={onEntryClick}
             onMouseDown={onEntryMouseDown}
+            onFocus={onEntryFocus}
             selected={selectedEntryId === entry.id}
             onToggleRead={onToggleRead}
             onToggleStar={onToggleStar}

--- a/src/components/entries/EntryListContainer.tsx
+++ b/src/components/entries/EntryListContainer.tsx
@@ -189,7 +189,7 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
   );
 
   // Keyboard shortcuts
-  const { selectedEntryId } = useKeyboardShortcuts({
+  const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
     entries,
     onOpenEntry: setOpenEntryId,
     onClose: () => setOpenEntryId(null),
@@ -206,6 +206,15 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
     onNavigateNext: goToNextEntry,
     onNavigatePrevious: goToPreviousEntry,
   });
+
+  // Sync selection with browser focus so Tabbing to a row makes `m`/`s` act on
+  // it (they key off the shortcut selection, which j/k also sets).
+  const handleEntryFocus = useCallback(
+    (entryId: string) => {
+      setSelectedEntryId(entryId);
+    },
+    [setSelectedEntryId]
+  );
 
   // Query state for the presentational EntryList
   const externalQueryState: ExternalQueryState = useMemo(
@@ -260,6 +269,7 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
     <EntryList
       onEntryClick={handleEntryClick}
       onEntryMouseDown={handleEntryMouseDown}
+      onEntryFocus={handleEntryFocus}
       selectedEntryId={selectedEntryId}
       onToggleRead={toggleRead}
       onToggleStar={toggleStar}

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -46,6 +46,12 @@ interface EntryListItemProps {
    */
   selected?: boolean;
   /**
+   * Callback when the entry row itself receives focus (e.g. via Tab). Used to
+   * sync the keyboard-shortcut selection with browser focus so `m`/`s` act on
+   * the tab-focused entry, not just one reached with j/k.
+   */
+  onFocus?: (entryId: string) => void;
+  /**
    * Callback when the read status indicator is clicked.
    * entryType and subscriptionId are required (but subscriptionId can be null) to force explicit handling.
    */
@@ -121,6 +127,7 @@ export const EntryListItem = memo(function EntryListItem({
   onClick,
   onMouseDown,
   selected = false,
+  onFocus,
   onToggleRead,
   onToggleStar,
   density = "comfortable",
@@ -152,6 +159,14 @@ export const EntryListItem = memo(function EntryListItem({
     onMouseDown?.(id);
   };
 
+  const handleFocus = (e: React.FocusEvent) => {
+    // Only sync selection when the row itself is focused (via Tab), not when a
+    // descendant control receives focus and bubbles up (focus events bubble).
+    if (e.target === e.currentTarget) {
+      onFocus?.(id);
+    }
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
@@ -177,6 +192,7 @@ export const EntryListItem = memo(function EntryListItem({
       onClick={handleClick}
       onMouseDown={handleMouseDown}
       onKeyDown={handleKeyDown}
+      onFocus={handleFocus}
       data-entry-id={id}
       className={getItemClasses(read, selected, density)}
       aria-label={`${read ? "Read" : "Unread"}${selected ? ", selected" : ""} article: ${displayTitle} from ${source}`}
@@ -189,10 +205,14 @@ export const EntryListItem = memo(function EntryListItem({
             // the padding with an equal negative margin so layout is unchanged.
             <button
               type="button"
+              // Kept out of the tab order: tabbing a row would otherwise stop on
+              // the row, then this dot, then the star. Keyboard users toggle read
+              // with `m` on the focused row; this stays available to pointer users.
+              tabIndex={-1}
               onClick={handleToggleRead}
               className="group/toggle -m-[17px] flex items-center justify-center rounded-full p-[17px]"
               aria-label={read ? "Mark as unread" : "Mark as read"}
-              title={read ? "Mark as unread" : "Mark as read"}
+              title={read ? "Mark as unread" : "Mark as read (m)"}
             >
               <span
                 className={`block h-2.5 w-2.5 rounded-full transition-colors ${
@@ -227,6 +247,9 @@ export const EntryListItem = memo(function EntryListItem({
             {onToggleStar ? (
               <button
                 type="button"
+                // Out of the tab order like the read dot above — keyboard users
+                // toggle the star with `s` on the focused row (pointer still works).
+                tabIndex={-1}
                 onClick={handleToggleStar}
                 // 44px WCAG touch target: pad the 16px icon out to 44px and cancel
                 // the padding with an equal negative margin so layout is unchanged.
@@ -236,7 +259,7 @@ export const EntryListItem = memo(function EntryListItem({
                     : "hover:text-star text-zinc-300 opacity-0 group-hover:opacity-100 dark:text-zinc-600"
                 }`}
                 aria-label={starred ? "Remove from starred" : "Add to starred"}
-                title={starred ? "Remove from starred" : "Add to starred"}
+                title={starred ? "Remove from starred (s)" : "Add to starred (s)"}
               >
                 {starred ? (
                   <StarFilledIcon className="h-4 w-4" />

--- a/src/components/layout/ScrollContainerContext.tsx
+++ b/src/components/layout/ScrollContainerContext.tsx
@@ -73,7 +73,13 @@ export function MainScrollContainer({ children, className }: MainScrollContainer
   );
 
   return (
-    <main ref={setRef} className={className}>
+    // tabIndex={-1} keeps this scroll region out of the sequential tab order.
+    // Firefox (and Chrome for childless scrollers) otherwise makes any scrollable
+    // element keyboard-focusable, adding a stray tab stop that renders as a focus
+    // outline "line" across the top of the content. The region is full of
+    // focusable controls (buttons, entries), so a tab stop on the container
+    // itself is redundant; keyboard users still reach and scroll it via those.
+    <main ref={setRef} tabIndex={-1} className={className}>
       {children}
     </main>
   );

--- a/tests/unit/frontend/components/EntryListItem.test.tsx
+++ b/tests/unit/frontend/components/EntryListItem.test.tsx
@@ -383,4 +383,55 @@ describe("EntryListItem", () => {
       expect(screen.getByRole("button")).toHaveAttribute("tabIndex", "0");
     });
   });
+
+  describe("tab order and focus", () => {
+    it("keeps the read marker out of the tab order (m shortcut handles it)", () => {
+      const entry = createMockEntry();
+      render(<EntryListItem entry={entry} onToggleRead={vi.fn()} />);
+
+      // Still a clickable button for pointer users, but not a tab stop — tabbing
+      // a row should land on the next row, not the read dot then the star.
+      expect(screen.getByRole("button", { name: "Mark as read" })).toHaveAttribute(
+        "tabIndex",
+        "-1"
+      );
+    });
+
+    it("keeps the star marker out of the tab order (s shortcut handles it)", () => {
+      const entry = createMockEntry();
+      render(<EntryListItem entry={entry} onToggleStar={vi.fn()} />);
+
+      expect(screen.getByRole("button", { name: "Add to starred" })).toHaveAttribute(
+        "tabIndex",
+        "-1"
+      );
+    });
+
+    it("calls onFocus with the entry id when the row itself is focused", () => {
+      const entry = createMockEntry({ id: "entry-123" });
+      const onFocus = vi.fn();
+      render(<EntryListItem entry={entry} onFocus={onFocus} />);
+
+      fireEvent.focusIn(screen.getByRole("button", { name: /article: Test Article Title/ }));
+      expect(onFocus).toHaveBeenCalledWith("entry-123");
+    });
+
+    it("does not call onFocus when a descendant control receives focus", () => {
+      const entry = createMockEntry({ id: "entry-123" });
+      const onFocus = vi.fn();
+      render(
+        <EntryListItem
+          entry={entry}
+          onFocus={onFocus}
+          onToggleRead={vi.fn()}
+          onToggleStar={vi.fn()}
+        />
+      );
+
+      // Focus events bubble; a marker button getting focus (e.g. via pointer)
+      // must not be mistaken for the row being tab-focused.
+      fireEvent.focusIn(screen.getByRole("button", { name: "Mark as read" }));
+      expect(onFocus).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Reported while tabbing through the reader:

1. **Stray tab stop before "Mark all read."** Tabbing from the account menu landed on a focus-outline "line across the top" of the content before reaching the first control. That's the `<main>` scroll container — **Firefox** (and Chrome, but only for scrollers without focusable children) makes every scrollable region keyboard-focusable. Ours is full of controls, so a tab stop on the container itself is redundant.
2. **Three tab stops per entry.** Each row was `entry → read dot → star`, and pressing **Enter** on a marker opened the article instead of toggling — the row's `onKeyDown` caught the bubbling Enter, called `preventDefault()`, and cancelled the button's own activation. So those inner buttons were keyboard-broken anyway.
3. **m/s didn't work on the list.** They act on the shortcut "selection," which only **j/k** (or a mouse click) set — **Tab focus never did**. And the article view only registered `m`, not `s`.

## Changes

- **Read/star markers `tabIndex={-1}`** — out of the tab order, still clickable for pointer users. Tabbing now moves row-to-row.
- **Focus → selection sync** — Tabbing to a row now sets the shortcut selection (guarded to the row itself, since focus events bubble), so `m` (read) and `s` (star) act on the focused entry, matching j/k. The selection ring follows Tab focus too.
- **`s` in the article view** — star now works there, like `m` already did.
- **`<main>` `tabIndex={-1}`** — drops the redundant Firefox scroll-container tab stop.

Per discussion, we deliberately rely on `m`/`s` (+ pointer) for the markers rather than keeping them as tab stops, so the row tabbing is clean.

## Verification

Ran the real app locally (seeded data, Chrome 151) and confirmed via Playwright:
- Tab goes **row → next row**; markers report `tabIndex="-1"`; `<main>` reports `tabIndex="-1"`.
- Tabbing a row sets `selected` + the ring; the aria-label updates to "…, selected article: …".
- `m` on a tab-focused row flips Unread↔Read; `s` flips the star.
- `s` in the article view toggles the star.

Added unit tests to `EntryListItem.test.tsx` (markers out of tab order; `onFocus` fires for the row but not for a bubbling descendant focus). Full unit suite green; `typecheck` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)