### PR TITLE
Fix db:seed crash: set last_seen_at on web entries

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -119,6 +119,10 @@ async function seed() {
         summary: `This is sample content for entry ${i + 1} from ${feed.title}...`,
         publishedAt: new Date(Date.now() - i * 24 * 60 * 60 * 1000), // Each day older
         fetchedAt: new Date(Date.now() - i * 24 * 60 * 60 * 1000),
+        // Web entries require last_seen_at (and only web entries may set it) per
+        // the entries_last_seen_only_fetched CHECK constraint. All seeded feeds
+        // are web, but gate on type so this stays correct if others are added.
+        lastSeenAt: feed.type === "web" ? new Date(Date.now() - i * 24 * 60 * 60 * 1000) : null,
         contentHash: hashContent(content),
       };
     });


### PR DESCRIPTION
## Problem

`pnpm db:seed` fails partway through:

```
error: new row for relation "entries" violates check constraint "entries_last_seen_only_fetched"
```

The `entries_last_seen_only_fetched` constraint requires `(type = 'web') = (last_seen_at IS NOT NULL)` — i.e. web entries **must** have `last_seen_at`, and non-web entries must leave it null. The seed inserts web entries without `last_seen_at`, so the entries insert throws and the script aborts after having already created the user and feeds — leaving a half-seeded, unusable database.

## Fix

Set `last_seen_at` on web entries (gated on `feed.type === "web"` so it stays correct if non-web sample feeds are ever added).

`user_entries.subscription_id` is intentionally **not** set here — the `user_entries_fill_denormalized` BEFORE INSERT trigger fills it from `user_id` + `feed_id`, exactly as the app's own insert paths rely on.

## Verification

Ran against a local DB (`pnpm services` + `pnpm db:seed`):

- Seed completes: `Created 15 entries`, `✓ Seed completed successfully!`
- All 15 entries are visible with **no** manual backfill — `SELECT count(*) FROM visible_entries WHERE user_id = <seeded user>` → `15`, and every `user_entries` row has `subscription_id` populated (by the trigger).
- `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)