### PR TITLE
Fix invisible-but-tappable hover actions on touch devices

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,6 +11,12 @@
    existing one like the built-in `dark` above. */
 @custom-variant epaper (&:where(.epaper, .epaper *));
 
+/* Devices whose primary input can't hover (phones/tablets). Tailwind v4 gates
+   `hover:`/`group-hover:` behind `@media (hover: hover)`, so hover-revealed
+   controls never appear on touch — but an `opacity-0` control still receives
+   taps. Use this variant to give such controls an always-visible fallback. */
+@custom-variant hover-none (@media (hover: none));
+
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -254,7 +254,7 @@ export const EntryListItem = memo(function EntryListItem({
                 className={`-m-[14px] flex shrink-0 items-center justify-center rounded-full p-[14px] transition-colors ${
                   starred
                     ? "text-star hover:text-star-hover"
-                    : "hover:text-star text-zinc-300 opacity-0 group-hover:opacity-100 dark:text-zinc-600"
+                    : "hover:text-star hover-none:opacity-100 text-zinc-300 opacity-0 group-hover:opacity-100 dark:text-zinc-600"
                 }`}
                 aria-label={starred ? "Remove from starred" : "Add to starred"}
                 title={starred ? "Remove from starred (s)" : "Add to starred (s)"}

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -254,7 +254,7 @@ export const EntryListItem = memo(function EntryListItem({
                 className={`-m-[14px] flex shrink-0 items-center justify-center rounded-full p-[14px] transition-colors ${
                   starred
                     ? "text-star hover:text-star-hover"
-                    : "hover:text-star hover-none:pointer-events-auto hover-none:opacity-100 pointer-events-none text-zinc-300 opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 dark:text-zinc-600"
+                    : "hover:text-star text-zinc-300 dark:text-zinc-600"
                 }`}
                 aria-label={starred ? "Remove from starred" : "Add to starred"}
                 title={starred ? "Remove from starred (s)" : "Add to starred (s)"}

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -254,7 +254,7 @@ export const EntryListItem = memo(function EntryListItem({
                 className={`-m-[14px] flex shrink-0 items-center justify-center rounded-full p-[14px] transition-colors ${
                   starred
                     ? "text-star hover:text-star-hover"
-                    : "hover:text-star hover-none:opacity-100 text-zinc-300 opacity-0 group-hover:opacity-100 dark:text-zinc-600"
+                    : "hover:text-star hover-none:pointer-events-auto hover-none:opacity-100 pointer-events-none text-zinc-300 opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 dark:text-zinc-600"
                 }`}
                 aria-label={starred ? "Remove from starred" : "Add to starred"}
                 title={starred ? "Remove from starred (s)" : "Add to starred (s)"}

--- a/src/components/layout/SubscriptionItem.tsx
+++ b/src/components/layout/SubscriptionItem.tsx
@@ -48,16 +48,18 @@ export function SubscriptionItem({
   const subHref = href ?? `/subscription/${subscription.id}`;
 
   return (
-    <li className="group relative">
+    <li className="group relative flex items-center">
       <ClientLink
         href={subHref}
         onNavigate={onClose}
         onPrefetch={onPrefetch}
-        className={`ui-text-sm flex min-h-[44px] items-center justify-between rounded-md px-3 py-2 transition-colors ${
+        className={`ui-text-sm flex min-h-[44px] min-w-0 flex-1 items-center justify-between rounded-md px-3 py-2 transition-colors ${
           isActive ? "bg-surface-muted text-body" : "text-body hover:bg-surface-muted"
         }`}
       >
-        <span className="truncate pr-8">{displayTitle}</span>
+        {/* pr-8 keeps long titles clear of the desktop hover-overlay buttons;
+            on hover-less devices the buttons are in-flow, so reclaim the space */}
+        <span className="hover-none:pr-2 truncate pr-8">{displayTitle}</span>
         {subscription.unreadCount > 0 && (
           <span className="ui-text-xs text-muted shrink-0 tabular-nums group-hover:hidden">
             ({subscription.unreadCount})
@@ -65,8 +67,10 @@ export function SubscriptionItem({
         )}
       </ClientLink>
 
-      {/* Action buttons - visible on hover/touch */}
-      <div className="absolute top-1/2 right-1 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+      {/* Action buttons — revealed on hover (and untappable while hidden, so an
+          invisible button never swallows a click); on hover-less devices they
+          sit in-flow after the unread count, always visible. */}
+      <div className="hover-none:static hover-none:translate-y-0 hover-none:pr-1 hover-none:opacity-100 hover-none:pointer-events-auto pointer-events-none absolute top-1/2 right-1 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
         <IconButton
           icon={<EditIcon />}
           aria-label={`Edit ${displayTitle}`}


### PR DESCRIPTION
## Problem

On mobile, tapping the right side of a feed in the sidebar seemingly randomly opened the edit or unsubscribe dialog.

Root cause: Tailwind v4 gates `hover:`/`group-hover:` behind `@media (hover: hover)`, so on touch devices the hover-revealed edit/unsubscribe buttons never become visible — but `opacity-0` doesn't block taps, so an **invisible** edit/unsubscribe button sat over the right side of every feed row.

## Fix

- New `hover-none` custom variant (`@media (hover: none)`), the exact complement of Tailwind's hover gate.
- **SubscriptionItem**: on devices that can't hover, the action buttons are always visible and sit in-flow after the unread count (no overlap, and the row link shrinks to fit). On hover devices the reveal behavior is unchanged, but the hidden buttons now get `pointer-events-none` so an invisible button can never swallow a click (e.g. hybrid touch-screen laptops).
- **EntryListItem**: the unstarred star button had the same bug — an invisible 44px tap target next to every entry title. It's now always shown (faint) on **all** devices — one consistent affordance instead of an accidental-tap trap, with no reveal/pointer-events machinery to keep in sync.

## Screenshots

### Sidebar, mobile (iPhone emulation)

| Before (buttons invisible but tappable) | After (in-flow, always visible) |
| --- | --- |
| ![sidebar mobile before](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/touch-hover-actions-1314/sidebar-mobile-before.png) | ![sidebar mobile after](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/touch-hover-actions-1314/sidebar-mobile-after.png) |

### Sidebar, desktop (unchanged)

| Idle | Hover |
| --- | --- |
| ![sidebar desktop idle](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/touch-hover-actions-1314/sidebar-desktop-idle-after.png) | ![sidebar desktop hover](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/touch-hover-actions-1314/sidebar-desktop-hover-after.png) |

### Entry list star (now always visible on every device)

| Before, mobile (invisible tap target) | After, mobile (faint star affordance) |
| --- | --- |
| ![list mobile before](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/touch-hover-actions-1314/list-mobile-before.png) | ![list mobile after](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/touch-hover-actions-1314/list-mobile-after.png) |

After, desktop (previously hover-revealed):

![list desktop after](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/touch-hover-actions-1314/list-desktop-after.png)

## Verification

Verified with Playwright under iPhone emulation (`hover: none`):
- Tapping a row (including its right edge / the unread count) navigates without opening any dialog — this was the reported bug.
- The edit/unsubscribe buttons are visible with `pointer-events: auto` and sit in static flow.
- Desktop computed styles are unchanged except the hidden state now also has `pointer-events: none` (idle: `opacity 0`, hover: `opacity 1`, absolute overlay as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
