### PR TITLE
Skip the redundant re-login after registration

### DIFF
--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -69,10 +69,28 @@ function RegisterForm() {
     form?: string;
   }>({});
 
+  // Registration succeeding logs the user straight in (the server creates a
+  // session and sets the httpOnly cookie on the response). A brand-new email
+  // account still has to accept ToS/Privacy (and, on EU-restricted instances,
+  // the not-in-EU cert) before the app shell will let it in, so we send them to
+  // /complete-signup rather than bouncing back to /login to re-enter the
+  // credentials they just chose. That navigation renders a server-side page and
+  // takes a moment, during which `registerMutation.isPending` has already
+  // cleared — keep the button in its loading state through it via this flag. It
+  // is never reset on the happy path (the component unmounts on navigation); on
+  // error it stays false so the button re-enables for a retry.
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
   const registerMutation = trpc.auth.register.useMutation({
     onSuccess: () => {
-      // Redirect to login with success message
-      router.push("/login?registered=true");
+      // The server already set the httpOnly session cookie, so the user is
+      // signed in — go straight to the confirmation step (which leads into the
+      // app) instead of asking them to sign in again. This is unconditionally
+      // where a new email account goes: the (app) layout redirects any
+      // not-yet-confirmed user to /complete-signup anyway.
+      setIsRedirecting(true);
+      router.push("/complete-signup");
+      router.refresh();
     },
     onError: (error) => {
       // Handle specific error codes
@@ -136,6 +154,10 @@ function RegisterForm() {
       inviteToken: inviteToken ?? undefined,
     });
   };
+
+  // Show the loading state while the request is in flight AND while the
+  // post-success navigation into the app is happening.
+  const isSubmitting = registerMutation.isPending || isRedirecting;
 
   // Which providers may sign up depends on whether an invite is present:
   // with a token, the full allowlist applies; without one, only public providers.
@@ -209,7 +231,7 @@ function RegisterForm() {
               onChange={(e) => setEmail(e.target.value)}
               error={errors.email}
               autoComplete="email"
-              disabled={registerMutation.isPending}
+              disabled={isSubmitting}
             />
 
             <Input
@@ -221,7 +243,7 @@ function RegisterForm() {
               onChange={(e) => setPassword(e.target.value)}
               error={errors.password}
               autoComplete="new-password"
-              disabled={registerMutation.isPending}
+              disabled={isSubmitting}
             />
 
             <Input
@@ -233,10 +255,10 @@ function RegisterForm() {
               onChange={(e) => setConfirmPassword(e.target.value)}
               error={errors.confirmPassword}
               autoComplete="new-password"
-              disabled={registerMutation.isPending}
+              disabled={isSubmitting}
             />
 
-            <Button type="submit" className="w-full" loading={registerMutation.isPending}>
+            <Button type="submit" className="w-full" loading={isSubmitting}>
               Create account
             </Button>
           </form>

--- a/tests/unit/frontend/components/RegisterPage.test.tsx
+++ b/tests/unit/frontend/components/RegisterPage.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Component integration tests for the registration form.
+ *
+ * Registration already creates a session and sets the httpOnly cookie on the
+ * server, so a successful signup logs the user straight in. A brand-new email
+ * account still owes ToS/Privacy consent, so the form sends them to
+ * /complete-signup (which leads into the app) rather than bouncing to /login to
+ * sign in again. Like the login form, it keeps the "Create account" button in
+ * its loading state continuously from click until that navigation happens (the
+ * request resolves before the server-rendered page finishes). On failure the
+ * button re-enables so the user can retry.
+ *
+ * These tests drive the real tRPC wiring through the mock-link harness:
+ *   - success -> navigates to /complete-signup AND button stays disabled,
+ *   - duplicate email -> button re-enables, shows the error, no navigation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { TRPCClientError } from "@trpc/client";
+import RegisterPage from "@/app/(auth)/register/page";
+import {
+  renderWithTrpc,
+  stubMemoryLocalStorage,
+  type ProcedureHandlers,
+} from "../../../utils/component-test-helpers";
+
+// The form navigates into the app via next/navigation's useRouter after a
+// successful registration; capture push/refresh instead of performing a real nav.
+const { mockPush, mockRefresh } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockRefresh: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+/** A TRPCClientError whose `.data.code` matches what the client surfaces. */
+function trpcError(code: string, message: string): TRPCClientError<never> {
+  const err = new TRPCClientError<never>(message);
+  Object.assign(err, { data: { code } });
+  return err;
+}
+
+/** signupConfig is a suspense query that fires on mount; email must be allowed. */
+function baseHandlers(overrides: ProcedureHandlers = {}): ProcedureHandlers {
+  return {
+    "auth.signupConfig": () => ({
+      euRestricted: false,
+      requiresInvite: false,
+      allowedSignupProviders: ["email", "google", "apple", "discord"],
+      publicSignupProviders: ["email", "google", "apple", "discord"],
+    }),
+    ...overrides,
+  };
+}
+
+async function renderRegister(handlers: ProcedureHandlers) {
+  const result = renderWithTrpc(<RegisterPage />, { handlers });
+  // Wait out the signupConfig suspense boundary so the form is mounted.
+  await screen.findByRole("button", { name: "Create account" });
+  return result;
+}
+
+function fillForm() {
+  fireEvent.change(screen.getByLabelText("Email"), {
+    target: { value: "user@example.com" },
+  });
+  fireEvent.change(screen.getByLabelText("Password"), {
+    target: { value: "hunter2hunter2" },
+  });
+  fireEvent.change(screen.getByLabelText("Confirm password"), {
+    target: { value: "hunter2hunter2" },
+  });
+}
+
+describe("RegisterPage auto-login + submit-button lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubMemoryLocalStorage();
+  });
+
+  it("navigates to the confirmation step and keeps the button disabled after signup succeeds", async () => {
+    await renderRegister(
+      baseHandlers({
+        "auth.register": () => ({
+          user: { id: "u1", email: "user@example.com", createdAt: new Date() },
+          sessionToken: "tok",
+        }),
+      })
+    );
+
+    fillForm();
+    const button = screen.getByRole("button", { name: "Create account" });
+    fireEvent.click(button);
+
+    // Goes to /complete-signup (not /login), and the button is still disabled at
+    // the point navigation fires (i.e. after isPending has already cleared).
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/complete-signup"));
+    expect(button).toBeDisabled();
+  });
+
+  it("re-enables the button and shows an error when the email already exists", async () => {
+    await renderRegister(
+      baseHandlers({
+        "auth.register": () => {
+          throw trpcError("CONFLICT", "exists");
+        },
+      })
+    );
+
+    fillForm();
+    const button = screen.getByRole("button", { name: "Create account" });
+    fireEvent.click(button);
+
+    expect(
+      await screen.findByText("An account with this email already exists")
+    ).toBeInTheDocument();
+    expect(button).toBeEnabled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

There's no reason to make people sign in right after they've just created an account. The `auth.register` endpoint already creates a session and sets the httpOnly session cookie on its response (`src/server/trpc/routers/auth.ts` — `createSession` + `setSessionCookie`), so a successful signup **fully authenticates** the user. But the form redirected to `/login?registered=true`, forcing them to re-enter the credentials they just chose.

Old flow: **register → log in again → complete-signup (accept ToS/Privacy) → app.**
New flow: **register → complete-signup → app.** No redundant login.

## Why `/complete-signup` and not `/all`

A brand-new email account is *authenticated* but not yet *confirmed*: `createUser` (`src/server/auth/signup.ts`) leaves `tosAgreedAt`/`privacyPolicyAgreedAt` NULL, and the authenticated app shell (`src/app/(app)/layout.tsx:51`) redirects any unconfirmed user to `/complete-signup` via `isSignupConfirmed` (`src/server/auth/confirmation.ts`). So navigating a fresh signup to `/all` would just bounce to `/complete-signup` anyway. We send them there directly. The ToS/Privacy consent step (and the EU not-in-EU cert on restricted instances) is a legally-required gate and is left unchanged — this PR only removes the redundant *login*, not the confirmation.

## What changed

`src/app/(auth)/register/page.tsx`:
- On success, `router.push("/complete-signup")` + `router.refresh()` instead of `router.push("/login?registered=true")`.
- Apply the same button fix as the login PR (#1344): keep the **Create account** button in its loading/disabled state through the post-signup navigation via an `isRedirecting` flag, rather than re-enabling the instant `registerMutation.isPending` clears. On failure the button re-enables so the user can retry.

No backend change is needed — registration already returns a session.

## Tests

Added `tests/unit/frontend/components/RegisterPage.test.tsx`:
- **success** → navigates to `/complete-signup` (not `/login`) and the button is still disabled at the point navigation fires (after `isPending` has cleared).
- **duplicate email** → button re-enables, shows "An account with this email already exists", no navigation.

Verified the test fails if reverted to the old redirect + `isPending`-only binding. `pnpm typecheck` passes.

## Notes / possible follow-ups

- The `?registered=true` success alert on the login page is now unreachable from the email-signup flow. Left in place to keep this PR separate from #1344 (which also edits `login/page.tsx`); can be removed in a follow-up.
- **Optional product/legal decision:** the register form footer already states "By creating an account, you agree to our Terms of Service and Privacy Policy". If clicking **Create account** is considered acceptance, we could record `tosAgreedAt`/`privacyPolicyAgreedAt` at registration and skip `/complete-signup` entirely (going straight to `/all`) — except on EU-restricted instances, where the not-in-EU cert still can't be inferred and the confirmation page would still be needed. That's a bigger, backend + legal change, so it's deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)