### PR TITLE
Never refetch deploy-static config queries on the public auth pages

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -9,6 +9,7 @@
 import { useState, useMemo, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc/client";
+import { STATIC_CONFIG_QUERY_OPTIONS } from "@/lib/trpc/query-client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
@@ -47,8 +48,12 @@ function LoginForm() {
 
   // Fetch signup configuration to determine if signup link should be shown. The
   // auth layout server-prefetches and hydrates this query (#1328), so it resolves
-  // as already-settled data on first render.
-  const [signupConfigData] = trpc.auth.signupConfig.useSuspenseQuery();
+  // as already-settled data on first render. The config is deploy-static, so
+  // never refetch it (STATIC_CONFIG_QUERY_OPTIONS).
+  const [signupConfigData] = trpc.auth.signupConfig.useSuspenseQuery(
+    undefined,
+    STATIC_CONFIG_QUERY_OPTIONS
+  );
 
   // Listen for OAuth completion from other tabs/windows (PWA support for Firefox Android)
   // When OAuth happens in a separate browser window, this allows the PWA to detect completion

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -16,6 +16,7 @@
 import { useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc/client";
+import { STATIC_CONFIG_QUERY_OPTIONS } from "@/lib/trpc/query-client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
@@ -42,7 +43,11 @@ function RegisterForm() {
   // Fetch signup configuration. The auth layout server-prefetches and hydrates
   // this query (#1328), so it resolves as already-settled data on first render —
   // useSuspenseQuery guarantees defined data without a client-side loading state.
-  const [signupConfigData] = trpc.auth.signupConfig.useSuspenseQuery();
+  // The config is deploy-static, so never refetch it (STATIC_CONFIG_QUERY_OPTIONS).
+  const [signupConfigData] = trpc.auth.signupConfig.useSuspenseQuery(
+    undefined,
+    STATIC_CONFIG_QUERY_OPTIONS
+  );
   const euRestricted = signupConfigData.euRestricted;
 
   // On EU-restricted instances, warn EU users up front that they can't sign up

--- a/src/components/auth/OAuthSignInButton.tsx
+++ b/src/components/auth/OAuthSignInButton.tsx
@@ -13,6 +13,7 @@
 
 import { useState } from "react";
 import { trpc } from "@/lib/trpc/client";
+import { STATIC_CONFIG_QUERY_OPTIONS } from "@/lib/trpc/query-client";
 import { SpinnerIcon } from "@/components/ui/icon-button";
 import { type OAuthProvider, providerNames, ProviderIcon, useAuthUrlQuery } from "./oauth-helpers";
 
@@ -37,7 +38,11 @@ export function OAuthSignInButton({
 }: OAuthSignInButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
 
-  const { data: providersData, isLoading: isProvidersLoading } = trpc.auth.providers.useQuery();
+  // Deploy-static config prefetched + hydrated by the auth layout — never refetch.
+  const { data: providersData, isLoading: isProvidersLoading } = trpc.auth.providers.useQuery(
+    undefined,
+    STATIC_CONFIG_QUERY_OPTIONS
+  );
 
   const authUrlQuery = useAuthUrlQuery(provider, inviteToken);
 

--- a/src/lib/trpc/query-client.ts
+++ b/src/lib/trpc/query-client.ts
@@ -19,6 +19,28 @@ import { TRPCClientError } from "@trpc/client";
 import superjson from "superjson";
 
 /**
+ * Query options for the deploy-static config queries the public pages read
+ * (`auth.signupConfig`, `auth.providers`). Their values come from server env and
+ * cannot change within a browser session, so we suppress every background
+ * refetch: `staleTime: Infinity` keeps the SSR-hydrated data permanently fresh,
+ * which alone stops the mount/focus/reconnect refetches (they all only fire on a
+ * stale query), and the explicit `refetchOn* : false` flags document that intent
+ * and keep it robust if `staleTime` is ever lowered.
+ *
+ * This is what keeps the signup/sign-in pages from re-hitting `/api/trpc` after
+ * hydration — a refetch there previously let a stale CDN-cached response
+ * overwrite the correct SSR value (the register page's EU-banner flash). The
+ * `no-store` header on tRPC responses stops the CDN from caching in the first
+ * place; this stops the client from asking at all.
+ */
+export const STATIC_CONFIG_QUERY_OPTIONS = {
+  staleTime: Infinity,
+  refetchOnMount: false,
+  refetchOnWindowFocus: false,
+  refetchOnReconnect: false,
+} as const;
+
+/**
  * Check if an error is a tRPC UNAUTHORIZED error indicating invalid session.
  */
 function isUnauthorizedError(error: unknown): boolean {

--- a/tests/unit/frontend/static-config-query-options.test.tsx
+++ b/tests/unit/frontend/static-config-query-options.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Regression test for STATIC_CONFIG_QUERY_OPTIONS: the deploy-static config
+ * queries the public auth pages read (`auth.signupConfig`, `auth.providers`)
+ * must not background-refetch. A refetch there previously let a stale
+ * CDN-cached tRPC response overwrite the correct SSR-hydrated value, flashing
+ * the register page's EU banner in and back out.
+ *
+ * We drive React Query's real `focusManager` (the mechanism behind
+ * `refetchOnWindowFocus`) against the real tRPC client wiring (mock-link
+ * harness). Without the options a window-focus refetches the stale query; with
+ * them (`staleTime: Infinity`) it never does. The mock-link QueryClient uses the
+ * default `staleTime: 0`, so a query is stale the instant it settles — exactly
+ * the condition under which a focus refetch fires — making the contrast crisp.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { act, waitFor } from "@testing-library/react";
+import { focusManager } from "@tanstack/react-query";
+import { trpc } from "@/lib/trpc/client";
+import { STATIC_CONFIG_QUERY_OPTIONS } from "@/lib/trpc/query-client";
+import { renderHookWithTrpc } from "../../utils/component-test-helpers";
+
+afterEach(() => {
+  // Leave the focus manager in its default (focused) state for other tests.
+  focusManager.setFocused(undefined);
+});
+
+/** Simulate the browser tab losing and regaining focus. */
+async function blurThenFocus(): Promise<void> {
+  await act(async () => {
+    focusManager.setFocused(false);
+    focusManager.setFocused(true);
+  });
+}
+
+describe("STATIC_CONFIG_QUERY_OPTIONS", () => {
+  it("does not refetch auth.providers on window focus", async () => {
+    const { result, callsFor } = renderHookWithTrpc(
+      () => trpc.auth.providers.useQuery(undefined, STATIC_CONFIG_QUERY_OPTIONS),
+      { handlers: { "auth.providers": () => ({ providers: ["google"] }) } }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(callsFor("auth.providers")).toHaveLength(1);
+
+    await blurThenFocus();
+
+    // staleTime: Infinity keeps the query fresh, so focus triggers no refetch.
+    expect(callsFor("auth.providers")).toHaveLength(1);
+  });
+
+  it("control: a default query DOES refetch on window focus", async () => {
+    // Guards the test itself — proves the harness's focus simulation actually
+    // drives a refetch, so the assertion above is meaningful (not a no-op).
+    const { result, callsFor } = renderHookWithTrpc(() => trpc.auth.providers.useQuery(), {
+      handlers: { "auth.providers": () => ({ providers: ["google"] }) },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(callsFor("auth.providers")).toHaveLength(1);
+
+    await blurThenFocus();
+
+    await waitFor(() => expect(callsFor("auth.providers")).toHaveLength(2));
+  });
+});


### PR DESCRIPTION
Follow-up to #1339 (the `no-store` tRPC fix, now merged). That header stops the CDN from caching tRPC responses; this stops the client from re-fetching them in the first place — defense in depth against the register-page EU-banner flash.

## Background

The signup/sign-in pages read `auth.signupConfig` and `auth.providers` via React Query. The `(auth)` layout prefetches + hydrates them (#1328), so first paint is correct. But the queries still **background-refetched** (on window focus / reconnect once past the 60s `staleTime`). That refetch is the mechanism that let a stale CDN-cached response overwrite the correct SSR value and flash the EU banner out.

These values come from server env (`process.env`) and cannot change within a browser session, so they never need to refetch.

## Change

- Add `STATIC_CONFIG_QUERY_OPTIONS` (`staleTime: Infinity` + `refetchOnMount/WindowFocus/Reconnect: false`) in `src/lib/trpc/query-client.ts`.
- Apply it to the `auth.signupConfig` `useSuspenseQuery` (register + login) and the `auth.providers` `useQuery` (`OAuthSignInButton`).

These pages now never re-hit `/api/trpc` after hydration. Demo and the legal pages (privacy/terms) make no tRPC queries, so nothing refetched there already; the `auth.*AuthUrl` queries in `oauth-helpers.tsx` are `enabled: false` (click-triggered), so they don't background-refetch either.

`refetchOnMount: false` only suppresses *background* refetches — the initial fetch is gated separately on `data === undefined`, so a page hit without the layout prefetch still loads correctly (verified against query-core 5.101.2).

## Testing

- `pnpm typecheck` passes
- New unit test (`static-config-query-options.test.tsx`) drives React Query's `focusManager` to prove the options suppress the focus refetch, with a control asserting a default query *does* refetch (so the assertion isn't a no-op)
- Full `pnpm test:unit` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)