### PR TITLE
Fix demo SSR/hydration mismatches: list header, welcome date, read state

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,16 @@ jobs:
         # Discord bot, which a build-time inline never reached — and keeps the
         # Docker image build independent of the SHA, so unchanged layers stay
         # cached. Short SHA to match the previous git-derived value.
-        run: flyctl deploy --remote-only --env GIT_COMMIT_SHA="$(git rev-parse --short HEAD)"
+        #
+        # NEXT_PUBLIC_BUILD_TIME is passed as BOTH a build arg (inlined into the
+        # client bundle) and a runtime env var, using one shared value so the
+        # demo's "Welcome" published time matches between the client and server
+        # renders (see src/app/demo/articles/welcome-published-at.ts).
+        run: |
+          BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          flyctl deploy --remote-only \
+            --build-arg NEXT_PUBLIC_BUILD_TIME="$BUILD_TIME" \
+            --env NEXT_PUBLIC_BUILD_TIME="$BUILD_TIME" \
+            --env GIT_COMMIT_SHA="$(git rev-parse --short HEAD)"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,15 @@ ENV REDIS_URL="redis://localhost:6379"
 ARG NEXT_PUBLIC_SENTRY_DSN=""
 ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 
+# Deploy timestamp, inlined into the client bundle so the demo's "Welcome"
+# article shows a stable published time that matches the server render (see
+# src/app/demo/articles/welcome-published-at.ts). CI passes the same value as a
+# runtime --env too, so the server reads an identical value; unset builds fall
+# back to a fixed date. Placed last among the NEXT_PUBLIC args so its per-deploy
+# churn only busts the build layer (which re-runs each deploy anyway).
+ARG NEXT_PUBLIC_BUILD_TIME=""
+ENV NEXT_PUBLIC_BUILD_TIME=$NEXT_PUBLIC_BUILD_TIME
+
 # Build Next.js application. The cache mount persists .next/cache (webpack's
 # persistent build cache) across builds, cutting warm build times — and keeps
 # it out of the image layers (it's build-time-only; the runtime recreates the

--- a/src/app/demo/DemoEntryListSSR.tsx
+++ b/src/app/demo/DemoEntryListSSR.tsx
@@ -10,20 +10,38 @@
 import { formatRelativeTime } from "@/lib/format";
 import { getItemClasses } from "@/components/entries/entryItemClasses";
 import { StarIcon, StarFilledIcon } from "@/components/ui/icon-button";
+import { DemoListHeader } from "./DemoListHeader";
 import { type DemoEntry } from "./data";
 
 interface DemoEntryListSSRProps {
   entries: DemoEntry[];
   backHref: string;
   title: string;
+  /**
+   * Whether to render the Mark All Read / Sort / Show-unread action buttons.
+   * False for Highlights, matching DemoRouter (which hides them there) so the
+   * SSR header and the post-hydration header are identical. Defaults to true.
+   */
+  showActions?: boolean;
 }
 
-export function DemoEntryListSSR({ entries, backHref, title }: DemoEntryListSSRProps) {
+export function DemoEntryListSSR({
+  entries,
+  backHref,
+  title,
+  showActions = true,
+}: DemoEntryListSSRProps) {
   return (
     <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
-      <div className="mb-4 flex items-center justify-between sm:mb-6">
-        <h1 className="ui-text-xl sm:ui-text-2xl text-body font-bold">{title}</h1>
-      </div>
+      {/* Buttons render statically (no handlers) here, then become interactive
+          when DemoRouter takes over on hydration — same markup, so no shift. */}
+      <DemoListHeader
+        title={title}
+        showActions={showActions}
+        sortOrder="newest"
+        showUnreadOnly={false}
+        markAllReadDescription={title}
+      />
       <div className="space-y-3">
         {entries.map((entry) => {
           const displayTitle = entry.title ?? "Untitled";

--- a/src/app/demo/DemoListHeader.tsx
+++ b/src/app/demo/DemoListHeader.tsx
@@ -1,0 +1,71 @@
+/**
+ * DemoListHeader Component
+ *
+ * The entry-list header (title + Mark All Read / Sort / Show-unread controls),
+ * shared by BOTH the SSR list (DemoEntryListSSR, a server component) and the
+ * interactive client list (DemoRouter). Rendering the identical markup in both
+ * is what keeps the action buttons from popping in — and the whole list from
+ * shifting down ~a pixel — when DemoLayoutContent swaps the SSR HTML for the
+ * client router on hydration.
+ *
+ * This component is intentionally NOT a "use client" module: it composes the
+ * shared button components (which are themselves client components) but adds no
+ * client-only APIs of its own, so a server component can render it as long as
+ * it passes no handlers. The handlers are optional — the SSR path omits them
+ * (the buttons render inert, then are replaced by the interactive router on
+ * hydration), while DemoRouter passes the real DemoStateContext actions.
+ */
+
+import { MarkAllReadButton } from "@/components/entries/MarkAllReadButton";
+import { SortToggle } from "@/components/entries/SortToggle";
+import { UnreadToggle } from "@/components/entries/UnreadToggle";
+
+interface DemoListHeaderProps {
+  /** Page title (e.g. "All Features", a subscription/tag name, "Highlights"). */
+  title: string;
+  /**
+   * Whether to show the action buttons. False for Highlights (mirroring
+   * DemoRouter, which hides them there) so the SSR and client headers match.
+   */
+  showActions: boolean;
+  /** Current sort order (defaults to "newest" on the SSR path). */
+  sortOrder: "newest" | "oldest";
+  /** Whether only unread entries are shown (defaults to false on the SSR path). */
+  showUnreadOnly: boolean;
+  /** Description used in the mark-all-read confirmation dialog. */
+  markAllReadDescription: string;
+  /** Confirm handler for mark-all-read (omitted during SSR). */
+  onMarkAllRead?: () => void;
+  /** Sort-order toggle handler (omitted during SSR). */
+  onToggleSort?: () => void;
+  /** Unread-only toggle handler (omitted during SSR). */
+  onToggleUnread?: () => void;
+}
+
+export function DemoListHeader({
+  title,
+  showActions,
+  sortOrder,
+  showUnreadOnly,
+  markAllReadDescription,
+  onMarkAllRead,
+  onToggleSort,
+  onToggleUnread,
+}: DemoListHeaderProps) {
+  return (
+    <div className="mb-4 flex items-center justify-between sm:mb-6">
+      <h1 className="ui-text-xl sm:ui-text-2xl text-body font-bold">{title}</h1>
+      {showActions && (
+        <div className="flex gap-2">
+          <MarkAllReadButton
+            contextDescription={markAllReadDescription}
+            isLoading={false}
+            onConfirm={onMarkAllRead}
+          />
+          <SortToggle sortOrder={sortOrder} onToggle={onToggleSort} />
+          <UnreadToggle showUnreadOnly={showUnreadOnly} onToggle={onToggleUnread} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/demo/DemoRouter.tsx
+++ b/src/app/demo/DemoRouter.tsx
@@ -14,13 +14,11 @@
 import { useMemo, useEffect, useCallback, useRef, Suspense } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useSwipeGesture } from "@/lib/hooks/useSwipeGesture";
-import { SortToggle } from "@/components/entries/SortToggle";
-import { UnreadToggle } from "@/components/entries/UnreadToggle";
-import { MarkAllReadButton } from "@/components/entries/MarkAllReadButton";
 import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
 import { clientPush, extractParamsFromPathname } from "@/lib/navigation";
 import { DemoArticleView } from "./DemoArticleView";
 import { DemoEntryList } from "./DemoEntryList";
+import { DemoListHeader } from "./DemoListHeader";
 import { DemoListSkeleton } from "./DemoListSkeleton";
 import { useDemoState } from "./DemoStateContext";
 import {
@@ -230,28 +228,22 @@ function DemoRouterContent() {
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-4 sm:p-6">
-      {/* Header with title and action buttons */}
-      <div className="mb-4 flex items-center justify-between sm:mb-6">
-        <h1 className="ui-text-xl sm:ui-text-2xl text-body font-bold">{pageTitle}</h1>
-        {!isHighlights && (
-          <div className="flex gap-2">
-            <MarkAllReadButton
-              contextDescription={markAllReadDescription}
-              isLoading={false}
-              onConfirm={() => {
-                // Mark all currently-visible base entries as read
-                const ids = baseEntries.map((e) => e.id);
-                demoState.markAllRead(ids);
-              }}
-            />
-            <SortToggle sortOrder={demoState.sortOrder} onToggle={demoState.toggleSortOrder} />
-            <UnreadToggle
-              showUnreadOnly={demoState.showUnreadOnly}
-              onToggle={demoState.toggleShowUnreadOnly}
-            />
-          </div>
-        )}
-      </div>
+      {/* Header with title and action buttons — same component (and markup) the
+          SSR list renders, so the swap on hydration is seamless. */}
+      <DemoListHeader
+        title={pageTitle}
+        showActions={!isHighlights}
+        sortOrder={demoState.sortOrder}
+        showUnreadOnly={demoState.showUnreadOnly}
+        markAllReadDescription={markAllReadDescription}
+        onMarkAllRead={() => {
+          // Mark all currently-visible base entries as read
+          const ids = baseEntries.map((e) => e.id);
+          demoState.markAllRead(ids);
+        }}
+        onToggleSort={demoState.toggleSortOrder}
+        onToggleUnread={demoState.toggleShowUnreadOnly}
+      />
 
       {/* Entry list */}
       <DemoEntryList

--- a/src/app/demo/DemoStateContext.tsx
+++ b/src/app/demo/DemoStateContext.tsx
@@ -9,7 +9,16 @@
 
 "use client";
 
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+import {
+  createContext,
+  Suspense,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useSearchParams } from "next/navigation";
 import { DEMO_ENTRIES, type DemoEntry } from "./data";
 
 // ============================================================================
@@ -83,12 +92,29 @@ const DemoStateContext = createContext<DemoStateContextValue | null>(null);
 // Provider
 // ============================================================================
 
-export function DemoStateProvider({ children }: { children: ReactNode }) {
+function DemoStateProviderImpl({
+  initialReadEntryId,
+  children,
+}: {
+  /**
+   * Entry to seed as already-read (the one open on first load, from `?entry=`).
+   * The real app auto-marks an opened entry read; seeding it into the initial
+   * state — on both the server and the client's first render — means the read
+   * toggle and unread counts render read from the first paint, with no flash as
+   * DemoRouter's mark-read effect runs after hydration.
+   */
+  initialReadEntryId: string | null;
+  children: ReactNode;
+}) {
   const [state, setState] = useState<DemoState>(() => {
-    // Initialize from static data defaults
+    // Initialize from static data defaults, treating the initially-open entry
+    // as read so it matches the real app's open-marks-read behavior.
     const entryStates = new Map<string, EntryState>();
     for (const entry of DEMO_ENTRIES) {
-      entryStates.set(entry.id, { read: entry.read, starred: entry.starred });
+      entryStates.set(entry.id, {
+        read: entry.read || entry.id === initialReadEntryId,
+        starred: entry.starred,
+      });
     }
     return {
       entryStates,
@@ -246,6 +272,35 @@ export function DemoStateProvider({ children }: { children: ReactNode }) {
   );
 
   return <DemoStateContext.Provider value={value}>{children}</DemoStateContext.Provider>;
+}
+
+/**
+ * Reads the open entry id from the URL and seeds it as read. Isolated so the
+ * `useSearchParams()` call sits under the Suspense boundary in DemoStateProvider
+ * (required by Next for client components that read search params).
+ */
+function DemoStateProviderWithInitialRead({ children }: { children: ReactNode }) {
+  const initialReadEntryId = useSearchParams().get("entry");
+  return (
+    <DemoStateProviderImpl initialReadEntryId={initialReadEntryId}>
+      {children}
+    </DemoStateProviderImpl>
+  );
+}
+
+export function DemoStateProvider({ children }: { children: ReactNode }) {
+  // On these dynamic demo routes the search params are available during SSR, so
+  // the server and the client's first render both seed the same open entry as
+  // read (no hydration mismatch). The Suspense fallback — a provider with
+  // nothing pre-seeded — only ever shows if params aren't yet resolved, and is
+  // required so useSearchParams doesn't opt the whole subtree out of SSR.
+  return (
+    <Suspense
+      fallback={<DemoStateProviderImpl initialReadEntryId={null}>{children}</DemoStateProviderImpl>}
+    >
+      <DemoStateProviderWithInitialRead>{children}</DemoStateProviderWithInitialRead>
+    </Suspense>
+  );
 }
 
 // ============================================================================

--- a/src/app/demo/DemoStateContext.tsx
+++ b/src/app/demo/DemoStateContext.tsx
@@ -294,6 +294,14 @@ export function DemoStateProvider({ children }: { children: ReactNode }) {
   // read (no hydration mismatch). The Suspense fallback — a provider with
   // nothing pre-seeded — only ever shows if params aren't yet resolved, and is
   // required so useSearchParams doesn't opt the whole subtree out of SSR.
+  //
+  // ASSUMPTION: every /demo route stays dynamically rendered (each page awaits
+  // `searchParams`). That keeps useSearchParams resolved on first render so the
+  // fallback never mounts. If a demo route were ever made static, SSR would
+  // render the fallback (seeding nothing) while the client seeds from `?entry=`
+  // — reintroducing exactly the article read/unread hydration mismatch this
+  // provider exists to prevent, plus resetting state on the fallback→resolved
+  // swap. Keep demo routes dynamic.
   return (
     <Suspense
       fallback={<DemoStateProviderImpl initialReadEntryId={null}>{children}</DemoStateProviderImpl>}

--- a/src/app/demo/articles/welcome-published-at.ts
+++ b/src/app/demo/articles/welcome-published-at.ts
@@ -1,0 +1,47 @@
+/**
+ * Resolve the "Welcome to Lion Reader" article's published time.
+ *
+ * This value has two hard requirements:
+ *
+ * 1. **SSR and client render must agree.** The demo renders the welcome article
+ *    on the server (src/app/demo/**\/page.tsx) and again on the client after
+ *    hydration (DemoRouter), reading the same `publishedAt` from static data.
+ *    The old `new Date()` was evaluated at module-load time, which differs
+ *    between the long-running server (≈ deploy time) and the browser (page
+ *    load) — so the relative time jumped (e.g. "31 minutes ago" → "just now")
+ *    on hydration. Reading a build/deploy-stamped value instead makes both
+ *    sides render the identical time, so there is no flash.
+ *
+ * 2. **Welcome must stay pinned to the top** of the newest-first list
+ *    (`sortNewestFirst`), so its date must be newer than every other demo
+ *    article. The deploy time always is; the dev fallback is chosen to be.
+ *
+ * `NEXT_PUBLIC_BUILD_TIME` is stamped at deploy time as BOTH a build arg (so
+ * it's inlined into the client bundle) and a runtime env var (so the server
+ * reads the same value) — see the Dockerfile and .github/workflows/deploy.yml.
+ * When unset (local dev, or a build that didn't stamp it) we fall back to a
+ * fixed recent date. The function is pure so the parsing/fallback logic is
+ * unit-tested; the impure `process.env` read stays at the call site.
+ */
+
+/** Fixed fallback published date for dev / unstamped builds. Must stay newer
+ * than every other demo article so "Welcome" remains first in the list. */
+export const WELCOME_FALLBACK_PUBLISHED_AT = "2026-07-01T00:00:00Z";
+
+/**
+ * Resolve the welcome article's published date from a build/deploy timestamp.
+ *
+ * @param buildTime An ISO-8601 timestamp (typically `NEXT_PUBLIC_BUILD_TIME`),
+ *   or undefined when unstamped.
+ * @returns The parsed build time, or {@link WELCOME_FALLBACK_PUBLISHED_AT} when
+ *   `buildTime` is absent or not a valid date.
+ */
+export function resolveWelcomePublishedAt(buildTime: string | undefined): Date {
+  if (buildTime) {
+    const parsed = new Date(buildTime);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  return new Date(WELCOME_FALLBACK_PUBLISHED_AT);
+}

--- a/src/app/demo/articles/welcome.ts
+++ b/src/app/demo/articles/welcome.ts
@@ -1,4 +1,5 @@
 import { type DemoArticle } from "./types";
+import { resolveWelcomePublishedAt } from "./welcome-published-at";
 
 const article: DemoArticle = {
   id: "welcome",
@@ -9,7 +10,10 @@ const article: DemoArticle = {
   author: null,
   summary:
     "An AI-native, all-in-one reader for feeds, newsletters, and read-later. Explore the demo to see what it can do.",
-  publishedAt: new Date(),
+  // Build/deploy-stamped so SSR and the post-hydration client render show the
+  // identical time (no "31 minutes ago" → "just now" jump). See
+  // resolveWelcomePublishedAt for the full rationale.
+  publishedAt: resolveWelcomePublishedAt(process.env.NEXT_PUBLIC_BUILD_TIME),
   starred: true,
   heroImage: "/demo/welcome.png",
   heroImageAlt:

--- a/src/app/demo/highlights/page.tsx
+++ b/src/app/demo/highlights/page.tsx
@@ -42,6 +42,12 @@ export default async function DemoHighlightsPage({ searchParams }: Props) {
 
   const starredEntries = sortNewestFirst(DEMO_ENTRIES.filter((e) => e.starred));
   return (
-    <DemoEntryListSSR entries={starredEntries} backHref="/demo/highlights" title="Highlights" />
+    <DemoEntryListSSR
+      entries={starredEntries}
+      backHref="/demo/highlights"
+      title="Highlights"
+      // Highlights has no list actions (matching DemoRouter's `!isHighlights`).
+      showActions={false}
+    />
   );
 }

--- a/src/components/entries/MarkAllReadButton.tsx
+++ b/src/components/entries/MarkAllReadButton.tsx
@@ -16,8 +16,12 @@ interface MarkAllReadButtonProps {
   contextDescription: string;
   /** Whether the mark all read mutation is in progress */
   isLoading: boolean;
-  /** Called when the user confirms marking all as read */
-  onConfirm: () => void;
+  /**
+   * Called when the user confirms marking all as read. Optional so the button
+   * can render as a static control during SSR (see the demo's crawlable list
+   * header), where no handler can cross the server/client boundary.
+   */
+  onConfirm?: () => void;
 }
 
 export function MarkAllReadButton({
@@ -45,7 +49,7 @@ export function MarkAllReadButton({
         contextDescription={contextDescription}
         isLoading={isLoading}
         onConfirm={() => {
-          onConfirm();
+          onConfirm?.();
           setShowDialog(false);
         }}
         onCancel={() => setShowDialog(false)}

--- a/src/components/entries/SortToggle.tsx
+++ b/src/components/entries/SortToggle.tsx
@@ -17,9 +17,10 @@ interface SortToggleProps {
   sortOrder: "newest" | "oldest";
 
   /**
-   * Callback when the toggle is clicked.
+   * Callback when the toggle is clicked. Optional so it can render inert during
+   * SSR (see StateToggleButton).
    */
-  onToggle: () => void;
+  onToggle?: () => void;
 
   /**
    * Optional class name for additional styling.

--- a/src/components/entries/UnreadToggle.tsx
+++ b/src/components/entries/UnreadToggle.tsx
@@ -17,9 +17,10 @@ interface UnreadToggleProps {
   showUnreadOnly: boolean;
 
   /**
-   * Callback when the toggle is clicked.
+   * Callback when the toggle is clicked. Optional so it can render inert during
+   * SSR (see StateToggleButton).
    */
-  onToggle: () => void;
+  onToggle?: () => void;
 
   /**
    * Optional class name for additional styling.

--- a/src/components/ui/state-toggle-button.tsx
+++ b/src/components/ui/state-toggle-button.tsx
@@ -29,9 +29,11 @@ interface StateToggleButtonProps {
   isPressed: boolean;
 
   /**
-   * Callback when the button is clicked.
+   * Callback when the button is clicked. Optional so the button can render as a
+   * static, inert control during SSR (e.g. the demo's crawlable list header),
+   * where no handler can cross the server/client boundary.
    */
-  onToggle: () => void;
+  onToggle?: () => void;
 
   /**
    * Optional additional class names.
@@ -61,10 +63,12 @@ export function StateToggleButton({
   onToggle,
   className = "",
 }: StateToggleButtonProps) {
-  const handleClick = (e: MouseEvent) => {
-    e.preventDefault();
-    onToggle();
-  };
+  const handleClick = onToggle
+    ? (e: MouseEvent) => {
+        e.preventDefault();
+        onToggle();
+      }
+    : undefined;
 
   return (
     <button

--- a/tests/unit/welcome-published-at.test.ts
+++ b/tests/unit/welcome-published-at.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveWelcomePublishedAt,
+  WELCOME_FALLBACK_PUBLISHED_AT,
+} from "@/app/demo/articles/welcome-published-at";
+import { DEMO_ARTICLES } from "@/app/demo/articles";
+
+describe("resolveWelcomePublishedAt", () => {
+  it("parses a valid ISO build timestamp", () => {
+    const result = resolveWelcomePublishedAt("2026-07-15T09:30:00Z");
+    expect(result.toISOString()).toBe("2026-07-15T09:30:00.000Z");
+  });
+
+  it("falls back to the fixed date when build time is undefined", () => {
+    const result = resolveWelcomePublishedAt(undefined);
+    expect(result.toISOString()).toBe(new Date(WELCOME_FALLBACK_PUBLISHED_AT).toISOString());
+  });
+
+  it("falls back to the fixed date when build time is empty", () => {
+    const result = resolveWelcomePublishedAt("");
+    expect(result.toISOString()).toBe(new Date(WELCOME_FALLBACK_PUBLISHED_AT).toISOString());
+  });
+
+  it("falls back to the fixed date when build time is unparseable", () => {
+    const result = resolveWelcomePublishedAt("not-a-date");
+    expect(result.toISOString()).toBe(new Date(WELCOME_FALLBACK_PUBLISHED_AT).toISOString());
+  });
+
+  it("keeps the welcome article newer than every other demo article", () => {
+    // Guards the pinned-to-top invariant: the fallback (and thus any real
+    // deploy time, which is later still) must sort ahead of all other articles
+    // in the newest-first demo list.
+    const fallback = resolveWelcomePublishedAt(undefined).getTime();
+    const others = DEMO_ARTICLES.filter((a) => a.id !== "welcome");
+    expect(others.length).toBeGreaterThan(0);
+    for (const article of others) {
+      expect(article.publishedAt.getTime()).toBeLessThan(fallback);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The demo's first paint changed after hydration in three places (continuing the "first load shouldn't shift after it finishes loading" work):

1. **Welcome published time jumped.** The Welcome article used `publishedAt: new Date()`, evaluated at module-load time — different between the long-running server (≈ deploy time) and the browser (page load). So the shown time changed on hydration (e.g. "…11:29 AM" → "…12:00 PM", perceived as "31 minutes ago → now").
2. **Mark All Read / Newest / Show All buttons weren't in SSR.** They existed only in the interactive (post-hydration) list, so they popped in — and because the taller button row is vertically centered against the title, the whole list (title included) shifted down ~1px on hydration.
3. **Read flash on the open entry.** The open entry (Welcome) rendered *unread*, then flipped to *read* once the auto-mark-read effect ran after hydration.

## Fix

1. **Welcome date** — read a build/deploy-stamped `NEXT_PUBLIC_BUILD_TIME` via a pure, unit-tested resolver (`resolveWelcomePublishedAt`). Passed at deploy as **both** a build arg (inlined into the client bundle) and a runtime env var (read by the server), using one shared value, so client and server render the identical time. Falls back to a fixed recent date in dev / unstamped builds, and stays newer than every other article so Welcome remains pinned to the top of the newest-first list.
2. **List header** — factor a shared `DemoListHeader` rendered by **both** the SSR list (`DemoEntryListSSR`) and the client `DemoRouter`, so the markup is byte-identical across the hydration swap. The toggle/mark-all-read handlers are now optional so the SSR path renders identical, inert controls. Hidden on Highlights, matching `DemoRouter`'s `!isHighlights`.
3. **Read state** — seed the entry from `?entry=` as read in the initial `DemoState`, on both the server and the client's first render (via `useSearchParams` under a Suspense boundary), so it paints read with no flash. Matches the real app's open-marks-read behavior; the existing mark-read effect becomes a no-op for the initial entry.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (2536 passing, incl. new `welcome-published-at` tests) all green.
- Ran the app in a real browser:
  - Welcome page: SSR and post-hydration render the **identical** time (`Friday, July 17, 2026 at 5:00 AM`), and the entry paints **read**.
  - List page (`/demo/all`): Mark All Read / Newest / Show All render in SSR and after hydration; Highlights has none.
  - **No hydration warnings** in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude