### PR TITLE
Only send reasoning_effort to models that support it

### DIFF
--- a/src/server/services/ai-providers.ts
+++ b/src/server/services/ai-providers.ts
@@ -114,8 +114,23 @@ export interface ChatCompletionOptions {
   jsonObject?: boolean;
   /** Sampling temperature. Ignored for Anthropic. */
   temperature?: number;
-  /** Reasoning effort for reasoning models (gpt-oss). Ignored for Anthropic. */
+  /**
+   * Reasoning effort for reasoning models. Ignored for Anthropic, and only
+   * sent to models that accept the parameter (see
+   * {@link supportsReasoningEffort}) — Groq/Cerebras reject it with a 400 on
+   * non-reasoning models like Llama.
+   */
   reasoningEffort?: "low" | "medium" | "high";
+}
+
+/**
+ * Whether a provider-native model ID accepts the OpenAI-style
+ * `reasoning_effort` low/medium/high parameter. Currently only the gpt-oss
+ * family does on Groq and Cerebras; other models (Llama, Qwen, ...) return
+ * `400 reasoning_effort is not supported with this model`.
+ */
+export function supportsReasoningEffort(model: string): boolean {
+  return model.toLowerCase().includes("gpt-oss");
 }
 
 /**
@@ -157,7 +172,9 @@ export async function generateChatCompletion(
         model: ref.model,
         max_completion_tokens: options.maxTokens,
         ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
-        ...(options.reasoningEffort ? { reasoning_effort: options.reasoningEffort } : {}),
+        ...(options.reasoningEffort && supportsReasoningEffort(ref.model)
+          ? { reasoning_effort: options.reasoningEffort }
+          : {}),
         ...(options.jsonObject ? { response_format: { type: "json_object" as const } } : {}),
         messages: [
           ...(options.system ? [{ role: "system" as const, content: options.system }] : []),
@@ -175,7 +192,9 @@ export async function generateChatCompletion(
         model: ref.model,
         max_completion_tokens: options.maxTokens,
         ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
-        ...(options.reasoningEffort ? { reasoning_effort: options.reasoningEffort } : {}),
+        ...(options.reasoningEffort && supportsReasoningEffort(ref.model)
+          ? { reasoning_effort: options.reasoningEffort }
+          : {}),
         ...(options.jsonObject ? { response_format: { type: "json_object" as const } } : {}),
         messages: [
           ...(options.system ? [{ role: "system" as const, content: options.system }] : []),

--- a/tests/unit/ai-providers.test.ts
+++ b/tests/unit/ai-providers.test.ts
@@ -3,6 +3,7 @@ import {
   getAvailableProviders,
   isChatModelId,
   isProviderAvailable,
+  supportsReasoningEffort,
 } from "@/server/services/ai-providers";
 import { getNarrationModelRef } from "@/server/services/narration";
 import { getSummarizationModelId } from "@/server/services/summarization";
@@ -133,6 +134,17 @@ describe("getNarrationModelRef", () => {
     expect(getNarrationModelRef("some-bare-model")).toEqual(
       getNarrationModelRef(DEFAULT_NARRATION_MODEL)
     );
+  });
+});
+
+describe("supportsReasoningEffort", () => {
+  it("allows reasoning effort only for the gpt-oss family", () => {
+    expect(supportsReasoningEffort("openai/gpt-oss-20b")).toBe(true);
+    expect(supportsReasoningEffort("gpt-oss-120b")).toBe(true);
+    // Groq/Cerebras 400 on reasoning_effort for non-reasoning models
+    expect(supportsReasoningEffort("meta-llama/llama-4-scout-17b-16e-instruct")).toBe(false);
+    expect(supportsReasoningEffort("llama-3.3-70b-versatile")).toBe(false);
+    expect(supportsReasoningEffort("qwen-3-32b")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes summarization (and narration) failing with `400 reasoning_effort is not supported with this model` when a non-reasoning Groq/Cerebras model (e.g. `llama-4-scout`) is selected.

`generateChatCompletion` now only includes `reasoning_effort` for models that accept it — currently the gpt-oss family — via a new `supportsReasoningEffort` helper. Other models (Llama, Qwen) get the same request minus that parameter.

## Testing

- New unit test covering the gpt-oss allow / Llama & Qwen deny cases
- `pnpm typecheck`, `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)