### PR TITLE
Fix markdown `...` frontmatter closer; stop preferring markdown in full-content fetch (#1280)

### DIFF
--- a/src/server/http/fetch.ts
+++ b/src/server/http/fetch.ts
@@ -291,10 +291,17 @@ const FEED_ACCEPT_HEADER =
 
 /**
  * Accept header for HTML page requests.
- * Prefers Markdown (text/markdown) but also accepts HTML.
+ *
+ * We deliberately do NOT advertise a preference for `text/markdown`. Some sites
+ * (Quartz/turntrout, gwern.net) honor `Accept: text/markdown` by returning a
+ * whole-page markdown dump or Pandoc-flavored markdown that our GFM converter
+ * mangles — leaking page chrome, dropping content, and losing article structure
+ * Readability would otherwise recover (#1280). Requesting HTML like a browser
+ * lets Readability do article extraction. The trailing wildcard still lets a
+ * markdown-only endpoint (e.g. a raw `.md` URL) respond with markdown, which the
+ * caller detects via Content-Type and converts as a fallback.
  */
-const HTML_ACCEPT_HEADER =
-  "text/markdown,text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
+const HTML_ACCEPT_HEADER = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
 
 // ============================================================================
 // Fetch Utilities
@@ -364,8 +371,10 @@ export interface FetchHtmlPageResult {
 /**
  * Fetches an HTML page with appropriate settings.
  *
- * Uses a longer timeout (30s) and HTML Accept header.
- * Prefers Markdown if available, but accepts HTML.
+ * Uses a longer timeout (30s) and an HTML Accept header. Requests HTML (not
+ * Markdown — see HTML_ACCEPT_HEADER / #1280), but still reports `isMarkdown`
+ * when a server returns markdown anyway (e.g. a raw `.md` URL) so the caller
+ * can convert it as a fallback.
  *
  * @param url - The URL to fetch
  * @returns The content and whether it's Markdown

--- a/src/server/markdown/index.ts
+++ b/src/server/markdown/index.ts
@@ -33,9 +33,14 @@ interface FrontmatterResult {
   content: string;
 }
 
-// Regex to match YAML frontmatter at the start of a document
-// Must start with --- on its own line, end with --- on its own line
-const FRONTMATTER_REGEX = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
+// Regex to match YAML frontmatter at the start of a document.
+// Must start with --- on its own line, and end with either --- or ... on its
+// own line. YAML uses `...` as an explicit end-of-document marker, and tools
+// like Pandoc (e.g. gwern.net) close frontmatter with it. Accepting only `---`
+// as the closer made the lazy body matcher run past a `...` terminator and latch
+// onto the first later `---` thematic break, silently swallowing the whole intro
+// as "frontmatter" (see #1280).
+const FRONTMATTER_REGEX = /^---[ \t]*\r?\n([\s\S]*?)\r?\n(?:---|\.\.\.)[ \t]*(?:\r?\n|$)/;
 
 /**
  * Extracts and parses YAML frontmatter from Markdown content.

--- a/src/server/services/full-content.ts
+++ b/src/server/services/full-content.ts
@@ -118,8 +118,11 @@ export async function fetchFullContent(
     const result = await fetchHtmlPage(url);
     const resolveUrl = result.finalUrl;
 
-    // If we got Markdown, convert it to HTML and skip Readability
-    // Markdown is already clean content, no need for article extraction
+    // We request HTML, not Markdown (#1280), so this is a fallback: a server
+    // returned Markdown anyway (e.g. a raw `.md` URL). Convert it to HTML and
+    // skip Readability — a markdown-only endpoint's body is the content itself,
+    // and once flattened to markdown the DOM structure Readability needs to
+    // separate chrome from content is already gone.
     if (result.isMarkdown) {
       logger.debug("Converting Markdown to HTML (skipping Readability)", { url });
       const { html: contentCleaned } = await processMarkdown(result.content);

--- a/tests/unit/markdown.test.ts
+++ b/tests/unit/markdown.test.ts
@@ -180,6 +180,45 @@ Content here.`;
     expect(result.content).toBe("\nContent here.");
   });
 
+  it("closes frontmatter on a `...` end-of-document marker (#1280)", () => {
+    // gwern.net / Pandoc close YAML frontmatter with `...`, not `---`. Accepting
+    // only `---` made the lazy matcher run past this terminator to the first
+    // later `---` thematic break, swallowing the intro as frontmatter.
+    const markdown = `---
+title: Catapulting
+confidence: unlikely
+...
+
+Intro paragraph that must survive.
+
+# Intelligence, Broadly
+
+A scaling-centric view.
+
+---
+
+# Anomalies`;
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.title).toBe("Catapulting");
+    // The intro, the heading, and the thematic break all remain in the body.
+    expect(result.content).toContain("Intro paragraph that must survive.");
+    expect(result.content).toContain("# Intelligence, Broadly");
+    expect(result.content).toContain("A scaling-centric view.");
+    // The `---` thematic break is body content, not a frontmatter closer.
+    expect(result.content).toContain("\n---\n");
+    // The YAML must not leak into the body.
+    expect(result.content).not.toContain("confidence: unlikely");
+  });
+
+  it("handles `...` end marker with CRLF line endings (#1280)", () => {
+    const markdown = "---\r\ntitle: Windows Dots\r\n...\r\n\r\nBody content.";
+
+    const result = extractFrontmatter(markdown);
+    expect(result.frontmatter?.title).toBe("Windows Dots");
+    expect(result.content).toBe("\r\nBody content.");
+  });
+
   it("requires frontmatter at document start", () => {
     const markdown = `Some text before
 
@@ -383,6 +422,40 @@ The full content of the article.`;
     expect(result.summary).toBe("A brief summary.");
     expect(result.author).toBe("Jane Smith");
     expect(result.html).toContain("full content");
+  });
+
+  it("keeps the intro when frontmatter is closed with `...` (#1280)", async () => {
+    // Regression: gwern-style frontmatter (`...` closer) followed by an intro,
+    // a heading, and a `---` thematic break. The intro must not be swallowed.
+    const markdown = `---
+title: Catapulting
+importance: 10
+...
+
+<div class="abstract">
+An abstract summarizing the article.
+</div>
+
+Because deep learning has continued to scale up, the intro begins here.
+
+# Intelligence, Broadly
+
+A scaling-centric view might be summed up like this:
+
+---
+
+# Anomalies
+
+But this paradigm doesn't explain everything.`;
+
+    const result = await processMarkdown(markdown);
+    expect(result.title).toBe("Catapulting");
+    expect(result.html).toContain("An abstract summarizing the article.");
+    expect(result.html).toContain("the intro begins here");
+    expect(result.html).toContain("Intelligence, Broadly");
+    expect(result.html).toContain("Anomalies");
+    // The YAML metadata must not leak into the rendered body.
+    expect(result.html).not.toContain("importance:");
   });
 
   it("handles frontmatter with unquoted colons in values (#818)", async () => {


### PR DESCRIPTION
## Summary

Two related fixes for `#1280`, in one PR because they touch the same markdown/full-content path and the frontmatter bug affects both markdown uploads and markdown HTTP responses.

### 1. Frontmatter regex: recognize YAML's `...` end-of-document marker

`extractFrontmatter` only accepted `---` as the closing fence. gwern.net / Pandoc close YAML frontmatter with `...`, so the lazy body matcher ran **past** the real terminator and latched onto the first later `---` thematic break — silently discarding the entire intro (abstract, opening paragraphs, first heading/section) as "frontmatter".

Concretely, for `https://gwern.net/llm-catapult` the rendered body began at the "Anomalies" section; the abstract, intro, and "Intelligence, Broadly" section were gone. **`marked` was not at fault — a raw `<div>` passes through fine; the content was already stripped before `marked` saw it.**

Fix: accept `---` **or** `...` as the closer. This is independent of content negotiation — it also affected uploaded `.md` files and markdown-only endpoints.

### 2. Full-content Accept header: stop preferring `text/markdown`

We advertised `Accept: text/markdown,text/html,…`. Sites that honor it return content our GFM (`marked`) converter can't handle:
- **Quartz/turntrout**: whole-page markdown dumps → nav/tags/"about"/ToC chrome leaks into the article.
- **gwern**: Pandoc-flavored markdown → inline footnotes `^[…]` dumped mid-paragraph, `!W`/`{.attr}` syntax leaking as literal text, `{.include}` transclusions silently dropped.

In both cases we also **skip Readability**, so none of it gets cleaned. We now request HTML like a browser and let Readability do article extraction (verified: on gwern's HTML, Readability keeps the full intro, correct order, and even the server-rendered transclusion content).

The trailing wildcard still lets a markdown-only endpoint (raw `.md`) respond with markdown, which is detected via `Content-Type` and converted as a fallback — that branch is retained.

## Tests

- `extractFrontmatter`: `...` closer strips YAML but keeps a later `---` thematic break as body (plain + CRLF).
- `processMarkdown`: gwern-style input (`...` closer, abstract div, intro, `---` break) keeps the intro end-to-end.
- Full unit suite: 2538 pass; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)