### PR TITLE
Add explicit dimensions to demo hero images

### DIFF
--- a/src/app/demo/data.ts
+++ b/src/app/demo/data.ts
@@ -225,7 +225,10 @@ export function getDemoSubscription(subscriptionId: string): DemoSubscription | 
 function heroFigureHtml(entry: DemoEntry): string {
   if (!entry.heroImage) return "";
   const alt = entry.heroImageAlt ?? `${entry.title ?? "Article"} illustration`;
-  return `<figure><img src="${entry.heroImage}" alt="${alt}" /></figure>\n`;
+  // All demo hero images are 1200x630; the intrinsic width/height lets the
+  // browser reserve the aspect-ratio box up front (prose caps them at
+  // max-width:100%; height:auto) so they don't flash/reflow on load.
+  return `<figure><img src="${entry.heroImage}" alt="${alt}" width="1200" height="630" /></figure>\n`;
 }
 
 /** Get EntryArticle props for a demo entry */


### PR DESCRIPTION
## Summary

Demo hero images flashed / caused a layout reflow when they loaded because the `<img>` had no intrinsic dimensions, so the browser couldn't reserve space until the image arrived.

All demo hero images are 1200×630. This adds `width="1200" height="630"` to the hero `<img>` emitted by `heroFigureHtml`, letting the browser reserve the correct aspect-ratio box up front. The prose styles keep them responsive (`max-width:100%; height:auto`), so the aspect ratio is preserved.

Emoji `<img>`s in the Discord demo already have explicit sizes via inline `style`, so no change needed there.

## Testing

- `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)