### PR TITLE
Show only a nicely-formatted model name in the summary byline

### DIFF
--- a/src/lib/summarization/format-model-name.ts
+++ b/src/lib/summarization/format-model-name.ts
@@ -1,29 +1,46 @@
 /**
- * Formats an Anthropic model ID into a human-readable name for display.
+ * Formats a model reference into a human-readable name for display.
  *
- * Model IDs look like "claude-sonnet-4-6", "claude-opus-4-8", or the older
- * "claude-3-5-sonnet-20240620" shape. This:
+ * Accepts provider-qualified refs ("cerebras:gpt-oss-120b") as well as bare
+ * model IDs ("claude-sonnet-4-6", legacy stored values). Only the model is
+ * displayed — the provider prefix and any org prefix ("openai/") are
+ * dropped. Formatting:
  *
  * - Strips the "claude-" prefix and renders it as a leading "Claude"
  * - Drops a trailing 8-digit date suffix (e.g. "-20240620")
  * - Title-cases word segments ("sonnet" -> "Sonnet")
  * - Joins consecutive numeric segments with dots ("4-6" -> "4.6")
+ * - Uppercases known acronyms ("gpt" -> "GPT") and size/parameter suffixes
+ *   ("120b" -> "120B")
  *
  * Examples:
  *   "claude-sonnet-4-6"          -> "Claude Sonnet 4.6"
- *   "claude-opus-4-8"            -> "Claude Opus 4.8"
  *   "claude-3-5-sonnet-20240620" -> "Claude 3.5 Sonnet"
+ *   "cerebras:gpt-oss-120b"      -> "GPT-OSS 120B"
+ *   "groq:openai/gpt-oss-20b"    -> "GPT-OSS 20B"
+ *   "groq:llama-3.3-70b-versatile" -> "Llama 3.3 70B Versatile"
  *
- * Unknown / non-Claude IDs fall back to title-casing their segments so the
- * output is never worse than the raw ID.
+ * Unknown IDs fall back to title-casing their segments so the output is
+ * never worse than the raw ID.
  */
+
+import { parseModelRef } from "@/lib/ai/model-ref";
+
+/** Segments rendered fully uppercase. */
+const ACRONYMS = new Set(["gpt", "oss", "ai", "moe"]);
+
 export function formatModelName(modelId: string): string {
   if (!modelId) {
     return modelId;
   }
 
+  // Only display the model — drop the provider prefix ("cerebras:") and any
+  // org prefix in the provider-native ID ("openai/gpt-oss-20b").
+  const { model } = parseModelRef(modelId);
+  const withoutOrg = model.slice(model.lastIndexOf("/") + 1);
+
   // Drop a trailing 8-digit date suffix (e.g. "claude-sonnet-4-5-20250929").
-  const withoutDate = modelId.replace(/-\d{8}$/, "");
+  const withoutDate = withoutOrg.replace(/-\d{8}$/, "");
 
   const hasClaudePrefix = withoutDate.startsWith("claude-");
   const rest = hasClaudePrefix ? withoutDate.slice("claude-".length) : withoutDate;
@@ -47,12 +64,20 @@ export function formatModelName(modelId: string): string {
       numericRun.push(segment);
     } else {
       flushNumericRun();
-      groups.push(segment.charAt(0).toUpperCase() + segment.slice(1));
+      if (ACRONYMS.has(segment.toLowerCase())) {
+        groups.push(segment.toUpperCase());
+      } else if (/^\d+(?:\.\d+)?[bmk]$/i.test(segment)) {
+        // Parameter-count suffixes: "120b" -> "120B", "1.5b" -> "1.5B"
+        groups.push(segment.toUpperCase());
+      } else {
+        groups.push(segment.charAt(0).toUpperCase() + segment.slice(1));
+      }
     }
   }
   flushNumericRun();
 
-  const formatted = groups.join(" ");
+  // "GPT OSS" is branded with a hyphen.
+  const formatted = groups.join(" ").replace(/\bGPT OSS\b/, "GPT-OSS");
 
   if (hasClaudePrefix) {
     return formatted ? `Claude ${formatted}` : "Claude";

--- a/tests/unit/format-model-name.test.ts
+++ b/tests/unit/format-model-name.test.ts
@@ -24,7 +24,24 @@ describe("formatModelName", () => {
   });
 
   it("falls back to title-casing non-Claude IDs", () => {
-    expect(formatModelName("llama-3-1-70b")).toBe("Llama 3.1 70b");
+    expect(formatModelName("llama-3-1-70b")).toBe("Llama 3.1 70B");
+  });
+
+  it("drops the provider prefix from provider-qualified refs", () => {
+    expect(formatModelName("anthropic:claude-sonnet-5")).toBe("Claude Sonnet 5");
+    expect(formatModelName("cerebras:gpt-oss-120b")).toBe("GPT-OSS 120B");
+  });
+
+  it("drops org prefixes in provider-native IDs", () => {
+    expect(formatModelName("groq:openai/gpt-oss-20b")).toBe("GPT-OSS 20B");
+    expect(formatModelName("groq:meta-llama/llama-4-scout-17b-16e-instruct")).toBe(
+      "Llama 4 Scout 17B 16e Instruct"
+    );
+  });
+
+  it("uppercases acronyms and parameter-count suffixes", () => {
+    expect(formatModelName("groq:llama-3.3-70b-versatile")).toBe("Llama 3.3 70B Versatile");
+    expect(formatModelName("cerebras:qwen-3-32b")).toBe("Qwen 3 32B");
   });
 
   it("returns empty string unchanged", () => {


### PR DESCRIPTION
## Summary

Follow-up to #1322: the summary card's "Generated by" line ran the raw provider ref through the Claude-oriented `formatModelName`, producing e.g. **"Cerebras:gpt Oss 120b"**.

`formatModelName` now:
- parses the ref and displays **only the model** (drops the `cerebras:` provider prefix and `openai/` org prefix)
- uppercases known acronyms (`gpt` → GPT, `oss` → OSS) and parameter-count suffixes (`120b` → 120B), with the branded `GPT-OSS` hyphenation

| Input | Before | After |
| --- | --- | --- |
| `cerebras:gpt-oss-120b` | Cerebras:gpt Oss 120b | GPT-OSS 120B |
| `groq:openai/gpt-oss-20b` | Groq:openai/gpt Oss 20b | GPT-OSS 20B |
| `groq:llama-3.3-70b-versatile` | Groq:llama 3.3 70b Versatile | Llama 3.3 70B Versatile |
| `claude-sonnet-4-6` | Claude Sonnet 4.6 | Claude Sonnet 4.6 (unchanged) |

## Testing

- Extended `tests/unit/format-model-name.test.ts` (9 tests passing)
- `pnpm typecheck`, `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)