### PR TITLE
Announcement post: faster DB, search, and flexible AI (#1375)

### DIFF
--- a/blog/_posts/2026-07-18-faster-database-search-and-flexible-ai.md
+++ b/blog/_posts/2026-07-18-faster-database-search-and-flexible-ai.md
@@ -1,0 +1,31 @@
+---
+title: "A Faster Database, Search Is Back, and Bring-Your-Own AI"
+date: 2026-07-18
+author: Brendan Long
+---
+
+Three updates went out today, all aimed at making Lion Reader faster and more flexible.
+
+## A much faster database
+
+Lion Reader's database now runs on a much faster host. If you ran into occasional slowness before — lists taking a beat to load, an action hanging for a moment — that should be gone now. Sorry for the brief downtime while we moved it over this morning.
+
+The move also means we can scale the database up almost instantly from here on. If we ever need a bigger, faster machine, it won't take the kind of downtime it used to.
+
+## Full-text search is back
+
+Directly on the back of that faster database, we've **re-enabled [full-text search](https://lionreader.com/demo/all?entry=search)**. Press <strong>/</strong> or tap the search icon and start typing — Lion Reader searches every article in your archive by title and full text, and results come back near-instantly with the closest matches first.
+
+Search understands word variations (a search for "cook" also finds "cooking" and "cooked"), keeps whatever view you're already in — a subscription, a [tag](https://lionreader.com/demo/all?entry=tags), your [saved articles](https://lionreader.com/demo/all?entry=save-for-later), or starred items — and works everywhere you read, including through AI assistants via the [MCP server](https://lionreader.com/demo/all?entry=mcp-server).
+
+## Bring your own AI model
+
+We rebuilt the AI backend so it's no longer tied to a single provider. If you add an API key, you can now pick **any Groq, Anthropic, or Cerebras model for [summaries](https://lionreader.com/demo/all?entry=ai-summaries)**, and **any Groq or Cerebras model for [narration](https://lionreader.com/demo/all?entry=text-to-speech) cleanup** (the text preprocessing that makes articles sound natural when read aloud). Set your keys and preferred models under Settings → AI &amp; Narration.
+
+Our recommendation for most people is **[GPT-OSS-120B](https://openai.com/index/introducing-gpt-oss/) on [Cerebras](https://www.cerebras.ai/)**: summaries come back near-instantly, at roughly a tenth of the price of Claude Sonnet. It's not quite as sharp as Claude for the trickiest articles, but for triaging a reading list the speed and price are hard to beat. [Groq](https://groq.com/) offers some cheaper options too, though their paid tier looks to be waitlisted at the moment. And if you'd rather have the smartest possible summaries, [Anthropic's Claude](https://www.anthropic.com/) models are still there.
+
+As always, summaries and narration are only generated when you ask for them, and results are cached and shared across users so you rarely pay for the same article twice.
+
+---
+
+This feed only gets major announcements. For weekly detailed updates, subscribe to the [GitHub releases feed](https://github.com/brendanlong/lion-reader/releases.atom), and please [report bugs or feature requests on GitHub](https://github.com/brendanlong/lion-reader/issues) or [email me](mailto:self@brendanlong.com).

--- a/blog/_posts/2026-07-18-faster-database-search-and-flexible-ai.md
+++ b/blog/_posts/2026-07-18-faster-database-search-and-flexible-ai.md
@@ -20,7 +20,7 @@ Search understands word variations (a search for "cook" also finds "cooking" and
 
 ## Bring your own AI model
 
-We rebuilt the AI backend so it's no longer tied to a single provider. If you add an API key, you can now pick **any Groq, Anthropic, or Cerebras model for [summaries](https://lionreader.com/demo/all?entry=ai-summaries)**, and **any Groq or Cerebras model for [narration](https://lionreader.com/demo/all?entry=text-to-speech) cleanup** (the text preprocessing that makes articles sound natural when read aloud). Set your keys and preferred models under Settings → AI &amp; Narration.
+We rebuilt the AI backend so it's no longer tied to a single provider. If you add an API key, you can now pick **any Groq, Anthropic, or Cerebras model for [summaries](https://lionreader.com/demo/all?entry=ai-summaries)**, and **any Groq or Cerebras model for [narration](https://lionreader.com/demo/all?entry=text-to-speech) cleanup** (the text preprocessing that makes articles sound natural when read aloud). Set your keys and preferred models under Settings → AI & Narration.
 
 Our recommendation for most people is **[GPT-OSS-120B](https://openai.com/index/introducing-gpt-oss/) on [Cerebras](https://www.cerebras.ai/)**: summaries come back near-instantly, at roughly a tenth of the price of Claude Sonnet. It's not quite as sharp as Claude for the trickiest articles, but for triaging a reading list the speed and price are hard to beat. [Groq](https://groq.com/) offers some cheaper options too, though their paid tier looks to be waitlisted at the moment. And if you'd rather have the smartest possible summaries, [Anthropic's Claude](https://www.anthropic.com/) models are still there.
 

--- a/src/app/(public)/demo/articles/ai-summaries.ts
+++ b/src/app/(public)/demo/articles/ai-summaries.ts
@@ -24,9 +24,13 @@ const article: DemoArticle = {
 
     <h3>Privacy-Respecting Design</h3>
 
-    <p>Unlike some readers that automatically summarize everything (consuming API credits and sharing your reading habits), Lion Reader only generates summaries when you explicitly request them. Click the &ldquo;Summarize&rdquo; button in the article header, and <a href="https://www.anthropic.com/" target="_blank" rel="noopener noreferrer">Anthropic Claude</a> generates a concise overview focusing on the main topic, key findings, and important conclusions.</p>
+    <p>Unlike some readers that automatically summarize everything (consuming API credits and sharing your reading habits), Lion Reader only generates summaries when you explicitly request them. Click the &ldquo;Summarize&rdquo; button in the article header, and your chosen model generates a concise overview focusing on the main topic, key findings, and important conclusions.</p>
 
     <p>The summary appears in a collapsible card above the article content. You can expand or collapse it as needed, or dismiss it entirely if you decide to read the full article instead.</p>
+
+    <h3>Bring Your Own Model</h3>
+
+    <p>Add an API key under Settings &rarr; AI &amp; Narration and pick any model from <a href="https://groq.com/" target="_blank" rel="noopener noreferrer">Groq</a>, <a href="https://www.anthropic.com/" target="_blank" rel="noopener noreferrer">Anthropic</a>, or <a href="https://www.cerebras.ai/" target="_blank" rel="noopener noreferrer">Cerebras</a>. For most people we recommend <a href="https://openai.com/index/introducing-gpt-oss/" target="_blank" rel="noopener noreferrer">GPT-OSS-120B</a> on Cerebras &mdash; summaries come back near-instantly at roughly a tenth of the price of Claude Sonnet &mdash; but Anthropic&rsquo;s Claude models are there when you want the sharpest possible summary.</p>
 
     <h3>Efficient Caching</h3>
 

--- a/src/app/(public)/demo/articles/text-to-speech.ts
+++ b/src/app/(public)/demo/articles/text-to-speech.ts
@@ -25,7 +25,7 @@ const article: DemoArticle = {
 
     <h3>Stage 1: AI Text Preprocessing</h3>
 
-    <p>Raw article HTML isn&rsquo;t ready for text-to-speech. Abbreviations like &ldquo;Dr.&rdquo; get mispronounced, URLs sound terrible when read aloud, and technical notation confuses speech engines. To solve this, Lion Reader first sends article content through an LLM (<a href="https://openai.com/index/introducing-gpt-oss/" target="_blank" rel="noopener noreferrer">GPT-OSS</a> via <a href="https://groq.com/" target="_blank" rel="noopener noreferrer">Groq</a>) that transforms the text for natural narration.</p>
+    <p>Raw article HTML isn&rsquo;t ready for text-to-speech. Abbreviations like &ldquo;Dr.&rdquo; get mispronounced, URLs sound terrible when read aloud, and technical notation confuses speech engines. To solve this, Lion Reader first sends article content through a fast LLM (<a href="https://openai.com/index/introducing-gpt-oss/" target="_blank" rel="noopener noreferrer">GPT-OSS-120B</a> by default, on <a href="https://www.cerebras.ai/" target="_blank" rel="noopener noreferrer">Cerebras</a> or <a href="https://groq.com/" target="_blank" rel="noopener noreferrer">Groq</a> &mdash; your pick under Settings &rarr; AI &amp; Narration) that transforms the text for natural narration.</p>
 
     <p>The AI expands abbreviations (&ldquo;Dr.&rdquo; becomes &ldquo;Doctor&rdquo;), converts URLs to readable phrases, formats lists and tables as natural language, and handles code blocks with clear verbal markers. Crucially, it maintains paragraph-level mapping so the app can synchronize highlighting as the audio plays. This preprocessing is cached by content hash, so the same article is only processed once &mdash; even if multiple users narrate it.</p>
 


### PR DESCRIPTION
Closes #1375.

## What

Adds a new [announcements blog](https://announcements.lionreader.com) post covering the three July 18th updates, and refreshes the two demo articles the changes touch.

### New announcement post
`blog/_posts/2026-07-18-faster-database-search-and-flexible-ai.md`:
- **Faster database** — moved to a much faster host (apologizes for the brief morning downtime), and can now scale up near-instantly.
- **Full-text search re-enabled** (#1249) — near-instant, scoped to your current view, works via MCP too.
- **Bring-your-own AI model** (#1322) — any Groq/Anthropic/Cerebras model for summaries, any Groq/Cerebras model for narration cleanup; recommends GPT-OSS-120B on Cerebras (near-instant, ~1/10 the price of Claude Sonnet), notes Groq's paid tier is currently waitlisted.

### Demo article refreshes
- `ai-summaries.ts`: no longer says summaries are Anthropic-only; adds a "Bring Your Own Model" section (Groq/Anthropic/Cerebras).
- `text-to-speech.ts`: narration cleanup now defaults to GPT-OSS-120B on Cerebras (or Groq), not "GPT-OSS via Groq".

## Verification
- Facts cross-checked against the code: `ai-providers.ts` (summaries: anthropic/groq/cerebras), `narration.ts` + `narration/constants.ts` (cleanup: groq/cerebras, default `cerebras:gpt-oss-120b`), search re-enable (#1371/#1249), settings label "AI & Narration".
- `pnpm typecheck` and Prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)