### PR TITLE
Make the not-in-the-EU signup step optional via EU_RESTRICTED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -394,3 +394,6 @@ PORT=3000
 #
 # The DATABASE_URL is typically set automatically when you run:
 #   fly postgres attach <postgres-app-name>
+
+# Uncomment to restrict access in the EU
+# EU_RESTRICTED = "true"

--- a/fly.toml
+++ b/fly.toml
@@ -45,6 +45,11 @@ kill_timeout = 30
   # apple/google are open to the public; email is allowed only with a valid invite.
   ALLOWED_SIGNUP_PROVIDERS = "apple,google,email"
   ALLOWED_PUBLIC_SIGNUP_PROVIDERS = "apple,google"
+
+  # The hosted instance is not offered to EU users: require the not-in-the-EU
+  # certification at signup and show the "not available in the EU" notice. Unset
+  # (the default) on self-hosted instances, which take on no EU obligation.
+  EU_RESTRICTED = "true"
   NEXT_PUBLIC_APP_URL = "https://lionreader.com"
   NODE_ENV = "production"
   PORT = "3000"

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -10,6 +10,7 @@ import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import { TRPCProvider } from "@/lib/trpc/provider";
 import { validateSession } from "@/server/auth/session";
+import { isSignupConfirmed } from "@/server/auth/confirmation";
 import { AuthLayoutContent } from "./AuthLayoutContent";
 
 interface AuthLayoutProps {
@@ -25,11 +26,7 @@ export default async function AuthLayout({ children }: AuthLayoutProps) {
     const session = await validateSession(sessionToken);
     if (session) {
       // User is signed in but hasn't completed signup confirmation
-      if (
-        !session.user.tosAgreedAt ||
-        !session.user.privacyPolicyAgreedAt ||
-        !session.user.notEuAgreedAt
-      ) {
+      if (!isSignupConfirmed(session.user)) {
         redirect("/complete-signup");
       }
       // User is fully authenticated, redirect to the app

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -46,10 +46,13 @@ function RegisterForm() {
   // here and point them at self-hosting.
   const euNotice = euRestricted ? (
     <Alert variant="warning" className="mb-4">
-      <span className="font-semibold">Not available in the European Union.</span> This is a free
-      hobby project, and we&apos;re not able to take on the EU&apos;s regulatory requirements or
-      liability, so please don&apos;t sign up if you&apos;re located in the EU. You&apos;re very
-      welcome to{" "}
+      <span className="font-semibold">Not available in the European Union.</span> Our
+      <a href="/privacy" target="_blank">
+        privacy policy
+      </a>{" "}
+      is unusually-strict, but EU requirements would additionally require us to
+      <a href="https://www.activemind.legal/guides/fine-eu-representative/">retain a laywer</a>,
+      which isn&apos;t viable for a free project. You&apos;re welcome to{" "}
       <a
         href="https://github.com/brendanlong/lion-reader"
         target="_blank"

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -22,6 +22,7 @@ import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
 import { OAuthButtons } from "@/components/auth/OAuthButtons";
 import { AuthFooter } from "@/components/auth/AuthFooter";
+import { EuRestrictionReason } from "@/components/auth/EuRestrictionNotice";
 
 export default function RegisterPage() {
   return (
@@ -46,22 +47,8 @@ function RegisterForm() {
   // here and point them at self-hosting.
   const euNotice = euRestricted ? (
     <Alert variant="warning" className="mb-4">
-      <span className="font-semibold">Not available in the European Union.</span> Our
-      <a href="/privacy" target="_blank">
-        privacy policy
-      </a>{" "}
-      is unusually-strict, but EU requirements would additionally require us to
-      <a href="https://www.activemind.legal/guides/fine-eu-representative/">retain a laywer</a>,
-      which isn&apos;t viable for a free project. You&apos;re welcome to{" "}
-      <a
-        href="https://github.com/brendanlong/lion-reader"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="underline"
-      >
-        self-host Lion Reader
-      </a>{" "}
-      instead.
+      <span className="font-semibold">Not available in the European Union.</span>{" "}
+      <EuRestrictionReason />
     </Alert>
   ) : null;
 

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -154,7 +154,6 @@ function RegisterForm() {
     return (
       <div>
         <h2 className="ui-text-xl text-body mb-6 font-semibold">Invite Required</h2>
-        {euNotice}
         <Alert variant="error" className="mb-4">
           This instance requires an invite to sign up. Please contact an administrator to request an
           invite.

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -40,6 +40,27 @@ function RegisterForm() {
 
   // Fetch signup configuration
   const { data: signupConfigData, isLoading: isLoadingConfig } = trpc.auth.signupConfig.useQuery();
+  const euRestricted = signupConfigData?.euRestricted ?? false;
+
+  // On EU-restricted instances, warn EU users up front that they can't sign up
+  // here and point them at self-hosting.
+  const euNotice = euRestricted ? (
+    <Alert variant="warning" className="mb-4">
+      <span className="font-semibold">Not available in the European Union.</span> This is a free
+      hobby project, and we&apos;re not able to take on the EU&apos;s regulatory requirements or
+      liability, so please don&apos;t sign up if you&apos;re located in the EU. You&apos;re very
+      welcome to{" "}
+      <a
+        href="https://github.com/brendanlong/lion-reader"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline"
+      >
+        self-host Lion Reader
+      </a>{" "}
+      instead.
+    </Alert>
+  ) : null;
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -143,6 +164,7 @@ function RegisterForm() {
     return (
       <div>
         <h2 className="ui-text-xl text-body mb-6 font-semibold">Invite Required</h2>
+        {euNotice}
         <Alert variant="error" className="mb-4">
           This instance requires an invite to sign up. Please contact an administrator to request an
           invite.
@@ -162,6 +184,8 @@ function RegisterForm() {
   return (
     <div>
       <h2 className="ui-text-xl text-body mb-6 font-semibold">Create your account</h2>
+
+      {euNotice}
 
       {errors.form && (
         <Alert variant="error" className="mb-4">

--- a/src/app/complete-signup/layout.tsx
+++ b/src/app/complete-signup/layout.tsx
@@ -12,6 +12,7 @@ import type { ReactNode } from "react";
 import { TRPCProvider } from "@/lib/trpc/provider";
 import { AuthErrorHandler } from "@/components/app/AuthErrorHandler";
 import { validateSession } from "@/server/auth/session";
+import { isSignupConfirmed } from "@/server/auth/confirmation";
 
 interface CompleteSignupLayoutProps {
   children: ReactNode;
@@ -31,11 +32,7 @@ export default async function CompleteSignupLayout({ children }: CompleteSignupL
   }
 
   // Already confirmed, go to app
-  if (
-    session.user.tosAgreedAt &&
-    session.user.privacyPolicyAgreedAt &&
-    session.user.notEuAgreedAt
-  ) {
+  if (isSignupConfirmed(session.user)) {
     redirect("/all");
   }
 

--- a/src/app/complete-signup/page.tsx
+++ b/src/app/complete-signup/page.tsx
@@ -16,6 +16,7 @@ import { trpc } from "@/lib/trpc/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
+import { EuRestrictionReason } from "@/components/auth/EuRestrictionNotice";
 
 export default function CompleteSignupPage() {
   const router = useRouter();
@@ -131,6 +132,12 @@ export default function CompleteSignupPage() {
               I confirm that I am not located in the European Union
             </span>
           </label>
+        )}
+
+        {euRestricted && (
+          <p className="ui-text-xs text-muted">
+            <EuRestrictionReason />
+          </p>
         )}
       </div>
 

--- a/src/app/complete-signup/page.tsx
+++ b/src/app/complete-signup/page.tsx
@@ -1,9 +1,11 @@
 /**
  * Complete Signup Page
  *
- * Requires users to accept Terms of Service, Privacy Policy, and confirm
- * they are not in the EU before they can use the app.
- * Also provides a button to delete their account if they don't want to proceed.
+ * Requires users to accept Terms of Service and Privacy Policy — and, on
+ * EU-restricted instances (EU_RESTRICTED=true, surfaced via the `euRestricted`
+ * signup-config flag), to confirm they are not in the EU — before they can use
+ * the app. Also provides a button to delete their account if they don't want to
+ * proceed.
  */
 
 "use client";
@@ -17,6 +19,9 @@ import { Alert } from "@/components/ui/alert";
 
 export default function CompleteSignupPage() {
   const router = useRouter();
+  const { data: signupConfigData } = trpc.auth.signupConfig.useQuery();
+  const euRestricted = signupConfigData?.euRestricted ?? false;
+
   const [acceptedTos, setAcceptedTos] = useState(false);
   const [acceptedPrivacy, setAcceptedPrivacy] = useState(false);
   const [confirmedNotInEu, setConfirmedNotInEu] = useState(false);
@@ -44,7 +49,7 @@ export default function CompleteSignupPage() {
     },
   });
 
-  const allChecked = acceptedTos && acceptedPrivacy && confirmedNotInEu;
+  const allChecked = acceptedTos && acceptedPrivacy && (!euRestricted || confirmedNotInEu);
   const isDeleteConfirmed = deleteConfirmation === "delete";
 
   function handleConfirm() {
@@ -52,7 +57,8 @@ export default function CompleteSignupPage() {
     confirmMutation.mutate({
       acceptedTermsOfService: true,
       acceptedPrivacyPolicy: true,
-      confirmedNotInEu: true,
+      // Only sent when the instance requires it; the server ignores it otherwise.
+      confirmedNotInEu: euRestricted ? true : undefined,
     });
   }
 
@@ -113,17 +119,19 @@ export default function CompleteSignupPage() {
           </span>
         </label>
 
-        <label className="flex cursor-pointer items-start gap-3">
-          <input
-            type="checkbox"
-            checked={confirmedNotInEu}
-            onChange={(e) => setConfirmedNotInEu(e.target.checked)}
-            className="text-body border-edge-input mt-0.5 h-5 w-5 shrink-0 rounded dark:bg-zinc-800"
-          />
-          <span className="ui-text-sm text-body">
-            I confirm that I am not located in the European Union
-          </span>
-        </label>
+        {euRestricted && (
+          <label className="flex cursor-pointer items-start gap-3">
+            <input
+              type="checkbox"
+              checked={confirmedNotInEu}
+              onChange={(e) => setConfirmedNotInEu(e.target.checked)}
+              className="text-body border-edge-input mt-0.5 h-5 w-5 shrink-0 rounded dark:bg-zinc-800"
+            />
+            <span className="ui-text-sm text-body">
+              I confirm that I am not located in the European Union
+            </span>
+          </label>
+        )}
       </div>
 
       <div className="space-y-3">

--- a/src/components/auth/EuRestrictionNotice.tsx
+++ b/src/components/auth/EuRestrictionNotice.tsx
@@ -12,15 +12,16 @@
 export function EuRestrictionReason() {
   return (
     <>
-      Our{" "}
-      <a href="/privacy" target="_blank" rel="noopener noreferrer">
+      Despite our strict{" "}
+      <a href="/privacy" target="_blank" rel="noopener noreferrer" className="underline">
         privacy policy
-      </a>{" "}
-      is unusually strict, but EU requirements would additionally require us to{" "}
+      </a>
+      , EU law would require us to{" "}
       <a
         href="https://www.activemind.legal/guides/fine-eu-representative/"
         target="_blank"
         rel="noopener noreferrer"
+        className="underline"
       >
         retain a lawyer
       </a>

--- a/src/components/auth/EuRestrictionNotice.tsx
+++ b/src/components/auth/EuRestrictionNotice.tsx
@@ -1,0 +1,39 @@
+/**
+ * Shared explanation of why Lion Reader isn't available in the European Union on
+ * EU-restricted instances (EU_RESTRICTED=true / the `euRestricted` signup-config
+ * flag).
+ *
+ * The prose is deduplicated here so the registration warning (which can't sign
+ * up) and the complete-signup footnote (which confirms you're not in the EU)
+ * stay in sync. Keep it as inline phrasing so each caller can wrap it in
+ * whatever container fits its context.
+ */
+
+export function EuRestrictionReason() {
+  return (
+    <>
+      Our{" "}
+      <a href="/privacy" target="_blank" rel="noopener noreferrer">
+        privacy policy
+      </a>{" "}
+      is unusually strict, but EU requirements would additionally require us to{" "}
+      <a
+        href="https://www.activemind.legal/guides/fine-eu-representative/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        retain a lawyer
+      </a>
+      , which isn&apos;t viable for a free project. You&apos;re welcome to{" "}
+      <a
+        href="https://github.com/brendanlong/lion-reader"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline"
+      >
+        self-host Lion Reader
+      </a>{" "}
+      instead.
+    </>
+  );
+}

--- a/src/lib/trpc/server.ts
+++ b/src/lib/trpc/server.ts
@@ -11,6 +11,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { createHydrationHelpers } from "@trpc/react-query/rsc";
 import { db } from "@/server/db";
 import { validateSession } from "@/server/auth/session";
+import { isSignupConfirmed } from "@/server/auth/confirmation";
 import { createCaller, type AppRouter } from "@/server/trpc/root";
 import type { Context } from "@/server/trpc/context";
 import { getQueryClient } from "./query-client";
@@ -140,7 +141,5 @@ export async function isAuthenticated(): Promise<boolean> {
 export async function isConfirmed(): Promise<boolean> {
   const ctx = await createServerContext();
   const user = ctx.session?.user;
-  return (
-    user?.tosAgreedAt != null && user?.privacyPolicyAgreedAt != null && user?.notEuAgreedAt != null
-  );
+  return user != null && isSignupConfirmed(user);
 }

--- a/src/server/auth/confirmation.ts
+++ b/src/server/auth/confirmation.ts
@@ -2,21 +2,26 @@
  * Signup confirmation check
  *
  * A user has completed signup confirmation once they have agreed to the Terms
- * of Service and Privacy Policy and answered the EU residency question. The
- * tRPC surface enforces this via `confirmedMiddleware`; every other credential
- * surface that mints its own tokens (MCP, Wallabag, Google Reader) must apply
- * the same gate so those APIs can't be used to bypass confirmation.
+ * of Service and Privacy Policy and — on EU-restricted instances — certified
+ * they are not in the EU. The tRPC surface enforces this via
+ * `confirmedMiddleware`; every other credential surface that mints its own
+ * tokens (MCP, Wallabag, Google Reader) must apply the same gate so those APIs
+ * can't be used to bypass confirmation.
  */
 
 import type { User } from "@/server/db/schema";
+import { signupConfig } from "@/server/config/env";
 
 /**
  * Returns true if the user has completed the signup confirmation flow (ToS,
- * Privacy Policy, EU check). Mirrors `confirmedMiddleware` in
- * `src/server/trpc/trpc.ts` — keep the two in sync.
+ * Privacy Policy, and — only when `EU_RESTRICTED` is set — the not-in-the-EU
+ * certification). This is the single source of truth for confirmation; the
+ * layouts, `confirmedMiddleware`, and `isConfirmed` all delegate here so the
+ * EU gate stays consistent everywhere.
  */
 export function isSignupConfirmed(
   user: Pick<User, "tosAgreedAt" | "privacyPolicyAgreedAt" | "notEuAgreedAt">
 ): boolean {
-  return !!(user.tosAgreedAt && user.privacyPolicyAgreedAt && user.notEuAgreedAt);
+  const euConfirmed = !signupConfig.euRestricted || !!user.notEuAgreedAt;
+  return !!(user.tosAgreedAt && user.privacyPolicyAgreedAt && euConfirmed);
 }

--- a/src/server/config/env.ts
+++ b/src/server/config/env.ts
@@ -83,6 +83,20 @@ export const signupConfig = {
   get publicSignupProviders(): readonly SignupProvider[] {
     return resolvePublicSignupProviders();
   },
+
+  /**
+   * When true, this instance restricts EU users: the signup flow requires users
+   * to certify they are not located in the European Union (the `notEuAgreedAt`
+   * confirmation), and the registration page tells EU users the service is not
+   * available to them and points them at self-hosting.
+   *
+   * Defaults to false so self-hosted instances take on no EU-related obligation
+   * unless the operator opts in. Set EU_RESTRICTED=true (the hosted lionreader.com
+   * instance does, via fly.toml). Read lazily so tests can set the env after import.
+   */
+  get euRestricted(): boolean {
+    return process.env.EU_RESTRICTED === "true";
+  },
 };
 
 /** Public-facing app URL. Used for sitemap, robots.txt, metadata, and User-Agent header. */

--- a/src/server/trpc/routers/auth.ts
+++ b/src/server/trpc/routers/auth.ts
@@ -827,6 +827,12 @@ export const authRouter = createTRPCRouter({
         allowedSignupProviders: z.array(z.enum(ALL_SIGNUP_PROVIDERS)),
         /** Providers allowed without an invite (subset of allowedSignupProviders). */
         publicSignupProviders: z.array(z.enum(ALL_SIGNUP_PROVIDERS)),
+        /**
+         * True when this instance restricts EU users (EU_RESTRICTED=true): the
+         * signup flow requires the not-in-the-EU certification and the register
+         * page shows a notice that the service is not available in the EU.
+         */
+        euRestricted: z.boolean(),
       })
     )
     .query(() => {
@@ -835,6 +841,7 @@ export const authRouter = createTRPCRouter({
         requiresInvite: publicSignupProviders.length === 0,
         allowedSignupProviders: [...signupConfig.allowedSignupProviders],
         publicSignupProviders,
+        euRestricted: signupConfig.euRestricted,
       };
     }),
 
@@ -883,10 +890,13 @@ export const authRouter = createTRPCRouter({
     }),
 
   /**
-   * Confirm signup by accepting Terms of Service, Privacy Policy, and EU check.
+   * Confirm signup by accepting Terms of Service, Privacy Policy, and — on
+   * EU-restricted instances (EU_RESTRICTED=true) — the not-in-the-EU check.
    *
-   * Users must confirm all three checkboxes before they can use the app.
-   * This sets the individual agreement timestamps on the user record.
+   * ToS and Privacy Policy are always required. The EU certification is only
+   * required when the instance is EU-restricted; otherwise `confirmedNotInEu`
+   * is ignored and `notEuAgreedAt` is left unset. This sets the individual
+   * agreement timestamps on the user record.
    */
   confirmSignup: protectedProcedure
     .input(
@@ -897,22 +907,30 @@ export const authRouter = createTRPCRouter({
         acceptedPrivacyPolicy: z.literal(true, {
           error: "You must accept the Privacy Policy",
         }),
-        confirmedNotInEu: z.literal(true, {
-          error: "You must confirm you are not in the EU",
-        }),
+        // Optional at the schema level so non-EU-restricted instances (where the
+        // checkbox isn't shown) can confirm; enforced below only when required.
+        confirmedNotInEu: z.boolean().optional(),
       })
     )
     .output(z.object({ success: z.boolean() }))
-    .mutation(async ({ ctx }) => {
+    .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
       const now = new Date();
+
+      const euRestricted = signupConfig.euRestricted;
+      if (euRestricted && input.confirmedNotInEu !== true) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "You must confirm you are not in the EU",
+        });
+      }
 
       await ctx.db
         .update(users)
         .set({
           tosAgreedAt: now,
           privacyPolicyAgreedAt: now,
-          notEuAgreedAt: now,
+          notEuAgreedAt: euRestricted ? now : null,
           updatedAt: now,
         })
         .where(eq(users.id, userId));

--- a/src/server/trpc/trpc.ts
+++ b/src/server/trpc/trpc.ts
@@ -26,6 +26,7 @@ import {
   validateAdminSecret,
 } from "@/server/auth/admin-session";
 import { extractBearerToken } from "@/server/auth/bearer";
+import { isSignupConfirmed } from "@/server/auth/confirmation";
 import { logger } from "@/lib/logger";
 import { trackTrpcProcedure } from "@/server/metrics/metrics";
 import * as Sentry from "@sentry/nextjs";
@@ -198,15 +199,16 @@ export const protectedProcedure = t.procedure
 /**
  * Middleware that enforces signup confirmation.
  * Throws FORBIDDEN with SIGNUP_CONFIRMATION_REQUIRED code if the user
- * has not completed the signup confirmation flow (ToS, Privacy, EU check).
+ * has not completed the signup confirmation flow (ToS, Privacy, and — on
+ * EU-restricted instances — the not-in-the-EU certification). Delegates to
+ * `isSignupConfirmed` so the EU gate stays consistent across surfaces.
  * Must be chained after authMiddleware.
  */
 const confirmedMiddleware = t.middleware(({ ctx, next }) => {
   const session = ctx.session!;
   const sessionToken = ctx.sessionToken!;
 
-  const { tosAgreedAt, privacyPolicyAgreedAt, notEuAgreedAt } = session.user;
-  if (!tosAgreedAt || !privacyPolicyAgreedAt || !notEuAgreedAt) {
+  if (!isSignupConfirmed(session.user)) {
     throw errors.signupConfirmationRequired();
   }
 

--- a/tests/unit/signup-confirmation.test.ts
+++ b/tests/unit/signup-confirmation.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { isSignupConfirmed } from "@/server/auth/confirmation";
+import { signupConfig } from "@/server/config/env";
+
+const NEVER = null;
+const NOW = new Date("2026-07-16T00:00:00.000Z");
+
+function user(overrides: {
+  tosAgreedAt: Date | null;
+  privacyPolicyAgreedAt: Date | null;
+  notEuAgreedAt: Date | null;
+}) {
+  return overrides;
+}
+
+describe("isSignupConfirmed", () => {
+  const ORIGINAL_EU = process.env.EU_RESTRICTED;
+
+  afterEach(() => {
+    // Restore so we don't leak env into other tests (the getter reads it lazily).
+    process.env.EU_RESTRICTED = ORIGINAL_EU;
+    if (ORIGINAL_EU === undefined) delete process.env.EU_RESTRICTED;
+  });
+
+  it("exposes euRestricted=false by default", () => {
+    delete process.env.EU_RESTRICTED;
+    expect(signupConfig.euRestricted).toBe(false);
+  });
+
+  it("exposes euRestricted=true only for the literal string 'true'", () => {
+    process.env.EU_RESTRICTED = "true";
+    expect(signupConfig.euRestricted).toBe(true);
+    process.env.EU_RESTRICTED = "false";
+    expect(signupConfig.euRestricted).toBe(false);
+    process.env.EU_RESTRICTED = "1";
+    expect(signupConfig.euRestricted).toBe(false);
+  });
+
+  describe("when the instance is not EU-restricted", () => {
+    it("is confirmed with ToS + Privacy even without the EU certification", () => {
+      delete process.env.EU_RESTRICTED;
+      expect(
+        isSignupConfirmed(
+          user({ tosAgreedAt: NOW, privacyPolicyAgreedAt: NOW, notEuAgreedAt: NEVER })
+        )
+      ).toBe(true);
+    });
+
+    it("is not confirmed while ToS or Privacy is missing", () => {
+      delete process.env.EU_RESTRICTED;
+      expect(
+        isSignupConfirmed(
+          user({ tosAgreedAt: NEVER, privacyPolicyAgreedAt: NOW, notEuAgreedAt: NEVER })
+        )
+      ).toBe(false);
+      expect(
+        isSignupConfirmed(
+          user({ tosAgreedAt: NOW, privacyPolicyAgreedAt: NEVER, notEuAgreedAt: NEVER })
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("when the instance is EU-restricted", () => {
+    it("requires the EU certification in addition to ToS + Privacy", () => {
+      process.env.EU_RESTRICTED = "true";
+      expect(
+        isSignupConfirmed(
+          user({ tosAgreedAt: NOW, privacyPolicyAgreedAt: NOW, notEuAgreedAt: NEVER })
+        )
+      ).toBe(false);
+      expect(
+        isSignupConfirmed(
+          user({ tosAgreedAt: NOW, privacyPolicyAgreedAt: NOW, notEuAgreedAt: NOW })
+        )
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Makes the "I confirm that I am not located in the European Union" certification step of signup **optional**, gated on a new `EU_RESTRICTED` env flag (set on for the hosted instance in `fly.toml`). Self-hosted instances default to no EU restriction, so they take on no EU-related obligation unless the operator opts in.

When `EU_RESTRICTED=true`:
- The complete-signup page shows the not-in-the-EU checkbox (required to continue).
- The register page shows a notice that the service **is not available in the EU**, explaining that EU users are welcome to self-host but we're not willing to take on the EU's regulatory requirements or liability for a free hobby project (with a link to the repo).

When unset (default): no EU checkbox, no notice, and the confirmation gate only requires ToS + Privacy.

## Changes

- **`src/server/config/env.ts`** — new `signupConfig.euRestricted` getter (`EU_RESTRICTED === "true"`).
- **`src/server/auth/confirmation.ts`** — `isSignupConfirmed` is now the single source of truth and only requires `notEuAgreedAt` when EU-restricted.
- **`src/server/trpc/trpc.ts`**, **`src/lib/trpc/server.ts`**, **`src/app/(auth)/layout.tsx`**, **`src/app/complete-signup/layout.tsx`** — all delegate the confirmation check to `isSignupConfirmed` (removes 3 inlined copies of the three-timestamp check).
- **`src/server/trpc/routers/auth.ts`** — `signupConfig` query returns `euRestricted`; `confirmSignup` makes `confirmedNotInEu` optional, enforcing it and stamping `notEuAgreedAt` only when EU-restricted.
- **`src/app/complete-signup/page.tsx`** — renders the EU checkbox only when EU-restricted.
- **`src/app/(auth)/register/page.tsx`** — renders the "not available in the EU" notice when EU-restricted.
- **`fly.toml`** — `EU_RESTRICTED = "true"` for the hosted instance.
- **`tests/unit/signup-confirmation.test.ts`** — covers the flag parsing and the gated confirmation logic.

## Testing

- `pnpm typecheck` ✅
- `pnpm test:unit` ✅ (added `signup-confirmation.test.ts`)
- eslint/prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)