### PR TITLE
Show hour/minute in admin user last-active times

### DIFF
--- a/src/components/admin/AdminUsersContent.tsx
+++ b/src/components/admin/AdminUsersContent.tsx
@@ -48,6 +48,16 @@ function formatDate(date: Date): string {
   }).format(new Date(date));
 }
 
+function formatDateTime(date: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(date));
+}
+
 function truncateId(id: string): string {
   if (id.length <= 12) return id;
   return `${id.slice(0, 8)}...`;
@@ -118,9 +128,9 @@ function UserRow({ user }: { user: User }) {
       {/* Stats row */}
       <div className="ui-text-xs text-muted flex flex-wrap gap-x-4 gap-y-1 tabular-nums">
         <span>Member since {formatDate(user.createdAt)}</span>
-        <span>Last active: {user.lastActiveAt ? formatDate(user.lastActiveAt) : "Never"}</span>
+        <span>Last active: {user.lastActiveAt ? formatDateTime(user.lastActiveAt) : "Never"}</span>
         <span>
-          Last API/MCP use: {user.lastTokenUsedAt ? formatDate(user.lastTokenUsedAt) : "Never"}
+          Last API/MCP use: {user.lastTokenUsedAt ? formatDateTime(user.lastTokenUsedAt) : "Never"}
         </span>
         <span>
           Subscriptions:{" "}


### PR DESCRIPTION
## Summary

Admin user list now shows the **hour and minute** for the "Last active" and "Last API/MCP use" timestamps (previously date-only), so admins can gauge intra-day activity — e.g. estimating how many users a database migration would affect.

- Added a `formatDateTime` helper (`Intl.DateTimeFormat` with `hour`/`minute`) alongside the existing `formatDate`.
- "Member since" keeps the date-only format; only the two activity timestamps gain a time.

## Testing

- `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
