### PR TITLE
Capacity load-test benchmark (bench/)

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -3,3 +3,5 @@
 sessions.json
 results-*.json
 prod-stats.txt
+# Real prod usage specifics — derived locally, not committed (see prod-params.example.json).
+prod-params.json

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,5 @@
+# Throwaway load-test artifacts — never commit.
+# sessions.json contains live session tokens.
+sessions.json
+results-*.json
+prod-stats.txt

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,87 @@
+# Lion Reader capacity benchmark
+
+Estimates how many users Lion Reader can support on a given machine by replaying
+a realistic logged-in-user workload against a running app and ramping
+concurrency until it saturates.
+
+## Why this exists
+
+Before posting to a big-traffic site (e.g. Hacker News) we want to know the
+registered-user ceiling per hardware tier, and how a traffic spike behaves given
+Fly's shared-CPU burst-balance throttling. See
+`~/wiki/pages/lion-reader-capacity-benchmark-2026.md` for results and method
+notes.
+
+## Pieces
+
+| File                    | Role                                                                                                                                           |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `characterize-prod.sql` | Read-only prod aggregates → the real per-user parameters. Run it, save output, drop numbers into `prod-params.json`.                           |
+| `config.ts`             | Workload parameters (seed shape, session behaviour, capacity translation). Defaults are estimates; `prod-params.json` overrides them.          |
+| `seed-bench.ts`         | Populates a DB with N synthetic users matching the prod distribution + one live session each → `sessions.json`.                                |
+| `loadtest.ts`           | The driver: ramps VUs through a staircase, replays the real request mix, finds the capacity knee, scrapes the server's own Prometheus metrics. |
+| `lib/trpc-client.ts`    | Per-VU tRPC client using the app's own superjson transformer (wire-identical to prod) over a large undici pool.                                |
+
+## What "one user" does per session
+
+Page-load bundle (`entries.list` + `subscriptions.list` + `tags.list` + 3×
+`entries.count`, fired together) → scroll a couple more list pages → open N
+articles (`entries.get` + single `entries.markRead`) with human think-time →
+occasional star / batch mark-read → rare mark-all-read. Each VU also holds one
+SSE connection (`/api/v1/events`) open, like the browser. Weights/counts live in
+`config.ts` `session`.
+
+## Reading the results — trust server-side, not client-side
+
+The driver is a **single Node process**. Above a few hundred VUs on a big host,
+decoding list responses saturates _its_ event loop and inflates _client-side_
+latency before the server is actually stressed. So the knee gates on
+**server-side** signals — the app's own `trpc_procedure_duration_seconds`
+histogram and the `db_pool_waiting_requests` gauge — and the summary says
+whether a failing stage was the **server saturating** (pool queued / server
+latency climbed) or merely **generator-bound** (server still flat). To push a
+big host past the generator cap, run the driver from a second machine (or
+multiple processes).
+
+## Capacity translation
+
+The load test yields a _concurrent-active-user_ knee. We report a
+_registered-user_ ceiling via
+`registered = knee / peakConcurrentFraction`, where `peakConcurrentFraction`
+comes from prod recency data (`characterize-prod.sql` §2: active-in-5min vs
+total registered, adjusted for a peak factor). Until real numbers land it
+defaults to 5%.
+
+## Run it
+
+```bash
+# 0. one-time: build native + app
+pnpm build:native && pnpm build:all      # (or: pnpm build && pnpm build:server && pnpm build:worker)
+
+# 1. local throwaway DB + Redis (leave running in the background)
+pnpm services
+
+# 2. start the prod app against the local DB, metrics on :9091
+PORT=39547 NODE_ENV=production METRICS_ENABLED=true \
+  npx dotenv -e .env.local-services -- node dist/server.js &
+PORT=39547 NODE_ENV=production METRICS_ENABLED=true WORKER_CONCURRENCY=1 \
+  npx dotenv -e .env.local-services -- node dist/worker.js &
+
+# 3. seed synthetic users (writes bench/sessions.json)
+USERS=1000 npx dotenv -e .env.local-services -- npx tsx bench/seed-bench.ts
+
+# 4. ramp
+BASE_URL=http://127.0.0.1:39547 METRICS_URL=http://127.0.0.1:9091/metrics \
+  STAGES=25,50,100,200,400,800 STAGE_SECONDS=45 RESULT_LABEL=local \
+  npx tsx bench/loadtest.ts
+```
+
+For the Fly test, point `BASE_URL` at the throwaway Fly app and `METRICS_URL` at
+its metrics endpoint (or omit metrics and rely on client error-rate + `flyctl`
+CPU-balance observation). See the wiki page.
+
+### Env knobs
+
+`USERS`, `STAGES` (comma list of VU counts), `STAGE_SECONDS`, `WARMUP_SECONDS`,
+`BASE_URL`, `METRICS_URL`, `RESULT_LABEL`, `MAX_CONNECTIONS`, `PG_POOL_MAX`
+(server side).

--- a/bench/README.md
+++ b/bench/README.md
@@ -85,3 +85,41 @@ CPU-balance observation). See the wiki page.
 `USERS`, `STAGES` (comma list of VU counts), `STAGE_SECONDS`, `WARMUP_SECONDS`,
 `BASE_URL`, `METRICS_URL`, `RESULT_LABEL`, `MAX_CONNECTIONS`, `PG_POOL_MAX`
 (server side).
+
+## Worker (feed-fetch) throughput — `bench/worker/`
+
+Answers "how many feeds can one worker keep polled before it falls behind?"
+Separate from the request-path benchmark above. Seeds M feeds (each with an
+active subscriber) all due now, pointed at a local mock feed server, then runs
+the real `dist/worker.js` and times how fast it drains the backlog — for a sweep
+of `WORKER_CONCURRENCY`, in two phases:
+
+- **FRESH** — first poll returns 200 + N items → full parse + entry processing +
+  sanitize + `user_entries` fanout (worst case: cold start / mass subscribe /
+  every feed updated at once).
+- **NOT-MODIFIED** — re-poll after the worker stored our ETag → 304 (steady
+  state: most real polls find nothing new).
+
+Runs against the **test** DB (`lionreader_test`) so it doesn't touch the capacity
+seed, and spawns the worker with `ALLOW_PRIVATE_NETWORK_FETCH=true` so it can
+reach `127.0.0.1`.
+
+```bash
+# realistic network latency (the number that matters — the worker is I/O-bound):
+FEEDS=500 CONCURRENCIES=1,3,8,16 ITEMS_PER_FEED=25 MOCK_LATENCY_MS=150 \
+  npx dotenv -e .env.local-services.test -- npx tsx bench/worker/worker-bench.ts
+
+# CPU/DB ceiling (0ms latency, more feeds to get a stable rate):
+FEEDS=2000 CONCURRENCIES=1,3,8,16 ITEMS_PER_FEED=25 MOCK_LATENCY_MS=0 \
+  npx dotenv -e .env.local-services.test -- npx tsx bench/worker/worker-bench.ts
+```
+
+Output per concurrency: feeds/s for FRESH and 304, and the implied feed count
+sustainable at hourly cadence. Set `MOCK_LATENCY_MS` to model real feed-server
+RTT — at `concurrency=1` throughput is ~`1/latency` (serial), so this dominates.
+Knobs: `FEEDS`, `CONCURRENCIES`, `ITEMS_PER_FEED`, `MOCK_LATENCY_MS`.
+
+> Caveat: the mock uses a uniform latency, so it does **not** model the slow-feed
+> tail. With `WORKER_CONCURRENCY=1`, a single feed that hangs to the 30 s fetch
+> timeout blocks the only slot for 30 s (head-of-line blocking) — the strongest
+> reason to raise concurrency is latency isolation, not raw throughput.

--- a/bench/README.md
+++ b/bench/README.md
@@ -86,6 +86,24 @@ CPU-balance observation). See the wiki page.
 `BASE_URL`, `METRICS_URL`, `RESULT_LABEL`, `MAX_CONNECTIONS`, `PG_POOL_MAX`
 (server side).
 
+## Anonymous-page load — `bench/anon-pages.ts`
+
+The HN-flood shape: unauthenticated visitors hitting SSR pages (`/demo/all`,
+`/login`, `/register`; `/` and `/demo` redirect to `/demo/all`). These pages make
+**zero DB queries** and open no SSE, but the root layout reads `cookies()`/
+`headers()` for the per-request CSP nonce, so each is a full React server-render
+(dynamic, not prerendered). Measures render throughput vs concurrency.
+
+```bash
+BASE_URL=http://127.0.0.1:39547 PATHS=/demo/all,/login,/register \
+  CONCURRENCIES=10,25,50,100,200 DURATION_S=12 npx tsx bench/anon-pages.ts
+```
+
+Local result (2 dedicated cores): ~210 renders/s, CPU-bound (~11 ms/render,
+~45 KB HTML), latency climbing past ~25 concurrent — _lower_ than the
+authenticated API throughput because SSR-ing a page costs more than a tRPC JSON
+response. Since these pages don't touch Postgres, they don't stress the DB knee.
+
 ## Worker (feed-fetch) throughput — `bench/worker/`
 
 Answers "how many feeds can one worker keep polled before it falls behind?"

--- a/bench/anon-pages.ts
+++ b/bench/anon-pages.ts
@@ -1,0 +1,137 @@
+/**
+ * Anonymous-page load test — the HN-flood shape: unauthenticated visitors
+ * hitting SSR pages (landing / demo / login / register). These pages don't touch
+ * Postgres or SSE, but the root layout reads cookies()/headers() for the
+ * per-request CSP nonce, so each one is a full React server-render (dynamic, not
+ * prerendered). This measures how many such renders the app serves per second
+ * and where latency degrades — i.e. whether a CDN in front of these HTML pages
+ * would meaningfully offload the app.
+ *
+ * No think time (max throughput per VU). Sweeps concurrency.
+ *
+ *   BASE_URL=http://127.0.0.1:39547 METRICS_URL=http://127.0.0.1:9091/metrics \
+ *     PATHS=/demo,/login,/register,/ CONCURRENCIES=10,25,50,100 DURATION_S=15 \
+ *     npx tsx bench/anon-pages.ts
+ */
+
+import { Agent, fetch as undiciFetch } from "undici";
+
+const BASE_URL = process.env.BASE_URL ?? "http://127.0.0.1:39547";
+const METRICS_URL = process.env.METRICS_URL ?? "";
+const PATHS = (process.env.PATHS ?? "/demo,/login,/register,/").split(",").map((s) => s.trim());
+const CONCURRENCIES = (process.env.CONCURRENCIES ?? "10,25,50,100,200")
+  .split(",")
+  .map((s) => Number(s.trim()))
+  .filter((n) => n > 0);
+const DURATION_S = Number(process.env.DURATION_S ?? 15);
+
+const dispatcher = new Agent({ connections: 4096, pipelining: 1, keepAliveTimeout: 60_000 });
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function pctl(arr: number[], p: number): number {
+  if (!arr.length) return 0;
+  const s = arr.slice().sort((a, b) => a - b);
+  return s[Math.max(0, Math.ceil(p * s.length) - 1)];
+}
+
+async function metricText(): Promise<string> {
+  if (!METRICS_URL) return "";
+  try {
+    return await (
+      await undiciFetch(METRICS_URL, { signal: AbortSignal.timeout(4000), dispatcher })
+    ).text();
+  } catch {
+    return "";
+  }
+}
+/** Sum sum/count for http_request_duration_seconds over the benchmarked paths. */
+function httpHist(text: string): { sum: number; count: number } {
+  let sum = 0;
+  let count = 0;
+  for (const p of PATHS) {
+    const esc = p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    for (const m of text.matchAll(
+      new RegExp(
+        `^http_request_duration_seconds_sum\\{[^}]*route="${esc}"[^}]*\\}\\s+([0-9.eE+-]+)`,
+        "gm"
+      )
+    ))
+      sum += Number(m[1]);
+    for (const m of text.matchAll(
+      new RegExp(
+        `^http_request_duration_seconds_count\\{[^}]*route="${esc}"[^}]*\\}\\s+([0-9.eE+-]+)`,
+        "gm"
+      )
+    ))
+      count += Number(m[1]);
+  }
+  return { sum, count };
+}
+
+async function stage(concurrency: number): Promise<void> {
+  const latencies: number[] = [];
+  let ok = 0;
+  let err = 0;
+  let bytes = 0;
+  const before = httpHist(await metricText());
+  const stopAt = Date.now() + DURATION_S * 1000;
+
+  const vu = async () => {
+    let i = 0;
+    while (Date.now() < stopAt) {
+      const path = PATHS[i++ % PATHS.length];
+      const t0 = performance.now();
+      try {
+        const res = await undiciFetch(BASE_URL + path, {
+          dispatcher,
+          headers: { accept: "text/html" },
+        });
+        const body = await res.arrayBuffer();
+        bytes += body.byteLength;
+        latencies.push(performance.now() - t0);
+        if (res.status >= 200 && res.status < 400) ok++;
+        else err++;
+      } catch {
+        err++;
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: concurrency }, vu));
+
+  const after = httpHist(await metricText());
+  const dc = after.count - before.count;
+  const serverMeanMs = dc > 0 ? ((after.sum - before.sum) / dc) * 1000 : undefined;
+  const total = ok + err;
+  const rps = total / DURATION_S;
+  console.log(
+    `  c=${String(concurrency).padStart(4)}  rps=${rps.toFixed(0).padStart(5)}  ` +
+      `client p50=${pctl(latencies, 0.5).toFixed(0)}ms p95=${pctl(latencies, 0.95).toFixed(0)}ms  ` +
+      `server-render mean=${serverMeanMs?.toFixed(1) ?? "?"}ms  ` +
+      `MB/s=${(bytes / 1e6 / DURATION_S).toFixed(1)}  errors=${err}`
+  );
+}
+
+async function main() {
+  console.log(
+    `Anonymous-page load → ${BASE_URL}  paths=[${PATHS.join(", ")}]  ${DURATION_S}s/stage`
+  );
+  // brief warmup to compile the routes
+  const warm = Date.now() + 5000;
+  await Promise.all(
+    Array.from({ length: 5 }, async () => {
+      while (Date.now() < warm) {
+        for (const p of PATHS)
+          await undiciFetch(BASE_URL + p, { dispatcher })
+            .then((r) => r.arrayBuffer())
+            .catch(() => {});
+      }
+    })
+  );
+  await sleep(300);
+  for (const c of CONCURRENCIES) await stage(c);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/bench/characterize-prod.sql
+++ b/bench/characterize-prod.sql
@@ -1,0 +1,138 @@
+-- Lion Reader — production usage characterization (READ ONLY)
+--
+-- Purpose: derive the real per-user parameters that drive the load-test
+-- workload + seed generator (bench/). Every statement is a SELECT; nothing is
+-- written. Safe to run against production.
+--
+-- How to run (you have the Fly perms; the agent's token cannot build a tunnel):
+--   flyctl mpg proxy k1v53olme1nr8q6p --local-port 16987      # in one shell
+--   psql "postgres://<user>:<pass>@127.0.0.1:16987/<db>" \
+--        -v ON_ERROR_STOP=1 -f bench/characterize-prod.sql -o bench/prod-stats.txt
+-- (get the URL from `flyctl mpg connect k1v53olme1nr8q6p --help` / the cluster
+--  credentials, or just run `flyctl mpg connect k1v53olme1nr8q6p` and `\i` this file)
+--
+-- Then paste bench/prod-stats.txt back to me. Runtime is a few seconds; the
+-- heaviest queries scan user_entries once (small for this app).
+
+\pset pager off
+\timing on
+
+-- Belt-and-suspenders: refuse to write even if something unexpected happens.
+SET default_transaction_read_only = on;
+
+\echo '==================== 1. TOTALS ===================='
+SELECT
+  (SELECT count(*) FROM users)                                              AS users_total,
+  (SELECT count(*) FROM subscriptions WHERE unsubscribed_at IS NULL)        AS active_subscriptions,
+  (SELECT count(*) FROM feeds)                                              AS feeds_total,
+  (SELECT count(*) FROM entries)                                            AS entries_total,
+  (SELECT count(*) FROM user_entries)                                       AS user_entries_total,
+  (SELECT count(*) FROM sessions WHERE revoked_at IS NULL
+                                   AND expires_at > now())                  AS live_sessions;
+
+\echo '==================== 2. ACTIVE USERS (recency) ===================='
+-- The registered->concurrent translation hinges on these windows.
+SELECT
+  count(*) FILTER (WHERE last_active_at > now() - interval '5 minutes')  AS active_5m,
+  count(*) FILTER (WHERE last_active_at > now() - interval '1 hour')     AS active_1h,
+  count(*) FILTER (WHERE last_active_at > now() - interval '1 day')      AS active_1d,
+  count(*) FILTER (WHERE last_active_at > now() - interval '7 days')     AS active_7d,
+  count(*) FILTER (WHERE last_active_at > now() - interval '30 days')    AS active_30d,
+  count(*) FILTER (WHERE last_active_at IS NULL)                         AS never_active
+FROM users;
+
+\echo '==================== 3. SUBSCRIPTIONS PER USER (distribution) ===================='
+WITH per_user AS (
+  SELECT user_id, count(*) AS subs
+  FROM subscriptions
+  WHERE unsubscribed_at IS NULL
+  GROUP BY user_id
+)
+SELECT
+  count(*)                                                    AS users_with_subs,
+  round(avg(subs), 1)                                         AS mean_subs,
+  percentile_cont(0.5)  WITHIN GROUP (ORDER BY subs)          AS p50_subs,
+  percentile_cont(0.9)  WITHIN GROUP (ORDER BY subs)          AS p90_subs,
+  percentile_cont(0.99) WITHIN GROUP (ORDER BY subs)          AS p99_subs,
+  max(subs)                                                   AS max_subs
+FROM per_user;
+
+\echo '==================== 4. UNREAD PER SUBSCRIPTION (distribution) ===================='
+SELECT
+  round(avg(unread_count), 1)                                       AS mean_unread,
+  percentile_cont(0.5) WITHIN GROUP (ORDER BY unread_count)         AS p50_unread,
+  percentile_cont(0.9) WITHIN GROUP (ORDER BY unread_count)         AS p90_unread,
+  max(unread_count)                                                 AS max_unread
+FROM subscriptions
+WHERE unsubscribed_at IS NULL;
+
+\echo '==================== 5. ENTRIES PER USER + READ/STAR RATES ===================='
+WITH per_user AS (
+  SELECT
+    user_id,
+    count(*)                                    AS entries,
+    count(*) FILTER (WHERE read)                AS read_entries,
+    count(*) FILTER (WHERE starred)             AS starred_entries
+  FROM user_entries
+  GROUP BY user_id
+)
+SELECT
+  round(avg(entries), 0)                                        AS mean_entries_per_user,
+  percentile_cont(0.5) WITHIN GROUP (ORDER BY entries)         AS p50_entries,
+  percentile_cont(0.9) WITHIN GROUP (ORDER BY entries)         AS p90_entries,
+  max(entries)                                                 AS max_entries_per_user,
+  round(100.0 * sum(read_entries)    / NULLIF(sum(entries),0), 1) AS pct_read,
+  round(100.0 * sum(starred_entries) / NULLIF(sum(entries),0), 2) AS pct_starred
+FROM per_user;
+
+\echo '==================== 6. ENTRY INFLOW (new entries / day) ===================='
+SELECT
+  count(*) FILTER (WHERE fetched_at > now() - interval '1 day')   AS entries_last_1d,
+  round(count(*) FILTER (WHERE fetched_at > now() - interval '7 days') / 7.0, 1)   AS entries_per_day_7d_avg,
+  round(count(*) FILTER (WHERE fetched_at > now() - interval '30 days') / 30.0, 1) AS entries_per_day_30d_avg
+FROM entries;
+
+\echo '==================== 7. FEEDS BY TYPE + POLL CADENCE ===================='
+SELECT type, count(*) AS feeds FROM feeds GROUP BY type ORDER BY feeds DESC;
+
+-- Effective poll interval currently scheduled (next_fetch_at - last_fetched_at).
+SELECT
+  count(*) FILTER (WHERE next_fetch_at IS NOT NULL)                                    AS feeds_scheduled,
+  round(avg(EXTRACT(EPOCH FROM (next_fetch_at - last_fetched_at)))/60.0, 1)            AS mean_interval_min,
+  round(percentile_cont(0.5) WITHIN GROUP (
+          ORDER BY EXTRACT(EPOCH FROM (next_fetch_at - last_fetched_at)))/60.0, 1)     AS p50_interval_min,
+  round(percentile_cont(0.9) WITHIN GROUP (
+          ORDER BY EXTRACT(EPOCH FROM (next_fetch_at - last_fetched_at)))/60.0, 1)     AS p90_interval_min
+FROM feeds
+WHERE last_fetched_at IS NOT NULL AND next_fetch_at IS NOT NULL;
+
+-- How many feed fetches actually happen per hour right now (worker load proxy):
+SELECT
+  count(*) FILTER (WHERE last_fetched_at > now() - interval '1 hour')  AS fetches_last_1h,
+  count(*) FILTER (WHERE last_fetched_at > now() - interval '1 day')   AS fetches_last_1d
+FROM feeds;
+
+\echo '==================== 8. SESSIONS PER USER ===================='
+WITH per_user AS (
+  SELECT user_id, count(*) AS sessions
+  FROM sessions
+  WHERE revoked_at IS NULL AND expires_at > now()
+  GROUP BY user_id
+)
+SELECT
+  count(*)                                                       AS users_with_live_session,
+  round(avg(sessions), 1)                                        AS mean_live_sessions,
+  max(sessions)                                                  AS max_live_sessions
+FROM per_user;
+
+\echo '==================== 9. TABLE SIZES (DB footprint) ===================='
+SELECT
+  relname AS table_name,
+  n_live_tup AS est_rows,
+  pg_size_pretty(pg_total_relation_size(relid)) AS total_size
+FROM pg_stat_user_tables
+WHERE schemaname = 'public'
+ORDER BY pg_total_relation_size(relid) DESC
+LIMIT 12;
+
+\echo '==================== DONE ===================='

--- a/bench/characterize-prod.sql
+++ b/bench/characterize-prod.sql
@@ -98,11 +98,13 @@ SELECT type, count(*) AS feeds FROM feeds GROUP BY type ORDER BY feeds DESC;
 -- Effective poll interval currently scheduled (next_fetch_at - last_fetched_at).
 SELECT
   count(*) FILTER (WHERE next_fetch_at IS NOT NULL)                                    AS feeds_scheduled,
-  round(avg(EXTRACT(EPOCH FROM (next_fetch_at - last_fetched_at)))/60.0, 1)            AS mean_interval_min,
-  round(percentile_cont(0.5) WITHIN GROUP (
-          ORDER BY EXTRACT(EPOCH FROM (next_fetch_at - last_fetched_at)))/60.0, 1)     AS p50_interval_min,
-  round(percentile_cont(0.9) WITHIN GROUP (
-          ORDER BY EXTRACT(EPOCH FROM (next_fetch_at - last_fetched_at)))/60.0, 1)     AS p90_interval_min
+  -- EXTRACT(EPOCH ...) and percentile_cont over it return double precision, and
+  -- round(double, int) doesn't exist in Postgres — cast to numeric first.
+  round((avg(EXTRACT(EPOCH FROM (next_fetch_at - last_fetched_at)))/60.0)::numeric, 1) AS mean_interval_min,
+  round((percentile_cont(0.5) WITHIN GROUP (
+          ORDER BY EXTRACT(EPOCH FROM (next_fetch_at - last_fetched_at)))/60.0)::numeric, 1)  AS p50_interval_min,
+  round((percentile_cont(0.9) WITHIN GROUP (
+          ORDER BY EXTRACT(EPOCH FROM (next_fetch_at - last_fetched_at)))/60.0)::numeric, 1)  AS p90_interval_min
 FROM feeds
 WHERE last_fetched_at IS NOT NULL AND next_fetch_at IS NOT NULL;
 

--- a/bench/config.ts
+++ b/bench/config.ts
@@ -1,0 +1,164 @@
+/**
+ * Benchmark configuration — the knobs that make the synthetic workload match
+ * real Lion Reader usage.
+ *
+ * The numbers below are DEFAULTS / ESTIMATES. Run `bench/characterize-prod.sql`
+ * against production and drop the results into `bench/prod-params.json` to
+ * override them with real figures (loaded automatically if the file exists).
+ *
+ * See bench/README.md for the methodology.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export interface WorkloadParams {
+  /** How each seeded user's data is shaped (drives bench/seed-bench.ts). */
+  seed: {
+    /** Subscriptions per user (≈ prod p50). */
+    subsPerUser: number;
+    /** Feeds shared per subscription cluster. Each user gets its own feeds. */
+    entriesPerFeed: number;
+    /** Fraction of a user's entries already marked read (0..1). */
+    readFraction: number;
+    /** Fraction starred (0..1). */
+    starredFraction: number;
+    /** Tags per user. */
+    tagsPerUser: number;
+    /** Uncategorized (untagged) subscriptions per user. */
+    uncategorizedSubs: number;
+  };
+
+  /**
+   * How a logged-in user behaves in one "session" (drives the action mix).
+   * A session = one page load bundle + a browse loop.
+   */
+  session: {
+    /** entries.list page size the client requests. */
+    listLimit: number;
+    /** Extra list pages fetched by scrolling, per session. */
+    scrollPages: number;
+    /** Articles opened per session (each = get + single markRead). */
+    articlesOpened: number;
+    /** Probability an opened article gets starred. */
+    starProbability: number;
+    /** Probability the session issues a batch markRead (mark several read). */
+    batchMarkReadProbability: number;
+    /** Batch size when it does. */
+    batchMarkReadSize: number;
+    /** Probability the session ends with a mark-all-read (rare, expensive). */
+    markAllReadProbability: number;
+    /** Whether each VU holds an SSE connection open for the session. */
+    holdSse: boolean;
+    /** Think time (ms) between actions — models human reading. [min,max] */
+    thinkMs: [number, number];
+    /** Pause (ms) between one session ending and the next starting. [min,max] */
+    betweenSessionsMs: [number, number];
+  };
+
+  /**
+   * Translating a measured "peak concurrent active users" ceiling into a
+   * "total registered users" ceiling. Derived from prod recency data
+   * (characterize-prod.sql section 2).
+   *
+   * registeredCeiling = concurrentCeiling / peakConcurrentFraction
+   *
+   * peakConcurrentFraction = (peak simultaneous users) / (total registered).
+   * We estimate it from: what fraction of registered users are active in a
+   * 5-minute window at peak. If prod is too small to observe a real peak, we
+   * fall back to an industry heuristic (see README).
+   */
+  translation: {
+    /** Fraction of registered users concurrently active at peak. */
+    peakConcurrentFraction: number;
+  };
+}
+
+const DEFAULTS: WorkloadParams = {
+  seed: {
+    subsPerUser: 40,
+    entriesPerFeed: 50,
+    readFraction: 0.6,
+    starredFraction: 0.01,
+    tagsPerUser: 5,
+    uncategorizedSubs: 8,
+  },
+  session: {
+    listLimit: 50,
+    scrollPages: 2,
+    articlesOpened: 5,
+    starProbability: 0.15,
+    batchMarkReadProbability: 0.4,
+    batchMarkReadSize: 10,
+    markAllReadProbability: 0.05,
+    holdSse: true,
+    thinkMs: [500, 3000],
+    betweenSessionsMs: [1000, 5000],
+  },
+  translation: {
+    // Placeholder: assume 5% of registered users are concurrently active at
+    // peak (typical for a consumer reader app). Replaced by prod-derived value.
+    peakConcurrentFraction: 0.05,
+  },
+};
+
+function deepMerge<T>(base: T, override: Partial<T> | undefined): T {
+  if (!override) return base;
+  const out = { ...base } as Record<string, unknown>;
+  for (const [k, v] of Object.entries(override)) {
+    const bv = (base as Record<string, unknown>)[k];
+    if (v && typeof v === "object" && !Array.isArray(v) && bv && typeof bv === "object") {
+      out[k] = deepMerge(bv, v as Record<string, unknown>);
+    } else if (v !== undefined) {
+      out[k] = v;
+    }
+  }
+  return out as T;
+}
+
+/** Loads params, overlaying bench/prod-params.json when present. */
+export function loadWorkload(): WorkloadParams {
+  const path = join(__dirname, "prod-params.json");
+  if (existsSync(path)) {
+    try {
+      const override = JSON.parse(readFileSync(path, "utf8")) as Partial<WorkloadParams>;
+      return deepMerge(DEFAULTS, override);
+    } catch (err) {
+      console.warn(`[config] failed to read prod-params.json, using defaults:`, err);
+    }
+  }
+  return DEFAULTS;
+}
+
+/** Concurrency staircase for the load test (VUs per stage). */
+export const DEFAULT_STAGES = [5, 10, 25, 50, 100, 200, 400];
+
+/** Seconds each stage runs. */
+export const DEFAULT_STAGE_SECONDS = 30;
+
+/**
+ * Pass/fail gate for a stage. The "knee" is the largest VU count whose stage
+ * still passes.
+ *
+ * NOTE on which signals to trust: the load generator is a single Node process,
+ * so above a few hundred VUs on a big host ITS event loop (superjson-decoding
+ * list responses) inflates *client-side* latency before the server saturates.
+ * We therefore gate primarily on SERVER-SIDE truth — the app's own tRPC latency
+ * histogram and pg-pool-waiting gauge — and keep the client p95 only as a loose
+ * sanity ceiling. When a stage fails, the summary reports whether the SERVER
+ * saturated (pool queued / server latency climbed) or the run was generator-
+ * bound (server still flat) so local numbers aren't misread.
+ */
+export const SLO = {
+  /** Server-side mean latency for entries.list must stay under this (ms). */
+  serverListMeanMs: 150,
+  /** Any queuing for a pg connection = DB saturation → fail. */
+  maxPoolWaiting: 0,
+  /** Overall client error rate must stay under this (fraction). */
+  maxErrorRate: 0.01,
+  /** Loose client-side p95 sanity ceiling (ms); breaching alone is a soft warn. */
+  clientListP95Ms: 2000,
+};

--- a/bench/config.ts
+++ b/bench/config.ts
@@ -20,7 +20,7 @@ export interface WorkloadParams {
   seed: {
     /** Subscriptions per user (≈ prod p50). */
     subsPerUser: number;
-    /** Feeds shared per subscription cluster. Each user gets its own feeds. */
+    /** Entries generated per feed (each user has its own feeds). */
     entriesPerFeed: number;
     /** Fraction of a user's entries already marked read (0..1). */
     readFraction: number;
@@ -39,6 +39,12 @@ export interface WorkloadParams {
   session: {
     /** entries.list page size the client requests. */
     listLimit: number;
+    /**
+     * Whether the list bundle filters to unread only. Production defaults to
+     * unreadOnly=true on essentially every route (getDefaultViewPreferences),
+     * so this is the query plan the SLO should gate on.
+     */
+    unreadOnly: boolean;
     /** Extra list pages fetched by scrolling, per session. */
     scrollPages: number;
     /** Articles opened per session (each = get + single markRead). */
@@ -88,6 +94,7 @@ const DEFAULTS: WorkloadParams = {
   },
   session: {
     listLimit: 50,
+    unreadOnly: true,
     scrollPages: 2,
     articlesOpened: 5,
     starProbability: 0.15,

--- a/bench/fly-bench/README.md
+++ b/bench/fly-bench/README.md
@@ -1,0 +1,108 @@
+# Fly `performance-2x/4GB` capacity test — runbook
+
+Runs the same benchmark as the local test against a **throwaway** Fly app on the
+cheapest dedicated-CPU tier you wanted to check (`performance-2x`, 2 dedicated
+cores, 4 GB). Tear it all down at the end.
+
+> **Why a runbook and not an automated script:** the agent that built this only
+> had an app-scoped Fly _deploy token_ — it can't create apps, tunnel, or SSH, so
+> it couldn't run or test this end-to-end. Run it yourself (you have full perms),
+> or hand the agent a broader token and it'll drive it. Review each step; this
+> creates real (cheap, short-lived) billable resources.
+>
+> **The local 2-core run is already a good proxy** for this tier (see
+> `~/wiki/pages/lion-reader-capacity-benchmark-2026.md`): ~200 concurrent active
+> users / ~400 rps, DB never the bottleneck. This run confirms it on real Fly
+> hardware and network.
+
+Everything below assumes you're in the repo root with `flyctl` authenticated.
+
+## 1. Create the throwaway app + datastores
+
+```bash
+fly apps create lion-reader-bench --org personal
+
+# Postgres — single node, dedicated CPU so the DB isn't the variable under test.
+fly postgres create --name lion-reader-bench-db --org personal \
+  --region lax --vm-size performance-1x --volume-size 10 --initial-cluster-size 1
+fly postgres attach lion-reader-bench-db -a lion-reader-bench   # sets DATABASE_URL
+
+# Redis (Upstash via Fly). Copy the redis:// URL it prints.
+fly redis create --name lion-reader-bench-redis --org personal --region lax
+fly secrets set -a lion-reader-bench REDIS_URL="redis://…"
+```
+
+The app needs **only** `DATABASE_URL` + `REDIS_URL` at boot (storage/OAuth secrets
+are lazy and unused by the load test).
+
+## 2. Deploy the CURRENT image on performance-2x
+
+Build the image once and deploy it with the benchmark config:
+
+```bash
+# Build & push the app image (or reuse a recent prod image tag).
+fly deploy -a lion-reader-bench --config bench/fly-bench/fly.bench.toml \
+  --build-only --push --image-label bench-$(date +%s)
+# ^ note the image ref it prints, then:
+fly deploy -a lion-reader-bench --config bench/fly-bench/fly.bench.toml \
+  --image registry.fly.io/lion-reader-bench:bench-…
+```
+
+(Or simply `fly deploy -a lion-reader-bench --config bench/fly-bench/fly.bench.toml`
+to build from the Dockerfile. `release_command` runs migrations.)
+
+Confirm one `performance-2x` app machine is up: `fly status -a lion-reader-bench`.
+
+## 3. Seed the throwaway DB
+
+Open a proxy to the bench Postgres and run the seeder against it from your box:
+
+```bash
+fly proxy 15432:5432 -a lion-reader-bench-db &       # local :15432 → bench DB
+# DATABASE_URL from `fly postgres attach` output, host swapped to 127.0.0.1:15432
+USERS=1000 DATABASE_URL="postgres://…@127.0.0.1:15432/lion_reader_bench" \
+  npx tsx bench/seed-bench.ts
+```
+
+This writes `bench/sessions.json` (1000 live sessions) — same as local.
+
+## 4. Run the load test from your box against the Fly app
+
+Scrape server-side metrics through a second proxy (Fly's internal metrics port
+isn't public):
+
+```bash
+fly proxy 9091:9091 -a lion-reader-bench &           # server-side metrics
+BASE_URL=https://lion-reader-bench.fly.dev \
+  METRICS_URL=http://127.0.0.1:9091/metrics \
+  STAGES=25,50,100,150,200,300 STAGE_SECONDS=45 RESULT_LABEL=fly-perf2x \
+  npx tsx bench/loadtest.ts
+```
+
+Also watch Fly's own CPU signal during the run (dedicated cores shouldn't
+throttle, but confirm): `fly_instance_cpu_balance` in `fly dashboard metrics`, and
+`fly logs -a lion-reader-bench`.
+
+> Network note: the driver runs on your box, so client-side latency includes
+> WAN RTT to `lax`. Trust the **server-side** `list.mean` / `markRead.mean` from
+> the metrics scrape for the capacity knee (same as the local method).
+
+## 5. Compare & tear down
+
+Compare `bench/results-fly-perf2x.json` `knee` to the local 2-core run. Then:
+
+```bash
+kill %1 %2 2>/dev/null                                # close proxies
+fly apps destroy lion-reader-bench --yes
+fly postgres detach lion-reader-bench-db -a lion-reader-bench 2>/dev/null || true
+fly apps destroy lion-reader-bench-db --yes
+fly redis destroy lion-reader-bench-redis --yes 2>/dev/null || true
+```
+
+## Optional: measure the CURRENT shared-cpu tier (the real HN risk)
+
+To see the throttling collapse directly, repeat with `size = "shared-cpu-2x"` /
+`memory = "512mb"` in `fly.bench.toml`. Expect the burst balance to carry the
+first ~seconds, then server-side latency to blow up as it hard-caps at the
+6.25 %-per-vCPU baseline — the failure mode a HN spike would hit today. See
+`~/wiki/pages/lion-reader-hosting-options-2026.md`.

--- a/bench/fly-bench/README.md
+++ b/bench/fly-bench/README.md
@@ -11,8 +11,8 @@ cores, 4 GB). Tear it all down at the end.
 > creates real (cheap, short-lived) billable resources.
 >
 > **The local 2-core run is already a good proxy** for this tier (see
-> `~/wiki/pages/lion-reader-capacity-benchmark-2026.md`): ~200 concurrent active
-> users / ~400 rps, DB never the bottleneck. This run confirms it on real Fly
+> `~/wiki/pages/lion-reader-capacity-benchmark-2026.md`): ~250 concurrent active
+> users / ~350 rps, DB never the bottleneck. This run confirms it on real Fly
 > hardware and network.
 
 Everything below assumes you're in the repo root with `flyctl` authenticated.

--- a/bench/fly-bench/fly.bench.toml
+++ b/bench/fly-bench/fly.bench.toml
@@ -1,0 +1,46 @@
+# Throwaway Fly app for the capacity benchmark — NOT production.
+#
+# App-only (no worker/discord): the load test exercises the request path, so we
+# don't need feed polling. One app machine on the cheapest DEDICATED-CPU tier
+# you asked to test: performance-2x / 4GB. Deploy with the CURRENT app image.
+#
+# See bench/fly-bench/README.md for the full runbook (create DB+Redis, set
+# secrets, deploy, seed, run, destroy).
+
+app = "lion-reader-bench"
+primary_region = "lax"
+
+[build]
+  # Reuse the image the runbook builds/pins; no Dockerfile build needed if you
+  # pass --image. Left here for `fly deploy` from a checkout as a fallback.
+  dockerfile = "../../Dockerfile"
+
+[deploy]
+  release_command = "node dist/migrate.js"
+  strategy = "immediate"
+
+[processes]
+  app = "node dist/server.js"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "3000"
+  NEXT_PUBLIC_APP_URL = "https://lion-reader-bench.fly.dev"
+  # Turn on the Prometheus endpoint so the driver can scrape server-side truth
+  # (reach it via `fly proxy 9091:9091 -a lion-reader-bench` while testing).
+  METRICS_ENABLED = "true"
+  # Match prod's DB pool so the benchmark sees the same connection ceiling.
+  PG_POOL_MAX = "20"
+  FETCHER_CONTACT_EMAIL = "self@brendanlong.com"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = false      # never suspend mid-test
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[vm]]
+  size = "performance-2x"         # 2 dedicated cores
+  memory = "4gb"
+  processes = ["app"]

--- a/bench/lib/trpc-client.ts
+++ b/bench/lib/trpc-client.ts
@@ -1,0 +1,79 @@
+/**
+ * A tRPC client factory for load generation. Uses the app's OWN transformer
+ * (superjson) and router types, so the wire format is guaranteed identical to
+ * production — no hand-rolled batch/superjson encoding to get subtly wrong.
+ *
+ * We use httpLink (UNBATCHED) rather than the prod httpBatchLink so each action
+ * is exactly one HTTP request; this gives clean per-endpoint latency and lets
+ * the driver control offered load precisely. The server does the same
+ * per-procedure work either way. (Batching is noted as a caveat in the report.)
+ *
+ * All HTTP goes through a single shared undici Agent with a large connection
+ * pool so the LOAD GENERATOR never becomes the bottleneck (Node's built-in
+ * fetch uses a separate bundled undici, so we call undici's fetch explicitly
+ * and pass the dispatcher rather than relying on setGlobalDispatcher).
+ */
+
+import { createTRPCClient, httpLink } from "@trpc/client";
+import { Agent, fetch as undiciFetch } from "undici";
+import superjson from "superjson";
+import type { AppRouter } from "../../src/server/trpc/root";
+
+export type BenchClient = ReturnType<typeof createTRPCClient<AppRouter>>;
+
+const MAX_CONNECTIONS = Number(process.env.MAX_CONNECTIONS ?? 2048);
+export const dispatcher = new Agent({
+  connections: MAX_CONNECTIONS,
+  pipelining: 1,
+  keepAliveTimeout: 60_000,
+  keepAliveMaxTimeout: 120_000,
+});
+
+/** Builds a client authenticated as one seeded user via its session cookie. */
+export function makeClient(baseUrl: string, sessionToken: string): BenchClient {
+  return createTRPCClient<AppRouter>({
+    links: [
+      httpLink({
+        url: `${baseUrl}/api/trpc`,
+        transformer: superjson,
+        headers() {
+          return { cookie: `session=${sessionToken}` };
+        },
+        // undici fetch + shared dispatcher (large pool). Cast to the fetch shape
+        // tRPC expects; undici's Response is spec-compatible for tRPC's needs.
+        fetch: ((input: string | URL, init?: RequestInit) =>
+          undiciFetch(input, {
+            ...(init as object),
+            dispatcher,
+          })) as unknown as typeof fetch,
+      }),
+    ],
+  });
+}
+
+/**
+ * Opens an SSE connection (GET /api/v1/events) and holds it open, discarding
+ * data, until aborted. Mirrors the browser's single long-lived EventSource.
+ * Returns a function that closes it.
+ */
+export function openSse(baseUrl: string, sessionToken: string): () => void {
+  const controller = new AbortController();
+  void undiciFetch(`${baseUrl}/api/v1/events`, {
+    method: "GET",
+    headers: { cookie: `session=${sessionToken}`, accept: "text/event-stream" },
+    signal: controller.signal,
+    dispatcher,
+  })
+    .then(async (res) => {
+      if (!res.body) return;
+      const reader = res.body.getReader();
+      for (;;) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    })
+    .catch(() => {
+      /* aborted or connection dropped — expected */
+    });
+  return () => controller.abort();
+}

--- a/bench/loadtest.ts
+++ b/bench/loadtest.ts
@@ -1,0 +1,467 @@
+/**
+ * Lion Reader load driver.
+ *
+ * Replays a realistic logged-in-user workload (page-load bundle + browse loop)
+ * against a running app, ramping concurrency through a staircase of "virtual
+ * users" (VUs) to find the capacity knee: the largest VU count whose stage
+ * still meets the SLO (bench/config.ts).
+ *
+ * Each VU authenticates as a distinct seeded user (bench/sessions.json) using
+ * the app's real tRPC client, so the wire format matches production exactly.
+ * At each stage boundary we also scrape the server's own Prometheus metrics
+ * (server-side tRPC latency + pg pool saturation) for ground truth independent
+ * of client-side timing.
+ *
+ * Usage:
+ *   BASE_URL=http://127.0.0.1:3000 METRICS_URL=http://127.0.0.1:9091/metrics \
+ *     STAGES=5,10,25,50,100,200 STAGE_SECONDS=30 tsx bench/loadtest.ts
+ *
+ * Output: a table per stage + a final capacity summary (JSON to
+ * bench/results-<label>.json if RESULT_LABEL is set).
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { makeClient, openSse, type BenchClient } from "./lib/trpc-client";
+import { loadWorkload, DEFAULT_STAGES, DEFAULT_STAGE_SECONDS, SLO } from "./config";
+// The load generator's HTTP pool (large, so it never bottlenecks) lives in
+// ./lib/trpc-client via an explicit undici dispatcher.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const BASE_URL = process.env.BASE_URL ?? "http://127.0.0.1:3000";
+const METRICS_URL = process.env.METRICS_URL ?? "";
+const STAGES = (
+  process.env.STAGES?.split(",").map((s) => Number(s.trim())) ?? DEFAULT_STAGES
+).filter((n) => n > 0);
+const STAGE_SECONDS = Number(process.env.STAGE_SECONDS ?? DEFAULT_STAGE_SECONDS);
+const RESULT_LABEL = process.env.RESULT_LABEL ?? "";
+
+const workload = loadWorkload();
+const S = workload.session;
+
+interface SessionInfo {
+  userId: string;
+  sessionToken: string;
+}
+
+// ---------------------------------------------------------------------------
+// Metrics recording
+// ---------------------------------------------------------------------------
+
+class Recorder {
+  private samples = new Map<string, number[]>();
+  errors = 0;
+  ok = 0;
+
+  record(action: string, ms: number): void {
+    let arr = this.samples.get(action);
+    if (!arr) {
+      arr = [];
+      this.samples.set(action, arr);
+    }
+    arr.push(ms);
+  }
+
+  reset(): void {
+    this.samples.clear();
+    this.errors = 0;
+    this.ok = 0;
+  }
+
+  stats(action: string): { n: number; p50: number; p95: number; p99: number; max: number } {
+    const arr = (this.samples.get(action) ?? []).slice().sort((a, b) => a - b);
+    if (arr.length === 0) return { n: 0, p50: 0, p95: 0, p99: 0, max: 0 };
+    const q = (p: number) => arr[Math.min(arr.length - 1, Math.floor(p * arr.length))];
+    return { n: arr.length, p50: q(0.5), p95: q(0.95), p99: q(0.99), max: arr[arr.length - 1] };
+  }
+
+  actions(): string[] {
+    return [...this.samples.keys()].sort();
+  }
+
+  totalRequests(): number {
+    return this.ok + this.errors;
+  }
+}
+
+const rec = new Recorder();
+
+async function timed<T>(action: string, fn: () => Promise<T>): Promise<T | undefined> {
+  const t0 = performance.now();
+  try {
+    const r = await fn();
+    rec.record(action, performance.now() - t0);
+    rec.ok++;
+    return r;
+  } catch {
+    rec.record(action, performance.now() - t0);
+    rec.errors++;
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The scripted user session
+// ---------------------------------------------------------------------------
+
+function rand([lo, hi]: [number, number]): number {
+  return lo + Math.random() * (hi - lo);
+}
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function runSession(client: BenchClient, stopAt: number): Promise<void> {
+  // 1. Page-load bundle (browser fires these together on load).
+  const [listRes] = await Promise.all([
+    timed("entries.list", () => client.entries.list.query({ limit: S.listLimit })),
+    timed("subscriptions.list", () => client.subscriptions.list.query({ limit: 100 })),
+    timed("tags.list", () => client.tags.list.query()),
+    timed("entries.count(all)", () => client.entries.count.query({})),
+    timed("entries.count(saved)", () => client.entries.count.query({ type: "saved" })),
+    timed("entries.count(starred)", () => client.entries.count.query({ starredOnly: true })),
+  ]);
+
+  let items = (listRes as { items?: { id: string }[] } | undefined)?.items ?? [];
+  let cursor = (listRes as { nextCursor?: string } | undefined)?.nextCursor;
+
+  // 2. Scroll to load more pages.
+  for (let p = 0; p < S.scrollPages && cursor && Date.now() < stopAt; p++) {
+    await sleep(rand(S.thinkMs));
+    const more = await timed("entries.list(scroll)", () =>
+      client.entries.list.query({ limit: S.listLimit, cursor })
+    );
+    const moreItems = (more as { items?: { id: string }[] } | undefined)?.items ?? [];
+    items = items.concat(moreItems);
+    cursor = (more as { nextCursor?: string } | undefined)?.nextCursor;
+  }
+
+  const pool = items.map((i) => i.id);
+  let poolIdx = 0;
+  const nextId = (): string | undefined => (poolIdx < pool.length ? pool[poolIdx++] : undefined);
+
+  // 3. Browse loop: open articles (get + markRead), occasional star.
+  for (let a = 0; a < S.articlesOpened && Date.now() < stopAt; a++) {
+    const id = nextId();
+    if (!id) break;
+    await sleep(rand(S.thinkMs));
+    await timed("entries.get", () => client.entries.get.query({ id }));
+    await timed("entries.markRead(1)", () =>
+      client.entries.markRead.mutate({ entries: [{ id }], read: true })
+    );
+    if (Math.random() < S.starProbability) {
+      await timed("entries.setStarred", () =>
+        client.entries.setStarred.mutate({ id, starred: true })
+      );
+    }
+  }
+
+  // 4. Occasional batch mark-read.
+  if (Math.random() < S.batchMarkReadProbability && Date.now() < stopAt) {
+    const batch = pool.slice(poolIdx, poolIdx + S.batchMarkReadSize).map((id) => ({ id }));
+    if (batch.length) {
+      await timed(`entries.markRead(${batch.length})`, () =>
+        client.entries.markRead.mutate({ entries: batch, read: true })
+      );
+    }
+  }
+
+  // 5. Rare mark-all-read.
+  if (Math.random() < S.markAllReadProbability && Date.now() < stopAt) {
+    await timed("entries.markAllRead", () => client.entries.markAllRead.mutate({}));
+  }
+}
+
+/** One VU: loops sessions until the stage deadline. */
+async function runVu(session: SessionInfo, stopAt: number): Promise<void> {
+  const client = makeClient(BASE_URL, session.sessionToken);
+  const closeSse = S.holdSse ? openSse(BASE_URL, session.sessionToken) : () => {};
+  try {
+    while (Date.now() < stopAt) {
+      await runSession(client, stopAt);
+      if (Date.now() >= stopAt) break;
+      await sleep(rand(S.betweenSessionsMs));
+    }
+  } finally {
+    closeSse();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server metrics scrape (Prometheus text format)
+// ---------------------------------------------------------------------------
+
+interface ServerSnapshot {
+  /** Peak connections in the pg pool observed during the stage. */
+  peakPoolTotal?: number;
+  /** Peak queued (waiting-for-connection) requests during the stage. */
+  peakPoolWaiting?: number;
+  /** Peak active SSE connections during the stage. */
+  peakSseActive?: number;
+  /** Server-side mean latency (ms) over the stage, from the tRPC histogram. */
+  serverListMeanMs?: number;
+  serverMarkReadMeanMs?: number;
+}
+
+async function fetchMetrics(): Promise<string | undefined> {
+  if (!METRICS_URL) return undefined;
+  try {
+    const res = await fetch(METRICS_URL, { signal: AbortSignal.timeout(5000) });
+    return await res.text();
+  } catch {
+    return undefined;
+  }
+}
+
+function gauge(text: string, name: string): number | undefined {
+  const m = text.match(new RegExp(`^${name}(?:\\{[^}]*\\})?\\s+([0-9.eE+-]+)`, "m"));
+  return m ? Number(m[1]) : undefined;
+}
+
+/** Sum + count for a tRPC procedure's duration histogram (seconds). */
+function trpcHist(text: string, procedure: string): { sum: number; count: number } {
+  const sumRe = new RegExp(
+    `^trpc_procedure_duration_seconds_sum\\{[^}]*procedure="${procedure}"[^}]*\\}\\s+([0-9.eE+-]+)`,
+    "m"
+  );
+  const cntRe = new RegExp(
+    `^trpc_procedure_duration_seconds_count\\{[^}]*procedure="${procedure}"[^}]*\\}\\s+([0-9.eE+-]+)`,
+    "m"
+  );
+  const sum = text.match(sumRe);
+  const cnt = text.match(cntRe);
+  return { sum: sum ? Number(sum[1]) : 0, count: cnt ? Number(cnt[1]) : 0 };
+}
+
+/**
+ * Samples pool/SSE gauges every `intervalMs` until `stopAt`, tracking peaks.
+ * Runs concurrently with a stage's VUs so it captures live saturation.
+ */
+async function sampleGaugesDuring(
+  stopAt: number,
+  intervalMs: number
+): Promise<Pick<ServerSnapshot, "peakPoolTotal" | "peakPoolWaiting" | "peakSseActive">> {
+  const peak = { peakPoolTotal: 0, peakPoolWaiting: 0, peakSseActive: 0 };
+  if (!METRICS_URL) return peak;
+  while (Date.now() < stopAt) {
+    const text = await fetchMetrics();
+    if (text) {
+      peak.peakPoolTotal = Math.max(
+        peak.peakPoolTotal,
+        gauge(text, "db_pool_total_connections") ?? 0
+      );
+      peak.peakPoolWaiting = Math.max(
+        peak.peakPoolWaiting,
+        gauge(text, "db_pool_waiting_requests") ?? 0
+      );
+      peak.peakSseActive = Math.max(peak.peakSseActive, gauge(text, "sse_connections_active") ?? 0);
+    }
+    await sleep(intervalMs);
+  }
+  return peak;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+interface StageResult {
+  vus: number;
+  durationS: number;
+  totalRequests: number;
+  rps: number;
+  errorRate: number;
+  listP95: number;
+  listP50: number;
+  server: ServerSnapshot;
+  pass: boolean;
+  limiter: string;
+}
+
+function loadSessions(): SessionInfo[] {
+  const path = join(__dirname, "sessions.json");
+  const data = JSON.parse(readFileSync(path, "utf8")) as {
+    users: { userId: string; sessionToken: string }[];
+  };
+  if (!data.users?.length) throw new Error("sessions.json has no users — run seed-bench.ts first");
+  return data.users;
+}
+
+async function runStage(vus: number, sessions: SessionInfo[]): Promise<StageResult> {
+  rec.reset();
+  const stopAt = Date.now() + STAGE_SECONDS * 1000;
+
+  // Snapshot server-side histograms before the stage to compute per-stage means.
+  const before = await fetchMetrics();
+  const listBefore = before ? trpcHist(before, "entries.list") : { sum: 0, count: 0 };
+  const mrBefore = before ? trpcHist(before, "entries.markRead") : { sum: 0, count: 0 };
+
+  const vuPromises: Promise<void>[] = [];
+  for (let i = 0; i < vus; i++) {
+    // Distinct user per VU where possible; wrap around if fewer sessions.
+    vuPromises.push(runVu(sessions[i % sessions.length], stopAt));
+  }
+  const gaugesPromise = sampleGaugesDuring(stopAt, 2000);
+  await Promise.all(vuPromises);
+  const peaks = await gaugesPromise;
+
+  // Server-side mean latency over the stage (histogram delta).
+  const after = await fetchMetrics();
+  const listAfter = after ? trpcHist(after, "entries.list") : { sum: 0, count: 0 };
+  const mrAfter = after ? trpcHist(after, "entries.markRead") : { sum: 0, count: 0 };
+  const meanMs = (a: { sum: number; count: number }, b: { sum: number; count: number }) => {
+    const dc = a.count - b.count;
+    return dc > 0 ? ((a.sum - b.sum) / dc) * 1000 : undefined;
+  };
+  const server: ServerSnapshot = {
+    ...peaks,
+    serverListMeanMs: meanMs(listAfter, listBefore),
+    serverMarkReadMeanMs: meanMs(mrAfter, mrBefore),
+  };
+
+  const listStats = rec.stats("entries.list");
+  const total = rec.totalRequests();
+  const errorRate = total > 0 ? rec.errors / total : 0;
+
+  // Server-side-primary gate (see config SLO note).
+  const serverListMean = server.serverListMeanMs ?? 0;
+  const poolWaiting = server.peakPoolWaiting ?? 0;
+  const serverSaturated =
+    poolWaiting > SLO.maxPoolWaiting ||
+    (METRICS_URL !== "" && serverListMean > SLO.serverListMeanMs);
+  const pass = total > 0 && errorRate <= SLO.maxErrorRate && !serverSaturated;
+  // Diagnose the limiter for the summary.
+  const clientHot = listStats.p95 > SLO.clientListP95Ms;
+  const limiter = !pass
+    ? poolWaiting > SLO.maxPoolWaiting
+      ? "DB pool saturated (queries queued for a connection)"
+      : serverListMean > SLO.serverListMeanMs
+        ? "server CPU/latency (server-side list latency climbed)"
+        : errorRate > SLO.maxErrorRate
+          ? "errors"
+          : "unknown"
+    : clientHot
+      ? "generator-bound (client p95 high but server still flat)"
+      : "";
+
+  // Per-action table.
+  console.log(`\n===== STAGE: ${vus} VUs (${STAGE_SECONDS}s) =====`);
+  console.log(
+    `${"action".padEnd(26)} ${"n".padStart(7)} ${"p50".padStart(8)} ${"p95".padStart(8)} ${"p99".padStart(8)} ${"max".padStart(8)}`
+  );
+  for (const action of rec.actions()) {
+    const s = rec.stats(action);
+    console.log(
+      `${action.padEnd(26)} ${String(s.n).padStart(7)} ${s.p50.toFixed(0).padStart(8)} ` +
+        `${s.p95.toFixed(0).padStart(8)} ${s.p99.toFixed(0).padStart(8)} ${s.max.toFixed(0).padStart(8)}`
+    );
+  }
+  const rps = total / STAGE_SECONDS;
+  console.log(
+    `\n  requests=${total} rps=${rps.toFixed(1)} errors=${rec.errors} (${(errorRate * 100).toFixed(2)}%) ` +
+      `list.p95=${listStats.p95.toFixed(0)}ms`
+  );
+  if (METRICS_URL) {
+    console.log(
+      `  server: peakPool=${server.peakPoolTotal ?? "?"} peakWaiting=${server.peakPoolWaiting ?? "?"} ` +
+        `peakSSE=${server.peakSseActive ?? "?"} | serverside list.mean=${server.serverListMeanMs?.toFixed(1) ?? "?"}ms ` +
+        `markRead.mean=${server.serverMarkReadMeanMs?.toFixed(1) ?? "?"}ms`
+    );
+  }
+  console.log(
+    `  SLO: ${pass ? "PASS ✅" : "FAIL ❌"} ` +
+      `(serverList.mean<=${SLO.serverListMeanMs}ms, poolWaiting<=${SLO.maxPoolWaiting}, err<=${SLO.maxErrorRate * 100}%)` +
+      (limiter ? `  → ${limiter}` : "")
+  );
+
+  return {
+    vus,
+    durationS: STAGE_SECONDS,
+    totalRequests: total,
+    rps,
+    errorRate,
+    listP95: listStats.p95,
+    listP50: listStats.p50,
+    server,
+    pass,
+    limiter,
+  };
+}
+
+async function main() {
+  const sessions = loadSessions();
+  console.log(`Load test → ${BASE_URL}`);
+  console.log(`Sessions available: ${sessions.length}`);
+  console.log(
+    `Stages (VUs): ${STAGES.join(", ")}  |  ${STAGE_SECONDS}s each  |  SSE hold: ${S.holdSse}`
+  );
+  if (METRICS_URL) console.log(`Server metrics: ${METRICS_URL}`);
+
+  // Warmup: run a little traffic to warm the JIT + pg pool so stage 1 isn't
+  // penalised by cold-start latency. Discarded (the first real stage resets rec).
+  const warmupS = Number(process.env.WARMUP_SECONDS ?? 8);
+  if (warmupS > 0) {
+    console.log(`\nWarming up for ${warmupS}s…`);
+    const stopAt = Date.now() + warmupS * 1000;
+    const n = Math.min(STAGES[0], sessions.length);
+    await Promise.all(
+      Array.from({ length: n }, (_, i) => runVu(sessions[i % sessions.length], stopAt))
+    );
+  }
+
+  const results: StageResult[] = [];
+  let knee = 0;
+  for (const vus of STAGES) {
+    const r = await runStage(vus, sessions);
+    results.push(r);
+    if (r.pass) knee = vus;
+    else {
+      console.log(
+        `\n>>> SLO breached at ${vus} VUs (${r.limiter}) — stopping ramp. Knee = ${knee} concurrent VUs.`
+      );
+      break;
+    }
+  }
+  const lastStage = results[results.length - 1];
+
+  const frac = workload.translation.peakConcurrentFraction;
+  const registeredCeiling = knee > 0 ? Math.round(knee / frac) : 0;
+
+  console.log(`\n================ CAPACITY SUMMARY ================`);
+  console.log(`Sustainable concurrent active users (knee): ${knee}`);
+  if (lastStage && !lastStage.pass) {
+    console.log(`Limiter at first failing stage (${lastStage.vus} VUs): ${lastStage.limiter}`);
+    if (lastStage.limiter.startsWith("generator-bound")) {
+      console.log(
+        `  ⚠ The SERVER still had headroom here (pool never queued, server latency flat).`
+      );
+      console.log(
+        `    The single-process generator capped the run — the real server ceiling is HIGHER.`
+      );
+      console.log(`    Use more generator processes / a second box to push further.`);
+    }
+  } else if (knee === STAGES[STAGES.length - 1]) {
+    console.log(`Ramp completed without breaching SLO — true knee is ≥ ${knee} (raise STAGES).`);
+  }
+  console.log(`Peak-concurrent fraction (from prod): ${(frac * 100).toFixed(1)}%`);
+  console.log(`=> Registered-user ceiling ≈ ${registeredCeiling.toLocaleString()}`);
+  console.log(`   (registered = concurrent / peakConcurrentFraction)`);
+
+  if (RESULT_LABEL) {
+    const out = join(__dirname, `results-${RESULT_LABEL}.json`);
+    writeFileSync(
+      out,
+      JSON.stringify(
+        { label: RESULT_LABEL, baseUrl: BASE_URL, knee, registeredCeiling, frac, stages: results },
+        null,
+        2
+      )
+    );
+    console.log(`\nWrote ${out}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/bench/loadtest.ts
+++ b/bench/loadtest.ts
@@ -37,6 +37,10 @@ const STAGES = (
 ).filter((n) => n > 0);
 const STAGE_SECONDS = Number(process.env.STAGE_SECONDS ?? DEFAULT_STAGE_SECONDS);
 const RESULT_LABEL = process.env.RESULT_LABEL ?? "";
+// When running several generator processes in parallel against one server, give
+// each a distinct SESSION_OFFSET so they drive DISTINCT users (not the same
+// first-N), avoiding artificial same-user contention.
+const SESSION_OFFSET = Number(process.env.SESSION_OFFSET ?? 0);
 
 const workload = loadWorkload();
 const S = workload.session;
@@ -73,7 +77,8 @@ class Recorder {
   stats(action: string): { n: number; p50: number; p95: number; p99: number; max: number } {
     const arr = (this.samples.get(action) ?? []).slice().sort((a, b) => a - b);
     if (arr.length === 0) return { n: 0, p50: 0, p95: 0, p99: 0, max: 0 };
-    const q = (p: number) => arr[Math.min(arr.length - 1, Math.floor(p * arr.length))];
+    // Nearest-rank: the p-quantile is the ceil(p*n)-th value (1-indexed).
+    const q = (p: number) => arr[Math.max(0, Math.ceil(p * arr.length) - 1)];
     return { n: arr.length, p50: q(0.5), p95: q(0.95), p99: q(0.99), max: arr[arr.length - 1] };
   }
 
@@ -114,7 +119,9 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 async function runSession(client: BenchClient, stopAt: number): Promise<void> {
   // 1. Page-load bundle (browser fires these together on load).
   const [listRes] = await Promise.all([
-    timed("entries.list", () => client.entries.list.query({ limit: S.listLimit })),
+    timed("entries.list", () =>
+      client.entries.list.query({ limit: S.listLimit, unreadOnly: S.unreadOnly })
+    ),
     timed("subscriptions.list", () => client.subscriptions.list.query({ limit: 100 })),
     timed("tags.list", () => client.tags.list.query()),
     timed("entries.count(all)", () => client.entries.count.query({})),
@@ -129,7 +136,7 @@ async function runSession(client: BenchClient, stopAt: number): Promise<void> {
   for (let p = 0; p < S.scrollPages && cursor && Date.now() < stopAt; p++) {
     await sleep(rand(S.thinkMs));
     const more = await timed("entries.list(scroll)", () =>
-      client.entries.list.query({ limit: S.listLimit, cursor })
+      client.entries.list.query({ limit: S.listLimit, unreadOnly: S.unreadOnly, cursor })
     );
     const moreItems = (more as { items?: { id: string }[] } | undefined)?.items ?? [];
     items = items.concat(moreItems);
@@ -218,19 +225,25 @@ function gauge(text: string, name: string): number | undefined {
   return m ? Number(m[1]) : undefined;
 }
 
-/** Sum + count for a tRPC procedure's duration histogram (seconds). */
+/**
+ * Sum + count for a tRPC procedure's duration histogram (seconds), summed
+ * across ALL label series for that procedure. The histogram is labelled
+ * `procedure,type,ok`, so a procedure that has both succeeded and errored emits
+ * separate `_sum`/`_count` series (ok="true" and ok="false"); we must add them
+ * all, not take the first match (which prom-client emits in hash order, not a
+ * stable true-first order — so the first match could be the error series).
+ */
 function trpcHist(text: string, procedure: string): { sum: number; count: number } {
-  const sumRe = new RegExp(
-    `^trpc_procedure_duration_seconds_sum\\{[^}]*procedure="${procedure}"[^}]*\\}\\s+([0-9.eE+-]+)`,
-    "m"
-  );
-  const cntRe = new RegExp(
-    `^trpc_procedure_duration_seconds_count\\{[^}]*procedure="${procedure}"[^}]*\\}\\s+([0-9.eE+-]+)`,
-    "m"
-  );
-  const sum = text.match(sumRe);
-  const cnt = text.match(cntRe);
-  return { sum: sum ? Number(sum[1]) : 0, count: cnt ? Number(cnt[1]) : 0 };
+  const sumOf = (metric: string): number => {
+    const re = new RegExp(
+      `^trpc_procedure_duration_seconds_${metric}\\{[^}]*procedure="${procedure}"[^}]*\\}\\s+([0-9.eE+-]+)`,
+      "gm"
+    );
+    let total = 0;
+    for (const m of text.matchAll(re)) total += Number(m[1]);
+    return total;
+  };
+  return { sum: sumOf("sum"), count: sumOf("count") };
 }
 
 /**
@@ -299,7 +312,8 @@ async function runStage(vus: number, sessions: SessionInfo[]): Promise<StageResu
   const vuPromises: Promise<void>[] = [];
   for (let i = 0; i < vus; i++) {
     // Distinct user per VU where possible; wrap around if fewer sessions.
-    vuPromises.push(runVu(sessions[i % sessions.length], stopAt));
+    // SESSION_OFFSET lets parallel generators cover disjoint user ranges.
+    vuPromises.push(runVu(sessions[(i + SESSION_OFFSET) % sessions.length], stopAt));
   }
   const gaugesPromise = sampleGaugesDuring(stopAt, 2000);
   await Promise.all(vuPromises);
@@ -442,6 +456,13 @@ async function main() {
     }
   } else if (knee === STAGES[STAGES.length - 1]) {
     console.log(`Ramp completed without breaching SLO — true knee is ≥ ${knee} (raise STAGES).`);
+    if (lastStage?.limiter.startsWith("generator-bound")) {
+      console.log(
+        `  ⚠ The top stage was GENERATOR-BOUND (client p95 high, server flat) — this` +
+          ` single generator can't push the server harder. Run parallel generators` +
+          ` (SESSION_OFFSET) to find the true knee; the number below is a lower bound.`
+      );
+    }
   }
   console.log(`Peak-concurrent fraction (from prod): ${(frac * 100).toFixed(1)}%`);
   console.log(`=> Registered-user ceiling ≈ ${registeredCeiling.toLocaleString()}`);

--- a/bench/prod-params.example.json
+++ b/bench/prod-params.example.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Copy to prod-params.json and fill from bench/characterize-prod.sql output. Any subset of keys overrides the defaults in config.ts. Delete keys you don't want to override.",
+  "seed": {
+    "subsPerUser": 40,
+    "entriesPerFeed": 50,
+    "readFraction": 0.6,
+    "starredFraction": 0.01,
+    "tagsPerUser": 5,
+    "uncategorizedSubs": 8
+  },
+  "translation": {
+    "_comment": "peakConcurrentFraction = (peak simultaneous active users) / (total registered). Derive from §2: e.g. if active_5m peaks around 8% of users_total, use ~0.08. This converts the concurrent knee into the registered-user ceiling.",
+    "peakConcurrentFraction": 0.05
+  }
+}

--- a/bench/seed-bench.ts
+++ b/bench/seed-bench.ts
@@ -1,0 +1,210 @@
+/**
+ * Seeds a benchmark database with N synthetic users whose data shape matches
+ * production (subs/user, entries, read/star rates from bench/config.ts, which
+ * is overridden by bench/prod-params.json once characterize-prod.sql is run).
+ *
+ * Each user gets its OWN feeds (no cross-user sharing) so per-user queries scan
+ * realistic volumes and there's no unrealistic cache sharing. A live session is
+ * created per user and written to bench/sessions.json for the load driver.
+ *
+ * Usage:
+ *   USERS=500 tsx bench/seed-bench.ts          # against $DATABASE_URL
+ *
+ * Run against the throwaway local DB:
+ *   dotenv -e .env.local-services -- env USERS=500 tsx bench/seed-bench.ts
+ *
+ * Bulk inserts use generate_series in SQL (fast); mirrors
+ * tests/integration/entries-perf.test.ts.
+ */
+
+import crypto from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { Pool } from "pg";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import * as schema from "../src/server/db/schema";
+import { generateUuidv7 } from "../src/lib/uuidv7";
+import { loadWorkload } from "./config";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const USERS = Number(process.env.USERS ?? 200);
+const w = loadWorkload().seed;
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error("DATABASE_URL is not set. Prefix with dotenv -e .env.local-services --");
+  process.exit(1);
+}
+
+const pool = new Pool({ connectionString: DATABASE_URL, max: 10 });
+const db = drizzle(pool, { schema });
+
+interface SeededSession {
+  userId: string;
+  email: string;
+  sessionToken: string;
+}
+
+function sha256Hex(s: string): string {
+  return crypto.createHash("sha256").update(s).digest("hex");
+}
+
+async function main() {
+  const t0 = Date.now();
+  const feedsPerUser = w.subsPerUser;
+  const entriesPerUser = feedsPerUser * w.entriesPerFeed;
+  console.log(
+    `Seeding ${USERS} users × ${feedsPerUser} feeds × ${w.entriesPerFeed} entries ` +
+      `= ${(USERS * entriesPerUser).toLocaleString()} entries total`
+  );
+  console.log(
+    `  readFraction=${w.readFraction} starredFraction=${w.starredFraction} ` +
+      `tags/user=${w.tagsPerUser} uncategorized=${w.uncategorizedSubs}`
+  );
+
+  console.log("Truncating existing data…");
+  await db.execute(sql`TRUNCATE subscription_tags, tags, user_entries, entries,
+    subscriptions, feeds, sessions, users CASCADE`);
+
+  const sessions: SeededSession[] = [];
+
+  // Process users in batches to bound memory / statement size.
+  const USER_BATCH = 25;
+  for (let start = 0; start < USERS; start += USER_BATCH) {
+    const end = Math.min(start + USER_BATCH, USERS);
+
+    for (let u = start; u < end; u++) {
+      const userId = generateUuidv7();
+      const email = `bench-${userId}@example.com`;
+      const now = new Date();
+
+      await db.insert(schema.users).values({
+        id: userId,
+        email,
+        emailVerifiedAt: now,
+        tosAgreedAt: now,
+        privacyPolicyAgreedAt: now,
+        notEuAgreedAt: now,
+        lastActiveAt: now,
+      });
+
+      // Session (raw token in cookie, sha256 hash stored — mirrors createSession).
+      const sessionToken = crypto.randomBytes(32).toString("base64url");
+      await db.insert(schema.sessions).values({
+        id: generateUuidv7(),
+        userId,
+        tokenHash: sha256Hex(sessionToken),
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      });
+      sessions.push({ userId, email, sessionToken });
+
+      // Tags.
+      const tagIds: string[] = [];
+      const tagValues = [];
+      for (let t = 0; t < w.tagsPerUser; t++) {
+        const id = generateUuidv7();
+        tagIds.push(id);
+        tagValues.push({ id, userId, name: `Tag ${t}` });
+      }
+      if (tagValues.length) await db.insert(schema.tags).values(tagValues);
+
+      // Feeds (unique per user).
+      const feedRows = await db.execute(sql`
+        INSERT INTO feeds (id, type, url, title, last_fetched_at, last_entries_updated_at, next_fetch_at, created_at, updated_at)
+        SELECT
+          gen_random_uuid(), 'web',
+          'https://bench-${sql.raw(userId.replace(/-/g, ""))}-' || i || '.example.com/feed.xml',
+          'Bench Feed ' || i,
+          now(), now(), now() + interval '1 hour', now(), now()
+        FROM generate_series(1, ${feedsPerUser}) AS i
+        RETURNING id
+      `);
+      const feedIds = feedRows.rows.map((r) => (r as { id: string }).id);
+
+      // Subscriptions (one per feed).
+      const subValues = feedIds.map((feedId) => ({
+        id: generateUuidv7(),
+        userId,
+        feedId,
+        subscribedAt: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000),
+      }));
+      await db.insert(schema.subscriptions).values(subValues);
+      const subIds = subValues.map((s) => s.id);
+
+      // Assign tags to all but `uncategorizedSubs` subscriptions.
+      const taggedCount = Math.max(0, subIds.length - w.uncategorizedSubs);
+      const stValues: { subscriptionId: string; tagId: string }[] = [];
+      for (let i = 0; i < taggedCount; i++) {
+        stValues.push({ subscriptionId: subIds[i], tagId: tagIds[i % tagIds.length] });
+      }
+      if (stValues.length) await db.insert(schema.subscriptionTags).values(stValues);
+
+      // Entries for this user's feeds (bulk via generate_series).
+      await db.execute(sql`
+        INSERT INTO entries (id, feed_id, type, guid, title, content_cleaned, content_hash,
+                            fetched_at, published_at, last_seen_at, created_at, updated_at)
+        SELECT
+          gen_random_uuid(), f.id, 'web',
+          f.id || '-' || e.i, 'Entry ' || e.i,
+          'Test content for entry ' || e.i || '. Lorem ipsum dolor sit amet, consectetur.',
+          f.id || '-' || e.i,
+          now() - ((${w.entriesPerFeed} - e.i) || ' minutes')::interval,
+          now() - ((${w.entriesPerFeed} - e.i) || ' minutes')::interval,
+          now(), now(), now()
+        FROM (SELECT unnest(${`{${feedIds.join(",")}}`}::uuid[]) AS id) f
+        CROSS JOIN generate_series(1, ${w.entriesPerFeed}) AS e(i)
+      `);
+
+      // user_entries: read/starred deterministically to hit target fractions.
+      await db.execute(sql`
+        INSERT INTO user_entries (user_id, entry_id, read, starred, read_changed_at, starred_changed_at, updated_at, published_or_fetched_at)
+        SELECT
+          ${userId}::uuid, e.id,
+          (row_number() OVER (PARTITION BY e.feed_id ORDER BY e.id))::float
+            / ${w.entriesPerFeed} <= ${w.readFraction},
+          (row_number() OVER (PARTITION BY e.feed_id ORDER BY e.id))
+            % ${Math.max(1, Math.round(1 / Math.max(w.starredFraction, 0.0001)))} = 0,
+          e.published_at, e.published_at, now(),
+          COALESCE(e.published_at, e.fetched_at)
+        FROM entries e
+        WHERE e.feed_id = ANY(${`{${feedIds.join(",")}}`}::uuid[])
+      `);
+    }
+    console.log(`  seeded ${end}/${USERS} users (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
+  }
+
+  console.log("ANALYZE…");
+  await db.execute(
+    sql`ANALYZE users, sessions, feeds, subscriptions, subscription_tags, tags, entries, user_entries`
+  );
+
+  const outPath = join(__dirname, "sessions.json");
+  writeFileSync(
+    outPath,
+    JSON.stringify({ baseUrlHint: "set at run time", users: sessions }, null, 0)
+  );
+  console.log(`Wrote ${sessions.length} sessions -> ${outPath}`);
+
+  // Size report.
+  const sizes = await db.execute(sql`
+    SELECT relname AS t, n_live_tup AS rows, pg_size_pretty(pg_total_relation_size(relid)) AS size
+    FROM pg_stat_user_tables WHERE schemaname='public'
+    ORDER BY pg_total_relation_size(relid) DESC LIMIT 8
+  `);
+  console.log("Table sizes:");
+  for (const r of sizes.rows) {
+    const row = r as { t: string; rows: number; size: string };
+    console.log(`  ${row.t.padEnd(20)} ${String(row.rows).padStart(12)} rows  ${row.size}`);
+  }
+  console.log(`Done in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/bench/seed-bench.ts
+++ b/bench/seed-bench.ts
@@ -158,15 +158,17 @@ async function main() {
         CROSS JOIN generate_series(1, ${w.entriesPerFeed}) AS e(i)
       `);
 
-      // user_entries: read/starred deterministically to hit target fractions.
+      // user_entries: read set by a per-feed fraction (deterministic); starred
+      // by a Bernoulli draw so the target fraction holds even when
+      // starredFraction * entriesPerFeed < 1 (e.g. 1% of 50 = 0.5/feed — a
+      // per-feed modulus would round to zero starred, #starred-bug).
       await db.execute(sql`
         INSERT INTO user_entries (user_id, entry_id, read, starred, read_changed_at, starred_changed_at, updated_at, published_or_fetched_at)
         SELECT
           ${userId}::uuid, e.id,
           (row_number() OVER (PARTITION BY e.feed_id ORDER BY e.id))::float
             / ${w.entriesPerFeed} <= ${w.readFraction},
-          (row_number() OVER (PARTITION BY e.feed_id ORDER BY e.id))
-            % ${Math.max(1, Math.round(1 / Math.max(w.starredFraction, 0.0001)))} = 0,
+          random() < ${w.starredFraction},
           e.published_at, e.published_at, now(),
           COALESCE(e.published_at, e.fetched_at)
         FROM entries e

--- a/bench/worker/mock-feed-server.ts
+++ b/bench/worker/mock-feed-server.ts
@@ -1,0 +1,98 @@
+/**
+ * A local mock feed server for the worker throughput benchmark. Serves valid
+ * RSS 2.0 so the worker's real fetch → parse → process → sanitize → fanout path
+ * runs end-to-end, without hitting any remote server (the worker must run with
+ * ALLOW_PRIVATE_NETWORK_FETCH=true to reach 127.0.0.1).
+ *
+ * Conditional-GET aware: once the worker has stored our stable ETag, a re-poll
+ * sends `If-None-Match` and we return 304 — that's the steady-state case (most
+ * real polls find nothing new). A first poll (no If-None-Match) returns 200 with
+ * `itemsPerFeed` items — the "fresh"/catch-up case (full parse + fanout).
+ */
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+const STABLE_ETAG = '"bench-v1"';
+
+function buildRss(feedPath: string, items: number): string {
+  const now = new Date().toUTCString();
+  const entries: string[] = [];
+  for (let i = 0; i < items; i++) {
+    // guid stable per (feed, item) so a re-poll with changed body would dedup by
+    // content_hash; but re-polls are 304 here so this mainly keeps items valid.
+    const guid = `${feedPath}#item-${i}`;
+    entries.push(
+      `<item>` +
+        `<title>Benchmark entry ${i}</title>` +
+        `<link>http://127.0.0.1/article/${i}</link>` +
+        `<guid isPermaLink="false">${guid}</guid>` +
+        `<pubDate>${now}</pubDate>` +
+        `<description><![CDATA[<p>Paragraph one with a <a href="http://example.com">link</a> and <strong>bold</strong> text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><p>Second paragraph of body content for entry ${i}.</p>]]></description>` +
+        `</item>`
+    );
+  }
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<rss version="2.0"><channel>` +
+    `<title>Bench Feed ${feedPath}</title>` +
+    `<link>http://127.0.0.1/</link>` +
+    `<description>worker benchmark feed</description>` +
+    entries.join("") +
+    `</channel></rss>`
+  );
+}
+
+export interface MockFeedServer {
+  port: number;
+  server: Server;
+  stats: () => { served200: number; served304: number };
+  reset: () => void;
+}
+
+export function startMockFeedServer(opts: {
+  itemsPerFeed: number;
+  latencyMs: number;
+}): Promise<MockFeedServer> {
+  let served200 = 0;
+  let served304 = 0;
+
+  const server = createServer((req, res) => {
+    const respond = () => {
+      const inm = req.headers["if-none-match"];
+      if (inm && inm.includes("bench-v1")) {
+        served304++;
+        res.writeHead(304, { ETag: STABLE_ETAG });
+        res.end();
+        return;
+      }
+      served200++;
+      const body = buildRss(req.url ?? "/feed", opts.itemsPerFeed);
+      res.writeHead(200, {
+        "Content-Type": "application/rss+xml; charset=utf-8",
+        ETag: STABLE_ETAG,
+      });
+      res.end(body);
+    };
+    if (opts.latencyMs > 0) setTimeout(respond, opts.latencyMs);
+    else respond();
+  });
+
+  // Large backlog so concurrent worker connections don't get ECONNREFUSED.
+  server.maxConnections = 10_000;
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        port,
+        server,
+        stats: () => ({ served200, served304 }),
+        reset: () => {
+          served200 = 0;
+          served304 = 0;
+        },
+      });
+    });
+  });
+}

--- a/bench/worker/worker-bench.ts
+++ b/bench/worker/worker-bench.ts
@@ -1,0 +1,254 @@
+/**
+ * Worker (feed-fetch) throughput benchmark.
+ *
+ * Answers: "how many feeds can one worker keep polled before it falls behind?"
+ *
+ * Method: seed M feeds (each with an active subscriber) all DUE now, pointed at
+ * a local mock feed server, then run the real worker (`dist/worker.js`) and time
+ * how fast it drains the backlog. Two phases per concurrency level:
+ *   - FRESH: first poll returns 200 + `itemsPerFeed` items → full parse + entry
+ *     processing + sanitize + user_entries fanout. This is the worst case
+ *     (cold start / mass subscribe / every feed updated at once).
+ *   - NOT-MODIFIED: re-poll after the worker stored our ETag → 304, the
+ *     steady-state case (most real polls find nothing new).
+ * Sweeps WORKER_CONCURRENCY to show how I/O concurrency lifts throughput.
+ *
+ * Runs against the TEST db so it doesn't touch the capacity seed. Example:
+ *   FEEDS=3000 CONCURRENCIES=1,3,8,16 ITEMS_PER_FEED=25 MOCK_LATENCY_MS=100 \
+ *     dotenv -e .env.local-services.test -- tsx bench/worker/worker-bench.ts
+ *
+ * The worker child is spawned with ALLOW_PRIVATE_NETWORK_FETCH=true so it can
+ * reach 127.0.0.1.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { Pool } from "pg";
+import { startMockFeedServer, type MockFeedServer } from "./mock-feed-server";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..", "..");
+
+const FEEDS = Number(process.env.FEEDS ?? 3000);
+const CONCURRENCIES = (process.env.CONCURRENCIES ?? "1,3,8,16")
+  .split(",")
+  .map((s) => Number(s.trim()))
+  .filter((n) => n > 0);
+const ITEMS_PER_FEED = Number(process.env.ITEMS_PER_FEED ?? 25);
+const MOCK_LATENCY_MS = Number(process.env.MOCK_LATENCY_MS ?? 0);
+const DATABASE_URL = process.env.DATABASE_URL;
+const REDIS_URL = process.env.REDIS_URL;
+const WORKER_METRICS = "http://127.0.0.1:9092/metrics";
+const WORKER_HEALTH = "http://127.0.0.1:9092/health";
+
+if (!DATABASE_URL || !REDIS_URL) {
+  console.error(
+    "DATABASE_URL + REDIS_URL required (prefix with dotenv -e .env.local-services.test --)"
+  );
+  process.exit(1);
+}
+
+const pool = new Pool({ connectionString: DATABASE_URL, max: 8 });
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function seedAll(mockPort: number): Promise<void> {
+  await pool.query(
+    `TRUNCATE jobs, user_entries, entries, subscription_tags, subscriptions, feeds, users CASCADE`
+  );
+  await pool.query(
+    `INSERT INTO users (id, email, created_at, updated_at)
+     VALUES (gen_random_uuid(), 'worker-bench@example.com', now(), now())`
+  );
+  await pool.query(
+    `INSERT INTO feeds (id, type, url, title, created_at, updated_at)
+     SELECT gen_random_uuid(), 'web',
+            'http://127.0.0.1:' || $1::text || '/feed/' || i,
+            'Bench Feed ' || i, now(), now()
+     FROM generate_series(1, $2) AS i`,
+    [mockPort, FEEDS]
+  );
+  await pool.query(
+    `INSERT INTO subscriptions (id, user_id, feed_id, subscribed_at, created_at, updated_at)
+     SELECT gen_random_uuid(), (SELECT id FROM users LIMIT 1), f.id, now(), now(), now()
+     FROM feeds f`
+  );
+  await pool.query(
+    `INSERT INTO jobs (id, type, payload, next_run_at, created_at, updated_at)
+     SELECT gen_random_uuid(), 'fetch_feed',
+            jsonb_build_object('feedId', f.id::text),
+            now() - interval '1 second', now(), now()
+     FROM feeds f`
+  );
+  await pool.query(`ANALYZE feeds, subscriptions, jobs`);
+}
+
+/** Re-arm every fetch_feed job as due now (keeps feed ETag → 304 path). */
+async function resetDue(): Promise<void> {
+  await pool.query(
+    `UPDATE jobs SET next_run_at = now() - interval '1 second', running_since = NULL
+     WHERE type = 'fetch_feed'`
+  );
+}
+
+async function dueBacklog(): Promise<number> {
+  const r = await pool.query<{ n: string }>(
+    `SELECT count(*)::int AS n FROM jobs WHERE type = 'fetch_feed' AND next_run_at <= now()`
+  );
+  return Number(r.rows[0].n);
+}
+
+async function fetchWorkerMetrics(): Promise<string> {
+  try {
+    const r = await fetch(WORKER_METRICS, { signal: AbortSignal.timeout(4000) });
+    return await r.text();
+  } catch {
+    return "";
+  }
+}
+
+async function waitForWorkerHealth(timeoutMs: number): Promise<boolean> {
+  const until = Date.now() + timeoutMs;
+  while (Date.now() < until) {
+    try {
+      const r = await fetch(WORKER_HEALTH, { signal: AbortSignal.timeout(2000) });
+      if (r.ok) return true;
+    } catch {
+      /* not up yet */
+    }
+    await sleep(300);
+  }
+  return false;
+}
+
+function spawnWorker(concurrency: number): ChildProcess {
+  return spawn("node", ["dist/worker.js"], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      DATABASE_URL,
+      REDIS_URL,
+      NODE_ENV: "production",
+      METRICS_ENABLED: "true",
+      ALLOW_PRIVATE_NETWORK_FETCH: "true",
+      WORKER_CONCURRENCY: String(concurrency),
+      WORKER_POLL_INTERVAL_MS: "100",
+      FEED_MIN_FETCH_INTERVAL_MINUTES: "60",
+    },
+    stdio: "ignore",
+  });
+}
+
+async function killWorker(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null) return;
+  await new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+    child.kill("SIGKILL");
+    setTimeout(resolve, 5000); // safety
+  });
+}
+
+/** Drain the current due backlog, returning throughput (feeds/sec). */
+async function drain(): Promise<{ feedsPerSec: number; elapsedS: number; drained: number }> {
+  let t0: number | null = null;
+  let backlogAtT0 = 0;
+  const initial = await dueBacklog();
+  for (;;) {
+    const b = await dueBacklog();
+    if (t0 === null && b < initial) {
+      t0 = Date.now();
+      backlogAtT0 = b;
+    }
+    if (b === 0) {
+      const t1 = Date.now();
+      if (t0 === null) return { feedsPerSec: 0, elapsedS: 0, drained: 0 };
+      const elapsedS = (t1 - t0) / 1000;
+      return {
+        feedsPerSec: elapsedS > 0 ? backlogAtT0 / elapsedS : 0,
+        elapsedS,
+        drained: backlogAtT0,
+      };
+    }
+    await sleep(200);
+  }
+}
+
+async function runConcurrency(concurrency: number, mock: MockFeedServer): Promise<void> {
+  // Fresh seed (no ETag, no entries) so phase 1 does full processing.
+  await seedAll(mock.port);
+  mock.reset();
+  const worker = spawnWorker(concurrency);
+  const healthy = await waitForWorkerHealth(20000);
+  if (!healthy) {
+    console.log(`  [c=${concurrency}] worker health never came up — skipping`);
+    await killWorker(worker);
+    return;
+  }
+
+  const m0 = await fetchWorkerMetrics();
+  const fresh = await drain();
+  const m1 = await fetchWorkerMetrics();
+  const freshStats = mock.stats();
+
+  // Steady-state: re-arm due; worker now sends If-None-Match → mock 304.
+  mock.reset();
+  await resetDue();
+  const notmod = await drain();
+  const m2 = await fetchWorkerMetrics();
+  const notmodStats = mock.stats();
+
+  await killWorker(worker);
+
+  // Per-fetch server-side latency from the histogram (delta), if present.
+  const fetchSum = (t: string) =>
+    Number((t.match(/^feed_fetch_duration_seconds_sum\s+([0-9.eE+-]+)/m) ?? [])[1] ?? 0);
+  const fetchCnt = (t: string) =>
+    Number((t.match(/^feed_fetch_duration_seconds_count\s+([0-9.eE+-]+)/m) ?? [])[1] ?? 0);
+  const freshMeanMs =
+    fetchCnt(m1) > fetchCnt(m0)
+      ? ((fetchSum(m1) - fetchSum(m0)) / (fetchCnt(m1) - fetchCnt(m0))) * 1000
+      : 0;
+  const notmodMeanMs =
+    fetchCnt(m2) > fetchCnt(m1)
+      ? ((fetchSum(m2) - fetchSum(m1)) / (fetchCnt(m2) - fetchCnt(m1))) * 1000
+      : 0;
+
+  const perHourFresh = Math.round(fresh.feedsPerSec * 3600);
+  const perHourNotmod = Math.round(notmod.feedsPerSec * 3600);
+
+  console.log(
+    `\n  concurrency=${concurrency}` +
+      `\n    FRESH (200, ${ITEMS_PER_FEED} new items/feed): ${fresh.feedsPerSec.toFixed(1)} feeds/s ` +
+      `(${fresh.drained} in ${fresh.elapsedS.toFixed(1)}s, mock 200=${freshStats.served200}) ` +
+      `perFetch≈${freshMeanMs.toFixed(0)}ms` +
+      `\n      → sustains ~${perHourFresh.toLocaleString()} feeds at hourly cadence (worst case)` +
+      `\n    NOT-MODIFIED (304): ${notmod.feedsPerSec.toFixed(1)} feeds/s ` +
+      `(mock 304=${notmodStats.served304}, 200=${notmodStats.served200}) perFetch≈${notmodMeanMs.toFixed(0)}ms` +
+      `\n      → sustains ~${perHourNotmod.toLocaleString()} feeds at hourly cadence (steady state)`
+  );
+}
+
+async function main() {
+  console.log(
+    `Worker throughput benchmark: FEEDS=${FEEDS} items/feed=${ITEMS_PER_FEED} ` +
+      `mockLatency=${MOCK_LATENCY_MS}ms concurrencies=[${CONCURRENCIES.join(", ")}]`
+  );
+  const mock = await startMockFeedServer({
+    itemsPerFeed: ITEMS_PER_FEED,
+    latencyMs: MOCK_LATENCY_MS,
+  });
+  console.log(`Mock feed server on 127.0.0.1:${mock.port}`);
+
+  for (const c of CONCURRENCIES) {
+    await runConcurrency(c, mock);
+  }
+
+  mock.server.close();
+  await pool.end();
+  console.log(`\nDone.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What & why

Ahead of a possible Hacker News launch, this adds **capacity benchmarks** to estimate how many users Lion Reader can support per hardware tier, how a traffic spike behaves given Fly's shared-CPU throttling, and whether the feed-fetching **worker** can keep up as feeds grow.

Full writeup + results: `~/wiki/pages/lion-reader-capacity-benchmark-2026.md`.

## Headline findings (local, real prod per-user params)

- **App: the bottleneck is the single Node event loop (CPU), not Postgres** — pg pool never queued. **2 dedicated cores ≈ ~200 concurrent active users / ~280 rps** → **~6,700 registered** at the observed 3% concurrent fraction. Capacity scales ~linearly with app-machine count.
- **Worker: ~15× headroom.** One worker at `WORKER_CONCURRENCY=1` sustains ~21k feeds at hourly cadence (worst case) vs ~1,444 active feeds today. Concurrency scales it near-linearly to 200k+. The real reason to raise concurrency is slow-feed head-of-line blocking, not throughput.
- **The real HN risk is the CURRENT `shared-cpu-2x` tier** — 6.25%/vCPU throttle collapses sustained throughput to ~1/8–1/16 of dedicated cores after the burst balance drains. **Move the app off shared CPU + `fly scale count` before posting.**

## The harness (`bench/`)

- `characterize-prod.sql` — read-only prod aggregates → `prod-params.json` (gitignored).
- `seed-bench.ts` / `loadtest.ts` / `lib/trpc-client.ts` — request-path load test (wire-identical tRPC, server-side-gated knee).
- **`worker/`** — worker throughput benchmark: mock feed server + backlog-drain timing across a `WORKER_CONCURRENCY` sweep (FRESH + 304 phases).
- `fly-bench/` — turnkey runbook + `performance-2x/4GB` fly.toml for the real cloud test.

Independent review pass + fixes applied (unreadOnly list, starred seed, histogram series-summing, etc. — see comments).

## Status

- [x] Harness (request-path + worker) built, reviewed, fixed
- [x] Real prod params characterized + plugged in
- [x] Local results: 2-core capacity knee + worker throughput sweep
- [ ] **Optional (agent token can't create Fly apps):** real `performance-2x/4GB` run via `bench/fly-bench/` runbook — local 2-core run is a solid proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude