### PR TITLE
Recover from ChunkLoadError by reloading once

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { appUrl } from "@/server/config/env";
 import { ThemeProvider } from "@/lib/theme/ThemeProvider";
 import { DEFAULT_THEME, THEME_STORAGE_KEY, THEMES } from "@/lib/theme/config";
 import { buildTextAppearanceScript } from "@/lib/appearance/config";
+import { buildChunkReloadScript } from "@/lib/chunk-reload";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -121,6 +122,14 @@ const themeScript = `
 const textAppearanceScript = buildTextAppearanceScript();
 
 /**
+ * Blocking script that reloads once to recover from a webpack ChunkLoadError
+ * (stale CDN-cached HTML pointing at a chunk hash a redeploy removed). Inline in
+ * <head> so the listener is registered before any chunk loads — a React handler
+ * living in a chunk can't catch its own failure to load. See src/lib/chunk-reload.ts.
+ */
+const chunkReloadScript = buildChunkReloadScript();
+
+/**
  * Service worker registration script.
  *
  * Registers the service worker for PWA support including:
@@ -169,6 +178,13 @@ export default async function RootLayout({
         {/* suppressHydrationWarning: browsers blank the nonce content attribute
             after parsing (nonce hiding), so hydration would see nonce="" and
             warn on every load. The scripts have executed by then either way. */}
+        {/* Registered first so the ChunkLoadError listener is live before any
+            other script or chunk can fail to load. */}
+        <script
+          nonce={nonce}
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: chunkReloadScript }}
+        />
         <script
           nonce={nonce}
           suppressHydrationWarning

--- a/src/lib/chunk-reload.ts
+++ b/src/lib/chunk-reload.ts
@@ -20,12 +20,16 @@
  * `src/app/layout.tsx`) the listener is registered before any chunk loads and
  * covers every route from the single root-layout mount.
  *
- * On a chunk error we force one full reload, which re-fetches the current HTML
- * (browsers revalidate our pages — `max-age=0`) and with it the current chunk
- * hashes. The reload is guarded by a short time window in `sessionStorage` so
- * that if the reload comes back still referencing the missing chunk (e.g. the
- * CDN is briefly still serving the stale copy) we don't spin in a reload loop —
- * we reload at most once per `RELOAD_WINDOW_MS`, then let the error surface. A
+ * On a chunk error we force one full reload to re-fetch the HTML and, with it,
+ * the current chunk hashes. Our pages carry `max-age=0`, so the browser always
+ * revalidates — but the request hits the CDN, which may still hand back the same
+ * stale copy within its `s-maxage`/`stale-while-revalidate` window, so a reload
+ * is not guaranteed to fix things on its own; the deploy-time CDN purge is what
+ * makes the fresh build available. The reload is therefore guarded by a short
+ * time window in `sessionStorage`: if it comes back still referencing the
+ * missing chunk we don't spin in a reload loop — we reload at most once per
+ * `RELOAD_WINDOW_MS`, then let the error surface (and if `sessionStorage` is
+ * unavailable we skip the reload entirely rather than risk an unguarded loop). A
  * genuinely later mismatch (a deploy mid-session) is outside the window and
  * still recovers. The generated string is pinned by
  * `tests/unit/chunk-reload.test.ts`.
@@ -57,10 +61,21 @@ export function buildChunkReloadScript(): string {
     var last = 0;
     try { last = parseInt(window.sessionStorage.getItem(KEY), 10) || 0; } catch (e) {}
     if (now - last < WINDOW_MS) return;
-    try { window.sessionStorage.setItem(KEY, String(now)); } catch (e) {}
-    window.location.reload();
+    // Only reload if we could persist the guard timestamp. If storage is
+    // unavailable (private mode / disabled) the guard can't advance, so a reload
+    // that came back still broken would loop forever — better to leave a
+    // manually-recoverable broken page than to spin. This keeps "reload at most
+    // once per window" a hard invariant.
+    var recorded = false;
+    try { window.sessionStorage.setItem(KEY, String(now)); recorded = true; } catch (e) {}
+    if (recorded) window.location.reload();
   }
-  window.addEventListener('error', function(e) { recover(e && e.error); });
+  // On the error event the thrown Error is usually on e.error, but a resource/
+  // script-load failure can surface with e.error null and the detail on the
+  // ErrorEvent itself, so fall back to e. (webpack's hydration chunk failure
+  // arrives as a rejected import() promise, caught by the unhandledrejection
+  // path, but cover both.)
+  window.addEventListener('error', function(e) { recover(e && (e.error || e)); });
   window.addEventListener('unhandledrejection', function(e) { recover(e && e.reason); });
 })();
 `;

--- a/src/lib/chunk-reload.ts
+++ b/src/lib/chunk-reload.ts
@@ -1,0 +1,67 @@
+/**
+ * Blocking <head> script that recovers from webpack `ChunkLoadError`.
+ *
+ * Every App Router page — even a fully SSR'd one like the demo — ships a client
+ * bundle to hydrate the markup into an interactive React tree, split into
+ * content-hashed chunks under `/_next/static/chunks/`. When the browser loads
+ * HTML from build A but the origin has since deployed build B (whose chunks have
+ * different hashes), the request for `chunks/<id>-<hashA>.js` 404s and hydration
+ * throws `ChunkLoadError`. Our public pages are CDN-cached (see
+ * `src/server/http/page-cache.ts`), which widens the window in which a visitor
+ * can be served stale HTML that points at a chunk the current build no longer
+ * has. A deploy-time CDN purge shrinks that window; this makes an individual tab
+ * that still hits it self-heal.
+ *
+ * Why an inline head script rather than a "use client" component: the thing that
+ * fails is chunk loading, so a recovery handler that itself lives in a chunk and
+ * only registers its listener from a `useEffect` after hydration is unreliable —
+ * hydration can throw the `ChunkLoadError` before that effect ever commits. Run
+ * inline in <head> (like `themeScript` / the appearance script in
+ * `src/app/layout.tsx`) the listener is registered before any chunk loads and
+ * covers every route from the single root-layout mount.
+ *
+ * On a chunk error we force one full reload, which re-fetches the current HTML
+ * (browsers revalidate our pages — `max-age=0`) and with it the current chunk
+ * hashes. The reload is guarded by a short time window in `sessionStorage` so
+ * that if the reload comes back still referencing the missing chunk (e.g. the
+ * CDN is briefly still serving the stale copy) we don't spin in a reload loop —
+ * we reload at most once per `RELOAD_WINDOW_MS`, then let the error surface. A
+ * genuinely later mismatch (a deploy mid-session) is outside the window and
+ * still recovers. The generated string is pinned by
+ * `tests/unit/chunk-reload.test.ts`.
+ */
+
+/** Don't reload more than once per this window, so a still-broken reload can't loop. */
+export const RELOAD_WINDOW_MS = 10_000;
+
+/** `sessionStorage` key holding the epoch-ms of the last recovery reload. */
+export const RELOAD_TIMESTAMP_KEY = "lr-chunk-reload-at";
+
+export function buildChunkReloadScript(): string {
+  return `
+(function() {
+  var KEY = ${JSON.stringify(RELOAD_TIMESTAMP_KEY)};
+  var WINDOW_MS = ${RELOAD_WINDOW_MS};
+  function isChunkError(err) {
+    if (!err) return false;
+    if (typeof err.name === 'string' && err.name === 'ChunkLoadError') return true;
+    var msg = typeof err.message === 'string'
+      ? err.message
+      : (typeof err === 'string' ? err : '');
+    return msg.indexOf('ChunkLoadError') !== -1 ||
+      /Loading( CSS)? chunk [^\\s]+ failed/i.test(msg);
+  }
+  function recover(err) {
+    if (!isChunkError(err)) return;
+    var now = Date.now();
+    var last = 0;
+    try { last = parseInt(window.sessionStorage.getItem(KEY), 10) || 0; } catch (e) {}
+    if (now - last < WINDOW_MS) return;
+    try { window.sessionStorage.setItem(KEY, String(now)); } catch (e) {}
+    window.location.reload();
+  }
+  window.addEventListener('error', function(e) { recover(e && e.error); });
+  window.addEventListener('unhandledrejection', function(e) { recover(e && e.reason); });
+})();
+`;
+}

--- a/tests/unit/chunk-reload.test.ts
+++ b/tests/unit/chunk-reload.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the blocking <head> ChunkLoadError recovery script.
+ *
+ * The script is a hand-written string that runs before the bundle loads (so it
+ * can catch a chunk failing to load during hydration). These tests execute the
+ * actual generated script against a fake `window` and drive its registered
+ * `error` / `unhandledrejection` listeners, asserting it reloads exactly once
+ * per window on a chunk error and never on unrelated errors.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildChunkReloadScript,
+  RELOAD_TIMESTAMP_KEY,
+  RELOAD_WINDOW_MS,
+} from "../../src/lib/chunk-reload";
+
+type Listener = (event: unknown) => void;
+
+interface FakeWindow {
+  listeners: Record<string, Listener[]>;
+  addEventListener: (type: string, fn: Listener) => void;
+  sessionStorage: {
+    getItem: (k: string) => string | null;
+    setItem: (k: string, v: string) => void;
+  };
+  location: { reload: () => void };
+  reloadCount: number;
+  store: Map<string, string>;
+}
+
+function makeWindow(): FakeWindow {
+  const store = new Map<string, string>();
+  const listeners: Record<string, Listener[]> = {};
+  const win: FakeWindow = {
+    listeners,
+    store,
+    reloadCount: 0,
+    addEventListener(type, fn) {
+      (listeners[type] ??= []).push(fn);
+    },
+    sessionStorage: {
+      getItem: (k) => (store.has(k) ? (store.get(k) as string) : null),
+      setItem: (k, v) => {
+        store.set(k, v);
+      },
+    },
+    location: {
+      reload() {
+        win.reloadCount += 1;
+      },
+    },
+  };
+  return win;
+}
+
+/** Install the script's listeners onto a fresh fake window. */
+function install(): FakeWindow {
+  const win = makeWindow();
+  // The script is an IIFE referencing `window` (and the global `Date`); shadow
+  // `window` with our fake so we can drive its listeners.
+  const fn = new Function("window", buildChunkReloadScript());
+  fn(win);
+  return win;
+}
+
+/** Dispatch to every listener registered for `type`. */
+function dispatch(win: FakeWindow, type: string, event: unknown): void {
+  for (const fn of win.listeners[type] ?? []) fn(event);
+}
+
+function chunkError(): Error {
+  const err = new Error("Loading chunk 3241 failed.\n(error: /_next/static/chunks/3241-abc.js)");
+  err.name = "ChunkLoadError";
+  return err;
+}
+
+describe("buildChunkReloadScript", () => {
+  it("registers error and unhandledrejection listeners", () => {
+    const win = install();
+    expect(win.listeners["error"]?.length).toBe(1);
+    expect(win.listeners["unhandledrejection"]?.length).toBe(1);
+  });
+
+  it("reloads on a ChunkLoadError surfaced via the error event", () => {
+    const win = install();
+    dispatch(win, "error", { error: chunkError() });
+    expect(win.reloadCount).toBe(1);
+    expect(win.store.get(RELOAD_TIMESTAMP_KEY)).toBeTruthy();
+  });
+
+  it("reloads on a ChunkLoadError surfaced via unhandledrejection", () => {
+    const win = install();
+    dispatch(win, "unhandledrejection", { reason: chunkError() });
+    expect(win.reloadCount).toBe(1);
+  });
+
+  it("detects a chunk error by message even without the ChunkLoadError name", () => {
+    const win = install();
+    dispatch(win, "error", { error: new Error("Loading CSS chunk 42 failed.") });
+    expect(win.reloadCount).toBe(1);
+  });
+
+  it("does not reload on unrelated errors", () => {
+    const win = install();
+    dispatch(win, "error", { error: new TypeError("x is not a function") });
+    dispatch(win, "unhandledrejection", { reason: new Error("Failed to fetch") });
+    dispatch(win, "error", { error: null });
+    dispatch(win, "error", {});
+    expect(win.reloadCount).toBe(0);
+  });
+
+  it("reloads at most once within the guard window (no reload loop)", () => {
+    const win = install();
+    dispatch(win, "error", { error: chunkError() });
+    dispatch(win, "error", { error: chunkError() });
+    dispatch(win, "unhandledrejection", { reason: chunkError() });
+    expect(win.reloadCount).toBe(1);
+  });
+
+  it("recovers again once the guard window has elapsed (later deploy mid-session)", () => {
+    const win = install();
+    // Simulate a prior reload that happened longer ago than the guard window.
+    win.store.set(RELOAD_TIMESTAMP_KEY, String(Date.now() - RELOAD_WINDOW_MS - 1));
+    dispatch(win, "error", { error: chunkError() });
+    expect(win.reloadCount).toBe(1);
+  });
+});

--- a/tests/unit/chunk-reload.test.ts
+++ b/tests/unit/chunk-reload.test.ts
@@ -125,4 +125,20 @@ describe("buildChunkReloadScript", () => {
     dispatch(win, "error", { error: chunkError() });
     expect(win.reloadCount).toBe(1);
   });
+
+  it("does not reload when sessionStorage is unavailable (no unguarded loop)", () => {
+    // Private mode / disabled storage: the guard can't be persisted, so we must
+    // skip the reload rather than reload unguarded and risk an infinite loop.
+    const win = makeWindow();
+    win.sessionStorage.getItem = () => {
+      throw new Error("SecurityError: storage disabled");
+    };
+    win.sessionStorage.setItem = () => {
+      throw new Error("SecurityError: storage disabled");
+    };
+    new Function("window", buildChunkReloadScript())(win);
+    dispatch(win, "error", { error: chunkError() });
+    dispatch(win, "unhandledrejection", { reason: chunkError() });
+    expect(win.reloadCount).toBe(0);
+  });
 });


### PR DESCRIPTION
## Problem

`https://lionreader.b-cdn.net/demo/all` intermittently throws:

```
ChunkLoadError: Loading chunk 3241 failed.
(error: .../_next/static/chunks/3241-0c8c6c0909f9cc2f.js)
```

I confirmed with live requests that the failing chunk **404s on both the CDN and the origin** — it isn't a CDN reliability problem, it's version skew. The demo HTML is CDN-cached (`s-maxage=3600, stale-while-revalidate=604800`, see `src/server/http/page-cache.ts`), so a visitor can be served HTML from an older build that references a chunk hash a later deploy replaced. Even though `/demo/all` is fully SSR'd, App Router still ships a client bundle to *hydrate* it into an interactive tree, so it must load those chunks — the fetch is hydration, not deferred rendering.

## Fix

A blocking `<head>` script (`src/lib/chunk-reload.ts`, mounted in the root layout next to the theme/appearance scripts) listens for `ChunkLoadError` via the `error` / `unhandledrejection` events and forces **one** full reload to pull the current HTML + chunk hashes. A `sessionStorage` time-window guard (`RELOAD_WINDOW_MS`) prevents a reload loop if the reload still lands on the missing chunk, while a genuinely later mismatch (a deploy mid-session) is outside the window and still recovers.

**Why an inline head script, not a `"use client"` component:** the failure mode is chunk loading itself. A handler that lives in a chunk and registers from a `useEffect` can't reliably catch its own failure to load — hydration can throw before that effect commits. Inline in `<head>`, the listener is live before any chunk loads and covers every route from one mount point.

Pairs with the deploy-time CDN purge (being added separately) that shrinks the stale-HTML window; this makes any tab that still hits skew self-heal.

## Tests

`tests/unit/chunk-reload.test.ts` executes the generated script against a fake `window` and drives its listeners: reloads once on a chunk error (via both event types, and by message without the `ChunkLoadError` name), never on unrelated errors, at most once per guard window, and again after the window elapses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)