### PR TITLE
Stop service-worker caching of images (fix alt-text flash on navigation)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -44,18 +44,18 @@ const withPWAConfig = withPWA({
           },
         },
       },
-      // Cache images with stale-while-revalidate
-      {
-        urlPattern: /\.(?:png|jpg|jpeg|svg|gif|webp|ico)$/i,
-        handler: "StaleWhileRevalidate",
-        options: {
-          cacheName: "static-images",
-          expiration: {
-            maxEntries: 100,
-            maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days
-          },
-        },
-      },
+      // NOTE: images are deliberately NOT runtime-cached by the service worker.
+      // Once a SW owns an image response, the browser can no longer serve that
+      // image from its fast in-memory image cache — it must run the fetch
+      // handler and read the bytes from Cache Storage asynchronously on every
+      // render. Paging between entries mounts fresh <img> nodes, so that async
+      // round-trip shows up as a flash of alt text before the (already "cached")
+      // image paints, even on a 0ms cache hit. StaleWhileRevalidate made it
+      // worse by also firing a redundant background revalidation each time.
+      // Letting image requests fall through to the browser's native HTTP cache
+      // (our content images are CDN-served with long cache-control headers)
+      // restores instant, flash-free painting — the way a normal site behaves.
+      // See https://github.com/brendanlong/lion-reader (image-flash fix).
     ],
   },
 });


### PR DESCRIPTION
## Follow-up to #1337

After #1337 merged, images **still flashed** (a flash of alt text before the image paints). #1337's `decoding="sync"` fix only helps when the bytes are already available synchronously — but it turns out they aren't, because of the service worker.

## Root cause: the service worker

The Workbox `runtimeCaching` rule (`next.config.ts`) intercepted **every** image by extension with `StaleWhileRevalidate`. Once a service worker owns an image response, the browser can no longer serve that image from its fast **in-memory image cache** — it must run the fetch handler and read the bytes back from Cache Storage **asynchronously** on every render. Paging between entries mounts fresh `<img>` nodes, so that async round-trip surfaces as a flash of alt text before the (already "cached") image paints, even on a 0ms cache hit. `StaleWhileRevalidate` compounded it by also firing a redundant background network revalidation every load.

This is exactly why images showed as served by the **"service worker"** in the network panel instead of **"(memory cache)"** — and why a normal HTML site in Firefox (no SW) paints the same image straight from memory, synchronously and flash-free. (Thanks to @brendanlong for that observation — it was the key clue.)

Note this is a **production-only** issue: the PWA/SW is disabled in dev (`disable: NODE_ENV === "development"`), which is why it couldn't be reproduced locally while working on #1337.

## Fix

Remove the image `runtimeCaching` rule so image requests fall through to the browser's native HTTP cache. Our content images are CDN-served with long `cache-control` headers (`public, max-age=86400, stale-while-revalidate=604800`), so they stay cached — we only give up SW-backed *offline* image availability, a marginal benefit next to a flash on every in-app navigation. Font runtime caching and `_next/static` precaching are unchanged.

There is no SW cache strategy that avoids this; any SW-owned image response bypasses the browser's synchronous memory-cache paint. Letting the browser handle images is the fix.

## Verification

Ran a real production build (`pnpm build`) and inspected the generated `public/sw.js`:
- ✅ `static-images` route removed; no `png|jpg` URL pattern remains.
- ✅ Google Fonts routes (`google-fonts-stylesheets`, `google-fonts-webfonts`) still present.

Because the SW only runs in production, final confirmation is best done post-deploy: with the new SW active, image requests should show as **(memory cache)** / native browser cache rather than **service worker**, and the alt-text flash should be gone. `skipWaiting`/`clientsClaim` are set, so the new SW takes over on next load; the orphaned `static-images` cache ages out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)