### PR TITLE
mcp(upload_article): clarify that the title is plain text (not HTML)

### DIFF
--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -176,8 +176,18 @@ const uploadArticleArgs = z.object({
   content: z
     .string()
     .min(1)
-    .describe("Article content in Markdown format (GitHub Flavored Markdown supported)"),
-  title: z.string().min(1).describe("Article title"),
+    .describe(
+      "Article content in GitHub Flavored Markdown. Supports footnotes ([^1] … [^1]: …) " +
+        "and math ($…$ inline, $$…$$ display). This is Markdown, not HTML — pass raw " +
+        "characters and do NOT HTML-escape (write & < >, not &amp; &lt; &gt;)."
+    ),
+  title: z
+    .string()
+    .min(1)
+    .describe(
+      "Article title as plain text. Do NOT HTML-escape it (write & not &amp;) — it is " +
+        "rendered as text, so entities would show up literally."
+    ),
 });
 
 const listSubscriptionsArgs = z.object({

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -178,15 +178,16 @@ const uploadArticleArgs = z.object({
     .min(1)
     .describe(
       "Article content in GitHub Flavored Markdown. Supports footnotes ([^1] … [^1]: …) " +
-        "and math ($…$ inline, $$…$$ display). This is Markdown, not HTML — pass raw " +
-        "characters and do NOT HTML-escape (write & < >, not &amp; &lt; &gt;)."
+        "and math ($…$ inline, $$…$$ display). Standard CommonMark: raw characters and " +
+        "HTML entities both work in the body (& and &amp; both render as &)."
     ),
   title: z
     .string()
     .min(1)
     .describe(
-      "Article title as plain text. Do NOT HTML-escape it (write & not &amp;) — it is " +
-        "rendered as text, so entities would show up literally."
+      "Article title as plain text (NOT Markdown or HTML). Do NOT HTML-escape it — write " +
+        "& not &amp;, since the title is rendered as literal text and an entity like " +
+        "&amp; would show up verbatim."
     ),
 });
 


### PR DESCRIPTION
## Summary

While testing #1385 I uploaded an article via the MCP `upload_article` tool and habitually HTML-escaped the **title** (`&amp;` for `&`). The title is a plain-text field rendered as literal text (not HTML — this is the standard/deliberate behavior for feed-controlled text, per SECURITY.md), so the literal `&amp;` got stored and displays verbatim.

This clarifies the parameter descriptions:

- **title**: "plain text (NOT Markdown or HTML). Do NOT HTML-escape — write `&` not `&amp;`, since the title is rendered as literal text."
- **content**: notes it's GitHub Flavored Markdown and now supports **footnotes** and **math** (#1385). Entities are **not** a problem here — marked is CommonMark-compliant, so raw `&` and `&amp;` both render as `&`, and `&lt;`/`&copy;`/numeric refs decode correctly.

### Note

My first pass over-corrected and told callers not to HTML-escape *content* too (even "write `<` not `&lt;`"). That's wrong — entities work fine in the Markdown body (verified against the real pipeline). The no-escape rule only applies to the title. The second commit fixes that.

Doc-only change to two `.describe()` strings; typecheck + lint clean.

Related: #1386 (excerpt/summary math-doubling, separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)