### PR TITLE
Fix: drop MathML TeX annotation from plain-text excerpts (#1386)

### DIFF
--- a/src/server/html/strip-html.ts
+++ b/src/server/html/strip-html.ts
@@ -40,8 +40,15 @@ const BLOCK_TAGS = new Set([
 
 /**
  * Tags whose content should be skipped entirely.
+ *
+ * `annotation`/`annotation-xml` hold MathML's alternate encodings (e.g. the raw
+ * TeX that KaTeX emits alongside its presentation MathML). Including them would
+ * duplicate each equation in the plain-text excerpt — once from the presentation
+ * glyphs and once from the TeX annotation (#1386) — so we drop their content,
+ * mirroring the read-path sanitizer's DROP_WITH_CONTENT policy. Feed math
+ * (MathJax→MathML) has no annotation, so this is a no-op there.
  */
-const SKIP_TAGS = new Set(["script", "style", "head"]);
+const SKIP_TAGS = new Set(["script", "style", "head", "annotation", "annotation-xml"]);
 
 /**
  * Extracts text from HTML with proper spacing between block elements.

--- a/tests/unit/entry-summary.test.ts
+++ b/tests/unit/entry-summary.test.ts
@@ -108,6 +108,34 @@ describe("stripHtml", () => {
     });
   });
 
+  describe("MathML annotations", () => {
+    // KaTeX (output: "mathml") emits presentation MathML *plus* an
+    // <annotation encoding="application/x-tex"> holding the raw TeX. Without
+    // dropping the annotation, the equation appears twice in the excerpt (#1386).
+    it("drops the TeX annotation so the equation is not duplicated", () => {
+      const html =
+        "<p>The formula <math><semantics><mrow><mi>E</mi><mo>=</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow>" +
+        '<annotation encoding="application/x-tex">E = mc^2</annotation></semantics></math> is famous.</p>';
+      const result = stripHtml(html, 300);
+      expect(result).not.toContain("E = mc^2");
+      expect(result).toBe("The formula E=mc2 is famous.");
+    });
+
+    it("drops annotation-xml content too", () => {
+      const html =
+        "<p>Value <math><semantics><mrow><mi>x</mi></mrow>" +
+        '<annotation-xml encoding="MathML-Content"><ci>x</ci></annotation-xml></semantics></math> here.</p>';
+      const result = stripHtml(html, 300);
+      expect(result).toBe("Value x here.");
+    });
+
+    it("keeps presentation glyphs from feed math (no annotation)", () => {
+      const html =
+        "<p>Range <math><mrow><mi>μ</mi><mo>±</mo><mn>2</mn><mi>σ</mi></mrow></math> shown.</p>";
+      expect(stripHtml(html, 300)).toBe("Range μ±2σ shown.");
+    });
+  });
+
   describe("HTML entity decoding", () => {
     it("decodes common HTML entities", () => {
       const html = "<p>Rock &amp; Roll</p>";


### PR DESCRIPTION
## Summary

Fixes #1386. Uploaded Markdown containing `$…$` / `$$…$$` math had its list-view excerpt / stored summary duplicate each equation (e.g. `E=mc2E = mc^2`, `μ±2σ\mu \pm 2\sigma`). The rendered article body was already correct — this was preview-only.

## Root cause

KaTeX (`output: "mathml"`) emits presentation MathML **plus** an `<annotation encoding="application/x-tex">` holding the raw TeX. `generateSummary(...)` → `stripHtml` runs on the **pre-sanitize** HTML and concatenated all text nodes: the presentation glyphs (`E=mc2`) *and* the annotation TeX (`E = mc^2`), so the equation appeared twice. The read-path sanitizer already drops `<annotation>`, so the rendered body is fine — but the excerpt is generated before sanitization.

## Fix

Add `annotation` / `annotation-xml` to `stripHtml`'s skip-content set, mirroring the sanitizer's `DROP_WITH_CONTENT` policy. Presentation glyphs are kept once; the TeX annotation is dropped. Feed math (MathJax→MathML) has no annotation, so this is a no-op there.

Chose option (a) from the issue — keep presentation text once — because it matches what the read-path sanitizer produces for the rendered body.

## Testing

- Added unit tests in `tests/unit/entry-summary.test.ts` covering KaTeX annotation drop, `annotation-xml` drop, and feed-math presentation glyphs (no annotation).
- `pnpm test:unit` (relevant files) + `pnpm typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)