### PR TITLE
Apply theme class in &lt;head&gt; to prevent dark-mode flash on full-page navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { defaultOpenGraph } from "@/lib/metadata";
 import { appUrl } from "@/server/config/env";
 import { ThemeProvider } from "@/lib/theme/ThemeProvider";
 import { DEFAULT_THEME, THEME_STORAGE_KEY, THEMES } from "@/lib/theme/config";
+import { buildTextAppearanceScript } from "@/lib/appearance/config";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -110,62 +111,14 @@ const themeScript = `
 /**
  * Blocking script to apply text appearance settings before first paint.
  *
- * This runs synchronously in the <head> to prevent flash of wrong text size/font.
- * Must be kept in sync with settings.ts storage key and logic.
+ * Runs synchronously in the <head> to prevent a flash of wrong text size/font.
+ * Built from the shared appearance config (storage key, defaults, font metrics,
+ * size formula) so it can't drift from the runtime store / useEntryTextStyles;
+ * the appearance-head-script unit test pins its output to entryTextStyleVars.
  *
  * Note: Theme (dark/light mode) is handled by next-themes plus themeScript above.
- *
- * Sets CSS custom properties for text appearance:
- * - --entry-font-family
- * - --entry-font-size
- * - --entry-line-height
- * - --entry-text-align
  */
-const textAppearanceScript = `
-(function() {
-  try {
-    var stored = localStorage.getItem('lion-reader-appearance-settings');
-    var settings = {
-      textSize: 'medium',
-      fontFamily: 'system',
-      textJustification: 'left'
-    };
-    if (stored) {
-      var parsed = JSON.parse(stored);
-      if (['small', 'medium', 'large', 'x-large'].indexOf(parsed.textSize) >= 0) {
-        settings.textSize = parsed.textSize;
-      }
-      if (['system', 'merriweather', 'literata', 'inter', 'source-sans'].indexOf(parsed.fontFamily) >= 0) {
-        settings.fontFamily = parsed.fontFamily;
-      }
-      if (parsed.textJustification === 'justify') {
-        settings.textJustification = 'justify';
-      }
-    }
-
-    // Font configs with size adjustments for visual consistency
-    var fontConfigs = {
-      'system': { family: 'inherit', sizeAdjust: 1, lineHeight: 1.7 },
-      'merriweather': { family: 'var(--font-merriweather), Georgia, serif', sizeAdjust: 0.929, lineHeight: 1.8 },
-      'literata': { family: 'var(--font-literata), Georgia, serif', sizeAdjust: 1, lineHeight: 1.75 },
-      'inter': { family: 'var(--font-inter), system-ui, sans-serif', sizeAdjust: 0.945, lineHeight: 1.7 },
-      'source-sans': { family: 'var(--font-source-sans), system-ui, sans-serif', sizeAdjust: 1.061, lineHeight: 1.7 }
-    };
-    var baseSizes = { 'small': 0.875, 'medium': 1, 'large': 1.125, 'x-large': 1.25 };
-
-    var fontConfig = fontConfigs[settings.fontFamily] || fontConfigs['system'];
-    var baseSize = baseSizes[settings.textSize] || 1;
-    var adjustedSize = baseSize * fontConfig.sizeAdjust;
-
-    // Set CSS custom properties for entry text styling
-    var style = document.documentElement.style;
-    style.setProperty('--entry-font-family', fontConfig.family);
-    style.setProperty('--entry-font-size', adjustedSize + 'rem');
-    style.setProperty('--entry-line-height', fontConfig.lineHeight);
-    style.setProperty('--entry-text-align', settings.textJustification);
-  } catch (e) {}
-})();
-`;
+const textAppearanceScript = buildTextAppearanceScript();
 
 /**
  * Service worker registration script.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Geist, Geist_Mono, Merriweather, Literata, Inter, Source_Sans_3 } from 
 import { defaultOpenGraph } from "@/lib/metadata";
 import { appUrl } from "@/server/config/env";
 import { ThemeProvider } from "@/lib/theme/ThemeProvider";
+import { DEFAULT_THEME, THEME_STORAGE_KEY, THEMES } from "@/lib/theme/config";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -77,24 +78,25 @@ export const viewport: Viewport = {
  * the class here in <head>, before any body parsing, closes that gap; next-themes
  * re-asserts the identical class on hydration (idempotent, no visible change).
  *
- * Must be kept in sync with the next-themes config in ThemeProvider.tsx
- * (storageKey "lion-reader-theme", themes light/dark/epaper, defaultTheme
- * "system", attribute=class, enableSystem). The e-ink "system → epaper" override
- * is left to EInkSystemThemeOverride post-hydration, exactly as before.
+ * The storageKey / themes / default come from the shared theme config (used by
+ * ThemeProvider too) so the two can't drift; the resolution *logic* here still
+ * mirrors next-themes' own inline script (the library doesn't export it), and
+ * attribute=class / enableSystem must stay matched. The e-ink "system → epaper"
+ * override is left to EInkSystemThemeOverride post-hydration, exactly as before.
  */
 const themeScript = `
 (function() {
   try {
-    var stored = localStorage.getItem('lion-reader-theme') || 'system';
-    var resolved = stored;
-    if (['light', 'dark', 'epaper'].indexOf(stored) < 0) {
-      resolved = 'system';
-    }
+    var themes = ${JSON.stringify(THEMES)};
+    var stored = localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)}) || ${JSON.stringify(
+      DEFAULT_THEME
+    )};
+    var resolved = themes.indexOf(stored) < 0 ? ${JSON.stringify(DEFAULT_THEME)} : stored;
     if (resolved === 'system') {
       resolved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     }
     var el = document.documentElement;
-    el.classList.remove('light', 'dark', 'epaper');
+    el.classList.remove.apply(el.classList, themes);
     el.classList.add(resolved);
     // next-themes sets color-scheme only for light/dark; .epaper declares its own
     // (color-scheme: light) in globals.css.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,12 +65,53 @@ export const viewport: Viewport = {
 };
 
 /**
+ * Blocking script to apply the theme class (dark/light/epaper) before first paint.
+ *
+ * next-themes injects its own theme script, but only where <ThemeProvider> is
+ * mounted — inside <body>. That means <html> gets the theme class only after the
+ * whole <head> is parsed, so a browser that paints the canvas background during
+ * head parsing (Firefox notably) shows a light flash for a user who explicitly
+ * chose dark on a light-scheme OS, on every full-page navigation (the demo/auth
+ * pages use full document loads). The `@media (prefers-color-scheme)` fallback in
+ * globals.css only covers *system*-theme users, not an explicit choice. Applying
+ * the class here in <head>, before any body parsing, closes that gap; next-themes
+ * re-asserts the identical class on hydration (idempotent, no visible change).
+ *
+ * Must be kept in sync with the next-themes config in ThemeProvider.tsx
+ * (storageKey "lion-reader-theme", themes light/dark/epaper, defaultTheme
+ * "system", attribute=class, enableSystem). The e-ink "system → epaper" override
+ * is left to EInkSystemThemeOverride post-hydration, exactly as before.
+ */
+const themeScript = `
+(function() {
+  try {
+    var stored = localStorage.getItem('lion-reader-theme') || 'system';
+    var resolved = stored;
+    if (['light', 'dark', 'epaper'].indexOf(stored) < 0) {
+      resolved = 'system';
+    }
+    if (resolved === 'system') {
+      resolved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    var el = document.documentElement;
+    el.classList.remove('light', 'dark', 'epaper');
+    el.classList.add(resolved);
+    // next-themes sets color-scheme only for light/dark; .epaper declares its own
+    // (color-scheme: light) in globals.css.
+    if (resolved === 'light' || resolved === 'dark') {
+      el.style.colorScheme = resolved;
+    }
+  } catch (e) {}
+})();
+`;
+
+/**
  * Blocking script to apply text appearance settings before first paint.
  *
  * This runs synchronously in the <head> to prevent flash of wrong text size/font.
  * Must be kept in sync with settings.ts storage key and logic.
  *
- * Note: Theme (dark/light mode) is handled by next-themes, not this script.
+ * Note: Theme (dark/light mode) is handled by next-themes plus themeScript above.
  *
  * Sets CSS custom properties for text appearance:
  * - --entry-font-family
@@ -173,6 +214,11 @@ export default async function RootLayout({
         {/* suppressHydrationWarning: browsers blank the nonce content attribute
             after parsing (nonce hiding), so hydration would see nonce="" and
             warn on every load. The scripts have executed by then either way. */}
+        <script
+          nonce={nonce}
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: themeScript }}
+        />
         <script
           nonce={nonce}
           suppressHydrationWarning

--- a/src/lib/appearance/AppearanceProvider.tsx
+++ b/src/lib/appearance/AppearanceProvider.tsx
@@ -9,12 +9,8 @@
 
 import { createContext, useContext, useEffect, useCallback, useMemo, type ReactNode } from "react";
 import { useTheme } from "next-themes";
-import {
-  useAppearanceSettings,
-  type AppearanceSettings,
-  type TextSize,
-  type FontFamily,
-} from "./settings";
+import { useAppearanceSettings, type AppearanceSettings } from "./settings";
+import { entryTextStyleVars } from "./config";
 
 interface AppearanceContextValue {
   settings: AppearanceSettings;
@@ -69,61 +65,15 @@ export function useAppearance(): AppearanceContextValue {
 }
 
 /**
- * Font configuration with normalized sizing.
- *
- * Different fonts have different x-heights and metrics, so they appear
- * different sizes at the same font-size. We apply size adjustments and
- * tuned line-heights to make them visually consistent.
- */
-interface FontConfig {
-  family: string;
-  /** Size multiplier to normalize apparent size (1 = baseline) */
-  sizeAdjust: number;
-  /** Line height tuned for this font */
-  lineHeight: number;
-}
-
-const FONT_CONFIGS: Record<FontFamily, FontConfig> = {
-  system: {
-    family: "inherit",
-    // Varies by platform (San Francisco, Segoe UI, Roboto, etc.)
-    sizeAdjust: 1,
-    lineHeight: 1.7,
-  },
-  merriweather: {
-    family: "var(--font-merriweather), Georgia, serif",
-    // Smaller x-height, scale up to match Literata baseline
-    sizeAdjust: 0.929,
-    lineHeight: 1.8,
-  },
-  literata: {
-    family: "var(--font-literata), Georgia, serif",
-    // Baseline reference font
-    sizeAdjust: 1,
-    lineHeight: 1.75,
-  },
-  inter: {
-    family: "var(--font-inter), system-ui, sans-serif",
-    // Slightly smaller x-height than Literata
-    sizeAdjust: 0.945,
-    lineHeight: 1.7,
-  },
-  "source-sans": {
-    family: "var(--font-source-sans), system-ui, sans-serif",
-    // Larger x-height, scale down to match
-    sizeAdjust: 1.061,
-    lineHeight: 1.7,
-  },
-};
-
-/**
  * Hook to get text style classes for entry content.
  *
  * Returns Tailwind classes and inline styles for applying text appearance settings.
  *
  * Uses CSS custom properties set by the head script for initial render to avoid
  * flash of wrong styles during hydration. The React state is still tracked to
- * update the CSS vars when settings change.
+ * update the CSS vars when settings change. The vars come from the shared
+ * `entryTextStyleVars` (the same mapping the head script bakes in), so runtime
+ * updates and the pre-paint values can't diverge.
  */
 export function useEntryTextStyles(): {
   className: string;
@@ -133,26 +83,11 @@ export function useEntryTextStyles(): {
 
   // Update CSS custom properties when settings change (for client-side updates)
   useEffect(() => {
-    const baseSizes: Record<TextSize, number> = {
-      small: 0.875,
-      medium: 1,
-      large: 1.125,
-      "x-large": 1.25,
-    };
-
-    const fontConfig = FONT_CONFIGS[settings.fontFamily] || FONT_CONFIGS.system;
-    const baseSize = baseSizes[settings.textSize] || baseSizes.medium;
-    const adjustedSize = baseSize * fontConfig.sizeAdjust;
-
     const style = document.documentElement.style;
-    style.setProperty("--entry-font-family", fontConfig.family);
-    style.setProperty("--entry-font-size", `${adjustedSize}rem`);
-    style.setProperty("--entry-line-height", String(fontConfig.lineHeight));
-    style.setProperty(
-      "--entry-text-align",
-      settings.textJustification === "justify" ? "justify" : "left"
-    );
-  }, [settings.textSize, settings.fontFamily, settings.textJustification]);
+    for (const [prop, value] of Object.entries(entryTextStyleVars(settings))) {
+      style.setProperty(prop, value);
+    }
+  }, [settings]);
 
   // Return styles that use CSS custom properties (set by head script on initial load)
   return useMemo(

--- a/src/lib/appearance/config.ts
+++ b/src/lib/appearance/config.ts
@@ -115,7 +115,7 @@ export const FONT_CONFIGS: Record<FontFamily, FontConfig> = {
   },
 };
 
-/** Base font-size (rem) per text-size option, before per-font sizeAdjust. */
+/** Base font size (rem) for each size option, before per-font sizeAdjust. */
 export const BASE_SIZES: Record<TextSize, number> = {
   small: 0.875,
   medium: 1,

--- a/src/lib/appearance/config.ts
+++ b/src/lib/appearance/config.ts
@@ -1,0 +1,220 @@
+/**
+ * Single source of truth for the text-appearance config (fonts, sizes,
+ * justification). Framework-agnostic and dependency-free so it can be shared by:
+ *
+ * - the React runtime — the settings store (`settings.ts`) and the CSS-var
+ *   applier (`useEntryTextStyles` in `AppearanceProvider.tsx`); and
+ * - the blocking `<head>` script in `src/app/layout.tsx` that sets the entry
+ *   text CSS vars before first paint. That script can't import at runtime (it
+ *   runs before the bundle loads), so `buildTextAppearanceScript()` here bakes
+ *   this same data into the inline source. Because both sides read these
+ *   constants, the numbers can't drift and reintroduce a flash of wrong
+ *   size/font on navigation.
+ *
+ * Theme (dark/light) config lives in `../theme/config.ts`.
+ */
+
+/** localStorage key the appearance settings are persisted under. */
+export const APPEARANCE_STORAGE_KEY = "lion-reader-appearance-settings";
+
+/** Text size options for entry content. */
+export const TEXT_SIZES = ["small", "medium", "large", "x-large"] as const;
+/** Text justification options for entry content. */
+export const TEXT_JUSTIFICATIONS = ["left", "justify"] as const;
+/** Font family options for entry content. */
+export const FONT_FAMILIES = [
+  "system",
+  "merriweather",
+  "literata",
+  "inter",
+  "source-sans",
+] as const;
+/**
+ * List density options for the entry list.
+ *
+ * - "comfortable": roomy bordered cards (the default reading view).
+ * - "compact": a single divided list with tighter padding and no excerpt, for
+ *   scanning/triaging many items at once.
+ */
+export const LIST_DENSITIES = ["comfortable", "compact"] as const;
+
+export type TextSize = (typeof TEXT_SIZES)[number];
+export type TextJustification = (typeof TEXT_JUSTIFICATIONS)[number];
+export type FontFamily = (typeof FONT_FAMILIES)[number];
+export type ListDensity = (typeof LIST_DENSITIES)[number];
+
+/**
+ * User preferences for text appearance.
+ *
+ * Note: Theme (dark/light mode) is managed by next-themes, not here.
+ */
+export interface AppearanceSettings {
+  /** Text size for entry content. */
+  textSize: TextSize;
+  /** Text justification for entry content. */
+  textJustification: TextJustification;
+  /** Font family for entry content. */
+  fontFamily: FontFamily;
+  /** Vertical density of the entry list. */
+  listDensity: ListDensity;
+}
+
+/** Default appearance settings. */
+export const DEFAULT_APPEARANCE_SETTINGS: AppearanceSettings = {
+  textSize: "medium",
+  textJustification: "left",
+  fontFamily: "system",
+  listDensity: "comfortable",
+};
+
+/**
+ * Font configuration with normalized sizing.
+ *
+ * Different fonts have different x-heights and metrics, so they appear different
+ * sizes at the same font-size. We apply size adjustments and tuned line-heights
+ * to make them visually consistent.
+ */
+export interface FontConfig {
+  family: string;
+  /** Size multiplier to normalize apparent size (1 = baseline). */
+  sizeAdjust: number;
+  /** Line height tuned for this font. */
+  lineHeight: number;
+}
+
+export const FONT_CONFIGS: Record<FontFamily, FontConfig> = {
+  system: {
+    family: "inherit",
+    // Varies by platform (San Francisco, Segoe UI, Roboto, etc.)
+    sizeAdjust: 1,
+    lineHeight: 1.7,
+  },
+  merriweather: {
+    family: "var(--font-merriweather), Georgia, serif",
+    // Smaller x-height, scale up to match Literata baseline
+    sizeAdjust: 0.929,
+    lineHeight: 1.8,
+  },
+  literata: {
+    family: "var(--font-literata), Georgia, serif",
+    // Baseline reference font
+    sizeAdjust: 1,
+    lineHeight: 1.75,
+  },
+  inter: {
+    family: "var(--font-inter), system-ui, sans-serif",
+    // Slightly smaller x-height than Literata
+    sizeAdjust: 0.945,
+    lineHeight: 1.7,
+  },
+  "source-sans": {
+    family: "var(--font-source-sans), system-ui, sans-serif",
+    // Larger x-height, scale down to match
+    sizeAdjust: 1.061,
+    lineHeight: 1.7,
+  },
+};
+
+/** Base font-size (rem) per text-size option, before per-font sizeAdjust. */
+export const BASE_SIZES: Record<TextSize, number> = {
+  small: 0.875,
+  medium: 1,
+  large: 1.125,
+  "x-large": 1.25,
+};
+
+/**
+ * The `--entry-*` CSS custom properties for a given set of settings.
+ *
+ * The single definition of how settings map to CSS vars — used by
+ * `useEntryTextStyles` at runtime and mirrored by the head script (see
+ * `buildTextAppearanceScript`), which the appearance-head-script unit test pins
+ * to this output so the two can't diverge.
+ */
+export function entryTextStyleVars(settings: AppearanceSettings): Record<string, string> {
+  const fontConfig = FONT_CONFIGS[settings.fontFamily] || FONT_CONFIGS.system;
+  const baseSize = BASE_SIZES[settings.textSize] || BASE_SIZES.medium;
+  const adjustedSize = baseSize * fontConfig.sizeAdjust;
+  return {
+    "--entry-font-family": fontConfig.family,
+    "--entry-font-size": `${adjustedSize}rem`,
+    "--entry-line-height": String(fontConfig.lineHeight),
+    "--entry-text-align": settings.textJustification === "justify" ? "justify" : "left",
+  };
+}
+
+/**
+ * Validate and merge a parsed (untrusted) settings object with the defaults,
+ * keeping only known values. Shared by the runtime store and — via
+ * `buildTextAppearanceScript`'s inlined mirror — the head script.
+ */
+export function coerceAppearanceSettings(parsed: Partial<AppearanceSettings>): AppearanceSettings {
+  const pick = <T extends string>(value: unknown, valid: readonly T[], fallback: T): T =>
+    valid.includes(value as T) ? (value as T) : fallback;
+  return {
+    textSize: pick(parsed.textSize, TEXT_SIZES, DEFAULT_APPEARANCE_SETTINGS.textSize),
+    textJustification: pick(
+      parsed.textJustification,
+      TEXT_JUSTIFICATIONS,
+      DEFAULT_APPEARANCE_SETTINGS.textJustification
+    ),
+    fontFamily: pick(parsed.fontFamily, FONT_FAMILIES, DEFAULT_APPEARANCE_SETTINGS.fontFamily),
+    listDensity: pick(parsed.listDensity, LIST_DENSITIES, DEFAULT_APPEARANCE_SETTINGS.listDensity),
+  };
+}
+
+/**
+ * Build the blocking `<head>` script (plain ES5 string, injected via
+ * dangerouslySetInnerHTML with a CSP nonce) that applies the entry text CSS vars
+ * before first paint, preventing a flash of wrong size/font on full-page loads.
+ *
+ * All data is baked from the constants above; the inline logic mirrors
+ * `coerceAppearanceSettings` (validate/merge) and `entryTextStyleVars` (the
+ * size/family/line-height formula). Only the `textSize`/`textJustification`/
+ * `fontFamily` fields affect CSS vars, so `listDensity` is intentionally omitted.
+ */
+export function buildTextAppearanceScript(): string {
+  const data = {
+    key: APPEARANCE_STORAGE_KEY,
+    defaults: DEFAULT_APPEARANCE_SETTINGS,
+    valid: {
+      textSize: TEXT_SIZES,
+      textJustification: TEXT_JUSTIFICATIONS,
+      fontFamily: FONT_FAMILIES,
+    },
+    fontConfigs: FONT_CONFIGS,
+    baseSizes: BASE_SIZES,
+  };
+  return `
+(function() {
+  try {
+    var d = ${JSON.stringify(data)};
+    var settings = {
+      textSize: d.defaults.textSize,
+      textJustification: d.defaults.textJustification,
+      fontFamily: d.defaults.fontFamily
+    };
+    // Guard only the read/parse so unreadable or malformed storage leaves the
+    // defaults in place (and still gets applied below), rather than skipping
+    // the whole apply.
+    try {
+      var stored = localStorage.getItem(d.key);
+      if (stored) {
+        var parsed = JSON.parse(stored);
+        Object.keys(d.valid).forEach(function(k) {
+          if (d.valid[k].indexOf(parsed[k]) >= 0) settings[k] = parsed[k];
+        });
+      }
+    } catch (e) {}
+    var fontConfig = d.fontConfigs[settings.fontFamily] || d.fontConfigs.system;
+    var baseSize = d.baseSizes[settings.textSize] || d.baseSizes.medium;
+    var adjustedSize = baseSize * fontConfig.sizeAdjust;
+    var style = document.documentElement.style;
+    style.setProperty('--entry-font-family', fontConfig.family);
+    style.setProperty('--entry-font-size', adjustedSize + 'rem');
+    style.setProperty('--entry-line-height', String(fontConfig.lineHeight));
+    style.setProperty('--entry-text-align', settings.textJustification === 'justify' ? 'justify' : 'left');
+  } catch (e) {}
+})();
+`;
+}

--- a/src/lib/appearance/settings.ts
+++ b/src/lib/appearance/settings.ts
@@ -10,72 +10,23 @@
 "use client";
 
 import { useCallback, useSyncExternalStore } from "react";
+import {
+  APPEARANCE_STORAGE_KEY,
+  DEFAULT_APPEARANCE_SETTINGS,
+  coerceAppearanceSettings,
+  type AppearanceSettings,
+} from "./config";
 
-/**
- * Text size options for entry content.
- */
-export type TextSize = "small" | "medium" | "large" | "x-large";
-
-/**
- * Text justification options for entry content.
- */
-export type TextJustification = "left" | "justify";
-
-/**
- * Font family options for entry content.
- */
-export type FontFamily = "system" | "merriweather" | "literata" | "inter" | "source-sans";
-
-/**
- * List density options for the entry list.
- *
- * - "comfortable": roomy bordered cards (the default reading view).
- * - "compact": a single divided list with tighter padding and no excerpt, for
- *   scanning/triaging many items at once.
- */
-export type ListDensity = "comfortable" | "compact";
-
-/**
- * User preferences for text appearance.
- *
- * Note: Theme (dark/light mode) is managed by next-themes, not here.
- */
-export interface AppearanceSettings {
-  /**
-   * Text size for entry content.
-   */
-  textSize: TextSize;
-
-  /**
-   * Text justification for entry content.
-   */
-  textJustification: TextJustification;
-
-  /**
-   * Font family for entry content.
-   */
-  fontFamily: FontFamily;
-
-  /**
-   * Vertical density of the entry list.
-   */
-  listDensity: ListDensity;
-}
-
-/**
- * Default appearance settings.
- */
-const DEFAULT_APPEARANCE_SETTINGS: AppearanceSettings = {
-  textSize: "medium",
-  textJustification: "left",
-  fontFamily: "system",
-  listDensity: "comfortable",
-};
-
-/**
- * localStorage key for appearance settings.
- */
-const STORAGE_KEY = "lion-reader-appearance-settings";
+// The appearance types and config are single-sourced in ./config (shared with
+// the blocking <head> script in the root layout); re-exported here so existing
+// `@/lib/appearance/settings` importers are unaffected.
+export type {
+  AppearanceSettings,
+  TextSize,
+  TextJustification,
+  FontFamily,
+  ListDensity,
+} from "./config";
 
 /**
  * Loads appearance settings from localStorage.
@@ -92,39 +43,11 @@ function loadAppearanceSettings(): AppearanceSettings {
   }
 
   try {
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const stored = localStorage.getItem(APPEARANCE_STORAGE_KEY);
     if (!stored) {
       return DEFAULT_APPEARANCE_SETTINGS;
     }
-
-    const parsed = JSON.parse(stored) as Partial<AppearanceSettings>;
-
-    // Validate and merge with defaults
-    const validTextSizes: TextSize[] = ["small", "medium", "large", "x-large"];
-    const validJustifications: TextJustification[] = ["left", "justify"];
-    const validFontFamilies: FontFamily[] = [
-      "system",
-      "merriweather",
-      "literata",
-      "inter",
-      "source-sans",
-    ];
-    const validListDensities: ListDensity[] = ["comfortable", "compact"];
-
-    return {
-      textSize: validTextSizes.includes(parsed.textSize as TextSize)
-        ? (parsed.textSize as TextSize)
-        : DEFAULT_APPEARANCE_SETTINGS.textSize,
-      textJustification: validJustifications.includes(parsed.textJustification as TextJustification)
-        ? (parsed.textJustification as TextJustification)
-        : DEFAULT_APPEARANCE_SETTINGS.textJustification,
-      fontFamily: validFontFamilies.includes(parsed.fontFamily as FontFamily)
-        ? (parsed.fontFamily as FontFamily)
-        : DEFAULT_APPEARANCE_SETTINGS.fontFamily,
-      listDensity: validListDensities.includes(parsed.listDensity as ListDensity)
-        ? (parsed.listDensity as ListDensity)
-        : DEFAULT_APPEARANCE_SETTINGS.listDensity,
-    };
+    return coerceAppearanceSettings(JSON.parse(stored) as Partial<AppearanceSettings>);
   } catch {
     // If parsing fails, return defaults
     return DEFAULT_APPEARANCE_SETTINGS;
@@ -142,7 +65,7 @@ function saveAppearanceSettings(settings: AppearanceSettings): void {
   }
 
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    localStorage.setItem(APPEARANCE_STORAGE_KEY, JSON.stringify(settings));
   } catch {
     // Silently fail if localStorage is full or unavailable
   }

--- a/src/lib/theme/ThemeProvider.tsx
+++ b/src/lib/theme/ThemeProvider.tsx
@@ -10,6 +10,7 @@
 import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
 import { useEffect, type ReactNode } from "react";
 import { useIsEInkDisplay } from "./eink";
+import { DEFAULT_THEME, THEME_STORAGE_KEY, THEMES } from "./config";
 
 interface ThemeProviderProps {
   children: ReactNode;
@@ -121,11 +122,11 @@ export function ThemeProvider({ children, nonce }: ThemeProviderProps) {
   return (
     <NextThemesProvider
       attribute="class"
-      defaultTheme="system"
+      defaultTheme={DEFAULT_THEME}
       enableSystem
-      themes={["light", "dark", "epaper"]}
+      themes={[...THEMES]}
       disableTransitionOnChange
-      storageKey="lion-reader-theme"
+      storageKey={THEME_STORAGE_KEY}
       nonce={nonce}
     >
       <EInkSystemThemeOverride />

--- a/src/lib/theme/config.ts
+++ b/src/lib/theme/config.ts
@@ -1,0 +1,25 @@
+/**
+ * Single source of truth for the theme config shared by the two places that must
+ * resolve the theme identically:
+ *
+ * - the next-themes `<ThemeProvider>` (`src/lib/theme/ThemeProvider.tsx`), and
+ * - the blocking `<head>` theme script in `src/app/layout.tsx`, which applies the
+ *   theme class before first paint (next-themes' own script runs too late — it's
+ *   inside `<body>`).
+ *
+ * If these drift, the head script and next-themes pick different classes and the
+ * dark-mode flash the head script exists to prevent comes back on hydration. Keep
+ * them wired to these constants rather than re-typing the literals.
+ */
+
+/** localStorage key next-themes persists the chosen theme under. */
+export const THEME_STORAGE_KEY = "lion-reader-theme";
+
+/**
+ * The explicitly-selectable themes (map to `.light` / `.dark` / `.epaper` on
+ * `<html>`). next-themes appends `"system"` itself because `enableSystem` is set.
+ */
+export const THEMES = ["light", "dark", "epaper"] as const;
+
+/** Default when nothing is stored — follow the OS via `prefers-color-scheme`. */
+export const DEFAULT_THEME = "system";

--- a/tests/unit/appearance-head-script.test.ts
+++ b/tests/unit/appearance-head-script.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for the blocking <head> text-appearance script.
+ *
+ * The script is a hand-written string that runs before the bundle loads, so it
+ * necessarily re-implements the validate/merge + CSS-var formula that the React
+ * runtime uses. These tests execute the actual generated script against a fake
+ * localStorage/document and assert it produces exactly `entryTextStyleVars(...)`
+ * of the coerced settings — pinning the two mirrors together so a change to the
+ * font metrics/sizes/formula in one can't silently diverge from the other.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildTextAppearanceScript,
+  coerceAppearanceSettings,
+  entryTextStyleVars,
+  DEFAULT_APPEARANCE_SETTINGS,
+  TEXT_SIZES,
+  FONT_FAMILIES,
+  TEXT_JUSTIFICATIONS,
+  type AppearanceSettings,
+} from "../../src/lib/appearance/config";
+
+/**
+ * Run the generated head script with a stubbed `localStorage`/`document` and
+ * return the CSS custom properties it set on documentElement.
+ */
+function runHeadScript(storedValue: string | null): Record<string, string> {
+  const props: Record<string, string> = {};
+  const fakeLocalStorage = { getItem: () => storedValue };
+  const fakeDocument = {
+    documentElement: {
+      style: {
+        setProperty: (prop: string, value: string) => {
+          props[prop] = value;
+        },
+      },
+    },
+  };
+  // The script is an IIFE referencing `localStorage`/`document`/`JSON` as globals;
+  // supply the first two as params that shadow them.
+  const fn = new Function("localStorage", "document", buildTextAppearanceScript());
+  fn(fakeLocalStorage, fakeDocument);
+  return props;
+}
+
+describe("buildTextAppearanceScript", () => {
+  it("applies defaults when nothing is stored", () => {
+    expect(runHeadScript(null)).toEqual(entryTextStyleVars(DEFAULT_APPEARANCE_SETTINGS));
+  });
+
+  it("applies defaults on malformed JSON", () => {
+    expect(runHeadScript("{not json")).toEqual(entryTextStyleVars(DEFAULT_APPEARANCE_SETTINGS));
+  });
+
+  it("matches entryTextStyleVars for every size × font × justification", () => {
+    for (const textSize of TEXT_SIZES) {
+      for (const fontFamily of FONT_FAMILIES) {
+        for (const textJustification of TEXT_JUSTIFICATIONS) {
+          const settings: AppearanceSettings = {
+            textSize,
+            fontFamily,
+            textJustification,
+            listDensity: "comfortable",
+          };
+          expect(runHeadScript(JSON.stringify(settings))).toEqual(entryTextStyleVars(settings));
+        }
+      }
+    }
+  });
+
+  it("ignores unknown field values and falls back to defaults for them", () => {
+    const stored = JSON.stringify({
+      textSize: "gigantic",
+      fontFamily: "comic-sans",
+      textJustification: "center",
+    });
+    const expected = entryTextStyleVars(
+      coerceAppearanceSettings(JSON.parse(stored) as Partial<AppearanceSettings>)
+    );
+    expect(runHeadScript(stored)).toEqual(expected);
+    expect(runHeadScript(stored)).toEqual(entryTextStyleVars(DEFAULT_APPEARANCE_SETTINGS));
+  });
+});


### PR DESCRIPTION
## Problem

Navigating between the demo pages and the sign-in/register pages showed a flash of a light background when dark mode is enabled.

## Root cause

next-themes injects its blocking theme script where `<ThemeProvider>` mounts — which is inside `<body>` (the App Router requires the provider to wrap `children`). So `<html>` only gets the `.dark`/`.light`/`.epaper` class **after the entire `<head>` is parsed**. A browser that paints the canvas/`<body>` background during head parsing (Firefox notably — the reporter's console message with curly quotes is Firefox's) paints white first, then the body script adds `.dark`.

This only manifests on the demo and auth pages because those use `<PageLink>` (real full-document loads), so the whole document re-parses each navigation. The SPA app pages navigate client-side and never re-flash. The `@media (prefers-color-scheme: dark)` fallback in `globals.css` only covers *system*-theme users, so a user who **explicitly** chose dark on a light-scheme OS flashes white every time.

The CSP console message `Ignoring 'self' within script-src: 'strict-dynamic' specified` is **unrelated and harmless** — `'strict-dynamic'` makes browsers ignore `'self'` by spec. It is not blocking the theme script (verified: no CSP violation, script executes).

## Fix

Add a blocking `<head>` script that mirrors the next-themes config (`storageKey` `lion-reader-theme`, themes light/dark/epaper, `defaultTheme` system, `attribute=class`, `enableSystem`) and applies the resolved theme class + `color-scheme` before any body parsing. This is the same pattern the file already uses for the text-appearance FOUC. next-themes re-asserts the identical class on hydration (idempotent, no visible change), and the e-ink system→epaper override stays post-hydration exactly as before.

## Verification

- `pnpm typecheck` clean, eslint clean.
- Confirmed in a browser (localStorage `lion-reader-theme=dark`): the theme script now runs in `<head>`, `<html>` carries `.dark`, `color-scheme: dark`, body background `rgb(10,10,10)` — with no CSP violation in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)