### PR TITLE
Fix: build saved-article excerpt from cleaned content, not raw plugin HTML

### DIFF
--- a/src/server/services/saved-excerpt.ts
+++ b/src/server/services/saved-excerpt.ts
@@ -1,0 +1,46 @@
+import { generateSummary } from "@/server/html/strip-html";
+
+/**
+ * Choose the plain-text excerpt for a saved article.
+ *
+ * Precedence: Markdown frontmatter summary → Readability's cleaned extraction →
+ * raw plugin HTML → raw Markdown HTML.
+ *
+ * The `cleaned` (Readability) branch must be checked **before** the plugin branch.
+ * When Readability ran, its output is what we store and display, so the excerpt
+ * has to come from it too. Readability only runs (leaving `cleaned` non-null) when
+ * it wasn't skipped, and a plugin can keep it (`skipReadability: false`, e.g.
+ * arXiv). The raw arXiv HTML body opens with a table-of-contents `<nav>`, so
+ * summarizing the raw plugin HTML yielded the ToC instead of the article text
+ * (#1398). Plugins that skip Readability (Google Docs) leave `cleaned` null and
+ * correctly fall through to their own HTML.
+ *
+ * Pure (no DB/network) so it can be unit-tested directly.
+ */
+export function computeSavedArticleExcerpt(params: {
+  markdownResult: { summary: string | null } | null;
+  cleaned: { excerpt: string; textContent: string } | null;
+  pluginContent: { html: string } | null;
+  html: string;
+}): string | null {
+  const { markdownResult, cleaned, pluginContent, html } = params;
+
+  if (markdownResult?.summary) {
+    // Use summary from frontmatter
+    return markdownResult.summary;
+  }
+  if (cleaned) {
+    let excerpt = cleaned.excerpt || cleaned.textContent.slice(0, 300).trim() || null;
+    if (excerpt && excerpt.length > 300) {
+      excerpt = excerpt.slice(0, 297) + "...";
+    }
+    return excerpt;
+  }
+  if (pluginContent) {
+    return generateSummary(pluginContent.html) || null;
+  }
+  if (markdownResult) {
+    return generateSummary(html) || null;
+  }
+  return null;
+}

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -27,6 +27,7 @@ import { absolutizeUrls, cleanContentAsync } from "@/server/feed/content-cleaner
 import { sanitizeEntryHtmlAsync } from "@/server/html/sanitize";
 import { getOrCreateSavedFeed, getSavedFeedId, SAVED_FEED_TITLE } from "@/server/feed/saved-feed";
 import { generateSummary, stripHtml } from "@/server/html/strip-html";
+import { computeSavedArticleExcerpt } from "@/server/services/saved-excerpt";
 import { escapeHtml } from "@/server/http/html";
 import { sanitizeEntryContentFamily } from "@/server/html/sanitize-entry";
 import { logger } from "@/lib/logger";
@@ -967,21 +968,8 @@ export async function saveArticle(
   const shouldSkipReadability = Boolean(pluginContent?.skipReadability) || markdownResult !== null;
   const cleaned = shouldSkipReadability ? null : await cleanContentAsync(html, { url: contentUrl });
 
-  // Generate excerpt - prefer frontmatter summary for Markdown content
-  let excerpt: string | null = null;
-  if (markdownResult?.summary) {
-    // Use summary from frontmatter
-    excerpt = markdownResult.summary;
-  } else if (pluginContent) {
-    excerpt = generateSummary(pluginContent.html) || null;
-  } else if (markdownResult) {
-    excerpt = generateSummary(html) || null;
-  } else if (cleaned) {
-    excerpt = cleaned.excerpt || cleaned.textContent.slice(0, 300).trim() || null;
-    if (excerpt && excerpt.length > 300) {
-      excerpt = excerpt.slice(0, 297) + "...";
-    }
-  }
+  // Generate excerpt (see computeSavedArticleExcerpt for precedence rationale).
+  const excerpt = computeSavedArticleExcerpt({ markdownResult, cleaned, pluginContent, html });
 
   // Build final values - prefer plugin/API data, then provided hint, then
   // extracted metadata, then Readability

--- a/tests/unit/saved-article-excerpt.test.ts
+++ b/tests/unit/saved-article-excerpt.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { computeSavedArticleExcerpt } from "@/server/services/saved-excerpt";
+
+describe("computeSavedArticleExcerpt", () => {
+  it("prefers Markdown frontmatter summary above everything", () => {
+    const excerpt = computeSavedArticleExcerpt({
+      markdownResult: { summary: "Frontmatter wins" },
+      cleaned: { excerpt: "Readability excerpt", textContent: "Body text" },
+      pluginContent: { html: "<p>Plugin</p>" },
+      html: "<p>Raw</p>",
+    });
+    expect(excerpt).toBe("Frontmatter wins");
+  });
+
+  it("uses Readability output when it ran, even for plugin content (arXiv ToC bug #1398)", () => {
+    // Raw arXiv HTML opens with a table-of-contents nav; Readability strips it and
+    // extracts the article body. Because Readability ran (cleaned is non-null), the
+    // excerpt must come from the cleaned content, not the raw plugin HTML.
+    const tocHtml =
+      "<nav><ol><li>1 Introduction</li><li>2 Monitoring Frontier Reasoning Models</li>" +
+      "<li>2.1 Catching Systemic Reward Hacking</li></ol></nav>";
+    const excerpt = computeSavedArticleExcerpt({
+      markdownResult: null,
+      cleaned: {
+        excerpt: "",
+        textContent:
+          "Bowen Baker, Joost Huizinga, Leo Gao. Mitigating reward hacking remains a key challenge.",
+      },
+      pluginContent: { html: tocHtml },
+      html: tocHtml,
+    });
+    expect(excerpt).toBe(
+      "Bowen Baker, Joost Huizinga, Leo Gao. Mitigating reward hacking remains a key challenge."
+    );
+    expect(excerpt).not.toContain("Introduction");
+  });
+
+  it("prefers the Readability excerpt when present, falling back to body text", () => {
+    expect(
+      computeSavedArticleExcerpt({
+        markdownResult: null,
+        cleaned: { excerpt: "A good article-specific excerpt.", textContent: "Body text here." },
+        pluginContent: null,
+        html: "<p>Raw</p>",
+      })
+    ).toBe("A good article-specific excerpt.");
+
+    expect(
+      computeSavedArticleExcerpt({
+        markdownResult: null,
+        cleaned: { excerpt: "", textContent: "The article begins here." },
+        pluginContent: null,
+        html: "<p>Raw</p>",
+      })
+    ).toBe("The article begins here.");
+  });
+
+  it("hard-truncates a long body-text fallback to <=300 chars (no ellipsis)", () => {
+    const long = "word ".repeat(200); // 1000 chars
+    const excerpt = computeSavedArticleExcerpt({
+      markdownResult: null,
+      cleaned: { excerpt: "", textContent: long },
+      pluginContent: null,
+      html: "",
+    });
+    expect(excerpt).not.toBeNull();
+    expect(excerpt!.length).toBeLessThanOrEqual(300);
+    expect(long.startsWith(excerpt!)).toBe(true);
+  });
+
+  it("truncates a long Readability excerpt to 297 chars + ellipsis", () => {
+    const long = "x".repeat(500);
+    const excerpt = computeSavedArticleExcerpt({
+      markdownResult: null,
+      cleaned: { excerpt: long, textContent: "body" },
+      pluginContent: null,
+      html: "",
+    });
+    expect(excerpt).toBe("x".repeat(297) + "...");
+  });
+
+  it("summarizes raw plugin HTML only when Readability was skipped (cleaned is null)", () => {
+    // e.g. Google Docs sets skipReadability: true, so no cleaned content exists.
+    const excerpt = computeSavedArticleExcerpt({
+      markdownResult: null,
+      cleaned: null,
+      pluginContent: { html: "<p>Google Doc body content.</p>" },
+      html: "<p>ignored</p>",
+    });
+    expect(excerpt).toBe("Google Doc body content.");
+  });
+
+  it("summarizes raw Markdown HTML when there is no frontmatter summary and no cleaned content", () => {
+    const excerpt = computeSavedArticleExcerpt({
+      markdownResult: { summary: null },
+      cleaned: null,
+      pluginContent: null,
+      html: "<h1>Title</h1><p>Markdown body.</p>",
+    });
+    expect(excerpt).toBe("Title Markdown body.");
+  });
+
+  it("returns null when nothing usable is available (Readability failed on a plain page)", () => {
+    expect(
+      computeSavedArticleExcerpt({
+        markdownResult: null,
+        cleaned: null,
+        pluginContent: null,
+        html: "<p>Raw page that Readability rejected.</p>",
+      })
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Saved arXiv papers (e.g. https://arxiv.org/abs/2503.11926) showed their **table of contents** as the excerpt instead of the article text.

The arXiv plugin keeps Readability (`skipReadability: false`), so the cleaned Readability output is what we store and display — but the excerpt was generated from the **raw plugin HTML**, which for arXiv's LaTeXML render opens with a table-of-contents `<nav>`. Stripping that to text produced "1 Introduction 2 Monitoring Frontier Reasoning Models 2.1 Catching Systemic Reward Hacking…".

Root cause is branch ordering in `saveArticle`: the `pluginContent` branch was checked **before** the `cleaned` branch, so plugin content won even when Readability had run and produced better content.

## Fix

- Extract the excerpt-precedence logic into a pure, unit-testable `computeSavedArticleExcerpt` helper (`src/server/services/saved-excerpt.ts`).
- Check the `cleaned` (Readability) branch **before** the plugin branch: whenever Readability ran, its output drives the excerpt too. Plugins that skip Readability (Google Docs) leave `cleaned` null and still fall through to their own HTML, unchanged.

Precedence is now: Markdown frontmatter summary → Readability cleaned content → raw plugin HTML → raw Markdown HTML.

arXiv's HTML render has no `<meta description>`, so `cleaned.excerpt` is empty and the excerpt correctly falls through to the article body text (authors/abstract).

## Scope

This fixes the plugin/raw-content ordering only. Two related items are **deliberately out of scope** and tracked separately:
- **#1400** — a distinct bug where non-plugin pages with a site-wide `<meta name="description">` (e.g. personal blogs) get that site tagline as the excerpt, entangled with a larger dedup of the parallel upload-HTML / saved-page / full-content excerpt pipelines.
- **#1399** — consider having the arXiv plugin fetch the abstract + authors from the arXiv API for the highest-quality excerpt/metadata.

## Tests

New `tests/unit/saved-article-excerpt.test.ts` covers the precedence, the arXiv ToC regression, the skip-Readability plugin path, Markdown, and truncation behavior (8 cases). Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)