### PR TITLE
Reorder Dockerfile builder to keep source-independent steps cached

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,16 +69,23 @@ WORKDIR /app
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
 
-# Copy source code
-COPY . .
+# Steps that depend ONLY on node_modules / the native-builder stage go ABOVE
+# `COPY . .` so a source-only change (the common deploy) leaves them cached and
+# jumps straight to `pnpm build`. public/onnx/ and native/*/*.node are in
+# .dockerignore, so the `COPY . .` overlay below won't clobber what we generate.
 
-# Run postinstall script (copies ONNX WASM files to public/)
+# Copy ONNX WASM files to public/ (reads node_modules only). Copy just the
+# script first so this layer busts only when the script itself changes.
+COPY scripts/copy-onnx-wasm.mjs ./scripts/copy-onnx-wasm.mjs
 RUN node scripts/copy-onnx-wasm.mjs
 
 # Compiled native modules (the runner also copies these out of this stage)
 COPY --from=native-builder /app/native/sanitizer/sanitizer.node ./native/sanitizer/sanitizer.node
 COPY --from=native-builder /app/native/readability/readability.node ./native/readability/readability.node
 COPY --from=native-builder /app/native/feed-parser/feed-parser.node ./native/feed-parser/feed-parser.node
+
+# Copy source code
+COPY . .
 
 # Set environment for build
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
## Summary

In the `builder` stage, the ONNX WASM copy and the three native `.node` copies sat *below* `COPY . .`, even though they depend only on `node_modules` and the `native-builder` stage. Any source change (the common deploy) invalidated `COPY . .` and forced all of them to redo ~2.7s of work before the real cost, `pnpm build`.

This moves those source-independent steps *above* `COPY . .` so a source-only build keeps them cached and jumps straight to `pnpm build`.

## Why it's safe

- `copy-onnx-wasm.mjs` reads only `node_modules/onnxruntime-web/dist` and writes `public/onnx/` — no source dependency. Only its script file is copied before the RUN, so that layer busts just when the script changes.
- `public/onnx/` and `native/*/*.node` are in `.dockerignore`, so the later `COPY . .` overlay does not clobber the generated artifacts.
- `pnpm build` still re-runs on every source change (it needs the source) — nothing about that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)