### PR TITLE
Unify entry selection with the focus outline

### DIFF
--- a/src/components/entries/EntryListContainer.tsx
+++ b/src/components/entries/EntryListContainer.tsx
@@ -259,7 +259,6 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
           sortOrder,
         }}
         skeletonCount={5}
-        selectedEntryId={selectedEntryId}
         onEntryClick={handleEntryClick}
       />
     );

--- a/src/components/entries/EntryListFallback.tsx
+++ b/src/components/entries/EntryListFallback.tsx
@@ -33,8 +33,6 @@ interface EntryListFallbackProps {
   filters: EntryListFilters;
   /** Number of skeleton items if no placeholder data */
   skeletonCount?: number;
-  /** Currently selected entry ID */
-  selectedEntryId?: string | null;
   /** Callback when entry is clicked (disabled during fallback) */
   onEntryClick?: (entryId: string) => void;
 }
@@ -51,7 +49,6 @@ interface EntryListFallbackProps {
 export function EntryListFallback({
   filters,
   skeletonCount = 5,
-  selectedEntryId,
   onEntryClick,
 }: EntryListFallbackProps) {
   const queryClient = useQueryClient();
@@ -80,7 +77,11 @@ export function EntryListFallback({
             key={entry.id}
             entry={entry}
             onClick={onEntryClick}
-            selected={selectedEntryId === entry.id}
+            // No selection here: the fallback is a brief pre-load state that
+            // isn't wired to keyboard focus (no onFocus), and selection is shown
+            // via the focused row's outline — so a `selected` prop would only
+            // ever set an aria-label with no matching focus. Selection appears
+            // once the real EntryList renders.
             // Disable mutations during fallback - they'd update stale data
             onToggleRead={undefined}
             onToggleStar={undefined}

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -42,7 +42,10 @@ interface EntryListItemProps {
    */
   onMouseDown?: (entryId: string) => void;
   /**
-   * Whether this entry is currently selected (for keyboard navigation).
+   * Whether this entry is the current keyboard selection. Selection is shown
+   * visually by the browser focus outline (the selected row is focused — see
+   * `onFocus` and the j/k handlers in useKeyboardShortcuts), so this only feeds
+   * the aria-label; it deliberately does not add a ring/border of its own.
    */
   selected?: boolean;
   /**
@@ -75,32 +78,27 @@ interface EntryListItemProps {
 }
 
 /**
- * Get the appropriate CSS classes for the entry item based on read, selected,
- * and density state.
+ * Get the appropriate CSS classes for the entry item based on read and density
+ * state.
  *
- * The unread/read/selected *color* language is identical across densities — only
- * the padding and border treatment change. In "compact" mode items are borderless
+ * Selection is *not* styled here: the keyboard/`j`-`k` cursor and Tab focus are
+ * unified onto the browser's single `:focus-visible` outline (the selected row is
+ * the focused row), so there's no separate ring/border to keep in sync — see
+ * `getItemClasses`'s former selected branch, removed in favor of the focus
+ * outline. This avoids the double outline (border + ring) and the ring lingering
+ * after focus moved elsewhere.
+ *
+ * The unread/read *color* language is identical across densities — only the
+ * padding and border treatment change. In "compact" mode items are borderless
  * rows in a single `divide-edge` list (see EntryList), so the per-card borders
  * (including the e-paper `border-zinc-500` fallback) are dropped; the darker
  * e-paper divider handles row separation instead.
  */
-export function getItemClasses(
-  read: boolean,
-  selected: boolean,
-  density: ListDensity = "comfortable"
-): string {
+export function getItemClasses(read: boolean, density: ListDensity = "comfortable"): string {
   const compact = density === "compact";
   const baseClasses = compact
     ? "group relative cursor-pointer px-3 py-2.5 transition-colors sm:px-4"
     : "group relative cursor-pointer rounded-lg border p-3 transition-colors sm:p-4";
-
-  if (selected) {
-    // Selected state takes priority - accent ring indicator. In compact mode the
-    // ring stands in for the border the cards would otherwise carry.
-    return `${baseClasses} ${compact ? "" : "border-accent "}ring-2 ring-accent ring-offset-1 ring-offset-surface ${
-      read ? "bg-canvas" : "bg-surface"
-    }`;
-  }
 
   if (read) {
     // Read entries recede into the page canvas: no fill of their own and a
@@ -194,7 +192,7 @@ export const EntryListItem = memo(function EntryListItem({
       onKeyDown={handleKeyDown}
       onFocus={handleFocus}
       data-entry-id={id}
-      className={getItemClasses(read, selected, density)}
+      className={getItemClasses(read, density)}
       aria-label={`${read ? "Read" : "Unread"}${selected ? ", selected" : ""} article: ${displayTitle} from ${source}`}
     >
       <div className="flex items-start gap-3">

--- a/src/lib/hooks/useKeyboardShortcuts.ts
+++ b/src/lib/hooks/useKeyboardShortcuts.ts
@@ -250,6 +250,18 @@ export function useKeyboardShortcuts(
   // re-registering handlers on every render
   const entryIds = useMemo(() => entries.map((e) => e.id), [entries]);
 
+  // Move browser focus onto a list row. Selection is shown by the shared
+  // `:focus-visible` outline (the selected row is the focused row), so j/k must
+  // actually focus the row — that unifies the keyboard cursor with Tab focus
+  // onto one indicator instead of a separate ring. The row already exists in the
+  // DOM (the list isn't virtualized), so this resolves synchronously; focusing
+  // also scrolls it into view. `onFocus` on the row keeps selectedEntryId in
+  // sync, so this and setSelectedEntryId agree.
+  const focusEntryRow = useCallback((id: string) => {
+    if (typeof document === "undefined") return;
+    document.querySelector<HTMLElement>(`[data-entry-id="${id}"]`)?.focus();
+  }, []);
+
   // Get the current index of the selected entry
   const getSelectedIndex = useCallback((): number => {
     if (!selectedEntryId) return -1;
@@ -268,15 +280,20 @@ export function useKeyboardShortcuts(
 
     const currentIndex = getSelectedIndex();
 
+    let nextId: string | undefined;
     if (currentIndex === -1) {
       // Nothing selected, select the first entry
-      setSelectedEntryId(entryIds[0]);
+      nextId = entryIds[0];
     } else if (currentIndex < entryIds.length - 1) {
       // Move to next entry
-      setSelectedEntryId(entryIds[currentIndex + 1]);
+      nextId = entryIds[currentIndex + 1];
     }
-    // If already at the last entry, do nothing
-  }, [entryIds, getSelectedIndex, setSelectedEntryId]);
+    // If already at the last entry, nextId stays undefined and we do nothing
+    if (nextId) {
+      setSelectedEntryId(nextId);
+      focusEntryRow(nextId);
+    }
+  }, [entryIds, getSelectedIndex, setSelectedEntryId, focusEntryRow]);
 
   // Move selection to the previous entry
   const selectPrevious = useCallback(() => {
@@ -284,15 +301,20 @@ export function useKeyboardShortcuts(
 
     const currentIndex = getSelectedIndex();
 
+    let prevId: string | undefined;
     if (currentIndex === -1) {
       // Nothing selected, select the last entry
-      setSelectedEntryId(entryIds[entryIds.length - 1]);
+      prevId = entryIds[entryIds.length - 1];
     } else if (currentIndex > 0) {
       // Move to previous entry
-      setSelectedEntryId(entryIds[currentIndex - 1]);
+      prevId = entryIds[currentIndex - 1];
     }
-    // If already at the first entry, do nothing
-  }, [entryIds, getSelectedIndex, setSelectedEntryId]);
+    // If already at the first entry, prevId stays undefined and we do nothing
+    if (prevId) {
+      setSelectedEntryId(prevId);
+      focusEntryRow(prevId);
+    }
+  }, [entryIds, getSelectedIndex, setSelectedEntryId, focusEntryRow]);
 
   // Open the currently selected entry
   const openSelected = useCallback(() => {
@@ -304,6 +326,15 @@ export function useKeyboardShortcuts(
   // Clear selection
   const clearSelection = useCallback(() => {
     setSelectedEntryId(null);
+    // Selection is shown by the focused row's outline, so clearing it (Escape)
+    // must also drop focus from that row — otherwise the outline would linger
+    // with nothing logically selected.
+    if (typeof document !== "undefined") {
+      const active = document.activeElement;
+      if (active instanceof HTMLElement && active.matches("[data-entry-id]")) {
+        active.blur();
+      }
+    }
   }, [setSelectedEntryId]);
 
   // Compute whether the selected entry is still in the list

--- a/tests/unit/frontend/components/EntryListItem.test.tsx
+++ b/tests/unit/frontend/components/EntryListItem.test.tsx
@@ -235,15 +235,21 @@ describe("EntryListItem", () => {
   });
 
   describe("selected state", () => {
-    it("applies selection ring when selected", () => {
+    // Selection is shown by the browser's global :focus-visible outline (the
+    // selected row is focused), not by a ring/border class — this avoids the
+    // double outline and the ring lingering after focus moves away. The only
+    // selected-specific rendering is the aria-label (covered below).
+    it("does not apply a selection ring/border when selected", () => {
       const entry = createMockEntry();
       render(<EntryListItem entry={entry} selected={true} />);
 
       const article = screen.getByRole("button");
-      expect(article).toHaveClass("ring-2", "ring-accent");
+      expect(article).not.toHaveClass("ring-2");
+      expect(article).not.toHaveClass("ring-accent");
+      expect(article).not.toHaveClass("border-accent");
     });
 
-    it("does not apply selection ring when not selected", () => {
+    it("does not apply a selection ring/border when not selected", () => {
       const entry = createMockEntry();
       render(<EntryListItem entry={entry} selected={false} />);
 

--- a/tests/unit/frontend/entry-list-item.test.ts
+++ b/tests/unit/frontend/entry-list-item.test.ts
@@ -1,8 +1,11 @@
 /**
  * Unit tests for EntryListItem utility functions.
  *
- * Tests the getItemClasses function which determines CSS classes
- * based on read and selected state.
+ * Tests the getItemClasses function which determines CSS classes based on read
+ * state and density. Selection is intentionally NOT reflected here: the keyboard
+ * cursor and Tab focus are unified onto the browser's single `:focus-visible`
+ * outline (the selected row is the focused row), so getItemClasses must never
+ * emit a ring/border of its own.
  */
 
 import { describe, it, expect } from "vitest";
@@ -12,9 +15,9 @@ describe("getItemClasses", () => {
   const baseClasses =
     "group relative cursor-pointer rounded-lg border p-3 transition-colors sm:p-4";
 
-  describe("unread, not selected", () => {
+  describe("unread", () => {
     it("returns unread styling classes", () => {
-      const classes = getItemClasses(false, false);
+      const classes = getItemClasses(false);
 
       expect(classes).toContain(baseClasses);
       // Unread stands out: raised surface card with a distinctly stronger border
@@ -29,9 +32,9 @@ describe("getItemClasses", () => {
     });
   });
 
-  describe("read, not selected", () => {
+  describe("read", () => {
     it("returns read styling classes", () => {
-      const classes = getItemClasses(true, false);
+      const classes = getItemClasses(true);
 
       expect(classes).toContain(baseClasses);
       // Read recedes into the page canvas with a faint hairline border
@@ -43,65 +46,33 @@ describe("getItemClasses", () => {
     });
   });
 
-  describe("unread, selected", () => {
-    it("returns selected styling with unread background", () => {
-      const classes = getItemClasses(false, true);
-
-      expect(classes).toContain(baseClasses);
-      // Selected state has accent ring
-      expect(classes).toContain("border-accent");
-      expect(classes).toContain("ring-2");
-      expect(classes).toContain("ring-accent");
-      expect(classes).toContain("ring-offset-1");
-      // Unread background within selected state (raised surface)
-      expect(classes).toContain("bg-surface");
-      // Ring-offset uses the surface token (was dark:ring-offset-zinc-900)
-      expect(classes).toContain("ring-offset-surface");
-    });
-  });
-
-  describe("read, selected", () => {
-    it("returns selected styling with read background", () => {
-      const classes = getItemClasses(true, true);
-
-      expect(classes).toContain(baseClasses);
-      // Selected state has accent ring
-      expect(classes).toContain("border-accent");
-      expect(classes).toContain("ring-2");
-      expect(classes).toContain("ring-accent");
-      expect(classes).toContain("ring-offset-1");
-      // Read background within selected state recedes into the canvas
-      expect(classes).toContain("bg-canvas");
-      // Ring-offset uses the surface token (was dark:ring-offset-zinc-900)
-      expect(classes).toContain("ring-offset-surface");
-    });
-  });
-
-  describe("selected state priority", () => {
-    it("prioritizes selected styling over read/unread styling", () => {
-      const selectedUnread = getItemClasses(false, true);
-      const selectedRead = getItemClasses(true, true);
-
-      // Both should have the accent ring (selected indicator)
-      expect(selectedUnread).toContain("ring-accent");
-      expect(selectedRead).toContain("ring-accent");
-
-      // Neither should have hover states that conflict with selection
-      expect(selectedUnread).not.toContain("hover:bg-surface-muted");
-      expect(selectedRead).not.toContain("hover:bg-surface");
+  describe("selection is the focus outline, not a class", () => {
+    it("never emits a ring or accent border in any density/read combination", () => {
+      for (const read of [false, true]) {
+        for (const density of ["comfortable", "compact"] as const) {
+          const classes = getItemClasses(read, density);
+          expect(classes).not.toContain("ring-2");
+          expect(classes).not.toContain("ring-accent");
+          expect(classes).not.toContain("ring-offset");
+          expect(classes).not.toContain("border-accent");
+          // And no per-component focus utilities (the global :focus-visible
+          // outline is the only focus/selection indicator).
+          expect(classes).not.toContain("focus:");
+        }
+      }
     });
   });
 
   describe("compact density", () => {
     it("defaults to comfortable when density is omitted", () => {
       // The explicit "comfortable" and the default must produce identical output.
-      expect(getItemClasses(false, false)).toBe(getItemClasses(false, false, "comfortable"));
-      expect(getItemClasses(true, true)).toBe(getItemClasses(true, true, "comfortable"));
+      expect(getItemClasses(false)).toBe(getItemClasses(false, "comfortable"));
+      expect(getItemClasses(true)).toBe(getItemClasses(true, "comfortable"));
     });
 
     it("drops the per-card border and rounding but keeps the color language", () => {
-      const unread = getItemClasses(false, false, "compact");
-      const read = getItemClasses(true, false, "compact");
+      const unread = getItemClasses(false, "compact");
+      const read = getItemClasses(true, "compact");
 
       // Borderless rows: the surrounding list supplies divide-edge separators.
       expect(unread).not.toContain("rounded-lg");
@@ -120,15 +91,6 @@ describe("getItemClasses", () => {
       expect(unread).toContain("hover:bg-surface-muted");
       expect(read).toContain("bg-canvas");
       expect(read).toContain("hover:bg-surface");
-    });
-
-    it("keeps the selection ring but no border in compact", () => {
-      const selected = getItemClasses(false, true, "compact");
-
-      expect(selected).toContain("ring-2");
-      expect(selected).toContain("ring-accent");
-      expect(selected).not.toContain("border-accent");
-      expect(selected).toContain("bg-surface");
     });
   });
 });


### PR DESCRIPTION
## Problem

When tabbing around the entry list, two issues showed up (reported by @brendanlong):

1. **Lingering orange border** — Selection follows Tab focus (`onFocus` → `setSelectedEntryId`), but nothing cleared it. Shift-Tab off a selected entry to a toolbar button moved the focus outline to the button while the entry kept its selection border.
2. **Double border** — The selected style layered *two* amber lines: `border-accent` (at the card edge) **and** `ring-2 ring-offset-1` (outside a 1px gap). That reads as two concentric borders even with nothing focused — not two selection systems, but one selection state drawn twice, plus the browser's own `:focus-visible` outline as a third when the row was focused.

There was also a latent bug: the ring used `ring-offset-surface`, but read+selected rows have a `bg-canvas` background, so the offset gap was the wrong color — the exact ring-offset pitfall called out in #1292.

## Fix

Unify the keyboard `j`/`k` cursor with the single global `:focus-visible` outline — **the selected row is now the focused row**, so there's only one indicator:

- Removed the selected ring/border from `getItemClasses`; selection no longer emits any class of its own (`selected` now only feeds the aria-label).
- `j`/`k` now move real DOM focus to the row (`focusEntryRow`), so the outline *is* the cursor and scrolls the row into view. Tab focus already synced selection, so the two agree.
- `Escape` blurs the focused row so clearing selection also clears the outline.

Single-pane layout (the list is `hidden` while reading), so no "currently reading" highlight is lost.

## Before / After

Selection (press `j`):

| Before (double border) | After (single outline) |
| --- | --- |
| ![before selected](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/entry-selection-focus-unify/before-selected.png) | ![after selected](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/entry-selection-focus-unify/after-selected.png) |

After Shift-Tab off the entry:

| Before (border lingers) | After (border gone) |
| --- | --- |
| ![before tab away](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/entry-selection-focus-unify/before-tabaway.png) | ![after tab away](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/entry-selection-focus-unify/after-tabaway.png) |

## Testing

- Updated `getItemClasses` unit tests (new signature; asserts no ring/border/focus utilities are ever emitted) and the `EntryListItem` selected-state component tests.
- `pnpm typecheck`, `pnpm test:unit` (2464 pass), `pnpm check:colors`, `pnpm check:theme-tokens` all green.
- Manually verified on `/demo` via Playwright: `j`/`k` move the outline through rows, Shift-Tab moves it cleanly to the toolbar with no residue, `Escape` clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)