### PR TITLE
Make /demo and anonymous /login, /register CDN-cacheable

### DIFF
--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -17,6 +17,7 @@ import { createServer } from "node:http";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { maybeCompressResponse } from "../src/server/http/compression";
+import { applyPageCacheHeaders } from "../src/server/http/page-cache";
 import { stripOauthSurfaceTrailingSlash } from "../src/server/http/trailing-slash";
 import {
   startMaintenancePoller,
@@ -122,6 +123,10 @@ app.prepare().then(() => {
     }
 
     maybeCompressResponse(req, res);
+    // Make the shareable public pages (/demo, and the anonymous render of
+    // /login and /register) CDN-cacheable, overriding Next's dynamic-route
+    // no-store. See src/server/http/page-cache.ts.
+    applyPageCacheHeaders(req, res);
     handle(req, res);
   });
 

--- a/src/server/http/CLAUDE.md
+++ b/src/server/http/CLAUDE.md
@@ -4,6 +4,12 @@ This file governs the outbound-HTTP helpers: SSRF-protected fetching (`ssrf.ts`)
 
 Every outgoing request must send our custom User-Agent (`USER_AGENT`/`buildUserAgent` from `@/server/http/user-agent`).
 
+## CDN Cache Headers for Public Pages (`page-cache.ts`)
+
+`applyPageCacheHeaders(req, res)` (wired in `scripts/server.ts`, right after `maybeCompressResponse`) makes the shareable public pages CDN-cacheable so a CDN can absorb an anonymous-traffic spike. These routes are all dynamically rendered — `/demo/*` reads `searchParams`; `/login` and `/register` render under `src/app/(auth)/layout.tsx`, which reads the session cookie — so Next stamps them `private, no-store` and a CDN caches nothing. We override that at the custom-server layer (not `next.config.ts` `headers()`, which can't reliably beat Next's own `Cache-Control` on a dynamic route nor branch on cookie presence) by patching `res.writeHead`, exactly like the compression wrapper. The pure decision is `pageCachePolicy(pathname, hasSessionCookie)`, unit-tested in `tests/unit/page-cache.test.ts`.
+
+Only the **anonymous** render of `/login` and `/register` is cacheable: a request carrying a `session` cookie gets `no-store` (its body is the signed-in redirect), and cacheable renders carry `Vary: Cookie`. `/demo/*` has no auth redirect in its subtree, so it's cacheable unconditionally. This origin-side gating is defense in depth under the CDN's own "bypass on session cookie" rule — never rely on either alone to keep a per-session redirect out of a shared cache.
+
 ## SSRF Protection
 
 All server-side fetches that target user-influenced URLs (feed preview/discover, feed fetching, full-content fetching, WebSub hub callbacks) are guarded against Server-Side Request Forgery to private/internal networks. The shared helper `fetchWithSsrfProtection(url, init)` in `src/server/http/ssrf.ts` performs the fetch and:

--- a/src/server/http/page-cache.ts
+++ b/src/server/http/page-cache.ts
@@ -1,0 +1,163 @@
+/**
+ * CDN cache policy for the public marketing/auth pages we want a CDN to absorb
+ * during a traffic spike (a Hacker News launch, etc.).
+ *
+ * These pages are all dynamically rendered — `/demo/*` reads `searchParams` and
+ * the auth pages sit under `src/app/(auth)/layout.tsx`, which reads the session
+ * cookie — so Next stamps them `private, no-store` by default and a CDN caches
+ * nothing. This module opts the *shareable* renders back into caching and is
+ * enforced at the custom-server layer (`applyPageCacheHeaders`), because
+ * `next.config.ts` `headers()` can neither reliably override Next's own
+ * `Cache-Control` on a dynamic route nor vary on cookie presence.
+ *
+ * The decision is a pure function so it can be unit-tested
+ * (`tests/unit/page-cache.test.ts`).
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { SESSION_COOKIE_NAME } from "@/server/auth/session-cookie";
+
+/**
+ * Shareable render: browsers always revalidate (`max-age=0`) so a deploy is
+ * picked up promptly, while a shared cache holds it for an hour and may serve
+ * stale for a day while it refetches. `s-maxage` drives the CDN.
+ */
+const CACHEABLE = "public, max-age=0, s-maxage=3600, stale-while-revalidate=604800";
+
+/** Per-session render (e.g. the signed-in redirect): never cache. */
+const NO_STORE = "private, no-store";
+
+export interface PageCachePolicy {
+  /** The Cache-Control value to force onto the response. */
+  cacheControl: string;
+  /** Extra Vary token to merge into the response's Vary header, if any. */
+  vary?: string;
+  /**
+   * True when this is the shareable render. Used to avoid stamping the cacheable
+   * header onto an error status (a 404/500 shouldn't be cached for an hour).
+   */
+  cacheable: boolean;
+}
+
+/**
+ * True if the raw `Cookie` request header carries a non-empty `session` cookie.
+ * Mirrors the hand-rolled parse in `src/server/maintenance/server-gate.ts` so it
+ * stays dependency-free on the hot path.
+ */
+export function cookieHeaderHasSession(cookieHeader: string | undefined): boolean {
+  if (!cookieHeader) return false;
+  for (const part of cookieHeader.split(/;\s*/)) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq) !== SESSION_COOKIE_NAME) continue;
+    return part.slice(eq + 1).length > 0;
+  }
+  return false;
+}
+
+/**
+ * Cache policy for a request, or `null` for every path we don't manage (leaving
+ * Next's own `Cache-Control` intact).
+ *
+ * - `/demo/*` has no auth redirect anywhere in its subtree, so the HTML is
+ *   identical for every visitor — always cacheable, no cookie dependence.
+ * - `/login` and `/register` are rendered under the `(auth)` layout, which
+ *   redirects a signed-in user to `/all` (or `/complete-signup`). The response
+ *   body is therefore per-session: only the anonymous (no session cookie) render
+ *   is shareable. A request carrying a session cookie gets `no-store` so the
+ *   redirect is never cached, and `Vary: Cookie` declares the dependency to any
+ *   intermediary cache. (Our CDN additionally bypasses cache whenever the
+ *   session cookie is present, so this is defense in depth, not the sole gate.)
+ *   The query params these pages accept (`?redirect`, `?registered`, `?error`,
+ *   `?invite`) are read client-side after hydration, so the SSR HTML is
+ *   query-independent and safe to share across query variants.
+ */
+export function pageCachePolicy(
+  pathname: string,
+  hasSessionCookie: boolean
+): PageCachePolicy | null {
+  if (pathname === "/demo" || pathname.startsWith("/demo/")) {
+    return { cacheControl: CACHEABLE, cacheable: true };
+  }
+  if (pathname === "/login" || pathname === "/register") {
+    return hasSessionCookie
+      ? { cacheControl: NO_STORE, cacheable: false }
+      : { cacheControl: CACHEABLE, vary: "Cookie", cacheable: true };
+  }
+  return null;
+}
+
+/**
+ * Remove every case-insensitive occurrence of `name` from an explicit headers
+ * value passed to `writeHead` (object form or the flat `[k, v, k, v, ...]` array
+ * form), so it can't override the value we set via `setHeader`.
+ */
+function scrubInlineHeader(headers: Record<string, unknown> | unknown[], name: string): void {
+  if (Array.isArray(headers)) {
+    for (let i = 0; i < headers.length - 1; i += 2) {
+      const key = headers[i];
+      if (typeof key === "string" && key.toLowerCase() === name) {
+        headers.splice(i, 2);
+        i -= 2;
+      }
+    }
+  } else {
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === name) delete headers[key];
+    }
+  }
+}
+
+/** Merge a Vary token into the response's existing Vary header, if not already present. */
+function mergeVary(res: ServerResponse, token: string): void {
+  const existing = res.getHeader("vary");
+  if (!existing) {
+    res.setHeader("Vary", token);
+  } else if (
+    typeof existing === "string" &&
+    !existing.toLowerCase().includes(token.toLowerCase())
+  ) {
+    res.setHeader("Vary", `${existing}, ${token}`);
+  }
+}
+
+/**
+ * Force our Cache-Control (and Vary) onto the responses for the cacheable public
+ * pages, overriding whatever Next set during dynamic rendering.
+ *
+ * Patches `res.writeHead` — the single point where headers are finalized before
+ * flush — mirroring `maybeCompressResponse`. This wins whether Next set its
+ * `Cache-Control` via `res.setHeader` (we overwrite it in the header map) or
+ * inline in `writeHead` (we scrub it from the passed value). Must run before the
+ * response starts, so call it before handing off to Next's request handler; the
+ * compression wrapper's later `Vary: Accept-Encoding` append composes with our
+ * `Vary: Cookie`.
+ */
+export function applyPageCacheHeaders(req: IncomingMessage, res: ServerResponse): void {
+  const pathname = (req.url ?? "/").split("?")[0];
+  const policy = pageCachePolicy(pathname, cookieHeaderHasSession(req.headers.cookie));
+  if (!policy) return;
+
+  const _writeHead = res.writeHead;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  res.writeHead = function (statusCode: number, ...args: any[]) {
+    // Don't cache an error render (404/500) of a page whose happy path is
+    // cacheable; leave Next's own no-store in place for those.
+    if (!(policy.cacheable && statusCode >= 400)) {
+      // Locate an explicit headers arg (writeHead(status, headers) or
+      // writeHead(status, statusMessage, headers)) and scrub any Cache-Control
+      // it carries so it can't override ours.
+      const headers = (typeof args[0] === "string" ? args[1] : args[0]) as
+        | Record<string, unknown>
+        | unknown[]
+        | undefined;
+      if (headers && typeof headers === "object") {
+        scrubInlineHeader(headers, "cache-control");
+      }
+      res.setHeader("Cache-Control", policy.cacheControl);
+      if (policy.vary) mergeVary(res, policy.vary);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (_writeHead as any).apply(res, [statusCode, ...args]);
+  } as typeof res.writeHead;
+}

--- a/tests/unit/page-cache.test.ts
+++ b/tests/unit/page-cache.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the CDN cache policy for public marketing/auth pages
+ * (custom-server hot path). Covers the pure decision and the writeHead-patching
+ * that forces the header over Next's dynamic-route no-store.
+ */
+
+import { describe, it, expect } from "vitest";
+import { ServerResponse } from "node:http";
+import { IncomingMessage } from "node:http";
+import { Socket } from "node:net";
+import {
+  pageCachePolicy,
+  cookieHeaderHasSession,
+  applyPageCacheHeaders,
+} from "../../src/server/http/page-cache";
+import { SESSION_COOKIE_NAME } from "../../src/server/auth/session-cookie";
+
+const CACHEABLE = "public, max-age=0, s-maxage=3600, stale-while-revalidate=604800";
+const NO_STORE = "private, no-store";
+
+describe("cookieHeaderHasSession", () => {
+  it("is false with no cookie header", () => {
+    expect(cookieHeaderHasSession(undefined)).toBe(false);
+    expect(cookieHeaderHasSession("")).toBe(false);
+  });
+
+  it("detects a non-empty session cookie among others", () => {
+    expect(cookieHeaderHasSession(`theme=dark; ${SESSION_COOKIE_NAME}=abc123; foo=bar`)).toBe(true);
+    expect(cookieHeaderHasSession(`${SESSION_COOKIE_NAME}=abc123`)).toBe(true);
+  });
+
+  it("is false for an empty or absent session cookie", () => {
+    expect(cookieHeaderHasSession(`${SESSION_COOKIE_NAME}=`)).toBe(false);
+    expect(cookieHeaderHasSession("theme=dark; other=1")).toBe(false);
+  });
+
+  it("does not match a cookie whose name merely contains 'session'", () => {
+    expect(cookieHeaderHasSession("admin_session=abc; oauth_state=xyz")).toBe(false);
+  });
+});
+
+describe("pageCachePolicy", () => {
+  it("makes /demo and its subtree cacheable regardless of cookie", () => {
+    for (const path of ["/demo", "/demo/all", "/demo/tag/1", "/demo/subscription/2"]) {
+      expect(pageCachePolicy(path, false)).toEqual({ cacheControl: CACHEABLE, cacheable: true });
+      // Even a signed-in user gets the same shareable render — demo never redirects.
+      expect(pageCachePolicy(path, true)).toEqual({ cacheControl: CACHEABLE, cacheable: true });
+    }
+  });
+
+  it("caches the anonymous render of /login and /register with Vary: Cookie", () => {
+    for (const path of ["/login", "/register"]) {
+      expect(pageCachePolicy(path, false)).toEqual({
+        cacheControl: CACHEABLE,
+        vary: "Cookie",
+        cacheable: true,
+      });
+    }
+  });
+
+  it("never caches /login or /register when a session cookie is present", () => {
+    for (const path of ["/login", "/register"]) {
+      expect(pageCachePolicy(path, true)).toEqual({ cacheControl: NO_STORE, cacheable: false });
+    }
+  });
+
+  it("does not match lookalike paths", () => {
+    // /demofoo must not be treated as under /demo
+    expect(pageCachePolicy("/demofoo", false)).toBeNull();
+    expect(pageCachePolicy("/login/extra", false)).toBeNull();
+    expect(pageCachePolicy("/all", true)).toBeNull();
+    expect(pageCachePolicy("/", true)).toBeNull();
+  });
+});
+
+/** Build a fake req/res pair for the header-patching tests. */
+function makeReqRes(url: string, cookie?: string): { req: IncomingMessage; res: ServerResponse } {
+  const req = new IncomingMessage(new Socket());
+  req.url = url;
+  if (cookie) req.headers.cookie = cookie;
+  const res = new ServerResponse(req);
+  return { req, res };
+}
+
+describe("applyPageCacheHeaders", () => {
+  it("forces the cacheable header on /demo, overriding Next's no-store", () => {
+    const { req, res } = makeReqRes("/demo/all?entry=welcome");
+    applyPageCacheHeaders(req, res);
+    // Simulate Next stamping its dynamic-route default via setHeader.
+    res.setHeader("Cache-Control", "private, no-store");
+    res.writeHead(200);
+    expect(res.getHeader("Cache-Control")).toBe(CACHEABLE);
+  });
+
+  it("scrubs an inline Cache-Control passed to writeHead", () => {
+    const { req, res } = makeReqRes("/login");
+    applyPageCacheHeaders(req, res);
+    res.writeHead(200, { "Cache-Control": "no-store", "X-Other": "1" });
+    expect(res.getHeader("Cache-Control")).toBe(CACHEABLE);
+    expect(res.getHeader("Vary")).toBe("Cookie");
+    expect(res.getHeader("X-Other")).toBe("1");
+  });
+
+  it("sends no-store for /login with a session cookie and does not add Vary", () => {
+    const { req, res } = makeReqRes("/login", `${SESSION_COOKIE_NAME}=abc`);
+    applyPageCacheHeaders(req, res);
+    res.setHeader("Cache-Control", "public, max-age=60");
+    res.writeHead(307);
+    expect(res.getHeader("Cache-Control")).toBe(NO_STORE);
+    expect(res.getHeader("Vary")).toBeUndefined();
+  });
+
+  it("merges Vary: Cookie with a pre-existing Vary", () => {
+    const { req, res } = makeReqRes("/register");
+    applyPageCacheHeaders(req, res);
+    res.setHeader("Vary", "Accept-Encoding");
+    res.writeHead(200);
+    expect(res.getHeader("Vary")).toBe("Accept-Encoding, Cookie");
+  });
+
+  it("does not cache an error render of a cacheable page", () => {
+    const { req, res } = makeReqRes("/demo/does-not-exist");
+    applyPageCacheHeaders(req, res);
+    res.setHeader("Cache-Control", "private, no-store");
+    res.writeHead(404);
+    expect(res.getHeader("Cache-Control")).toBe("private, no-store");
+  });
+
+  it("leaves unmanaged paths untouched", () => {
+    const { req, res } = makeReqRes("/all");
+    applyPageCacheHeaders(req, res);
+    res.setHeader("Cache-Control", "private, no-store");
+    res.writeHead(200);
+    expect(res.getHeader("Cache-Control")).toBe("private, no-store");
+  });
+});


### PR DESCRIPTION
## What

Makes the public marketing/auth pages CDN-cacheable so a CDN (BunnyCDN, per #1318) can absorb an anonymous-traffic spike (a possible HN launch) instead of the app machines.

All three routes are **dynamically rendered** today — `/demo/*` reads `searchParams`; `/login` and `/register` render under `src/app/(auth)/layout.tsx`, which reads the session cookie — so Next stamps them `private, no-store` and a CDN caches nothing. This adds `applyPageCacheHeaders` in the custom server to override that for the shareable renders.

## The signed-in redirect problem (the tricky part)

`/login` and `/register` sit under the `(auth)` layout, which **redirects a signed-in user to `/all`**. So the response body is per-session — caching it as shared HTML would break the redirect. The policy therefore caches **only the anonymous render**:

| Request | `Cache-Control` | `Vary` |
| --- | --- | --- |
| `/demo/*` (any) | `public, max-age=0, s-maxage=3600, stale-while-revalidate=604800` | — |
| `/login`,`/register` — no session cookie | cacheable (as above) | `Cookie` |
| `/login`,`/register` — session cookie present | `private, no-store` | — |
| everything else | untouched (Next's default) | — |

This origin-side gating is **defense in depth** under the planned CDN "bypass on session cookie" rule — neither alone should be trusted to keep a per-session redirect out of a shared cache. The query params these pages accept (`?redirect`, `?registered`, `?invite`, …) are read client-side after hydration, so the SSR HTML is query-independent and safe to share.

## How

- New pure, unit-tested decision `pageCachePolicy(pathname, hasSessionCookie)` in `src/server/http/page-cache.ts`.
- Enforced by patching `res.writeHead` (same technique as `maybeCompressResponse`) so it wins over whatever `Cache-Control` Next set during the dynamic render — `next.config.ts` `headers()` can neither reliably override that nor branch on cookie presence. Handles both the `setHeader` and inline-`writeHead` header forms, merges `Vary`, and skips stamping the cacheable value onto error statuses.

## Verification

Ran the app locally (`pnpm dev:local`) and curled each route:

- `/demo/all?entry=welcome` (anon) → cacheable ✅
- `/login`, `/register` (anon) → cacheable + `Vary: …, Cookie` ✅
- `/login` **with** a session cookie → `private, no-store`, no `Cookie` in `Vary` ✅
- `/all` (control) → untouched ✅

Plus 14 unit tests (`tests/unit/page-cache.test.ts`) covering the policy and the header-patching (setHeader override, inline scrub, Vary merge, error-status skip). `pnpm typecheck` + eslint clean.

Context: #1318 (BunnyCDN offload). This is the origin-side half; the CDN edge rules (cache these paths, bypass on session cookie, never cache `/api/*`) are configured separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)