### PR TITLE
Add Anthropic, Cerebras, Discord, Mailgun & object storage to privacy policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,10 @@ Don't try to invalidate the cache or look things up in the cache. Pass data down
 
 Always use our custom user agent (`USER_AGENT`/`buildUserAgent` from `@/server/http/user-agent`), and fetch user-influenced URLs only through `fetchWithSsrfProtection` (see `src/server/http/CLAUDE.md`).
 
+## Third-Party Providers
+
+When you add, remove, or change a third-party service that receives or stores user data (e.g. an LLM/AI provider, auth provider, email, object storage, hosting, error tracking), **update the privacy policy** (`src/app/privacy/page.tsx`) to keep its "Third-Party Services" section accurate, and bump the "Last updated" date. Note whether the feature is opt-in and what data is sent.
+
 ## Parsing
 
 Prefer SAX-style parsing unless the algorithm requires a DOM.

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -279,11 +279,11 @@ export default function PrivacyPolicyPage() {
             </p>
           </LegalSubsection>
 
-          <LegalSubsection title="Object Storage (AWS S3 / Fly.io Tigris)">
+          <LegalSubsection title="Object Storage (Fly.io Tigris)">
             <LegalParagraph tight>
               Images embedded in some articles (for example, images from imported Google Docs) are
-              stored on an S3-compatible object storage service (AWS S3 or Fly.io Tigris). These
-              stored images are served from that provider when you view the article.
+              stored on Fly.io&apos;s Tigris object storage. These stored images are served from
+              Tigris when you view the article.
             </LegalParagraph>
           </LegalSubsection>
         </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
 
 export default function PrivacyPolicyPage() {
   return (
-    <LegalPage title="Privacy Policy" lastUpdated="February 2026">
+    <LegalPage title="Privacy Policy" lastUpdated="July 2026">
       <LegalSection title="Overview">
         <LegalParagraph>
           Lion Reader is committed to protecting your privacy. We collect only the data necessary to
@@ -86,7 +86,10 @@ export default function PrivacyPolicyPage() {
           <li>To maintain your account and authenticate you when you sign in</li>
           <li>To fetch, store, and display RSS/Atom feeds you subscribe to</li>
           <li>To track your reading progress (read/unread status, starred items)</li>
-          <li>To enable optional features like audio narration and saved articles</li>
+          <li>
+            To enable optional features like article summarization, audio narration, saved articles,
+            and Discord integration
+          </li>
           <li>
             To monitor service health, diagnose errors, and improve performance (via Sentry and
             Grafana)
@@ -151,6 +154,42 @@ export default function PrivacyPolicyPage() {
 
         <div className="mt-4 space-y-6">
           <Card padding="md">
+            <LegalSubsection title="Article Summarization (Anthropic, Cerebras, Groq) — Optional">
+              <LegalParagraph>
+                <strong>This feature is optional and off by default.</strong> Summarization only
+                happens when you explicitly request a summary for an article and a summarization
+                model has been configured (either your own API key or a server-provided one). When
+                you generate a summary, the article&apos;s title and text content are sent to your
+                chosen AI provider—Anthropic, Cerebras, or Groq—to produce the summary.
+              </LegalParagraph>
+              <LegalParagraph>
+                You choose which provider and model to use in your settings, and you may provide a
+                custom summarization prompt. Generated summaries are cached on our servers so the
+                same article does not need to be reprocessed.
+              </LegalParagraph>
+              <p className="mt-2 flex flex-wrap gap-x-4 gap-y-1">
+                <TextLink
+                  href="https://www.anthropic.com/legal/privacy"
+                  external
+                  className="ui-text-sm"
+                >
+                  Anthropic&apos;s Privacy Policy &rarr;
+                </TextLink>
+                <TextLink
+                  href="https://www.cerebras.ai/privacy-policy"
+                  external
+                  className="ui-text-sm"
+                >
+                  Cerebras&apos;s Privacy Policy &rarr;
+                </TextLink>
+                <TextLink href="https://groq.com/privacy-policy/" external className="ui-text-sm">
+                  Groq&apos;s Privacy Policy &rarr;
+                </TextLink>
+              </p>
+            </LegalSubsection>
+          </Card>
+
+          <Card padding="md">
             <LegalSubsection title="Audio Narration (Groq) — Optional">
               <LegalParagraph>
                 <strong>This feature is optional and disabled by default.</strong> When you enable
@@ -198,11 +237,53 @@ export default function PrivacyPolicyPage() {
             </LegalParagraph>
           </LegalSubsection>
 
-          <LegalSubsection title="Authentication Providers (Google, Apple)">
+          <LegalSubsection title="Authentication Providers (Google, Apple, Discord)">
             <LegalParagraph tight>
-              If you choose to sign in with Google or Apple, we use their OAuth services. We only
-              receive your email address and profile ID—we do not access any other data from these
-              providers.
+              If you choose to sign in with Google, Apple, or Discord, we use their OAuth services.
+              We only receive your email address and profile ID—we do not access any other data from
+              these providers.
+            </LegalParagraph>
+          </LegalSubsection>
+
+          <LegalSubsection title="Discord Bot — Optional">
+            <LegalParagraph tight>
+              You can optionally link your Discord account to save articles through our Discord bot
+              (by reacting to a message or sending a link to the bot). If you enable this feature,
+              Discord processes the messages, reactions, and links involved in the interaction as
+              part of operating its platform, and we receive the Discord user ID and the links you
+              share so we can save them to your account. The bot is not active unless you
+              deliberately link it.
+            </LegalParagraph>
+            <p className="mt-2">
+              <TextLink href="https://discord.com/privacy" external className="ui-text-sm">
+                View Discord&apos;s Privacy Policy &rarr;
+              </TextLink>
+            </p>
+          </LegalSubsection>
+
+          <LegalSubsection title="Inbound Email (Mailgun)">
+            <LegalParagraph tight>
+              If you use the email newsletter feature, we use Mailgun to receive emails sent to your
+              unique ingest address and forward them to our servers, where they are stored as feed
+              entries. Mailgun processes the sender, subject, and content of those emails in order
+              to deliver them to us.
+            </LegalParagraph>
+            <p className="mt-2">
+              <TextLink
+                href="https://www.mailgun.com/legal/privacy-policy/"
+                external
+                className="ui-text-sm"
+              >
+                View Mailgun&apos;s Privacy Policy &rarr;
+              </TextLink>
+            </p>
+          </LegalSubsection>
+
+          <LegalSubsection title="Object Storage (AWS S3 / Fly.io Tigris)">
+            <LegalParagraph tight>
+              Images embedded in some articles (for example, images from imported Google Docs) are
+              stored on an S3-compatible object storage service (AWS S3 or Fly.io Tigris). These
+              stored images are served from that provider when you view the article.
             </LegalParagraph>
           </LegalSubsection>
         </div>
@@ -304,8 +385,8 @@ export default function PrivacyPolicyPage() {
             individual login sessions from your account settings
           </li>
           <li>
-            <strong>Control features:</strong> Disable optional features like AI text processing for
-            narration at any time
+            <strong>Control features:</strong> Enable or disable optional features like article
+            summarization, AI text processing for narration, and the Discord bot at any time
           </li>
           <li>
             <strong>Delete:</strong> Delete your account and all associated data at any time from


### PR DESCRIPTION
## Summary

Updates the privacy policy (`src/app/privacy/page.tsx`) to document the third-party services that were missing from the **Third-Party Services** section:

- **Article Summarization (Anthropic, Cerebras, Groq)** — new opt-in card. Documents that summarization only runs when a user explicitly requests it and a model is configured, that the article title + text content are sent to the user's chosen provider, that the user picks provider/model/prompt, and that summaries are cached server-side. Links each provider's privacy policy.
- **Discord** — added to the Authentication Providers subsection (OAuth sign-in), plus a new **Discord Bot — Optional** subsection covering the save-by-reaction/DM bot and what data flows to Discord.
- **Inbound Email (Mailgun)** — new subsection covering how newsletter ingest emails are received and forwarded.
- **Object Storage (AWS S3 / Fly.io Tigris)** — new subsection covering stored article images.

Also refreshed the **How We Use Your Data** and **Your Rights** feature lists to mention summarization / Discord, and bumped the *Last updated* date to July 2026.

All wording was based on a code audit of the actual integrations (summarization service, Discord bot, S3 storage, Mailgun webhook), not assumptions.

## Testing

- `pnpm typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)