### PR TITLE
SSR the auth pages so signup-config content renders on first paint (#1328)

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -9,6 +9,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import { TRPCProvider } from "@/lib/trpc/provider";
+import { createHydrationHelpersForRequest } from "@/lib/trpc/server";
 import { validateSession } from "@/server/auth/session";
 import { AuthLayoutContent } from "./AuthLayoutContent";
 
@@ -37,9 +38,25 @@ export default async function AuthLayout({ children }: AuthLayoutProps) {
     }
   }
 
+  // Prefetch the config the login/register forms depend on so their
+  // config-driven content renders in the SSR HTML instead of flashing a loading
+  // state and popping in once the client queries resolve. Both are static server
+  // env (which signup providers are allowed / which OAuth providers are
+  // configured), so awaiting them is cheap and lets the queries hydrate as
+  // already-settled data:
+  //   - auth.signupConfig: invite-required state, allowed signup providers, the
+  //     "Create one" link, and the register email form.
+  //   - auth.providers: which OAuth provider buttons (Google/Apple/Discord) to
+  //     render — OAuthSignInButton returns null until this resolves.
+  // See #1328.
+  const { trpc, HydrateClient } = await createHydrationHelpersForRequest();
+  await Promise.all([trpc.auth.signupConfig.prefetch(), trpc.auth.providers.prefetch()]);
+
   return (
     <TRPCProvider>
-      <AuthLayoutContent>{children}</AuthLayoutContent>
+      <HydrateClient>
+        <AuthLayoutContent>{children}</AuthLayoutContent>
+      </HydrateClient>
     </TRPCProvider>
   );
 }

--- a/tests/e2e/auth-ssr.spec.ts
+++ b/tests/e2e/auth-ssr.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * E2E tests that the auth pages (/login, /register) render their
+ * signup-config-driven content in the **initial SSR HTML**, not after a
+ * client-side query resolves (issue #1328).
+ *
+ * The forms depend on `auth.signupConfig` (invite-required state, allowed
+ * signup providers) and `auth.providers` (which OAuth buttons to show). Both
+ * are static server env, so `(auth)/layout.tsx` prefetches them and hydrates
+ * them into the React Query cache. These tests assert against the raw response
+ * body (before any hydration/JS runs) so a regression that reverts to the
+ * client-only query — which SSRs a "Loading..." placeholder and an empty
+ * invite/provider state — fails here.
+ *
+ * The e2e env sets no `ALLOWED_PUBLIC_SIGNUP_PROVIDERS`, so the instance is
+ * invite-only (public providers empty); `ALLOWED_SIGNUP_PROVIDERS` defaults to
+ * all, so presenting any `?invite=` token renders the full signup form.
+ */
+
+import { test, expect } from "@playwright/test";
+import { closeTestConnections } from "./helpers";
+
+test.afterAll(async () => {
+  await closeTestConnections();
+});
+
+test("/register SSRs the invite-required state, not a loading placeholder", async ({ request }) => {
+  const response = await request.get("/register");
+  expect(response.status()).toBe(200);
+  const html = await response.text();
+
+  // Config-driven content is present in the first paint...
+  expect(html).toContain("Invite Required");
+  // ...and the client-only loading placeholder is not.
+  expect(html).not.toContain("Loading...");
+});
+
+test("/register with an invite token SSRs the full signup form", async ({ request }) => {
+  const response = await request.get("/register?invite=any-token");
+  expect(response.status()).toBe(200);
+  const html = await response.text();
+
+  // With a token, the full allowlist applies (email is a default provider), so
+  // the account form renders server-side instead of the invite-required state.
+  expect(html).toContain("Create your account");
+  expect(html).not.toContain("Invite Required");
+  expect(html).not.toContain("Loading...");
+});
+
+test("/login SSRs signup-config-driven content without a loading flash", async ({ request }) => {
+  const response = await request.get("/login");
+  expect(response.status()).toBe(200);
+  const html = await response.text();
+
+  expect(html).toContain("Sign in to your account");
+  expect(html).not.toContain("Loading...");
+  // Invite-only instance: the "Create one" signup link is gated off in the SSR
+  // HTML (requiresInvite is true), so it must not be present.
+  expect(html).not.toContain("Create one");
+});


### PR DESCRIPTION
## Summary

Fixes #1328. The `/login` and `/register` forms depended entirely on **client-side** tRPC queries, so their config-driven content was missing from the SSR HTML and popped in only after hydration:

- `auth.signupConfig` — invite-required state, allowed signup providers, the "Create one" link on `/login`, and the register email form. `/register` masked this with a full `Loading...` gate, so the SSR HTML was just a placeholder.
- `auth.providers` — which OAuth buttons (Google/Apple/Discord) to render. `OAuthSignInButton` returns `null` until this resolves, so **no OAuth buttons were in the SSR HTML at all**.

Both are static server env (not per-user), so `(auth)/layout.tsx` now prefetches them via the existing tRPC hydration helpers (`createHydrationHelpersForRequest`) and wraps the pages in `HydrateClient`. The queries hydrate as already-settled data, so the forms render their real config-driven content in the first paint with no client-only flash — the "proper SSR/hydration" option (approach 1) from the issue, extended to cover the OAuth providers per the maintainer's note.

## Notes

- The issue's `/complete-signup` symptom references an `euRestricted` / `EU_RESTRICTED` flag that doesn't exist in the current code — that page's EU checkbox is rendered **statically** (always shown, no `signupConfig` dependency), so it already appears in the SSR HTML. No change was needed there.
- This is a server-prefetch of existing queries only; no cache-invalidation or query/mutation semantics changed, so `FRONTEND_STATE.md` needs no update.

## Testing

- `pnpm typecheck` passes.
- New e2e regression test (`tests/e2e/auth-ssr.spec.ts`) asserts the **raw** SSR response body (pre-hydration) for `/register`, `/register?invite=...`, and `/login` contains the config-driven content and no `Loading...` placeholder. All 3 pass locally.
- Manually verified via `curl` against a dev server: with default (invite-only) config `/register` SSRs "Invite Required"; with `ALLOWED_PUBLIC_SIGNUP_PROVIDERS` set it SSRs the full "Create your account" form — neither shows `Loading...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)