### PR TITLE
Ship Next standalone output in the runner image (#1305)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,13 @@ ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 RUN --mount=type=cache,id=next-cache,target=/app/.next/cache \
     pnpm build
 
+# `output: "standalone"` emitted a traced, minimal node_modules into
+# .next/standalone — the runner ships that instead of the full pruned tree
+# (issue #1305). Patch the gaps the trace misses (dynamic requires, next's
+# subpath shims, the @lion-reader workspace symlinks), then move it out of
+# .next so the runner's .next COPY doesn't pick up a duplicate node_modules.
+RUN node scripts/fixup-standalone.mjs && mv .next/standalone /standalone
+
 # Build custom server bundle (compression + Next.js wrapper)
 RUN pnpm build:server
 
@@ -117,12 +124,6 @@ RUN pnpm build:discord-bot
 
 # Build migration bundle (single optimized JS file)
 RUN pnpm build:migrate
-
-# Prune dev dependencies after build. CI=true lets pnpm remove/recreate the
-# modules directory without a confirmation prompt (there's no TTY in the
-# builder; without it prune fails with ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY).
-RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
-    CI=true pnpm prune --prod --ignore-scripts
 
 # =============================================================================
 # Stage 5: Production runner (minimal image, no pnpm needed)
@@ -146,8 +147,12 @@ ENV HOSTNAME="0.0.0.0"
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/package.json ./package.json
 
-# Copy production node_modules (already pruned in builder)
-COPY --from=builder /app/node_modules ./node_modules
+# Copy the traced standalone node_modules (a fraction of the full tree; see
+# the fixup-standalone step in the builder). dist/server.js keeps `next`
+# external and resolves it from here; the worker/discord bundles only need
+# their few runtime externals (argon2, html-rewriter-wasm, @lion-reader/*),
+# which the Next server graph also uses, so the trace covers them.
+COPY --from=builder /standalone/node_modules ./node_modules
 
 # The native modules: node_modules/@lion-reader/{sanitizer,readability,feed-parser}
 # are pnpm workspace symlinks into these directories, so they must exist in the
@@ -181,11 +186,10 @@ COPY --from=builder /app/dist/discord-bot.js ./dist/discord-bot.js
 COPY --from=builder /app/scripts/start-all.sh ./scripts/start-all.sh
 RUN chmod +x scripts/start-all.sh
 
-# Generate minimal next.config.js for runtime.
-# The full next.config.ts requires TypeScript and build-time-only deps (next-pwa,
-# sentry). Only compress:false is needed at runtime — everything else (headers,
-# webpack, etc.) is baked into .next/ at build time.
-RUN echo 'module.exports = { compress: false };' > next.config.js
+# No next.config.js in the image: dist/server.js hands next() the resolved
+# build-time config from .next/required-server-files.json (the standalone
+# mechanism) — the traced node_modules doesn't include the runtime
+# config-loading machinery. See scripts/server.ts.
 
 # Switch to non-root user
 USER nextjs

--- a/next.config.ts
+++ b/next.config.ts
@@ -88,6 +88,14 @@ const securityHeaders: { key: string; value: string }[] = [
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["127.0.0.1", "localhost"],
+  // Emit .next/standalone with a traced, minimal node_modules — the production
+  // image ships that instead of the full pruned node_modules (issue #1305).
+  // Our custom server (dist/server.js) keeps `next` external and resolves it
+  // from the standalone node_modules at runtime; deps only needed by the
+  // worker/discord bundles are bundled by esbuild, and their few runtime
+  // externals (argon2, html-rewriter-wasm, @lion-reader/*) are all also in the
+  // Next server graph, so the trace covers them.
+  output: "standalone",
   // Disable Next.js's built-in gzip compression. Our custom server applies
   // zstd/brotli/gzip/deflate compression to streaming SSR responses, and
   // Fly.io's edge handles non-streaming responses.

--- a/scripts/fixup-standalone.mjs
+++ b/scripts/fixup-standalone.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Fix up Next's standalone output (.next/standalone) for the production image.
+ *
+ * `output: "standalone"` traces the server build with @vercel/nft and emits a
+ * minimal node_modules, which the Dockerfile ships instead of the full pruned
+ * tree (issue #1305). The trace misses a few things our runtime needs:
+ *
+ * 1. Packages with dynamic requires nft can't follow statically:
+ *    - html-rewriter-wasm: dist/html_rewriter.js requires ./asyncify.js at
+ *      runtime; the trace only picks up the wasm + entry file.
+ *    - argon2: the prebuild is resolved per-platform/libc at runtime
+ *      (prebuilds/linux-x64/argon2.{glibc,musl}.node); the trace only includes
+ *      the variant matching the machine the build ran on.
+ *    Copy the whole (small) packages over the traced subset.
+ *
+ * 2. next's top-level subpath shims (constants.js etc., one-line re-exports
+ *    into dist/): dist/server.js requires `next/constants`, whose target IS
+ *    traced but the shim file itself isn't.
+ *
+ * 3. The @lion-reader workspace symlinks: the trace resolves them to their
+ *    real paths under native/, so no node_modules/@lion-reader entries exist.
+ *    Recreate the symlinks; the Dockerfile copies the actual native module
+ *    files (index.js + the musl .node binaries) into the runner's native/.
+ *
+ * Run after `pnpm build` (needs the full node_modules to copy from).
+ */
+
+import { cpSync, mkdirSync, readdirSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const standaloneDir = join(rootDir, ".next", "standalone");
+const require = createRequire(join(rootDir, "package.json"));
+
+/** Real (symlink-resolved) directory of an installed package. */
+function packageDir(name) {
+  return realpathSync(dirname(require.resolve(`${name}/package.json`)));
+}
+
+/** The standalone tree mirrors the repo layout, so reuse the relative path. */
+function standalonePath(realDir) {
+  return join(standaloneDir, relative(rootDir, realDir));
+}
+
+// 1. Copy whole packages whose dynamic requires the trace misses.
+for (const pkg of ["html-rewriter-wasm", "argon2"]) {
+  const realDir = packageDir(pkg);
+  cpSync(realDir, standalonePath(realDir), { recursive: true, force: true });
+  console.log(`Copied full package: ${pkg}`);
+}
+
+// 2. Copy next's top-level subpath shims (constants.js etc.).
+const nextDir = packageDir("next");
+const standaloneNextDir = standalonePath(nextDir);
+for (const file of readdirSync(nextDir)) {
+  if (file.endsWith(".js")) {
+    cpSync(join(nextDir, file), join(standaloneNextDir, file), { force: true });
+  }
+}
+console.log("Copied next's top-level subpath shims");
+
+// 3. Recreate the @lion-reader workspace symlinks.
+const scopeDir = join(standaloneDir, "node_modules", "@lion-reader");
+mkdirSync(scopeDir, { recursive: true });
+for (const name of ["sanitizer", "readability", "feed-parser"]) {
+  const link = join(scopeDir, name);
+  rmSync(link, { recursive: true, force: true });
+  symlinkSync(join("..", "..", "native", name), link);
+}
+console.log("Created @lion-reader symlinks");

--- a/scripts/fixup-standalone.mjs
+++ b/scripts/fixup-standalone.mjs
@@ -45,10 +45,14 @@ function standalonePath(realDir) {
   return join(standaloneDir, relative(rootDir, realDir));
 }
 
-// 1. Copy whole packages whose dynamic requires the trace misses.
+// 1. Copy whole packages whose dynamic requires the trace misses. Remove the
+// traced subset first: cpSync's `force` doesn't overwrite when the file type
+// differs (e.g. symlink vs regular file) and throws EEXIST instead.
 for (const pkg of ["html-rewriter-wasm", "argon2"]) {
   const realDir = packageDir(pkg);
-  cpSync(realDir, standalonePath(realDir), { recursive: true, force: true });
+  const dest = standalonePath(realDir);
+  rmSync(dest, { recursive: true, force: true });
+  cpSync(realDir, dest, { recursive: true });
   console.log(`Copied full package: ${pkg}`);
 }
 

--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -46,9 +46,18 @@ const FORCE_EXIT_TIMEOUT_MS = DRAIN_TIMEOUT_MS + 10_000;
 // generated .next/standalone/server.js uses — so it never tries to load
 // next.config.js at runtime.
 if (!dev) {
-  const requiredServerFiles = JSON.parse(
-    readFileSync(join(process.cwd(), ".next", "required-server-files.json"), "utf8")
-  ) as { config: Record<string, unknown> };
+  const manifestPath = join(process.cwd(), ".next", "required-server-files.json");
+  let requiredServerFiles: { config: Record<string, unknown> };
+  try {
+    requiredServerFiles = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      config: Record<string, unknown>;
+    };
+  } catch (error) {
+    throw new Error(
+      `Failed to read ${manifestPath} — the production server needs a completed ` +
+        `\`next build\` in the working directory. Original error: ${String(error)}`
+    );
+  }
   process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(requiredServerFiles.config);
 }
 

--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -14,6 +14,8 @@
 
 import next from "next";
 import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { maybeCompressResponse } from "../src/server/http/compression";
 import { stripOauthSurfaceTrailingSlash } from "../src/server/http/trailing-slash";
 import {
@@ -36,6 +38,19 @@ const port = parseInt(process.env.PORT || "3000", 10);
 const DRAIN_TIMEOUT_MS = dev ? 1_000 : 15_000;
 // Hard deadline for the whole shutdown (drain + pool/Redis cleanup).
 const FORCE_EXIT_TIMEOUT_MS = DRAIN_TIMEOUT_MS + 10_000;
+
+// In production we run against Next's `output: "standalone"` build, whose
+// traced node_modules deliberately omits the runtime config-loading machinery
+// (next/dist/compiled/webpack etc.). Hand `next()` the resolved build-time
+// config via __NEXT_PRIVATE_STANDALONE_CONFIG — the same mechanism the
+// generated .next/standalone/server.js uses — so it never tries to load
+// next.config.js at runtime.
+if (!dev) {
+  const requiredServerFiles = JSON.parse(
+    readFileSync(join(process.cwd(), ".next", "required-server-files.json"), "utf8")
+  ) as { config: Record<string, unknown> };
+  process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(requiredServerFiles.config);
+}
 
 const app = next({
   dev,

--- a/scripts/start-all.sh
+++ b/scripts/start-all.sh
@@ -1,19 +1,34 @@
 #!/bin/bash
-# Start API, worker, and optionally Discord bot in the same VM
-# Worker runs at lower CPU priority (nice 10) to avoid starving the API
-# If any process exits, concurrently kills the others and exits
+# Start API, worker, and optionally Discord bot in the same VM.
+# Worker runs at lower CPU priority (nice 10) to avoid starving the API.
+#
+# Plain bash job control (no concurrently): the production image ships only
+# Next's traced standalone node_modules, which doesn't include concurrently.
+# If any process exits, the others are killed and its exit code is propagated.
+# SIGTERM/SIGINT are forwarded so each process can shut down gracefully.
 
-set -e
+pids=()
 
-# Use concurrently to manage processes
-# --kill-others: kill all processes if one exits
+nice -n 10 node dist/worker.js &
+pids+=($!)
+
+node dist/server.js &
+pids+=($!)
+
 if [ -n "$DISCORD_BOT_TOKEN" ]; then
-  exec npx concurrently --kill-others --names "worker,api,discord" \
-    "nice -n 10 node dist/worker.js" \
-    "node dist/server.js" \
-    "node dist/discord-bot.js"
-else
-  exec npx concurrently --kill-others --names "worker,api" \
-    "nice -n 10 node dist/worker.js" \
-    "node dist/server.js"
+  node dist/discord-bot.js &
+  pids+=($!)
 fi
+
+forward_term() {
+  kill -TERM "${pids[@]}" 2>/dev/null
+}
+trap forward_term SIGTERM SIGINT
+
+# Block until the first process exits (or a signal interrupts the wait), then
+# take the rest down and propagate the exit code.
+wait -n "${pids[@]}"
+code=$?
+kill -TERM "${pids[@]}" 2>/dev/null
+wait
+exit "$code"


### PR DESCRIPTION
Closes #1305 (follow-up to #1304, deploy speedup item 3).

## What

Ship Next's `output: "standalone"` traced `node_modules` (~76 MB uncompressed) in the runner instead of the full `pnpm prune --prod` tree, cutting the image size and the copy/export/push/pull time it costs every deploy.

- **`next.config.ts`**: enable `output: "standalone"`.
- **`scripts/server.ts`**: in production, hand `next()` the resolved build-time config from `.next/required-server-files.json` via `__NEXT_PRIVATE_STANDALONE_CONFIG` — the same mechanism the generated standalone `server.js` uses. Without this, `next()` tries to load config at runtime and requires `next/dist/compiled/webpack/webpack-lib`, which the trace deliberately omits. This also removes the need for the generated one-line `next.config.js` in the image.
- **`scripts/fixup-standalone.mjs`** (new, run in the builder after `pnpm build`): patches the gaps `@vercel/nft` misses:
  - `html-rewriter-wasm` — `dist/html_rewriter.js` dynamically requires `./asyncify.js`, which isn't traced (instrumentation failed to load without it).
  - `argon2` — the prebuild is resolved per-platform/libc at runtime; the trace only includes the variant matching the build machine, so copy all `prebuilds/` (1.2 MB) to be safe across glibc/musl.
  - `next`'s top-level subpath shims — `dist/server.js` requires `next/constants`; the shim's *target* is traced but the one-line shim file isn't.
  - `@lion-reader/*` workspace symlinks — the trace resolves them to their real `native/` paths, so no `node_modules/@lion-reader` entries exist; recreate them (the Dockerfile still copies the actual native files/binaries from the native-builder stage).
- **`Dockerfile`**: run the fixup, `mv .next/standalone /standalone` so the runner's `.next` COPY doesn't ship a duplicate node_modules, copy the traced node_modules, drop the `pnpm prune --prod` step.
- **`scripts/start-all.sh`**: plain bash job control instead of `npx concurrently` (concurrently isn't in the traced tree). Forwards SIGTERM/SIGINT and propagates the first exit code. Fly runs each process directly via `[processes]`, so this only affects local/default-CMD runs.

## Verification

Assembled the exact runner layout (standalone node_modules + `.next` + `native/` + `dist/`) in a temp dir against a real Postgres/Redis (`pnpm services`) and verified:

- `dist/migrate.js` runs migrations successfully
- `dist/server.js` boots: `/api/health` 200 (DB+Redis healthy), `/login` SSR 200, `/api/openapi` 200 (trpc-to-openapi), static assets + `_next/static` chunks 200, brotli compression active
- `dist/worker.js` boots and processes jobs
- All runtime externals load from the traced tree: argon2 (hash+verify round-trip), sanitizer/readability/feed-parser natives, html-rewriter-wasm, trpc-to-openapi
- `pnpm typecheck`, `pnpm lint`, unit tests (2467 passed), and the e2e suite with `E2E_PRODUCTION=true` (50 passed) all green

Not verified here: an actual `docker build` (no daemon in this sandbox). The first deploy should confirm the final image size — the standalone node_modules is ~76 MB uncompressed vs the previous pruned tree, so the image should land in the neighborhood of the issue's ~120–150 MB estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)