### PR TITLE
Drop deprecated entries.*_sanitized columns (#1289)

### DIFF
--- a/migrations/0104_drop_sanitized_columns.sql
+++ b/migrations/0104_drop_sanitized_columns.sql
@@ -1,0 +1,74 @@
+-- Drop the deprecated entries.*_sanitized columns (issue #1289, phase 3 of #1282).
+--
+-- Sanitization became per-read in #1282/#1288: the persisted sanitized columns
+-- (content_original_sanitized, content_cleaned_sanitized, content_sanitized_version,
+-- and the full_content_* equivalents) are no longer read or written. Per the
+-- expand/contract rule they were kept for one release so the previous release
+-- (which re-sanitizes from raw when the stored version is NULL) could still serve
+-- content on a rollback. That release has shipped, so this is the contract step.
+--
+-- Expand/contract: safe for the previous (now-current) release. It selects
+-- explicit column lists everywhere (never SELECT *), no longer reads or writes
+-- these columns, and its Drizzle definitions of entries and visible_entries no
+-- longer reference them. visible_entries must be dropped and recreated because a
+-- column can't be dropped out from under a view.
+--
+-- Reclaims roughly half of the entry-content TOAST storage.
+
+DROP VIEW visible_entries;
+
+--> statement-breakpoint
+
+ALTER TABLE entries
+  DROP COLUMN content_original_sanitized,
+  DROP COLUMN content_cleaned_sanitized,
+  DROP COLUMN content_sanitized_version,
+  DROP COLUMN full_content_original_sanitized,
+  DROP COLUMN full_content_cleaned_sanitized,
+  DROP COLUMN full_content_sanitized_version;
+
+--> statement-breakpoint
+
+-- Identical to the prior definition minus the six *_sanitized columns.
+CREATE VIEW visible_entries AS
+ SELECT ue.user_id,
+    e.id,
+    e.feed_id,
+    e.type,
+    e.guid,
+    e.url,
+    e.title,
+    e.author,
+    e.content_original,
+    e.content_cleaned,
+    e.summary,
+    e.site_name,
+    e.image_url,
+    e.published_at,
+    e.fetched_at,
+    e.last_seen_at,
+    e.content_hash,
+    e.full_content_hash,
+    e.spam_score,
+    e.is_spam,
+    e.list_unsubscribe_mailto,
+    e.list_unsubscribe_https,
+    e.list_unsubscribe_post,
+    e.created_at,
+    GREATEST(e.updated_at, ue.updated_at) AS updated_at,
+    e.full_content_original,
+    e.full_content_cleaned,
+    e.full_content_fetched_at,
+    e.full_content_error,
+    ue.read,
+    ue.starred,
+    s.id AS subscription_id,
+    e.unsubscribe_url,
+    ue.read_changed_at,
+    ue.published_or_fetched_at,
+    e.greader_item_id,
+    s.greader_stream_id AS subscription_greader_stream_id
+   FROM ((user_entries ue
+     JOIN entries e ON ((e.id = ue.entry_id)))
+     LEFT JOIN subscriptions s ON ((s.id = ue.subscription_id)))
+  WHERE (((s.id IS NOT NULL) AND (s.unsubscribed_at IS NULL)) OR (ue.starred = true) OR (e.type = 'saved'::feed_type));

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -722,6 +722,13 @@
       "when": 1782953600000,
       "tag": "0103_drop_resanitize_index",
       "breakpoints": true
+    },
+    {
+      "idx": 103,
+      "version": "7",
+      "when": 1782953700000,
+      "tag": "0104_drop_sanitized_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -215,12 +215,6 @@ CREATE TABLE public.entries (
     full_content_error text,
     full_content_hash text,
     unsubscribe_url text,
-    content_original_sanitized text,
-    content_cleaned_sanitized text,
-    content_sanitized_version smallint,
-    full_content_original_sanitized text,
-    full_content_cleaned_sanitized text,
-    full_content_sanitized_version smallint,
     greader_item_id bigint NOT NULL,
     is_placeholder boolean DEFAULT false NOT NULL,
     CONSTRAINT entries_last_seen_only_fetched CHECK (((type = 'web'::public.feed_type) = (last_seen_at IS NOT NULL))),
@@ -233,10 +227,6 @@ ALTER TABLE ONLY public.entries ALTER COLUMN summary SET COMPRESSION lz4;
 ALTER TABLE ONLY public.entries ALTER COLUMN content_cleaned SET COMPRESSION lz4;
 ALTER TABLE ONLY public.entries ALTER COLUMN full_content_original SET COMPRESSION lz4;
 ALTER TABLE ONLY public.entries ALTER COLUMN full_content_cleaned SET COMPRESSION lz4;
-ALTER TABLE ONLY public.entries ALTER COLUMN content_original_sanitized SET COMPRESSION lz4;
-ALTER TABLE ONLY public.entries ALTER COLUMN content_cleaned_sanitized SET COMPRESSION lz4;
-ALTER TABLE ONLY public.entries ALTER COLUMN full_content_original_sanitized SET COMPRESSION lz4;
-ALTER TABLE ONLY public.entries ALTER COLUMN full_content_cleaned_sanitized SET COMPRESSION lz4;
 
 CREATE SEQUENCE public.entries_greader_item_id_seq
     AS bigint
@@ -581,12 +571,6 @@ CREATE VIEW public.visible_entries AS
     e.unsubscribe_url,
     ue.read_changed_at,
     ue.published_or_fetched_at,
-    e.content_original_sanitized,
-    e.content_cleaned_sanitized,
-    e.content_sanitized_version,
-    e.full_content_original_sanitized,
-    e.full_content_cleaned_sanitized,
-    e.full_content_sanitized_version,
     e.greader_item_id,
     s.greader_stream_id AS subscription_greader_stream_id
    FROM ((public.user_entries ue

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -468,12 +468,6 @@ export const entries = pgTable(
     author: text("author"),
     contentOriginal: text("content_original"),
     contentCleaned: text("content_cleaned"), // Readability-cleaned HTML
-    // DEPRECATED (issue #1282): sanitization is now per-read, so these columns
-    // are no longer read or written. Kept for one release for rollback safety
-    // (expand/contract); a follow-up migration drops them. See sanitize-entry.ts.
-    contentOriginalSanitized: text("content_original_sanitized"),
-    contentCleanedSanitized: text("content_cleaned_sanitized"),
-    contentSanitizedVersion: smallint("content_sanitized_version"),
     summary: text("summary"), // truncated for previews
 
     // Saved article metadata (only for type='saved')
@@ -496,10 +490,6 @@ export const entries = pgTable(
     fullContentHash: text("full_content_hash"), // SHA256 of full content (for separate summary caching)
     fullContentOriginal: text("full_content_original"), // Raw HTML from URL
     fullContentCleaned: text("full_content_cleaned"), // Readability-cleaned HTML
-    // DEPRECATED (issue #1282): see contentOriginalSanitized above.
-    fullContentOriginalSanitized: text("full_content_original_sanitized"),
-    fullContentCleanedSanitized: text("full_content_cleaned_sanitized"),
-    fullContentSanitizedVersion: smallint("full_content_sanitized_version"),
     fullContentFetchedAt: timestamp("full_content_fetched_at", { withTimezone: true }),
     fullContentError: text("full_content_error"), // Error message if fetch failed
 
@@ -850,12 +840,6 @@ export const visibleEntries = pgView("visible_entries", {
   unsubscribeUrl: text("unsubscribe_url"), // extracted from email HTML body
   readChangedAt: timestamp("read_changed_at", { withTimezone: true }),
   publishedOrFetchedAt: temporalTimestamp("published_or_fetched_at").notNull(), // denormalized timeline sort key (temporalTimestamp: µs-precise cursor sort key)
-  contentOriginalSanitized: text("content_original_sanitized"),
-  contentCleanedSanitized: text("content_cleaned_sanitized"),
-  contentSanitizedVersion: smallint("content_sanitized_version"),
-  fullContentOriginalSanitized: text("full_content_original_sanitized"),
-  fullContentCleanedSanitized: text("full_content_cleaned_sanitized"),
-  fullContentSanitizedVersion: smallint("full_content_sanitized_version"),
   // NOT NULL in reality (entries.greader_item_id is NOT NULL); typed non-null so
   // it flows into EntryListItem/EntryFull's non-null greaderItemId without a cast.
   // Doubles as the Wallabag entry id (reversed by resolveWallabagEntry).


### PR DESCRIPTION
Fixes #1289. Phase 3 (contract step) of #1282 / follow-up to #1288.

## What

Sanitization became per-read in #1288, which stopped reading and writing the persisted sanitized columns but kept them for one release for rollback safety (expand/contract). That release has shipped, so this drops them:

- `content_original_sanitized`, `content_cleaned_sanitized`, `content_sanitized_version`
- `full_content_original_sanitized`, `full_content_cleaned_sanitized`, `full_content_sanitized_version`

## Changes

- **`migrations/0104_drop_sanitized_columns.sql`** — `DROP VIEW visible_entries` → `ALTER TABLE entries DROP COLUMN ...` (×6) → recreate `visible_entries` without the columns (a column can't be dropped out from under a view). Journaled as idx 103.
- **`src/server/db/schema.ts`** — removed the six columns (marked `DEPRECATED (issue #1282)`) from both the `entries` table and the `visibleEntries` view definition.
- **`migrations/schema.sql`** — removed the column defs, their `lz4` compression `ALTER`s, and the view columns.

Reclaims roughly half of the entry-content TOAST storage. No running code reads these columns after #1288.

## Testing

- `pnpm typecheck` ✅
- `pnpm vitest run tests/unit/migrations-journal.test.ts` ✅ (every `.sql` is journaled)
- Migration applied cleanly to a fresh Postgres via `pnpm services`
- `tests/integration/{sanitized-entry-content,entries}.test.ts` ✅ (40 passed, exercises `visible_entries` and the per-read sanitize path against the migrated schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)