### PR TITLE
Let explicit regenerate bypass the summary error backoff

### DIFF
--- a/src/server/trpc/routers/summarization.ts
+++ b/src/server/trpc/routers/summarization.ts
@@ -318,8 +318,10 @@ export const summarizationRouter = createTRPCRouter({
         Date.now() - summaryRecord.errorAt.getTime() > RETRY_AFTER_MS;
 
       if (!canRetry) {
+        // Note this echoes the stored error from the *previous* attempt — no
+        // new request was made (the settings may have changed since).
         throw errors.internal(
-          `Summarization failed recently. Please try again later. Error: ${summaryRecord.error}`
+          `Summarization failed recently and this request was not retried. Use Regenerate to retry now, or try again later. Previous error: ${summaryRecord.error}`
         );
       }
 

--- a/src/server/trpc/routers/summarization.ts
+++ b/src/server/trpc/routers/summarization.ts
@@ -8,7 +8,11 @@
 import { z } from "zod";
 import { eq, and } from "drizzle-orm";
 
-import { createTRPCRouter, confirmedProtectedProcedure as protectedProcedure } from "../trpc";
+import {
+  createTRPCRouter,
+  confirmedProtectedProcedure as protectedProcedure,
+  expensiveConfirmedProtectedProcedure,
+} from "../trpc";
 import { errors } from "../errors";
 import { uuidSchema } from "../validation";
 import { entries, entrySummaries, userEntries } from "@/server/db/schema";
@@ -91,7 +95,10 @@ export const summarizationRouter = createTRPCRouter({
    * @param entryId - The entry ID
    * @returns Summary text, whether it was cached, model ID, and generation time
    */
-  generate: protectedProcedure
+  // Rate-limited (10 burst, 1/sec): makes an outbound LLM call, potentially on
+  // the server-wide API key, and explicit regenerate bypasses the error
+  // backoff below.
+  generate: expensiveConfirmedProtectedProcedure
     .meta({
       openapi: {
         method: "POST",

--- a/src/server/trpc/routers/summarization.ts
+++ b/src/server/trpc/routers/summarization.ts
@@ -300,9 +300,15 @@ export const summarizationRouter = createTRPCRouter({
         };
       }
 
-      // Check if we should retry after a previous error
+      // Check if we should retry after a previous error. The backoff guards
+      // against automatic retry loops; an explicit user retry (the error
+      // card's "Try again" / the regenerate button both send regenerate:
+      // true) always goes through — e.g. after the user fixes the failure by
+      // changing model or keys.
       const canRetry =
-        !summaryRecord.errorAt || Date.now() - summaryRecord.errorAt.getTime() > RETRY_AFTER_MS;
+        input.regenerate ||
+        !summaryRecord.errorAt ||
+        Date.now() - summaryRecord.errorAt.getTime() > RETRY_AFTER_MS;
 
       if (!canRetry) {
         throw errors.internal(


### PR DESCRIPTION
## Summary

Follow-up to #1325. The 1-hour summary error backoff also blocked explicit user retries: after an entry recorded an error (e.g. the `reasoning_effort` 400 on a non-gpt-oss model), the error card's "Try again" and the regenerate button kept returning "Summarization failed recently. Please try again later." until the backoff expired — even once the underlying cause was fixed (model switched, key added, or #1325 deployed).

Both of those UI actions send `regenerate: true`, so the router now lets explicit regenerate requests through immediately; the backoff still guards automatic retries.

## Testing

- `pnpm typecheck`, `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)