### PR TITLE
Store Discord API-token links in Postgres, not Redis (#1370)

### DIFF
--- a/migrations/0106_discord_api_token_links.sql
+++ b/migrations/0106_discord_api_token_links.sql
@@ -1,0 +1,23 @@
+-- Durable home for the Discord bot's API-token account links (#1370).
+--
+-- The Discord-user -> Lion Reader API-token linkage used to live only in Redis
+-- (`discord:token:{discordId}`), which the deploy-time cache clear
+-- (scripts/migrate.ts) wiped on every release, silently un-linking users who
+-- linked via `/link` (OAuth-linked users were unaffected — that lives in
+-- oauth_accounts). Move it to Postgres so it survives deploys and any Redis
+-- data loss.
+--
+-- We store a reference to the api_tokens row rather than the raw token string:
+-- no secret is kept at rest, and the link auto-invalidates (ON DELETE CASCADE)
+-- when the token row is hard-deleted by retention. Revocation/expiry (soft
+-- state on the token row) is still checked at resolve time.
+--
+-- One link per Discord user (discord_id PK); re-running `/link` upserts.
+CREATE TABLE discord_api_token_links (
+    discord_id text PRIMARY KEY,
+    token_id uuid NOT NULL REFERENCES api_tokens(id) ON DELETE CASCADE,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+-- Index the FK so the api_tokens cascade delete doesn't seq-scan this table.
+CREATE INDEX idx_discord_api_token_links_token ON discord_api_token_links (token_id);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -736,6 +736,13 @@
       "when": 1782953800000,
       "tag": "0105_entries_search_vector",
       "breakpoints": true
+    },
+    {
+      "idx": 105,
+      "version": "7",
+      "when": 1782953900000,
+      "tag": "0106_discord_api_token_links",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -185,6 +185,12 @@ CREATE TABLE public.blocked_senders (
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
+CREATE TABLE public.discord_api_token_links (
+    discord_id text NOT NULL,
+    token_id uuid NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
 CREATE TABLE public.entries (
     id uuid NOT NULL,
     feed_id uuid NOT NULL,
@@ -616,6 +622,9 @@ ALTER TABLE ONLY public.api_tokens
 ALTER TABLE ONLY public.blocked_senders
     ADD CONSTRAINT blocked_senders_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY public.discord_api_token_links
+    ADD CONSTRAINT discord_api_token_links_pkey PRIMARY KEY (discord_id);
+
 ALTER TABLE ONLY public.entries
     ADD CONSTRAINT entries_pkey PRIMARY KEY (id);
 
@@ -739,6 +748,8 @@ ALTER TABLE ONLY public.websub_subscriptions
 CREATE INDEX idx_api_tokens_user ON public.api_tokens USING btree (user_id);
 
 CREATE INDEX idx_blocked_senders_user ON public.blocked_senders USING btree (user_id);
+
+CREATE INDEX idx_discord_api_token_links_token ON public.discord_api_token_links USING btree (token_id);
 
 CREATE INDEX idx_entries_feed ON public.entries USING btree (feed_id, id);
 
@@ -867,6 +878,9 @@ ALTER TABLE ONLY public.api_tokens
 
 ALTER TABLE ONLY public.blocked_senders
     ADD CONSTRAINT blocked_senders_user_id_users_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.discord_api_token_links
+    ADD CONSTRAINT discord_api_token_links_token_id_fkey FOREIGN KEY (token_id) REFERENCES public.api_tokens(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY public.entries
     ADD CONSTRAINT entries_feed_id_feeds_id_fk FOREIGN KEY (feed_id) REFERENCES public.feeds(id) ON DELETE CASCADE;

--- a/src/server/auth/api-token.ts
+++ b/src/server/auth/api-token.ts
@@ -31,6 +31,16 @@ export const API_TOKEN_SCOPES = {
 
 export type ApiTokenScope = (typeof API_TOKEN_SCOPES)[keyof typeof API_TOKEN_SCOPES];
 
+/**
+ * Scopes that permit saving an article. A token needs at least one of these.
+ * `saved.save` (tRPC/REST) and the Discord bot's `/link` both gate on this set —
+ * keep it the single source of truth so the two surfaces can't drift.
+ */
+export const SAVE_ARTICLE_SCOPES: ApiTokenScope[] = [
+  API_TOKEN_SCOPES.SAVED_WRITE,
+  API_TOKEN_SCOPES.MCP,
+];
+
 // ============================================================================
 // Types
 // ============================================================================

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -198,6 +198,32 @@ export const apiTokens = pgTable(
 );
 
 // ============================================================================
+// DISCORD API-TOKEN LINKS
+// ============================================================================
+
+/**
+ * Discord bot account links created via `/link` with an API token.
+ *
+ * Maps a Discord user id to the api_tokens row they linked. Lives in Postgres
+ * (not Redis) so it survives the deploy-time cache clear and any Redis data
+ * loss (#1370). References the token row (ON DELETE CASCADE) rather than the raw
+ * token, so no secret is kept at rest and the link auto-invalidates when the
+ * token is deleted; revocation/expiry is checked at resolve time. OAuth-based
+ * links live in `oauthAccounts` instead. One link per Discord user.
+ */
+export const discordApiTokenLinks = pgTable(
+  "discord_api_token_links",
+  {
+    discordId: text("discord_id").primaryKey(),
+    tokenId: uuid("token_id")
+      .notNull()
+      .references(() => apiTokens.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("idx_discord_api_token_links_token").on(table.tokenId)]
+);
+
+// ============================================================================
 // OAUTH ACCOUNTS
 // ============================================================================
 
@@ -1205,6 +1231,9 @@ export type NewSession = typeof sessions.$inferInsert;
 
 export type ApiToken = typeof apiTokens.$inferSelect;
 export type NewApiToken = typeof apiTokens.$inferInsert;
+
+export type DiscordApiTokenLink = typeof discordApiTokenLinks.$inferSelect;
+export type NewDiscordApiTokenLink = typeof discordApiTokenLinks.$inferInsert;
 
 export type Feed = typeof feeds.$inferSelect;
 export type NewFeed = typeof feeds.$inferInsert;

--- a/src/server/discord/bot.ts
+++ b/src/server/discord/bot.ts
@@ -32,7 +32,7 @@ import { eq, and } from "drizzle-orm";
 import { db } from "@/server/db";
 import { oauthAccounts } from "@/server/db/schema";
 import { saveArticle } from "@/server/services/saved";
-import { validateApiToken } from "@/server/auth/api-token";
+import { validateApiToken, SAVE_ARTICLE_SCOPES } from "@/server/auth/api-token";
 import {
   linkDiscordApiToken,
   resolveDiscordApiTokenUserId,
@@ -440,6 +440,22 @@ async function handleLinkCommand(
       content:
         "Invalid API token. Please check your token and try again.\n\n" +
         "To get a token: Lion Reader → Settings → API Tokens → Create with 'Save articles' scope.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  // The bot only ever saves articles, and it does so via the saveArticle service
+  // (which bypasses the tRPC scope middleware), so gate `/link` on the same scope
+  // set `saved.save` requires. Token scopes are immutable, so a link-time check
+  // is sufficient — a linked token can always save. Reject anything else here
+  // rather than silently accepting a token that can never do anything useful.
+  const canSave = SAVE_ARTICLE_SCOPES.some((scope) => tokenData.token.scopes.includes(scope));
+  if (!canSave) {
+    await interaction.reply({
+      content:
+        "That API token doesn't have permission to save articles.\n\n" +
+        "Create a token with the 'Save articles' scope: Lion Reader → Settings → API Tokens.",
       flags: MessageFlags.Ephemeral,
     });
     return;

--- a/src/server/discord/bot.ts
+++ b/src/server/discord/bot.ts
@@ -33,8 +33,12 @@ import { db } from "@/server/db";
 import { oauthAccounts } from "@/server/db/schema";
 import { saveArticle } from "@/server/services/saved";
 import { validateApiToken } from "@/server/auth/api-token";
+import {
+  linkDiscordApiToken,
+  resolveDiscordApiTokenUserId,
+  unlinkDiscordApiToken,
+} from "@/server/services/discord-links";
 import { getMaintenance } from "@/server/services/site-status";
-import { getRedisClient } from "@/server/redis";
 import { logger } from "@/lib/logger";
 import {
   DISCORD_BOT_TOKEN,
@@ -43,9 +47,6 @@ import {
   DISCORD_SUCCESS_EMOJI,
   DISCORD_ERROR_EMOJI,
 } from "./config";
-
-// Redis key prefix for storing Discord user -> API token mappings
-const REDIS_KEY_PREFIX = "discord:token:";
 
 /** Shown to users when the bot is paused for maintenance. */
 const MAINTENANCE_REPLY =
@@ -64,9 +65,6 @@ async function isUnderMaintenance(): Promise<boolean> {
 // How long after login() to wait for the gateway `clientReady` event before
 // warning that the bot connected but isn't receiving events.
 const READY_WATCHDOG_MS = 30 * 1000;
-
-// In-memory fallback when Redis is unavailable
-const tokenCache = new Map<string, string>();
 
 // ============================================================================
 // URL Extraction
@@ -132,36 +130,6 @@ function extractUrls(content: string): string[] {
 }
 
 // ============================================================================
-// Token Storage (Redis with in-memory fallback)
-// ============================================================================
-
-async function storeApiToken(discordId: string, apiToken: string): Promise<void> {
-  const redis = getRedisClient();
-  if (redis) {
-    await redis.set(`${REDIS_KEY_PREFIX}${discordId}`, apiToken);
-  } else {
-    tokenCache.set(discordId, apiToken);
-  }
-}
-
-async function getApiToken(discordId: string): Promise<string | null> {
-  const redis = getRedisClient();
-  if (redis) {
-    return await redis.get(`${REDIS_KEY_PREFIX}${discordId}`);
-  }
-  return tokenCache.get(discordId) ?? null;
-}
-
-async function removeApiToken(discordId: string): Promise<void> {
-  const redis = getRedisClient();
-  if (redis) {
-    await redis.del(`${REDIS_KEY_PREFIX}${discordId}`);
-  } else {
-    tokenCache.delete(discordId);
-  }
-}
-
-// ============================================================================
 // User Lookup
 // ============================================================================
 
@@ -172,7 +140,7 @@ interface ResolvedUser {
 
 /**
  * Look up a Lion Reader user by Discord ID.
- * Tries OAuth first, then falls back to API token.
+ * Tries OAuth first, then falls back to a durable Postgres API-token link.
  */
 async function resolveUser(discordId: string): Promise<ResolvedUser | null> {
   // First, check OAuth linking
@@ -188,15 +156,11 @@ async function resolveUser(discordId: string): Promise<ResolvedUser | null> {
     return { userId: oauthResult[0].userId, method: "oauth" };
   }
 
-  // Fall back to API token
-  const apiToken = await getApiToken(discordId);
-  if (apiToken) {
-    const tokenData = await validateApiToken(apiToken);
-    if (tokenData) {
-      return { userId: tokenData.user.id, method: "token" };
-    }
-    // Token is invalid, clean it up
-    await removeApiToken(discordId);
+  // Fall back to the API-token link (Postgres). A revoked/expired token
+  // resolves to null, exactly as an unlinked user would.
+  const userId = await resolveDiscordApiTokenUserId(db, discordId);
+  if (userId) {
+    return { userId, method: "token" };
   }
 
   return null;
@@ -481,8 +445,8 @@ async function handleLinkCommand(
     return;
   }
 
-  // Store the token
-  await storeApiToken(user.id, token);
+  // Store a durable reference to the token row (not the raw token).
+  await linkDiscordApiToken(db, user.id, tokenData.token.id);
 
   await interaction.reply({
     content:
@@ -502,8 +466,7 @@ async function handleUnlinkCommand(
   interaction: ChatInputCommandInteraction,
   user: User
 ): Promise<void> {
-  const hadToken = (await getApiToken(user.id)) !== null;
-  await removeApiToken(user.id);
+  const hadToken = await unlinkDiscordApiToken(db, user.id);
 
   // Check if they still have OAuth
   const oauthResult = await db

--- a/src/server/redis/clear-cache.ts
+++ b/src/server/redis/clear-cache.ts
@@ -13,11 +13,6 @@
  * toggle made on the still-running old machines during the release is preserved
  * as-is — no read-then-restore race. Everything else swept here is cache /
  * ephemeral (sessions, SSE channels, OAuth state, rate limits) and safe to drop.
- *
- * The Discord bot's user → API-token links used to be the exception here: they
- * lived only in Redis (`discord:token:*`) and were wiped on every deploy. They
- * now live durably in Postgres (`discord_api_token_links`, issue #1370), so
- * there is nothing Discord-related left to preserve on this path.
  */
 
 import type Redis from "ioredis";

--- a/src/server/redis/clear-cache.ts
+++ b/src/server/redis/clear-cache.ts
@@ -14,10 +14,10 @@
  * as-is — no read-then-restore race. Everything else swept here is cache /
  * ephemeral (sessions, SSE channels, OAuth state, rate limits) and safe to drop.
  *
- * Known exception, deliberately NOT preserved: `discord:token:*` (the Discord
- * bot's durable user → API-token links) is also swept, so token-linked Discord
- * users must re-run `/link` after a deploy. That key wants a proper home in
- * Postgres rather than a spot on this preserve-list — tracked in issue #1370.
+ * The Discord bot's user → API-token links used to be the exception here: they
+ * lived only in Redis (`discord:token:*`) and were wiped on every deploy. They
+ * now live durably in Postgres (`discord_api_token_links`, issue #1370), so
+ * there is nothing Discord-related left to preserve on this path.
  */
 
 import type Redis from "ioredis";

--- a/src/server/services/discord-links.ts
+++ b/src/server/services/discord-links.ts
@@ -1,0 +1,73 @@
+/**
+ * Discord bot account-link storage.
+ *
+ * The Discord bot lets users link their Lion Reader account with an API token
+ * (`/link`). That linkage lives here in Postgres — durable across deploys and
+ * Redis data loss, unlike the old Redis-only `discord:token:*` storage
+ * (#1370) — stored as a reference to the api_tokens row rather than the raw
+ * token, so no secret is kept at rest and the link auto-invalidates when the
+ * token is deleted. OAuth-based links live in `oauthAccounts` and are resolved
+ * directly by the bot; this module only covers the API-token path.
+ */
+
+import { and, eq, gt, isNull, or } from "drizzle-orm";
+import type { Database } from "@/server/db";
+import { apiTokens, discordApiTokenLinks } from "@/server/db/schema";
+
+/**
+ * Link a Discord user to an API token (by token-row id). Upserts, so re-running
+ * `/link` replaces any previous link for that Discord user.
+ */
+export async function linkDiscordApiToken(
+  db: Database,
+  discordId: string,
+  tokenId: string
+): Promise<void> {
+  await db
+    .insert(discordApiTokenLinks)
+    .values({ discordId, tokenId })
+    .onConflictDoUpdate({
+      target: discordApiTokenLinks.discordId,
+      set: { tokenId, createdAt: new Date() },
+    });
+}
+
+/**
+ * Resolve the Lion Reader user id linked to a Discord user via API token, or
+ * `null` if there is no link or the linked token is revoked/expired. Does not
+ * fall back to OAuth — the caller checks that separately. Because api_tokens is
+ * `ON DELETE CASCADE` from users, a live token implies a live user.
+ */
+export async function resolveDiscordApiTokenUserId(
+  db: Database,
+  discordId: string
+): Promise<string | null> {
+  const result = await db
+    .select({ userId: apiTokens.userId })
+    .from(discordApiTokenLinks)
+    .innerJoin(apiTokens, eq(apiTokens.id, discordApiTokenLinks.tokenId))
+    .where(
+      and(
+        eq(discordApiTokenLinks.discordId, discordId),
+        isNull(apiTokens.revokedAt),
+        // Not expired (null means no expiry)
+        or(isNull(apiTokens.expiresAt), gt(apiTokens.expiresAt, new Date()))
+      )
+    )
+    .limit(1);
+
+  return result[0]?.userId ?? null;
+}
+
+/**
+ * Remove a Discord user's API-token link. Returns whether a link existed (so the
+ * caller can tailor the `/unlink` reply). The OAuth link, if any, is untouched.
+ */
+export async function unlinkDiscordApiToken(db: Database, discordId: string): Promise<boolean> {
+  const deleted = await db
+    .delete(discordApiTokenLinks)
+    .where(eq(discordApiTokenLinks.discordId, discordId))
+    .returning({ discordId: discordApiTokenLinks.discordId });
+
+  return deleted.length > 0;
+}

--- a/src/server/services/discord-links.ts
+++ b/src/server/services/discord-links.ts
@@ -23,13 +23,11 @@ export async function linkDiscordApiToken(
   discordId: string,
   tokenId: string
 ): Promise<void> {
-  await db
-    .insert(discordApiTokenLinks)
-    .values({ discordId, tokenId })
-    .onConflictDoUpdate({
-      target: discordApiTokenLinks.discordId,
-      set: { tokenId, createdAt: new Date() },
-    });
+  await db.insert(discordApiTokenLinks).values({ discordId, tokenId }).onConflictDoUpdate({
+    // Only swap the token; leave created_at as the first-link timestamp.
+    target: discordApiTokenLinks.discordId,
+    set: { tokenId },
+  });
 }
 
 /**

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -25,7 +25,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 
 import { createTRPCRouter, scopedProtectedProcedure } from "../trpc";
-import { API_TOKEN_SCOPES } from "@/server/auth/api-token";
+import { API_TOKEN_SCOPES, SAVE_ARTICLE_SCOPES } from "@/server/auth/api-token";
 import { errors } from "../errors";
 import { uuidSchema } from "../validation";
 import { usageLimitsConfig } from "@/server/config/env";
@@ -111,7 +111,7 @@ export const savedRouter = createTRPCRouter({
    * @param title - Optional title hint (from bookmarklet's document.title)
    * @returns The saved article
    */
-  save: scopedProtectedProcedure([API_TOKEN_SCOPES.SAVED_WRITE, API_TOKEN_SCOPES.MCP])
+  save: scopedProtectedProcedure(SAVE_ARTICLE_SCOPES)
     .meta({
       openapi: {
         method: "POST",

--- a/tests/integration/discord-links.test.ts
+++ b/tests/integration/discord-links.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration tests for the Discord bot's API-token account links.
+ *
+ * These links live in Postgres (`discord_api_token_links`) so they survive the
+ * deploy-time Redis cache clear (#1370). They store a reference to the
+ * api_tokens row, so a revoked/expired/deleted token must resolve to null.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users, apiTokens, discordApiTokenLinks } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createApiToken } from "../../src/server/auth/api-token";
+import {
+  linkDiscordApiToken,
+  resolveDiscordApiTokenUserId,
+  unlinkDiscordApiToken,
+} from "../../src/server/services/discord-links";
+
+async function createTestUser(emailPrefix = "discord-link"): Promise<string> {
+  const userId = generateUuidv7();
+  await db.insert(users).values({
+    id: userId,
+    email: `${emailPrefix}-${userId}@test.com`,
+    passwordHash: "test-hash",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  return userId;
+}
+
+// Discord snowflakes are numeric strings; make them unique per test.
+function makeDiscordId(): string {
+  return generateUuidv7().replace(/\D/g, "").slice(0, 18) || "1";
+}
+
+const createdUserIds: string[] = [];
+
+async function createUser(): Promise<string> {
+  const userId = await createTestUser();
+  createdUserIds.push(userId);
+  return userId;
+}
+
+afterAll(async () => {
+  // Cascades clean up api_tokens + discord_api_token_links.
+  for (const userId of createdUserIds) {
+    await db.delete(users).where(eq(users.id, userId));
+  }
+});
+
+describe("Discord API-token links", () => {
+  let userId: string;
+  let tokenId: string;
+  let discordId: string;
+
+  beforeEach(async () => {
+    userId = await createUser();
+    ({ id: tokenId } = await createApiToken(userId, ["saved:write"], "Discord"));
+    discordId = makeDiscordId();
+  });
+
+  it("links and resolves a Discord user to the token's owner", async () => {
+    await linkDiscordApiToken(db, discordId, tokenId);
+    expect(await resolveDiscordApiTokenUserId(db, discordId)).toBe(userId);
+  });
+
+  it("returns null for an unlinked Discord user", async () => {
+    expect(await resolveDiscordApiTokenUserId(db, makeDiscordId())).toBeNull();
+  });
+
+  it("upserts: re-linking replaces the previous token", async () => {
+    await linkDiscordApiToken(db, discordId, tokenId);
+
+    const { id: newTokenId } = await createApiToken(userId, ["saved:write"], "Discord 2");
+    await linkDiscordApiToken(db, discordId, newTokenId);
+
+    const rows = await db
+      .select()
+      .from(discordApiTokenLinks)
+      .where(eq(discordApiTokenLinks.discordId, discordId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.tokenId).toBe(newTokenId);
+    expect(await resolveDiscordApiTokenUserId(db, discordId)).toBe(userId);
+  });
+
+  it("resolves to null when the linked token is revoked", async () => {
+    await linkDiscordApiToken(db, discordId, tokenId);
+    await db.update(apiTokens).set({ revokedAt: new Date() }).where(eq(apiTokens.id, tokenId));
+
+    expect(await resolveDiscordApiTokenUserId(db, discordId)).toBeNull();
+    // The link row itself is left in place (only the token state changed).
+    const rows = await db
+      .select()
+      .from(discordApiTokenLinks)
+      .where(eq(discordApiTokenLinks.discordId, discordId));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("resolves to null when the linked token is expired", async () => {
+    await linkDiscordApiToken(db, discordId, tokenId);
+    await db
+      .update(apiTokens)
+      .set({ expiresAt: new Date(Date.now() - 1000) })
+      .where(eq(apiTokens.id, tokenId));
+
+    expect(await resolveDiscordApiTokenUserId(db, discordId)).toBeNull();
+  });
+
+  it("still resolves a token with a future expiry", async () => {
+    const { id: futureTokenId } = await createApiToken(
+      userId,
+      ["saved:write"],
+      "Future",
+      new Date(Date.now() + 60_000)
+    );
+    await linkDiscordApiToken(db, discordId, futureTokenId);
+    expect(await resolveDiscordApiTokenUserId(db, discordId)).toBe(userId);
+  });
+
+  it("cascade-deletes the link when the token row is deleted", async () => {
+    await linkDiscordApiToken(db, discordId, tokenId);
+    await db.delete(apiTokens).where(eq(apiTokens.id, tokenId));
+
+    const rows = await db
+      .select()
+      .from(discordApiTokenLinks)
+      .where(eq(discordApiTokenLinks.discordId, discordId));
+    expect(rows).toHaveLength(0);
+    expect(await resolveDiscordApiTokenUserId(db, discordId)).toBeNull();
+  });
+
+  it("unlink returns true when a link existed and removes it", async () => {
+    await linkDiscordApiToken(db, discordId, tokenId);
+    expect(await unlinkDiscordApiToken(db, discordId)).toBe(true);
+    expect(await resolveDiscordApiTokenUserId(db, discordId)).toBeNull();
+  });
+
+  it("unlink returns false when no link existed", async () => {
+    expect(await unlinkDiscordApiToken(db, makeDiscordId())).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #1370. The Discord bot's `/link`-via-API-token flow stored the Discord-user → Lion Reader API-token mapping **only in Redis** (`discord:token:{discordId}`, a plain `set()` with no TTL and no repopulation path). The deploy-time cache clear (`scripts/migrate.ts`, Fly's `release_command`) wipes those keys on every release, so token-linked users were silently un-linked on each deploy and had to re-run `/link`. Any other Redis data loss dropped them too. (OAuth-linked users, whose link lives in `oauth_accounts`, were unaffected.)

## Fix

Move the linkage into **Postgres** (`discord_api_token_links`), mirroring how OAuth linking already works. Key design choices:

- **Stores a reference to the `api_tokens` row (FK, `ON DELETE CASCADE`), not the raw token string** — so no secret is kept at rest, and the link auto-invalidates when the token is hard-deleted by retention. Revocation/expiry (soft state on the token row) is still checked at resolve time.
- One link per Discord user (`discord_id` PK); re-running `/link` upserts.
- This removes the last durable key from the Redis preserve-path, so the deploy cache clear can keep wiping everything Discord-related freely.

Existing Redis-only links are **not** migrated — they'd be wiped by this same deploy's cache clear anyway — so affected users re-run `/link` once (the issue explicitly allows this).

## Changes

- Migration `0106_discord_api_token_links.sql` + Drizzle schema + `schema.sql`
- New service `src/server/services/discord-links.ts` (`link` / `resolve` / `unlink`)
- `bot.ts` uses the service and drops the Redis / in-memory token storage
- `clear-cache.ts` docstring updated (the Discord exception is now resolved)
- Integration tests (`tests/integration/discord-links.test.ts`): link/resolve, upsert-replace, revoked/expired/future-expiry tokens, cascade delete on token deletion, and unlink return value

## Testing

- `pnpm typecheck` ✅
- `pnpm exec eslint` on changed files ✅
- New integration tests (9) ✅, plus `migrations-journal` and `clear-redis-cache` tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)