### PR TITLE
Refactor: unify cleaned-content excerpt generation into summarizeCleanedContent

### DIFF
--- a/src/server/feed/content-cleaner.ts
+++ b/src/server/feed/content-cleaner.ts
@@ -467,47 +467,6 @@ function finishCleaned(
   };
 }
 
-/**
- * Generates a summary from cleaned content.
- *
- * Uses the excerpt if available, otherwise truncates the text content.
- *
- * @param cleaned - The cleaned content result
- * @param maxLength - Maximum summary length (default: 300)
- * @returns Summary string
- */
-export function generateCleanedSummary(cleaned: CleanedContent, maxLength = 300): string {
-  // Prefer the excerpt if it's meaningful
-  if (cleaned.excerpt && cleaned.excerpt.length >= 50) {
-    return truncateText(cleaned.excerpt, maxLength);
-  }
-
-  // Fall back to truncated text content
-  return truncateText(cleaned.textContent, maxLength);
-}
-
-/**
- * Truncates text to a maximum length, adding ellipsis if needed.
- * Attempts to break at word boundaries.
- */
-function truncateText(text: string, maxLength: number): string {
-  const trimmed = text.trim();
-  if (trimmed.length <= maxLength) {
-    return trimmed;
-  }
-
-  // Try to find a word boundary before the max length
-  let truncated = trimmed.slice(0, maxLength);
-  const lastSpace = truncated.lastIndexOf(" ");
-
-  // If we found a space reasonably close to the end, use it
-  if (lastSpace > maxLength - 50) {
-    truncated = truncated.slice(0, lastSpace);
-  }
-
-  return truncated.trimEnd() + "...";
-}
-
 // ============================================================================
 // Feed-Specific Content Cleaners
 // ============================================================================

--- a/src/server/file/process-upload.ts
+++ b/src/server/file/process-upload.ts
@@ -10,7 +10,7 @@
 
 import * as mammoth from "mammoth";
 import { cleanContentAsync } from "@/server/feed/content-cleaner";
-import { generateSummary } from "@/server/html/strip-html";
+import { generateSummary, summarizeCleanedContent } from "@/server/html/strip-html";
 import { logger } from "@/lib/logger";
 import { processMarkdown as convertMarkdown } from "@/server/markdown";
 
@@ -114,7 +114,7 @@ async function processDocx(buffer: Buffer, filename: string): Promise<ProcessedF
 
   // Use cleaned content if available, otherwise use raw mammoth output
   const contentCleaned = cleaned?.content ?? rawHtml;
-  const excerpt = cleaned ? generateSummary(cleaned.content) : generateSummary(rawHtml);
+  const excerpt = cleaned ? summarizeCleanedContent(cleaned) : generateSummary(rawHtml);
 
   return {
     contentCleaned,
@@ -135,7 +135,7 @@ async function processHtml(content: string, filename: string): Promise<Processed
   if (cleaned) {
     return {
       contentCleaned: cleaned.content,
-      excerpt: cleaned.excerpt || generateSummary(cleaned.content) || null,
+      excerpt: summarizeCleanedContent(cleaned) || null,
       title: cleaned.title || titleFromFilename(filename),
       author: cleaned.byline || null,
       fileType: "html",

--- a/src/server/html/strip-html.ts
+++ b/src/server/html/strip-html.ts
@@ -155,3 +155,52 @@ export function stripHtml(html: string, maxLength?: number): string {
 export function generateSummary(html: string): string {
   return stripHtml(html, 300);
 }
+
+/**
+ * Truncates plain text to a maximum length at a word boundary, adding an
+ * ellipsis when it had to cut. (Operates on already-plain text, unlike
+ * `stripHtml`, which parses HTML first.)
+ */
+function truncateText(text: string, maxLength: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+
+  // Try to find a word boundary before the max length
+  let truncated = trimmed.slice(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(" ");
+  if (lastSpace > maxLength - 50) {
+    truncated = truncated.slice(0, lastSpace);
+  }
+
+  return truncated.trimEnd() + "...";
+}
+
+/**
+ * Builds a plain-text summary from already-cleaned (Readability) content.
+ *
+ * This is the single source of truth for turning cleaned content into an
+ * excerpt, shared by every surface that runs Readability then needs a preview
+ * (saved articles, uploaded HTML/docx). It prefers the extracted
+ * description/excerpt when it's substantial — that's usually a hand-written
+ * `og:description` / meta description and reads better than a truncated first
+ * paragraph — and only falls back to the article body text when the excerpt is
+ * missing or too short to be a real description. Both are truncated to
+ * `maxLength` at a word boundary.
+ *
+ * The ≥50-char guard keeps a junk/empty meta tag from winning; a page that sets
+ * a site-wide (rather than per-article) description is a site problem, not a bug
+ * to work around here — see the follow-up on smarter summary heuristics.
+ *
+ * Pure (no DB/network/native), so it can be unit-tested directly.
+ */
+export function summarizeCleanedContent(
+  cleaned: { excerpt: string; textContent: string },
+  maxLength = 300
+): string {
+  if (cleaned.excerpt && cleaned.excerpt.length >= 50) {
+    return truncateText(cleaned.excerpt, maxLength);
+  }
+  return truncateText(cleaned.textContent, maxLength);
+}

--- a/src/server/services/saved-excerpt.ts
+++ b/src/server/services/saved-excerpt.ts
@@ -1,4 +1,4 @@
-import { generateSummary } from "@/server/html/strip-html";
+import { generateSummary, summarizeCleanedContent } from "@/server/html/strip-html";
 
 /**
  * Choose the plain-text excerpt for a saved article.
@@ -15,6 +15,9 @@ import { generateSummary } from "@/server/html/strip-html";
  * (#1398). Plugins that skip Readability (Google Docs) leave `cleaned` null and
  * correctly fall through to their own HTML.
  *
+ * The cleaned branch defers to the shared `summarizeCleanedContent`, so saved
+ * articles and uploaded files derive excerpts identically (description-preferred).
+ *
  * Pure (no DB/network) so it can be unit-tested directly.
  */
 export function computeSavedArticleExcerpt(params: {
@@ -30,11 +33,7 @@ export function computeSavedArticleExcerpt(params: {
     return markdownResult.summary;
   }
   if (cleaned) {
-    let excerpt = cleaned.excerpt || cleaned.textContent.slice(0, 300).trim() || null;
-    if (excerpt && excerpt.length > 300) {
-      excerpt = excerpt.slice(0, 297) + "...";
-    }
-    return excerpt;
+    return summarizeCleanedContent(cleaned) || null;
   }
   if (pluginContent) {
     return generateSummary(pluginContent.html) || null;

--- a/tests/unit/content-cleaner.test.ts
+++ b/tests/unit/content-cleaner.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect } from "vitest";
 import {
   cleanContent,
-  generateCleanedSummary,
   absolutizeUrls,
   extractBaseHref,
   cleanLessWrongContent,
@@ -351,81 +350,6 @@ describe("cleanContent", () => {
       expect(result!.textContent).not.toMatch(/^\s/);
       expect(result!.textContent).not.toMatch(/\s$/);
     });
-  });
-});
-
-describe("generateCleanedSummary", () => {
-  it("should use excerpt when available and long enough", () => {
-    const cleaned = {
-      content: "<p>Full content here...</p>",
-      textContent: "Full content here...",
-      excerpt: "This is a meaningful excerpt that summarizes the article content well.",
-      title: "Test",
-      byline: null,
-    };
-
-    const summary = generateCleanedSummary(cleaned);
-
-    expect(summary).toBe(cleaned.excerpt);
-  });
-
-  it("should fall back to text content when excerpt is short", () => {
-    const cleaned = {
-      content: "<p>Full content here...</p>",
-      textContent: "This is the full text content that should be used for the summary.",
-      excerpt: "Too short",
-      title: "Test",
-      byline: null,
-    };
-
-    const summary = generateCleanedSummary(cleaned);
-
-    expect(summary).toContain("full text content");
-  });
-
-  it("should truncate long content", () => {
-    const longText = "A".repeat(500);
-    const cleaned = {
-      content: `<p>${longText}</p>`,
-      textContent: longText,
-      excerpt: "",
-      title: "Test",
-      byline: null,
-    };
-
-    const summary = generateCleanedSummary(cleaned, 300);
-
-    expect(summary.length).toBeLessThanOrEqual(303); // 300 + "..."
-    expect(summary.endsWith("...")).toBe(true);
-  });
-
-  it("should not truncate short content", () => {
-    const cleaned = {
-      content: "<p>Short content</p>",
-      textContent: "Short content",
-      excerpt: "",
-      title: "Test",
-      byline: null,
-    };
-
-    const summary = generateCleanedSummary(cleaned);
-
-    expect(summary).toBe("Short content");
-    expect(summary.endsWith("...")).toBe(false);
-  });
-
-  it("should handle empty content", () => {
-    const cleaned = {
-      content: "",
-      textContent: "",
-      excerpt: "",
-      title: "Test",
-      byline: null,
-    };
-
-    const summary = generateCleanedSummary(cleaned);
-
-    expect(summary).toBe("");
   });
 });
 

--- a/tests/unit/entry-summary.test.ts
+++ b/tests/unit/entry-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { stripHtml } from "@/server/html/strip-html";
+import { stripHtml, summarizeCleanedContent } from "@/server/html/strip-html";
 
 describe("stripHtml", () => {
   describe("basic text extraction", () => {
@@ -208,5 +208,44 @@ describe("stripHtml", () => {
       const html = "<a>X</a><p>Y</p>";
       expect(stripHtml(html, 300)).toBe("X Y");
     });
+  });
+});
+
+describe("summarizeCleanedContent", () => {
+  it("uses the excerpt when it is substantial (>= 50 chars)", () => {
+    const excerpt = "This is a meaningful excerpt that summarizes the article content well.";
+    expect(summarizeCleanedContent({ excerpt, textContent: "Full body text here." })).toBe(excerpt);
+  });
+
+  it("falls back to body text when the excerpt is too short", () => {
+    const summary = summarizeCleanedContent({
+      excerpt: "Too short",
+      textContent: "This is the full text content that should be used for the summary.",
+    });
+    expect(summary).toContain("full text content");
+  });
+
+  it("falls back to body text when there is no excerpt", () => {
+    expect(summarizeCleanedContent({ excerpt: "", textContent: "The article begins here." })).toBe(
+      "The article begins here."
+    );
+  });
+
+  it("truncates long content at a word boundary with an ellipsis", () => {
+    const longText = "word ".repeat(200).trim(); // 999 chars, spaces to break on
+    const summary = summarizeCleanedContent({ excerpt: "", textContent: longText });
+    expect(summary.length).toBeLessThanOrEqual(303); // 300 + "..."
+    expect(summary.endsWith("...")).toBe(true);
+    expect(summary.includes("wordword")).toBe(false); // broke on a space
+  });
+
+  it("does not truncate short content", () => {
+    const summary = summarizeCleanedContent({ excerpt: "", textContent: "Short content" });
+    expect(summary).toBe("Short content");
+    expect(summary.endsWith("...")).toBe(false);
+  });
+
+  it("returns an empty string for empty content", () => {
+    expect(summarizeCleanedContent({ excerpt: "", textContent: "" })).toBe("");
   });
 });

--- a/tests/unit/saved-article-excerpt.test.ts
+++ b/tests/unit/saved-article-excerpt.test.ts
@@ -35,16 +35,19 @@ describe("computeSavedArticleExcerpt", () => {
     expect(excerpt).not.toContain("Introduction");
   });
 
-  it("prefers the Readability excerpt when present, falling back to body text", () => {
+  it("delegates the cleaned branch to summarizeCleanedContent (description-preferred)", () => {
+    // A substantial excerpt (>= 50 chars) wins over the body text...
+    const excerpt = "A good, article-specific description that is clearly long enough.";
     expect(
       computeSavedArticleExcerpt({
         markdownResult: null,
-        cleaned: { excerpt: "A good article-specific excerpt.", textContent: "Body text here." },
+        cleaned: { excerpt, textContent: "Body text here." },
         pluginContent: null,
         html: "<p>Raw</p>",
       })
-    ).toBe("A good article-specific excerpt.");
+    ).toBe(excerpt);
 
+    // ...and the body text is used when there is no usable excerpt.
     expect(
       computeSavedArticleExcerpt({
         markdownResult: null,
@@ -55,28 +58,15 @@ describe("computeSavedArticleExcerpt", () => {
     ).toBe("The article begins here.");
   });
 
-  it("hard-truncates a long body-text fallback to <=300 chars (no ellipsis)", () => {
-    const long = "word ".repeat(200); // 1000 chars
-    const excerpt = computeSavedArticleExcerpt({
-      markdownResult: null,
-      cleaned: { excerpt: "", textContent: long },
-      pluginContent: null,
-      html: "",
-    });
-    expect(excerpt).not.toBeNull();
-    expect(excerpt!.length).toBeLessThanOrEqual(300);
-    expect(long.startsWith(excerpt!)).toBe(true);
-  });
-
-  it("truncates a long Readability excerpt to 297 chars + ellipsis", () => {
-    const long = "x".repeat(500);
-    const excerpt = computeSavedArticleExcerpt({
-      markdownResult: null,
-      cleaned: { excerpt: long, textContent: "body" },
-      pluginContent: null,
-      html: "",
-    });
-    expect(excerpt).toBe("x".repeat(297) + "...");
+  it("returns null when the cleaned content is empty", () => {
+    expect(
+      computeSavedArticleExcerpt({
+        markdownResult: null,
+        cleaned: { excerpt: "", textContent: "" },
+        pluginContent: null,
+        html: "<p>Raw</p>",
+      })
+    ).toBeNull();
   });
 
   it("summarizes raw plugin HTML only when Readability was skipped (cleaned is null)", () => {


### PR DESCRIPTION
## Motivation

Follow-up to #1398 / #1400. Three surfaces that run Readability and then need a preview each hand-rolled their own "cleaned content → excerpt" logic, and they had drifted apart:

| Surface | Old logic | Prefers description? |
|---|---|---|
| Saved articles (`saved-excerpt.ts`) | `cleaned.excerpt \|\| textContent.slice(0,300)` | yes (any non-empty) |
| Upload: HTML (`process-upload.ts`) | `cleaned.excerpt \|\| generateSummary(cleaned.content)` | yes (any non-empty) |
| Upload: docx (`process-upload.ts`) | `generateSummary(cleaned.content)` | **no** (body text) |
| `generateCleanedSummary` (`content-cleaner.ts`) | `cleaned.excerpt` if ≥50 else `truncateText(textContent)` | yes — but **dead code** (only its own test referenced it) |

## Change

- Add one canonical, description-preferring helper `summarizeCleanedContent` to the pure `strip-html.ts` module (no DB/native, so it's directly unit-testable): prefer the extracted description when substantial (≥50 chars), else the article body text, each truncated at a word boundary.
- Wire `saveArticle` (via `computeSavedArticleExcerpt`) and both upload paths to it. Behavior is now identical everywhere.
- Delete the orphaned `generateCleanedSummary` and its private `truncateText`.

## Policy decision

We deliberately **keep** the description preference — it's usually a better summary than a truncated first paragraph. The known failure mode (a site that serves one site-wide `<meta name="description">` for every page, e.g. the brethorsting.com example in #1400) is treated as a site issue rather than worked around here. **#1401** tracks investigating smarter heuristics (what does Google do?) for a future improvement.

Net behavior changes from consolidation (all minor, all toward consistency):
- docx uploads now also prefer the description (previously body-text only).
- Saved articles / HTML uploads now apply the ≥50-char guard (a tiny junk description no longer wins) and truncate the body-text fallback at a word boundary with an ellipsis instead of a hard 300-char slice.

## Tests

- `summarizeCleanedContent` gets its own unit coverage in `entry-summary.test.ts` (the old `generateCleanedSummary` cases moved here).
- `saved-article-excerpt.test.ts` updated to assert delegation + the ≥50 threshold.
- Full unit suite (2555 tests) + typecheck + lint + knip clean.

Part of #1400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)