### PR TITLE
Keep login button in loading state through post-login navigation

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -43,6 +43,16 @@ function LoginForm() {
     form?: string;
   }>({});
 
+  // Once login succeeds we start a router navigation into the app, but that
+  // navigation renders the authenticated shell server-side and can take a
+  // moment. `loginMutation.isPending` flips back to false as soon as the login
+  // request resolves, so binding the button to it alone would briefly re-enable
+  // the button during that navigation gap (looks like the click did nothing).
+  // Keep this true from success until the component unmounts on navigation; it
+  // is never reset back to false on the happy path. On error it stays false, so
+  // the button re-enables for a retry.
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
   // Get success message from registration redirect
   const registered = searchParams.get("registered") === "true";
 
@@ -61,7 +71,9 @@ function LoginForm() {
     const handleOAuthComplete = (message: { redirectTo: string }) => {
       // Clear the completion marker to prevent re-triggering
       clearOAuthCompletion();
-      // Navigate to the redirect destination - the session cookie should already be set
+      // Navigate to the redirect destination - the session cookie should already be set.
+      // No need to touch `isRedirecting` here: that flag is about the email/password
+      // submit button, whereas the OAuth buttons own their own loading state.
       router.push(message.redirectTo);
       router.refresh();
     };
@@ -107,6 +119,9 @@ function LoginForm() {
       // Get the redirect URL from query params or default to /all.
       // Sanitize to a same-origin path to prevent an open redirect.
       const redirectTo = safeRedirectPath(searchParams.get("redirect"));
+      // Keep the button in its loading state through the (server-rendered)
+      // navigation instead of letting it re-enable the instant isPending clears.
+      setIsRedirecting(true);
       router.push(redirectTo);
       router.refresh();
     },
@@ -146,6 +161,10 @@ function LoginForm() {
 
     loginMutation.mutate({ email, password });
   };
+
+  // Show the loading state while the login request is in flight AND while the
+  // post-success navigation into the app is happening.
+  const isSubmitting = loginMutation.isPending || isRedirecting;
 
   return (
     <div>
@@ -192,7 +211,7 @@ function LoginForm() {
           onChange={(e) => setEmail(e.target.value)}
           error={errors.email}
           autoComplete="email"
-          disabled={loginMutation.isPending}
+          disabled={isSubmitting}
         />
 
         <Input
@@ -204,10 +223,10 @@ function LoginForm() {
           onChange={(e) => setPassword(e.target.value)}
           error={errors.password}
           autoComplete="current-password"
-          disabled={loginMutation.isPending}
+          disabled={isSubmitting}
         />
 
-        <Button type="submit" className="w-full" loading={loginMutation.isPending}>
+        <Button type="submit" className="w-full" loading={isSubmitting}>
           Sign in
         </Button>
       </form>

--- a/tests/unit/frontend/components/LoginPage.test.tsx
+++ b/tests/unit/frontend/components/LoginPage.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Component integration tests for the login form's submit-button lifecycle.
+ *
+ * The "Sign in" button must stay in its loading/disabled state continuously
+ * from click until we actually navigate into the app. The login request itself
+ * resolves *before* the (server-rendered) navigation into `/all` completes, so
+ * binding the button to `loginMutation.isPending` alone briefly re-enabled it in
+ * the gap — the confusing "click did nothing" flash the user reported. A
+ * separate `isRedirecting` flag keeps it disabled through the navigation.
+ *
+ * These tests drive the real tRPC wiring through the mock-link harness:
+ *   - success -> button stays disabled after the request resolves (until nav),
+ *   - failure -> button re-enables so the user can retry, and shows the error.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { TRPCClientError } from "@trpc/client";
+import LoginPage from "@/app/(auth)/login/page";
+import {
+  renderWithTrpc,
+  stubMemoryLocalStorage,
+  type ProcedureHandlers,
+} from "../../../utils/component-test-helpers";
+
+// The form navigates into the app via next/navigation's useRouter after a
+// successful login; capture push/refresh instead of performing a real nav.
+const { mockPush, mockRefresh } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockRefresh: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+/** A TRPCClientError whose `.data.code` matches what the client surfaces. */
+function trpcError(code: string, message: string): TRPCClientError<never> {
+  const err = new TRPCClientError<never>(message);
+  Object.assign(err, { data: { code } });
+  return err;
+}
+
+/** signupConfig is a suspense query that fires on mount; give it a value. */
+function baseHandlers(overrides: ProcedureHandlers = {}): ProcedureHandlers {
+  return {
+    "auth.signupConfig": () => ({ requiresInvite: false }),
+    ...overrides,
+  };
+}
+
+async function renderLogin(handlers: ProcedureHandlers) {
+  const result = renderWithTrpc(<LoginPage />, { handlers });
+  // Wait out the signupConfig suspense boundary so the form is mounted.
+  await screen.findByRole("button", { name: "Sign in" });
+  return result;
+}
+
+function fillCredentials() {
+  fireEvent.change(screen.getByLabelText(/Email/i), {
+    target: { value: "user@example.com" },
+  });
+  fireEvent.change(screen.getByLabelText(/Password/i), {
+    target: { value: "hunter2hunter2" },
+  });
+}
+
+describe("LoginPage submit-button lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubMemoryLocalStorage();
+  });
+
+  it("keeps the Sign in button disabled after login resolves, until navigation", async () => {
+    await renderLogin(
+      baseHandlers({
+        "auth.login": () => ({
+          user: { id: "u1", email: "user@example.com", createdAt: new Date() },
+          sessionToken: "tok",
+        }),
+      })
+    );
+
+    fillCredentials();
+    const button = screen.getByRole("button", { name: "Sign in" });
+    fireEvent.click(button);
+
+    // Navigation being kicked off means the mutation already resolved and
+    // onSuccess ran — i.e. isPending is back to false. The button must still be
+    // disabled here (via isRedirecting), which is the regression this guards.
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/all"));
+    expect(button).toBeDisabled();
+  });
+
+  it("re-enables the Sign in button and shows an error when login fails", async () => {
+    await renderLogin(
+      baseHandlers({
+        "auth.login": () => {
+          throw trpcError("UNAUTHORIZED", "nope");
+        },
+      })
+    );
+
+    fillCredentials();
+    const button = screen.getByRole("button", { name: "Sign in" });
+    fireEvent.click(button);
+
+    expect(await screen.findByText("Invalid email or password")).toBeInTheDocument();
+    expect(button).toBeEnabled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

When you submit the login form, the **Sign in** button goes disabled for a moment (the login request), then **re-enables** (spinner gone), then a second or so later the app finally loads. If that last step is slow, there's a confusing gap where login "appears to have done nothing."

## Root cause

The button's loading state was bound to `loginMutation.isPending` alone. That flips back to `false` the instant the login network request resolves. But the actual navigation into the app doesn't start until `onSuccess` calls `router.push('/all')`, and that push has to render the authenticated app shell **server-side** (RSC) before the page swaps. So the sequence was:

1. mutation runs → button disabled (spinner)
2. mutation resolves → `isPending` false → **button re-enables, spinner gone** ← the confusing gap
3. `router.push('/all')` renders the shell server-side → page finally swaps

The "why is it slow" answer: step 3 is an inherent server round-trip to render the authenticated shell + data. We can't make it instant (the content is authenticated, so it can't be prefetched before login), but we *can* keep the user informed instead of flashing the button back to idle.

## Fix

Add an `isRedirecting` flag set in `onSuccess` (never reset on the happy path — the component unmounts when navigation completes) and drive the button + inputs off `isPending || isRedirecting`. The button now stays disabled with its spinner from click all the way until the page swaps, and only re-enables if login **failed**, so the user can retry.

## Tests

Added `tests/unit/frontend/components/LoginPage.test.tsx`:
- **success** → button stays disabled after the request resolves (asserted at the point `router.push` fires, i.e. after `isPending` has cleared) until navigation.
- **failure** → button re-enables and shows "Invalid email or password".

Verified the test fails if the button is reverted to `loading={loginMutation.isPending}`. `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)