### PR TITLE
Curate AI model pickers and default to fastest providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,8 +141,8 @@ PORT=3000
 
 # --- Narration (Text Processing) ---
 # Model for narration text processing; Groq or Cerebras only
-# (default: groq:openai/gpt-oss-20b)
-# NARRATION_MODEL=groq:openai/gpt-oss-20b
+# (default: the first configured provider's default model, Cerebras then Groq)
+# NARRATION_MODEL=cerebras:gpt-oss-120b
 
 # =============================================================================
 # Google Integration (Optional)

--- a/src/lib/narration/constants.ts
+++ b/src/lib/narration/constants.ts
@@ -5,16 +5,31 @@
  */
 
 /**
- * Default model for LLM narration preprocessing, as a `provider:model`
- * reference. Narration preprocessing only supports the OpenAI-compatible
- * providers (Groq, Cerebras) — it relies on JSON-object response formatting.
+ * Providers selectable for narration preprocessing. Narration preprocessing
+ * only supports the OpenAI-compatible providers (Groq, Cerebras) — it relies
+ * on JSON-object response formatting. This is also the preference order for the
+ * default model when the user hasn't picked one: Cerebras first (fastest), then
+ * Groq.
  */
-export const DEFAULT_NARRATION_MODEL = "groq:openai/gpt-oss-20b";
+export const NARRATION_PROVIDERS = ["cerebras", "groq"] as const;
+
+export type NarrationProvider = (typeof NARRATION_PROVIDERS)[number];
 
 /**
- * Providers selectable for narration preprocessing.
+ * Default narration preprocessing model per provider, as `provider:model`
+ * references. The effective default is the first configured provider's entry,
+ * in {@link NARRATION_PROVIDERS} order.
  */
-export const NARRATION_PROVIDERS = ["groq", "cerebras"] as const;
+export const DEFAULT_NARRATION_MODELS: Record<NarrationProvider, string> = {
+  cerebras: "cerebras:gpt-oss-120b",
+  groq: "groq:openai/gpt-oss-120b",
+};
+
+/**
+ * Default model for LLM narration preprocessing when no provider is known to be
+ * configured (e.g. as a frontend fallback before the models query resolves).
+ */
+export const DEFAULT_NARRATION_MODEL = DEFAULT_NARRATION_MODELS.cerebras;
 
 /**
  * Default speech rate (1.0 = normal speed).

--- a/src/lib/summarization/constants.ts
+++ b/src/lib/summarization/constants.ts
@@ -19,15 +19,17 @@ export const DEFAULT_SUMMARIZATION_MODELS: Record<AiProvider, string> = {
 
 /**
  * Provider preference order for the default summarization model when the user
- * hasn't picked one.
+ * hasn't picked one. Cerebras and Groq run gpt-oss far faster than Anthropic,
+ * and most users prefer the fastest possible summaries over minor quality
+ * gains, so the hosted OpenAI-compatible providers come first.
  */
-export const SUMMARIZATION_PROVIDER_PRIORITY: AiProvider[] = ["anthropic", "groq", "cerebras"];
+export const SUMMARIZATION_PROVIDER_PRIORITY: AiProvider[] = ["cerebras", "groq", "anthropic"];
 
 /**
  * Default summarization model when no provider is known to be configured
  * (e.g. as a frontend fallback before the models query resolves).
  */
-export const DEFAULT_SUMMARIZATION_MODEL = DEFAULT_SUMMARIZATION_MODELS.anthropic;
+export const DEFAULT_SUMMARIZATION_MODEL = DEFAULT_SUMMARIZATION_MODELS.cerebras;
 
 /**
  * Default maximum words for generated summaries.

--- a/src/server/services/ai-providers.ts
+++ b/src/server/services/ai-providers.ts
@@ -252,11 +252,83 @@ export function simplifyModelIds(
 
 /**
  * Groq's model list includes audio (whisper/TTS) and moderation models that
- * can't do chat completions; hide them from the pickers.
+ * can't do chat completions; hide them from the pickers. TTS families don't all
+ * spell "tts" in their IDs (Groq exposes Orpheus TTS as `canopylabs/orpheus-*`),
+ * so match those families by name too.
  */
 export function isChatModelId(id: string): boolean {
   const lower = id.toLowerCase();
-  return !lower.includes("whisper") && !lower.includes("tts") && !lower.includes("guard");
+  return (
+    !lower.includes("whisper") &&
+    !lower.includes("tts") &&
+    !lower.includes("guard") &&
+    !lower.includes("canopylabs") &&
+    !lower.includes("orpheus")
+  );
+}
+
+/**
+ * Minimum context window (in tokens) for a model to appear in the summarization
+ * and narration pickers. Summarization feeds up to ~12k tokens of article text
+ * plus the prompt and reserves several thousand output/reasoning tokens, so
+ * short-context models (e.g. Groq's 8k-context Gemma/older-Llama or small Qwen
+ * builds) can't reasonably summarize a full article. Models whose context
+ * window is unknown (Cerebras omits the field) are kept.
+ */
+const MIN_CONTEXT_WINDOW = 32768;
+
+/**
+ * Reads the optional `context_window` field the Groq models API returns. The
+ * provider SDK types don't expose it, so we read it defensively; Cerebras omits
+ * it entirely (returns `undefined`).
+ */
+function contextWindowOf(model: unknown): number | undefined {
+  const value = (model as { context_window?: unknown }).context_window;
+  return typeof value === "number" ? value : undefined;
+}
+
+/**
+ * Whether a Groq/Cerebras model is usable for summarization/narration: it must
+ * be a chat model and, when the provider reports a context window, have enough
+ * room to summarize a full article.
+ */
+function isUsableChatModel(model: { id: string }): boolean {
+  if (!isChatModelId(model.id)) {
+    return false;
+  }
+  const contextWindow = contextWindowOf(model);
+  return contextWindow === undefined || contextWindow >= MIN_CONTEXT_WINDOW;
+}
+
+/** Claude model families we surface, one (newest) model per family. */
+const CLAUDE_FAMILIES = ["opus", "sonnet", "haiku", "fable"] as const;
+
+/**
+ * Filters Anthropic models to the newest generation — the latest Opus, Sonnet,
+ * Haiku, and Fable — dropping older versions of each family. The Anthropic API
+ * returns models newest-first, so the first model seen for a family is its
+ * newest. Models that don't match a known family are kept (so a new family
+ * isn't accidentally hidden).
+ */
+export function filterToLatestClaudeGeneration(
+  models: { id: string; displayName: string }[]
+): { id: string; displayName: string }[] {
+  const seenFamilies = new Set<string>();
+  const result: { id: string; displayName: string }[] = [];
+
+  for (const model of models) {
+    const family = CLAUDE_FAMILIES.find((f) => model.id.toLowerCase().includes(f));
+    if (!family) {
+      result.push(model);
+      continue;
+    }
+    if (!seenFamilies.has(family)) {
+      seenFamilies.add(family);
+      result.push(model);
+    }
+  }
+
+  return result;
 }
 
 async function listProviderModels(provider: AiProvider, keys?: AiProviderKeys): Promise<AiModel[]> {
@@ -269,7 +341,7 @@ async function listProviderModels(provider: AiProvider, keys?: AiProviderKeys): 
       for await (const model of client.models.list({ limit: 100 })) {
         models.push({ id: model.id, displayName: model.display_name });
       }
-      return simplifyModelIds(models).map((model) => ({
+      return filterToLatestClaudeGeneration(simplifyModelIds(models)).map((model) => ({
         id: formatModelRef("anthropic", model.id),
         displayName: model.displayName,
         provider: "anthropic" as const,
@@ -280,7 +352,7 @@ async function listProviderModels(provider: AiProvider, keys?: AiProviderKeys): 
       if (!client) return [];
       const response = await client.models.list();
       return response.data
-        .filter((model) => isChatModelId(model.id))
+        .filter((model) => isUsableChatModel(model))
         .map((model) => ({
           id: formatModelRef("groq", model.id),
           displayName: model.id,
@@ -293,7 +365,7 @@ async function listProviderModels(provider: AiProvider, keys?: AiProviderKeys): 
       if (!client) return [];
       const response = await client.models.list();
       return response.data
-        .filter((model) => isChatModelId(model.id))
+        .filter((model) => isUsableChatModel(model))
         .map((model) => ({
           id: formatModelRef("cerebras", model.id),
           displayName: model.id,

--- a/src/server/services/narration.ts
+++ b/src/server/services/narration.ts
@@ -1,8 +1,8 @@
 /**
  * Narration service for LLM-based text preprocessing.
  *
- * Uses an OpenAI-compatible provider (Groq or Cerebras, default Groq
- * GPT-OSS 20B) to convert article HTML to narration-ready text for
+ * Uses an OpenAI-compatible provider (Cerebras or Groq, default Cerebras
+ * GPT-OSS 120B) to convert article HTML to narration-ready text for
  * text-to-speech. Falls back to simple HTML stripping when no provider is
  * available.
  */
@@ -10,7 +10,7 @@
 import { z } from "zod";
 import { logger } from "@/lib/logger";
 import { parseModelRef, type ModelRef } from "@/lib/ai/model-ref";
-import { DEFAULT_NARRATION_MODEL } from "@/lib/narration/constants";
+import { DEFAULT_NARRATION_MODELS, NARRATION_PROVIDERS } from "@/lib/narration/constants";
 import {
   generateChatCompletion,
   isProviderAvailable,
@@ -106,18 +106,23 @@ Return ONLY valid JSON.`;
 
 /**
  * Resolves the narration model as a `provider:model` reference.
- * Priority: user setting > `NARRATION_MODEL` env var > default.
+ * Priority: user setting > `NARRATION_MODEL` env var > the default model of the
+ * first configured provider (Cerebras, then Groq).
  *
  * Narration preprocessing requires JSON-object responses, which only the
  * OpenAI-compatible providers support — a reference that resolves to another
  * provider (e.g. a legacy bare model ID) falls back to the default model.
  */
-export function getNarrationModelRef(userModel?: string | null): ModelRef {
-  const ref = parseModelRef(userModel || process.env.NARRATION_MODEL || DEFAULT_NARRATION_MODEL);
-  if (ref.provider !== "groq" && ref.provider !== "cerebras") {
-    return parseModelRef(DEFAULT_NARRATION_MODEL);
+export function getNarrationModelRef(userModel?: string | null, keys?: AiProviderKeys): ModelRef {
+  const explicit = userModel || process.env.NARRATION_MODEL;
+  if (explicit) {
+    const ref = parseModelRef(explicit);
+    if (ref.provider === "groq" || ref.provider === "cerebras") {
+      return ref;
+    }
   }
-  return ref;
+  const provider = NARRATION_PROVIDERS.find((p) => isProviderAvailable(p, keys)) ?? "cerebras";
+  return parseModelRef(DEFAULT_NARRATION_MODELS[provider]);
 }
 
 /**
@@ -184,7 +189,7 @@ export async function generateNarration(
     userModel?: string | null;
   }
 ): Promise<GenerateNarrationResult> {
-  const modelRef = getNarrationModelRef(options?.userModel);
+  const modelRef = getNarrationModelRef(options?.userModel, options?.keys);
 
   // Convert HTML to structured paragraphs
   const { paragraphs: inputParagraphs } = htmlToNarrationInput(htmlContent);
@@ -286,5 +291,5 @@ export async function generateNarration(
  * narration model's provider has a user or server key set.
  */
 export function isNarrationLlmAvailable(keys?: AiProviderKeys, userModel?: string | null): boolean {
-  return isProviderAvailable(getNarrationModelRef(userModel).provider, keys);
+  return isProviderAvailable(getNarrationModelRef(userModel, keys).provider, keys);
 }

--- a/src/server/services/summarization.ts
+++ b/src/server/services/summarization.ts
@@ -262,7 +262,7 @@ export function isSummarizationAvailable(keys?: AiProviderKeys): boolean {
  * `parseModelRef`).
  *
  * Priority: user setting > `SUMMARIZATION_MODEL` env var > the default model
- * of the first configured provider (Anthropic, then Groq, then Cerebras).
+ * of the first configured provider (Cerebras, then Groq, then Anthropic).
  */
 export function getSummarizationModelId(userModel?: string | null, keys?: AiProviderKeys): string {
   if (userModel) {
@@ -272,7 +272,10 @@ export function getSummarizationModelId(userModel?: string | null, keys?: AiProv
     return process.env.SUMMARIZATION_MODEL;
   }
   const available = getAvailableProviders(keys);
+  // When nothing is configured summarization is disabled anyway, so the value
+  // is nominal — fall back to the highest-priority provider's default.
   const provider =
-    SUMMARIZATION_PROVIDER_PRIORITY.find((p) => available.includes(p)) ?? "anthropic";
+    SUMMARIZATION_PROVIDER_PRIORITY.find((p) => available.includes(p)) ??
+    SUMMARIZATION_PROVIDER_PRIORITY[0];
   return DEFAULT_SUMMARIZATION_MODELS[provider];
 }

--- a/src/server/trpc/routers/narration.ts
+++ b/src/server/trpc/routers/narration.ts
@@ -385,7 +385,7 @@ export const narrationRouter = createTRPCRouter({
       // Fetch API keys from DB on demand (not cached in session for security)
       const keys = await getUserApiKeys(ctx.session.user.id);
       const models = await listAllModels(keys, NARRATION_PROVIDERS);
-      const defaultRef = getNarrationModelRef(null);
+      const defaultRef = getNarrationModelRef(null, keys);
       return { models, defaultModelId: formatModelRef(defaultRef.provider, defaultRef.model) };
     }),
 });

--- a/tests/unit/ai-providers.test.ts
+++ b/tests/unit/ai-providers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import {
+  filterToLatestClaudeGeneration,
   getAvailableProviders,
   isChatModelId,
   isProviderAvailable,
@@ -11,7 +12,7 @@ import {
   DEFAULT_SUMMARIZATION_MODELS,
   SUMMARIZATION_PROVIDER_PRIORITY,
 } from "@/lib/summarization/constants";
-import { DEFAULT_NARRATION_MODEL } from "@/lib/narration/constants";
+import { DEFAULT_NARRATION_MODEL, DEFAULT_NARRATION_MODELS } from "@/lib/narration/constants";
 
 const ENV_VARS = [
   "ANTHROPIC_API_KEY",
@@ -77,21 +78,28 @@ describe("getSummarizationModelId", () => {
     expect(getSummarizationModelId(null, {})).toBe("groq:foo");
   });
 
-  it("defaults to the first configured provider by priority", () => {
+  it("defaults to the first configured provider by priority (Cerebras > Groq > Anthropic)", () => {
     clearEnv();
+    // Cerebras wins over both others when configured.
     expect(getSummarizationModelId(null, { groqApiKey: "g", cerebrasApiKey: "c" })).toBe(
-      DEFAULT_SUMMARIZATION_MODELS.groq
+      DEFAULT_SUMMARIZATION_MODELS.cerebras
     );
     expect(getSummarizationModelId(null, { anthropicApiKey: "a", cerebrasApiKey: "c" })).toBe(
-      DEFAULT_SUMMARIZATION_MODELS.anthropic
-    );
-    expect(getSummarizationModelId(null, { cerebrasApiKey: "c" })).toBe(
       DEFAULT_SUMMARIZATION_MODELS.cerebras
+    );
+    // Groq wins over Anthropic.
+    expect(getSummarizationModelId(null, { anthropicApiKey: "a", groqApiKey: "g" })).toBe(
+      DEFAULT_SUMMARIZATION_MODELS.groq
+    );
+    // Anthropic only when it's the sole option.
+    expect(getSummarizationModelId(null, { anthropicApiKey: "a" })).toBe(
+      DEFAULT_SUMMARIZATION_MODELS.anthropic
     );
   });
 
-  it("defaults to the Anthropic model when nothing is configured", () => {
+  it("defaults to the first-priority provider (Cerebras) when nothing is configured", () => {
     clearEnv();
+    expect(SUMMARIZATION_PROVIDER_PRIORITY[0]).toBe("cerebras");
     expect(getSummarizationModelId(null, {})).toBe(
       DEFAULT_SUMMARIZATION_MODELS[SUMMARIZATION_PROVIDER_PRIORITY[0]]
     );
@@ -99,19 +107,35 @@ describe("getSummarizationModelId", () => {
 });
 
 describe("getNarrationModelRef", () => {
-  it("defaults to the built-in narration model", () => {
+  it("defaults to the Cerebras gpt-oss-120b model when nothing is configured", () => {
     clearEnv();
     expect(getNarrationModelRef(null)).toEqual({
-      provider: "groq",
-      model: "openai/gpt-oss-20b",
+      provider: "cerebras",
+      model: "gpt-oss-120b",
     });
+  });
+
+  it("defaults to the first configured provider (Cerebras before Groq)", () => {
+    clearEnv();
+    // Only Groq configured → Groq default.
+    expect(getNarrationModelRef(null, { groqApiKey: "g" })).toEqual({
+      provider: "groq",
+      model: "openai/gpt-oss-120b",
+    });
+    expect(DEFAULT_NARRATION_MODELS.groq).toBe("groq:openai/gpt-oss-120b");
+    // Both configured → Cerebras wins (fastest, listed first).
+    expect(getNarrationModelRef(null, { groqApiKey: "g", cerebrasApiKey: "c" })).toEqual({
+      provider: "cerebras",
+      model: "gpt-oss-120b",
+    });
+    expect(DEFAULT_NARRATION_MODELS.cerebras).toBe("cerebras:gpt-oss-120b");
   });
 
   it("uses the user model when set", () => {
     clearEnv();
-    expect(getNarrationModelRef("cerebras:gpt-oss-120b")).toEqual({
-      provider: "cerebras",
-      model: "gpt-oss-120b",
+    expect(getNarrationModelRef("groq:openai/gpt-oss-20b")).toEqual({
+      provider: "groq",
+      model: "openai/gpt-oss-20b",
     });
   });
 
@@ -156,9 +180,42 @@ describe("isChatModelId", () => {
     expect(isChatModelId("meta-llama/llama-guard-4-12b")).toBe(false);
   });
 
+  it("filters TTS families that don't spell out 'tts'", () => {
+    // Groq exposes Orpheus TTS under the canopylabs org.
+    expect(isChatModelId("canopylabs/orpheus-3b-0.1-ft")).toBe(false);
+    expect(isChatModelId("orpheus-3b")).toBe(false);
+  });
+
   it("keeps chat models", () => {
     expect(isChatModelId("openai/gpt-oss-20b")).toBe(true);
     expect(isChatModelId("llama-3.3-70b-versatile")).toBe(true);
     expect(isChatModelId("qwen-3-32b")).toBe(true);
+  });
+});
+
+describe("filterToLatestClaudeGeneration", () => {
+  it("keeps only the newest model per family (API returns newest-first)", () => {
+    const models = [
+      { id: "claude-opus-4-8", displayName: "Claude Opus 4.8" },
+      { id: "claude-opus-4-7", displayName: "Claude Opus 4.7" },
+      { id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6" },
+      { id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5" },
+      { id: "claude-haiku-4-5", displayName: "Claude Haiku 4.5" },
+      { id: "claude-3-5-haiku", displayName: "Claude Haiku 3.5" },
+      { id: "claude-fable-5", displayName: "Claude Fable 5" },
+    ];
+    expect(filterToLatestClaudeGeneration(models).map((m) => m.id)).toEqual([
+      "claude-opus-4-8",
+      "claude-sonnet-4-6",
+      "claude-haiku-4-5",
+      "claude-fable-5",
+    ]);
+  });
+
+  it("keeps models that don't match a known family", () => {
+    const models = [{ id: "claude-some-new-family-1", displayName: "New" }];
+    expect(filterToLatestClaudeGeneration(models).map((m) => m.id)).toEqual([
+      "claude-some-new-family-1",
+    ]);
   });
 });

--- a/tests/unit/generate-narration-fallback.test.ts
+++ b/tests/unit/generate-narration-fallback.test.ts
@@ -12,14 +12,18 @@ import { generateNarration } from "../../src/server/services/narration";
 import { splitNarrationParagraphs } from "../../src/lib/narration/paragraph-map";
 
 describe("generateNarration fallback paragraph map", () => {
-  const prevKey = process.env.GROQ_API_KEY;
+  const prevGroqKey = process.env.GROQ_API_KEY;
+  const prevCerebrasKey = process.env.CEREBRAS_API_KEY;
 
-  // Force the no-LLM fallback path deterministically.
+  // Force the no-LLM fallback path deterministically by clearing every provider
+  // narration can use (Cerebras and Groq).
   beforeAll(() => {
     delete process.env.GROQ_API_KEY;
+    delete process.env.CEREBRAS_API_KEY;
   });
   afterAll(() => {
-    if (prevKey !== undefined) process.env.GROQ_API_KEY = prevKey;
+    if (prevGroqKey !== undefined) process.env.GROQ_API_KEY = prevGroqKey;
+    if (prevCerebrasKey !== undefined) process.env.CEREBRAS_API_KEY = prevCerebrasKey;
   });
 
   it("aligns the map with the split for clean per-<p> content", async () => {


### PR DESCRIPTION
## Summary

The summarization and narration-cleanup model pickers listed every model each provider's API returns, surfacing choices that don't make sense for the task (TTS models, models with too little context to summarize an article, and every historical Claude version). This curates the lists and switches the default provider order to prefer speed.

## Changes

**Filtering (`ai-providers.ts`)**
- `isChatModelId` now also excludes the Orpheus TTS family, which Groq exposes as `canopylabs/orpheus-*` and doesn't spell `tts` in the ID.
- New minimum context-window filter (32k tokens) for Groq/Cerebras: summarization feeds up to ~12k tokens of article plus prompt and reserves several thousand output/reasoning tokens, so short-context models (Groq's 8k Gemma/older-Llama, small Qwen builds) can't reasonably summarize a full article. Cerebras omits `context_window`, so unknown windows are kept.
- New `filterToLatestClaudeGeneration`: Anthropic now shows only the newest Opus, Sonnet, Haiku, and Fable (one per family, newest-first).

**Defaults**
- Summarization provider priority is now **Cerebras → Groq → Anthropic** (most users prefer the fastest summaries over minor quality gains).
- Narration provider priority is now **Cerebras → Groq**, and its default is key-aware (mirrors summarization) instead of a fixed `groq:openai/gpt-oss-20b`.
- Both hosted providers default to **gpt-oss-120b**.
- `.env.example` updated.

## Testing
- `pnpm typecheck` ✅
- `pnpm test:unit` ✅ (updated existing tests for the new priority + narration default; added coverage for the Orpheus/canopylabs exclusion and `filterToLatestClaudeGeneration`). Also fixed `generate-narration-fallback` to clear *all* narration provider keys, since Cerebras is now a default and `CEREBRAS_API_KEY` in the env otherwise routed it to the live LLM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)