### PR TITLE
Add PageLink for full-nav to standalone routes; stop RSC prefetch/soft-nav on public pages

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,7 +1,10 @@
 # Source Code Guidelines
 
 - Choose between Suspense and inline loading by the criterion below, not by default. Keep components well-factored with small boundaries either way.
-- Always use client-only navigation. Don't use Next.js's `<Link>` or `useRouter` - they trigger SSR fetches and prefetching we don't want. Use `<ClientLink>` from `@/components/ui` for internal navigation instead.
+- Never use Next.js's `<Link>` for internal navigation (nor a raw `<a>`) — `<Link>` triggers the RSC soft-nav/prefetching we don't want, and a soft nav bypasses the CDN-cached HTML of the public pages. Pick by whether the target is inside the SPA:
+  - **Inside the SPA shell** (the `(app)` routes, the demo's own views): `<ClientLink>` from `@/components/ui/client-link` — client-only pushState nav, no SSR fetch.
+  - **Standalone routes outside the SPA** (auth pages, public legal pages, demo → sign-in/up): `<PageLink>` from `@/components/ui/page-link` — a plain full-page `<a>` that loads the target document (hitting the CDN cache) with no RSC request. See `src/server/http/page-cache.ts` for which public pages are CDN-cacheable.
+- Avoid `useRouter` for navigation for the same reason; it's fine for post-mutation redirects (e.g. into the app after login) where a real router transition is intended.
 
 ## Suspense vs. inline loading
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -7,12 +7,12 @@
 "use client";
 
 import { useState, useMemo, useEffect, Suspense } from "react";
-import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
+import { PageLink } from "@/components/ui/page-link";
 import { OAuthButtons } from "@/components/auth/OAuthButtons";
 import { AuthFooter } from "@/components/auth/AuthFooter";
 import { safeRedirectPath } from "@/lib/safe-redirect";
@@ -45,8 +45,10 @@ function LoginForm() {
   // Get success message from registration redirect
   const registered = searchParams.get("registered") === "true";
 
-  // Fetch signup configuration to determine if signup link should be shown
-  const { data: signupConfigData } = trpc.auth.signupConfig.useQuery();
+  // Fetch signup configuration to determine if signup link should be shown. The
+  // auth layout server-prefetches and hydrates this query (#1328), so it resolves
+  // as already-settled data on first render.
+  const [signupConfigData] = trpc.auth.signupConfig.useSuspenseQuery();
 
   // Listen for OAuth completion from other tabs/windows (PWA support for Firefox Android)
   // When OAuth happens in a separate browser window, this allows the PWA to detect completion
@@ -205,12 +207,12 @@ function LoginForm() {
         </Button>
       </form>
 
-      {!signupConfigData?.requiresInvite && (
+      {!signupConfigData.requiresInvite && (
         <p className="ui-text-sm text-muted mt-6 text-center">
           Don&apos;t have an account?{" "}
-          <Link href="/register" className="text-body font-medium hover:underline">
+          <PageLink href="/register" className="text-body font-medium hover:underline">
             Create one
-          </Link>
+          </PageLink>
         </p>
       )}
 

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -14,12 +14,12 @@
 "use client";
 
 import { useState, Suspense } from "react";
-import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
+import { PageLink } from "@/components/ui/page-link";
 import { OAuthButtons } from "@/components/auth/OAuthButtons";
 import { AuthFooter } from "@/components/auth/AuthFooter";
 import { EuRestrictionReason } from "@/components/auth/EuRestrictionNotice";
@@ -39,9 +39,11 @@ function RegisterForm() {
   // Get invite token from URL query parameter
   const inviteToken = searchParams.get("invite");
 
-  // Fetch signup configuration
-  const { data: signupConfigData, isLoading: isLoadingConfig } = trpc.auth.signupConfig.useQuery();
-  const euRestricted = signupConfigData?.euRestricted ?? false;
+  // Fetch signup configuration. The auth layout server-prefetches and hydrates
+  // this query (#1328), so it resolves as already-settled data on first render —
+  // useSuspenseQuery guarantees defined data without a client-side loading state.
+  const [signupConfigData] = trpc.auth.signupConfig.useSuspenseQuery();
+  const euRestricted = signupConfigData.euRestricted;
 
   // On EU-restricted instances, warn EU users up front that they can't sign up
   // here and point them at self-hosting.
@@ -133,19 +135,9 @@ function RegisterForm() {
   // Which providers may sign up depends on whether an invite is present:
   // with a token, the full allowlist applies; without one, only public providers.
   const effectiveProviders = inviteToken
-    ? (signupConfigData?.allowedSignupProviders ?? [])
-    : (signupConfigData?.publicSignupProviders ?? []);
+    ? signupConfigData.allowedSignupProviders
+    : signupConfigData.publicSignupProviders;
   const isEmailAllowed = effectiveProviders.includes("email");
-
-  // Show loading state while fetching config
-  if (isLoadingConfig) {
-    return (
-      <div>
-        <h2 className="ui-text-xl text-body mb-6 font-semibold">Create your account</h2>
-        <div className="text-muted text-center">Loading...</div>
-      </div>
-    );
-  }
 
   // No provider can sign up in this context (no invite present and nothing is
   // public). With a token the allowlist is never empty, so this only triggers
@@ -160,9 +152,9 @@ function RegisterForm() {
         </Alert>
         <p className="ui-text-sm text-muted mt-6 text-center">
           Already have an account?{" "}
-          <Link href="/login" className="text-body font-medium hover:underline">
+          <PageLink href="/login" className="text-body font-medium hover:underline">
             Sign in
-          </Link>
+          </PageLink>
         </p>
 
         <AuthFooter />
@@ -248,20 +240,20 @@ function RegisterForm() {
 
       <p className="ui-text-xs text-muted mt-4 text-center">
         By creating an account, you agree to our{" "}
-        <Link href="/terms" className="hover:text-body underline">
+        <PageLink href="/terms" className="hover:text-body underline">
           Terms of Service
-        </Link>{" "}
+        </PageLink>{" "}
         and{" "}
-        <Link href="/privacy" className="hover:text-body underline">
+        <PageLink href="/privacy" className="hover:text-body underline">
           Privacy Policy
-        </Link>
+        </PageLink>
       </p>
 
       <p className="ui-text-sm text-muted mt-6 text-center">
         Already have an account?{" "}
-        <Link href="/login" className="text-body font-medium hover:underline">
+        <PageLink href="/login" className="text-body font-medium hover:underline">
           Sign in
-        </Link>
+        </PageLink>
       </p>
 
       <AuthFooter />

--- a/src/app/demo/DemoLayoutContent.tsx
+++ b/src/app/demo/DemoLayoutContent.tsx
@@ -12,8 +12,8 @@
 "use client";
 
 import { useState, useSyncExternalStore, type ReactNode } from "react";
-import Link from "next/link";
 import { CloseIcon, MenuIcon } from "@/components/ui/icon-button";
+import { PageLink } from "@/components/ui/page-link";
 import { LayoutShell } from "@/components/layout/LayoutShell";
 import {
   ScrollContainerProvider,
@@ -73,18 +73,18 @@ export function DemoLayoutContent({ children }: DemoLayoutContentProps) {
               }
               headerRight={
                 <div className="flex items-center gap-2">
-                  <Link
+                  <PageLink
                     href="/register"
                     className="btn-primary ui-text-sm inline-flex min-h-[40px] items-center gap-1.5 rounded-md px-3 font-medium"
                   >
                     Sign Up
-                  </Link>
-                  <Link
+                  </PageLink>
+                  <PageLink
                     href="/login"
                     className="ui-text-sm border-edge-strong bg-surface text-body hover:bg-surface-muted inline-flex min-h-[40px] items-center gap-1.5 rounded-md border px-3 font-medium transition-colors active:bg-zinc-100 dark:active:bg-zinc-700"
                   >
                     Sign In
-                  </Link>
+                  </PageLink>
                 </div>
               }
             >

--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -13,8 +13,8 @@
 
 import { useMemo, useEffect, useCallback, useRef, useState, Suspense } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
-import Link from "next/link";
 import { ClientLink } from "@/components/ui/client-link";
+import { PageLink } from "@/components/ui/page-link";
 import { ScrollContainer } from "@/components/layout/ScrollContainerContext";
 import { Button } from "@/components/ui/button";
 import { ArrowLeftIcon, SparklesIcon } from "@/components/ui/icon-button";
@@ -294,18 +294,18 @@ function DemoRouterContent() {
                 <div className="border-edge-strong bg-surface-subtle mb-6 rounded-lg border p-6 text-center">
                   <h2 className="text-body mb-4 text-2xl font-semibold">Get Started</h2>
                   <div className="flex flex-col justify-center gap-3 sm:flex-row sm:items-center">
-                    <Link
+                    <PageLink
                       href="/register"
                       className="btn-primary ui-text-base inline-flex h-12 w-full items-center justify-center rounded-md px-6 font-medium sm:w-auto"
                     >
                       Sign Up
-                    </Link>
-                    <Link
+                    </PageLink>
+                    <PageLink
                       href="/login"
                       className="ui-text-base bg-surface text-body border-edge-input hover:bg-surface-muted inline-flex h-12 w-full items-center justify-center rounded-md border px-6 font-medium transition-colors sm:w-auto"
                     >
                       Sign in
-                    </Link>
+                    </PageLink>
                   </div>
                 </div>
               )}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -6,7 +6,6 @@
  */
 
 import type { Metadata } from "next";
-import Link from "next/link";
 import {
   LegalList,
   LegalPage,
@@ -15,6 +14,7 @@ import {
   LegalSubsection,
 } from "@/components/legal/LegalProse";
 import { Card } from "@/components/ui/card";
+import { PageLink } from "@/components/ui/page-link";
 import { TextLink } from "@/components/ui/text-link";
 
 export const metadata: Metadata = {
@@ -391,12 +391,12 @@ export default function PrivacyPolicyPage() {
           <li>
             <strong>Delete:</strong> Delete your account and all associated data at any time from
             your{" "}
-            <Link
+            <PageLink
               href="/settings/delete-account"
               className="text-accent hover:text-accent-hover font-medium"
             >
               account settings
-            </Link>
+            </PageLink>
             . Account deletion is permanent and cannot be undone.
           </li>
         </LegalList>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -6,9 +6,9 @@
  */
 
 import type { Metadata } from "next";
-import Link from "next/link";
 import { LegalList, LegalPage, LegalParagraph, LegalSection } from "@/components/legal/LegalProse";
 import { Card } from "@/components/ui/card";
+import { PageLink } from "@/components/ui/page-link";
 import { TextLink } from "@/components/ui/text-link";
 
 export const metadata: Metadata = {
@@ -27,9 +27,9 @@ export default function TermsOfServicePage() {
         </LegalParagraph>
         <LegalParagraph>
           Please also review our{" "}
-          <Link href="/privacy" className="text-accent hover:text-accent-hover font-medium">
+          <PageLink href="/privacy" className="text-accent hover:text-accent-hover font-medium">
             Privacy Policy
-          </Link>
+          </PageLink>
           , which describes how we collect and use your data.
         </LegalParagraph>
       </LegalSection>
@@ -130,9 +130,9 @@ export default function TermsOfServicePage() {
         <LegalParagraph>
           You may also delete your account at any time. Upon termination, your personal data will be
           handled according to our{" "}
-          <Link href="/privacy" className="text-accent hover:text-accent-hover font-medium">
+          <PageLink href="/privacy" className="text-accent hover:text-accent-hover font-medium">
             Privacy Policy
-          </Link>
+          </PageLink>
           .
         </LegalParagraph>
       </LegalSection>

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -8,25 +8,26 @@ Reusable UI primitives are in `src/components/ui/`. **Always check for existing 
 
 ### Available Components
 
-| Component             | Purpose                                                       |
-| --------------------- | ------------------------------------------------------------- |
-| **Button**            | Primary, secondary, ghost, danger variants with loading state |
-| **Input**             | Text input with label and error handling                      |
-| **Alert**             | Status messages (error, success, warning, info)               |
-| **Dialog**            | Modal dialogs with backdrop, focus trap, escape handling      |
-| **Card**              | Container with border, background, and consistent padding     |
-| **CardSection**       | Subsection within a Card, separated by a top border           |
-| **NoteBox**           | Subtle zinc-tinted box for notes and secondary content        |
-| **StatusCard**        | Colored card for info/success/warning/error states            |
-| **ClientLink**        | Internal navigation links (use instead of Next.js Link)       |
-| **TextLink**          | Accent-colored inline text link (`external` for new tab)      |
-| **InlineCode**        | Small monospace chip for inline code, URLs, file names        |
-| **Kbd**               | Keyboard key chip for displaying shortcut keys                |
-| **NavLink**           | Sidebar navigation links with active state and counts         |
-| **IconButton**        | Small icon-only action buttons (edit, close, etc.)            |
-| **NotFoundCard**      | Card for 404/missing content states                           |
-| **ColorPicker**       | Color selection with `ColorDot` preview                       |
-| **StateToggleButton** | Toggle button with visual state indicator                     |
+| Component             | Purpose                                                                            |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| **Button**            | Primary, secondary, ghost, danger variants with loading state                      |
+| **Input**             | Text input with label and error handling                                           |
+| **Alert**             | Status messages (error, success, warning, info)                                    |
+| **Dialog**            | Modal dialogs with backdrop, focus trap, escape handling                           |
+| **Card**              | Container with border, background, and consistent padding                          |
+| **CardSection**       | Subsection within a Card, separated by a top border                                |
+| **NoteBox**           | Subtle zinc-tinted box for notes and secondary content                             |
+| **StatusCard**        | Colored card for info/success/warning/error states                                 |
+| **ClientLink**        | Soft, client-side navigation _within_ the SPA (pushState)                          |
+| **PageLink**          | Full-page nav to standalone routes outside the SPA (plain `<a>`, hits CDN, no RSC) |
+| **TextLink**          | Accent-colored inline text link (`external` for new tab)                           |
+| **InlineCode**        | Small monospace chip for inline code, URLs, file names                             |
+| **Kbd**               | Keyboard key chip for displaying shortcut keys                                     |
+| **NavLink**           | Sidebar navigation links with active state and counts                              |
+| **IconButton**        | Small icon-only action buttons (edit, close, etc.)                                 |
+| **NotFoundCard**      | Card for 404/missing content states                                                |
+| **ColorPicker**       | Color selection with `ColorDot` preview                                            |
+| **StateToggleButton** | Toggle button with visual state indicator                                          |
 
 ### Common Icons
 

--- a/src/components/auth/AuthFooter.tsx
+++ b/src/components/auth/AuthFooter.tsx
@@ -4,19 +4,19 @@
  * Displays attribution, legal links, and GitHub link in a compact format.
  */
 
-import Link from "next/link";
+import { PageLink } from "@/components/ui/page-link";
 
 export function AuthFooter() {
   return (
     <footer className="border-edge mt-8 border-t pt-6">
       <p className="ui-text-xs text-muted text-center">
-        <Link href="/terms" className="hover:text-body hover:underline">
+        <PageLink href="/terms" className="hover:text-body hover:underline">
           Terms of Service
-        </Link>{" "}
+        </PageLink>{" "}
         •{" "}
-        <Link href="/privacy" className="hover:text-body hover:underline">
+        <PageLink href="/privacy" className="hover:text-body hover:underline">
           Privacy Policy
-        </Link>
+        </PageLink>
       </p>
       <p className="ui-text-xs text-muted mt-2 text-center">
         Created by{" "}

--- a/src/components/legal/LegalProse.tsx
+++ b/src/components/legal/LegalProse.tsx
@@ -6,12 +6,13 @@
  * subsections, paragraphs, and lists. Use these instead of hand-styling
  * each element so the two pages can't drift apart.
  *
- * These pages intentionally use Next.js <Link> (not ClientLink) — they are
- * standalone routes outside the SPA shell.
+ * These pages intentionally navigate with <PageLink> (a plain full-page <a>),
+ * not ClientLink — they are standalone routes outside the SPA shell, and a full
+ * navigation hits the CDN-cached HTML without a Next.js RSC prefetch/soft-nav.
  */
 
-import Link from "next/link";
 import type { ReactNode } from "react";
+import { PageLink } from "@/components/ui/page-link";
 
 /**
  * Full legal-page scaffold: background, centered column, back link,
@@ -28,9 +29,9 @@ export function LegalPage({ title, lastUpdated, children }: LegalPageProps) {
     <div className="bg-canvas min-h-screen px-4 py-12">
       <main className="mx-auto max-w-3xl">
         <div className="mb-8">
-          <Link href="/" className="ui-text-sm text-muted hover:text-body">
+          <PageLink href="/" className="ui-text-sm text-muted hover:text-body">
             &larr; Back to Lion Reader
-          </Link>
+          </PageLink>
           <h1 className="text-body mt-4 text-3xl font-bold tracking-tight">{title}</h1>
           <p className="ui-text-sm text-muted mt-2">Last updated: {lastUpdated}</p>
         </div>

--- a/src/components/ui/page-link.tsx
+++ b/src/components/ui/page-link.tsx
@@ -1,0 +1,46 @@
+/**
+ * PageLink Component
+ *
+ * A link for full-page navigation to standalone routes that live *outside* the
+ * SPA shell — the auth pages, the public legal pages (privacy/terms), and the
+ * demo's sign-in/sign-up buttons.
+ *
+ * Renders a plain <a>, so clicking triggers a real browser navigation: it loads
+ * the target's HTML document — hitting our CDN cache for the cacheable public
+ * pages (see `src/server/http/page-cache.ts`) — and issues no Next.js RSC
+ * (`?_rsc=`) request and no viewport/hover prefetch, unlike `next/link`.
+ * Modifier/middle clicks, `target`, and `download` all fall through to the
+ * browser natively (a plain <a> needs no JS for that).
+ *
+ * Use this instead of `next/link` for any internal navigation that should leave
+ * or enter the SPA. For soft, client-side navigation *within* the SPA, use
+ * `<ClientLink>` instead. Between the two, never hand-roll a raw <a> for an
+ * internal href.
+ *
+ * Deliberately not a client component (no `"use client"`, no handlers) so it can
+ * render inside server components like the legal pages.
+ *
+ * @example
+ * ```tsx
+ * <PageLink href="/login" className="text-body font-medium hover:underline">
+ *   Sign in
+ * </PageLink>
+ * ```
+ */
+
+import { type ReactNode, type AnchorHTMLAttributes } from "react";
+
+export interface PageLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
+  /** Link destination (an internal route). */
+  href: string;
+  /** Link content. */
+  children: ReactNode;
+}
+
+export function PageLink({ href, children, ...props }: PageLinkProps) {
+  return (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+}

--- a/tests/unit/frontend/components/PageLink.test.tsx
+++ b/tests/unit/frontend/components/PageLink.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Unit tests for PageLink component.
+ *
+ * PageLink renders a plain <a> for full-page navigation to standalone routes
+ * outside the SPA shell. The contract that matters: it is a real anchor with the
+ * given href (so the browser does a full navigation to the CDN-cached document,
+ * not a Next.js RSC soft-nav) and it forwards arbitrary anchor props through.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PageLink } from "@/components/ui/page-link";
+
+describe("PageLink", () => {
+  it("renders a plain anchor with the given href and children", () => {
+    render(<PageLink href="/login">Sign in</PageLink>);
+    const link = screen.getByRole("link", { name: "Sign in" });
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("href", "/login");
+  });
+
+  it("forwards className and arbitrary anchor attributes", () => {
+    render(
+      <PageLink href="/register" className="text-body" aria-label="Create an account">
+        Create one
+      </PageLink>
+    );
+    const link = screen.getByRole("link");
+    expect(link.className).toContain("text-body");
+    expect(link).toHaveAttribute("aria-label", "Create an account");
+  });
+});


### PR DESCRIPTION
## Problem

On the login/register pages (and the demo's sign-in/up buttons, and the public legal pages), the Network tab shows a pile of duplicate `_rsc` prefetches — `login`, `register`, `terms`, `privacy`, each fetched **twice**:

- These pages use Next.js `<Link>`, which prefetches every linked route's RSC payload on load. The navigations are rare (users submit the auth form), so the prefetches are almost never redeemed.
- Each fires *twice* because the `<Suspense>` boundary + the `auth.signupConfig` query resolving changes Next's router-tree hash, so every `<Link>` re-prefetches under a new `_rsc` key.

More importantly, a `<Link>` **click** is the wrong navigation now that the anonymous HTML render of `/login`, `/register` (and `/demo`) is CDN-cacheable (d064a6ef):

- A soft nav fetches the `?_rsc=` payload from **origin**, bypassing the CDN-cached HTML document — defeating the point of the caching work during a spike.
- That RSC request even matches `applyPageCacheHeaders` by pathname but carries no `Vary: RSC`, muddying the shared cache (keyed on URL + `Vary: Cookie`).

## Changes

- **New `<PageLink>` component** (`src/components/ui/page-link.tsx`): a plain-`<a>` primitive for full-page navigation to standalone routes **outside** the SPA shell. A real browser navigation loads the target document (hitting the CDN cache) with no RSC request and no viewport/hover prefetch. Deliberately server-safe (no handlers) so the server-rendered legal pages can use it.
- This completes the navigation story and makes it enforceable: **`ClientLink`** for soft nav *within* the SPA, **`PageLink`** for full nav to standalone routes — never a raw `<a>` or `next/link` for internal links. Documented in `src/CLAUDE.md` + `src/components/CLAUDE.md`.
- **Migrated** the auth pages (login/register + `AuthFooter`), the demo sign-in/up buttons (`DemoLayoutContent`, `DemoRouter`), and the legal pages (`privacy`, `terms`, `LegalProse`) to `PageLink`.
- **Dropped the register page's "Loading…" state**: the auth layout already server-prefetches and hydrates `auth.signupConfig` (#1328), so switching `useQuery` → `useSuspenseQuery` yields guaranteed-settled data on first render (the documented pattern for SSR-hydrated page-load data). This also removes a latent misrender: with `useQuery`, undefined data (e.g. a failed prefetch) fell through to the `effectiveProviders.length === 0` branch and flashed **"Invite Required"**; `useSuspenseQuery` can't be undefined.

Programmatic post-submit redirects (`router.push` in the login/register mutation `onSuccess`) are left as-is — those are the SPA entry point / anonymous→login hop, not link targets, and a real router transition is intended.

## Testing

- `pnpm typecheck`, `eslint`, and a new `PageLink` unit test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)