### PR TITLE
Fix demo article date timezone flash (SSR UTC → client local)

### DIFF
--- a/src/app/demo/DemoArticleView.tsx
+++ b/src/app/demo/DemoArticleView.tsx
@@ -29,6 +29,17 @@ import { useEntryTextStyles } from "@/lib/appearance/AppearanceProvider";
 import { getDemoEntryArticleProps, type DemoEntry } from "./data";
 import { useDemoState } from "./DemoStateContext";
 
+/**
+ * Time zone used to format the article date during SSR only. The server has no
+ * way to know the visitor's zone, and defaulting to the host's UTC made the
+ * SSR'd date jump ~hours when the client re-rendered it in local time. Pinning
+ * SSR to a sensible default zone means it matches for visitors in that zone (and
+ * is a small, deliberate correction — not a UTC jump — for everyone else, whose
+ * client render then switches to their real local time). Client renders pass
+ * `undefined` so each visitor still sees their own local time.
+ */
+const SSR_FALLBACK_TIME_ZONE = "America/Los_Angeles";
+
 interface DemoArticleViewProps {
   /** The entry to render (live read/starred state is read from DemoStateContext). */
   entry: DemoEntry;
@@ -59,6 +70,10 @@ export function DemoArticleView({
     <ScrollContainer className="h-full overflow-y-auto">
       <EntryArticle
         {...getDemoEntryArticleProps(entry)}
+        // On the server (no visitor zone available) format in a fixed default
+        // zone; on the client use the visitor's local zone. See
+        // SSR_FALLBACK_TIME_ZONE.
+        dateTimeZone={typeof window === "undefined" ? SSR_FALLBACK_TIME_ZONE : undefined}
         textSizeClass={textSizeClass}
         textStyle={textStyle}
         onTouchStart={onTouchStart}

--- a/src/components/entries/EntryArticle.tsx
+++ b/src/components/entries/EntryArticle.tsx
@@ -25,6 +25,14 @@ export interface EntryArticleProps {
   author: string | null;
   /** The date to display */
   date: Date;
+  /**
+   * Optional IANA time zone for formatting `date`. Omit to use the ambient zone
+   * (the visitor's local zone). The demo passes a fixed zone on the server so
+   * its SSR'd date doesn't render in the host's UTC; the `<time>` is marked
+   * suppressHydrationWarning so switching to the visitor's local zone on the
+   * client is not flagged as a hydration error.
+   */
+  dateTimeZone?: string;
   /** Optional prefix for the date (e.g., "Saved") */
   datePrefix?: string;
   /** Pre-sanitized HTML content */
@@ -66,6 +74,7 @@ export function EntryArticle({
   source,
   author,
   date,
+  dateTimeZone,
   datePrefix,
   contentHtml,
   fallbackContent,
@@ -133,9 +142,16 @@ export function EntryArticle({
             <span aria-hidden="true" className="text-faint hidden sm:inline">
               |
             </span>
-            <time dateTime={date.toISOString()} className="basis-full sm:basis-auto">
+            <time
+              dateTime={date.toISOString()}
+              className="basis-full sm:basis-auto"
+              // The server may format in a fixed zone (see dateTimeZone) while
+              // the client uses the visitor's local zone; that difference is
+              // intentional, not a hydration bug.
+              suppressHydrationWarning
+            >
               {datePrefix ? `${datePrefix} ` : ""}
-              {formatDate(date)}
+              {formatDate(date, dateTimeZone)}
             </time>
           </div>
         </div>

--- a/src/components/entries/EntryContentHelpers.ts
+++ b/src/components/entries/EntryContentHelpers.ts
@@ -6,8 +6,14 @@
 
 /**
  * Format a date as a readable string.
+ *
+ * @param timeZone Optional IANA time zone (e.g. "America/Los_Angeles"). When
+ *   omitted the runtime's ambient zone is used (the visitor's local zone in the
+ *   browser). Pass an explicit zone to get a deterministic result independent of
+ *   where the code runs — e.g. so a server render doesn't default to the host's
+ *   UTC and then differ from the client's local render.
  */
-export function formatDate(date: Date): string {
+export function formatDate(date: Date, timeZone?: string): string {
   return date.toLocaleDateString("en-US", {
     weekday: "long",
     year: "numeric",
@@ -15,6 +21,7 @@ export function formatDate(date: Date): string {
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
+    ...(timeZone ? { timeZone } : {}),
   });
 }
 

--- a/tests/unit/format-date-timezone.test.ts
+++ b/tests/unit/format-date-timezone.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatDate } from "@/components/entries/EntryContentHelpers";
+
+describe("formatDate timeZone", () => {
+  // An instant that lands on different calendar days depending on the zone,
+  // which is exactly the case that made the demo's SSR (UTC host) disagree with
+  // the client (local zone). An explicit zone makes the output deterministic.
+  const instant = new Date("2026-07-18T00:55:00Z");
+
+  it("formats in an explicit IANA zone regardless of the host zone", () => {
+    expect(formatDate(instant, "America/Los_Angeles")).toBe("Friday, July 17, 2026 at 5:55 PM");
+    expect(formatDate(instant, "UTC")).toBe("Saturday, July 18, 2026 at 12:55 AM");
+  });
+
+  it("is stable for the same zone (server and client would match)", () => {
+    expect(formatDate(instant, "America/Los_Angeles")).toBe(
+      formatDate(instant, "America/Los_Angeles")
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to #1343 (which is merged). One SSR/hydration mismatch remained on the demo **entry page**: the article's published date flashed on load — e.g. "Saturday, July 18, 2026 at 12:55 AM" during SSR, then "Friday, July 17, 2026 at 5:55 PM" after hydration.

## Cause

`formatDate` (`EntryContentHelpers.ts`) formats with `toLocaleDateString("en-US", {…})` and **no `timeZone`**, so it uses the ambient zone — **UTC on the Fly server, the visitor's local zone in the browser**. The same instant therefore renders as a different day/time on the server vs the client. (The entry *list* is unaffected: it uses relative time, "9 minutes ago", which is a duration and so timezone-independent.)

This only surfaces in the demo, because the demo SSRs the article; the real app fetches entries client-side and never server-renders an article date.

## Fix

The server can't know the visitor's timezone, so "show local time **and** no flash" isn't possible. Chosen behavior: **default SSR to a fixed sensible zone (`America/Los_Angeles`), keep the visitor's local zone on the client.** So visitors in that zone get no flash, and everyone else gets a small correction to their real local time instead of a ~6-hour UTC jump.

- `formatDate(date, timeZone?)` — optional IANA zone; omitted keeps the current ambient-zone default (unchanged for the rest of the app).
- `EntryArticle` gains `dateTimeZone?`, threads it into `formatDate`, and marks the `<time>` `suppressHydrationWarning` (the server/client zone difference is deliberate, not a hydration bug).
- `DemoArticleView` passes `America/Los_Angeles` on the server (`typeof window === "undefined"`) and `undefined` on the client. It's a client component that runs in both environments and recomputes the value, so the differing value never crosses the RSC boundary.

Scoped to the demo — the shared `formatDate` default and every real-app caller are unchanged.

## Verification

- `pnpm typecheck` / `pnpm lint` green; new `tests/unit/format-date-timezone.test.ts` plus the existing suite pass.
- Verified the exact rendered strings via Node's ICU (`America/Los_Angeles` → "Friday, July 17, 2026 at 5:55 PM"; `UTC` → "Saturday, July 18, 2026 at 12:55 AM").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude