### PR TITLE
Stop the register EU-banner flash: no-store tRPC + no refetch of static config

### DIFF
--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -78,20 +78,27 @@ const handler = async (req: Request) => {
   // Record HTTP metrics
   endTimer(response.status);
 
+  const headers = new Headers(response.headers);
+
+  // tRPC uses GET for queries, and those responses carry per-request/per-user
+  // data (and change across deploys). Without an explicit Cache-Control, a shared
+  // cache — our CDN (Bunny) — stores and replays them. That served a stale
+  // pre-`euRestricted` auth.signupConfig on anonymous /register loads (no session
+  // cookie, so the CDN's cookie-based bypass doesn't apply): the EU banner
+  // rendered in SSR, then vanished when the client's background refetch read the
+  // stale cached response. Mark every tRPC response uncacheable by shared caches.
+  headers.set("Cache-Control", "private, no-store");
+
   // Add rate limit headers to the response
-  if (Object.keys(rateLimitHeaders).length > 0) {
-    const headers = new Headers(response.headers);
-    for (const [key, value] of Object.entries(rateLimitHeaders)) {
-      headers.set(key, value);
-    }
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers,
-    });
+  for (const [key, value] of Object.entries(rateLimitHeaders)) {
+    headers.set(key, value);
   }
 
-  return response;
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 };
 
 export { handler as GET, handler as POST };

--- a/tests/e2e/auth-ssr.spec.ts
+++ b/tests/e2e/auth-ssr.spec.ts
@@ -46,6 +46,23 @@ test("/register with an invite token SSRs the full signup form", async ({ reques
   expect(html).not.toContain("Loading...");
 });
 
+test("tRPC responses are marked uncacheable so a shared CDN can't replay them", async ({
+  request,
+}) => {
+  // The register/login forms refetch auth.signupConfig on the client. If a shared
+  // cache (our CDN) stores that GET, it can replay a stale cross-deploy response
+  // (e.g. one missing `euRestricted`), which makes the SSR-rendered EU banner
+  // vanish after the client refetch. Every tRPC response must be `no-store`.
+  // superjson encodes the procedure's `undefined` input as json:null + a meta
+  // marker (matches the real client's batch GET).
+  const input = encodeURIComponent(
+    JSON.stringify({ "0": { json: null, meta: { values: ["undefined"], v: 1 } } })
+  );
+  const response = await request.get(`/api/trpc/auth.providers?batch=1&input=${input}`);
+  expect(response.status()).toBe(200);
+  expect(response.headers()["cache-control"]).toContain("no-store");
+});
+
 test("/login SSRs signup-config-driven content without a loading flash", async ({ request }) => {
   const response = await request.get("/login");
   expect(response.status()).toBe(200);


### PR DESCRIPTION
Fixes the reported bug: on the CDN-served register page, the EU banner shows on first render then disappears.

## Root cause

The `/register` form reads `auth.signupConfig` via `useSuspenseQuery`; the `(auth)` layout prefetches + hydrates it (#1328), so **first paint is correct** (`euRestricted: true` → banner shows). React Query then background-refetches (`GET /api/trpc/…?batch=1`).

Two things combined to break it:
1. The tRPC route set **no `Cache-Control`**, so our CDN (Bunny) cached those GET responses. Anonymous `/register` loads carry no session cookie, so the CDN's cookie-based bypass doesn't apply — the public query fell straight into the shared cache, which replayed a **stale cross-deploy** response from before `euRestricted` existed (that's why the field is *absent*, not `false`).
2. The client **refetched** the config even though it's deploy-static, so it re-hit `/api/trpc`, received the stale JSON, and React Query overwrote the good hydrated value with `undefined` → banner vanished.

(The two log lines differ in batch order → different CDN cache keys, which is why one carried `euRestricted:true` and the other didn't.)

## Fix

**1. Don't let a shared cache store tRPC responses** — set `Cache-Control: private, no-store` on every tRPC response in `src/app/api/trpc/[trpc]/route.ts` (matching the OAuth routes). Scoped to `/api/trpc`; the `/api/v1/*` OpenAPI REST surface is a separate handler and left as-is.

**2. Don't refetch deploy-static config on the public pages** — add `STATIC_CONFIG_QUERY_OPTIONS` (`staleTime: Infinity` + `refetchOn* : false`) and apply it to the `auth.signupConfig` `useSuspenseQuery` (register + login) and the `auth.providers` `useQuery` (`OAuthSignInButton`). These pages now never re-hit `/api/trpc` after hydration. Demo and the legal pages (privacy/terms) make no tRPC queries, so nothing refetched there already.

Either fix alone resolves the flash; together they're defense in depth (server stops caching; client stops asking).

## Testing

- `pnpm typecheck` passes
- New e2e (`auth-ssr.spec.ts`): asserts tRPC responses carry `no-store`
- New unit (`static-config-query-options.test.tsx`): drives React Query's `focusManager` to prove the options suppress the focus refetch, with a control asserting a default query *does* refetch
- Full `pnpm test:unit` green; `pnpm test:e2e:local auth-ssr` — all 4 pass

## Follow-up

Purge the Bunny cache for `/api/trpc/*` after deploy (or let its default TTL age the stale entries out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)