### PR TITLE
Refactor: unify save-from-URL and file/Markdown upload into one content pipeline

### DIFF
--- a/src/server/feed/content-cleaner.ts
+++ b/src/server/feed/content-cleaner.ts
@@ -467,47 +467,6 @@ function finishCleaned(
   };
 }
 
-/**
- * Generates a summary from cleaned content.
- *
- * Uses the excerpt if available, otherwise truncates the text content.
- *
- * @param cleaned - The cleaned content result
- * @param maxLength - Maximum summary length (default: 300)
- * @returns Summary string
- */
-export function generateCleanedSummary(cleaned: CleanedContent, maxLength = 300): string {
-  // Prefer the excerpt if it's meaningful
-  if (cleaned.excerpt && cleaned.excerpt.length >= 50) {
-    return truncateText(cleaned.excerpt, maxLength);
-  }
-
-  // Fall back to truncated text content
-  return truncateText(cleaned.textContent, maxLength);
-}
-
-/**
- * Truncates text to a maximum length, adding ellipsis if needed.
- * Attempts to break at word boundaries.
- */
-function truncateText(text: string, maxLength: number): string {
-  const trimmed = text.trim();
-  if (trimmed.length <= maxLength) {
-    return trimmed;
-  }
-
-  // Try to find a word boundary before the max length
-  let truncated = trimmed.slice(0, maxLength);
-  const lastSpace = truncated.lastIndexOf(" ");
-
-  // If we found a space reasonably close to the end, use it
-  if (lastSpace > maxLength - 50) {
-    truncated = truncated.slice(0, lastSpace);
-  }
-
-  return truncated.trimEnd() + "...";
-}
-
 // ============================================================================
 // Feed-Specific Content Cleaners
 // ============================================================================

--- a/src/server/file/process-upload.ts
+++ b/src/server/file/process-upload.ts
@@ -1,16 +1,19 @@
 /**
- * File upload processing module.
+ * File upload conversion module.
  *
- * Handles conversion of uploaded files to HTML for storage as saved articles.
+ * Converts an uploaded file to raw article HTML. This is only the *acquisition*
+ * step — Readability cleaning, excerpt generation, and metadata (title / author /
+ * site name) all happen downstream in `buildArticleFields` (see `saved.ts`), so
+ * uploads share exactly the same processing as URL saves.
+ *
  * Supports:
- * - .docx files → mammoth conversion → Readability cleaning
- * - .html files → Readability cleaning
- * - .md files → marked conversion (no cleaning needed)
+ * - .docx files → mammoth conversion (Readability runs downstream)
+ * - .html files → passthrough (Readability runs downstream)
+ * - .md/.txt files → marked conversion (Readability skipped downstream, like a
+ *   Markdown URL save)
  */
 
 import * as mammoth from "mammoth";
-import { cleanContentAsync } from "@/server/feed/content-cleaner";
-import { generateSummary, summarizeCleanedContent } from "@/server/html/strip-html";
 import { logger } from "@/lib/logger";
 import { processMarkdown as convertMarkdown } from "@/server/markdown";
 
@@ -24,19 +27,27 @@ import { processMarkdown as convertMarkdown } from "@/server/markdown";
 export type SupportedFileType = "docx" | "html" | "markdown";
 
 /**
- * Result from processing an uploaded file.
+ * Raw content produced by converting an uploaded file. Fed to `buildArticleFields`
+ * as an article content bundle (with a null URL).
  */
-export interface ProcessedFile {
-  /** The cleaned/converted HTML content */
-  contentCleaned: string;
-  /** Plain text excerpt for preview */
-  excerpt: string | null;
-  /** Extracted or derived title (from filename or content) */
-  title: string | null;
-  /** Extracted author (from frontmatter, metadata, or Readability) */
-  author: string | null;
-  /** Original file type */
+export interface ConvertedUpload {
+  /** Raw article HTML (stored as content_original; Readability runs on it downstream). */
+  html: string;
+  /**
+   * Markdown conversion result — set for .md/.txt, null for .docx/.html. A
+   * non-null value tells `buildArticleFields` to skip Readability (as with a
+   * Markdown URL save) and use the frontmatter title/summary/author.
+   */
+  markdownResult: {
+    html: string;
+    title: string | null;
+    summary: string | null;
+    author: string | null;
+  } | null;
+  /** Detected file type (drives the display site name). */
   fileType: SupportedFileType;
+  /** Original filename, used downstream as a last-resort title. */
+  filename: string;
 }
 
 // ============================================================================
@@ -68,9 +79,10 @@ export function detectFileType(filename: string): SupportedFileType | null {
 }
 
 /**
- * Extracts a title from a filename by removing the extension.
+ * Extracts a title from a filename by removing the extension. Used downstream as
+ * a last-resort title when nothing better could be extracted from the content.
  */
-function titleFromFilename(filename: string): string {
+export function titleFromFilename(filename: string): string {
   // Remove extension
   let title = filename.replace(/\.(docx|html?|md|markdown|txt)$/i, "");
 
@@ -86,13 +98,13 @@ function titleFromFilename(filename: string): string {
 }
 
 // ============================================================================
-// File Processors
+// File Converters
 // ============================================================================
 
 /**
- * Converts a .docx file buffer to HTML using mammoth, then cleans with Readability.
+ * Converts a .docx file buffer to HTML using mammoth. Readability runs downstream.
  */
-async function processDocx(buffer: Buffer, filename: string): Promise<ProcessedFile> {
+async function convertDocx(buffer: Buffer, filename: string): Promise<ConvertedUpload> {
   const styleMap = ["p[style-name='Title'] => h1:fresh", "p[style-name='Subtitle'] => h2:fresh"];
 
   const result = await mammoth.convertToHtml({ buffer }, { styleMap });
@@ -104,105 +116,45 @@ async function processDocx(buffer: Buffer, filename: string): Promise<ProcessedF
     });
   }
 
-  const rawHtml = result.value;
-
-  // Wrap in HTML structure for Readability
-  const fullHtml = `<!DOCTYPE html><html><body>${rawHtml}</body></html>`;
-
-  // Clean with Readability
-  const cleaned = await cleanContentAsync(fullHtml, { minCleanedLength: 10 });
-
-  // Use cleaned content if available, otherwise use raw mammoth output
-  const contentCleaned = cleaned?.content ?? rawHtml;
-  const excerpt = cleaned ? summarizeCleanedContent(cleaned) : generateSummary(rawHtml);
-
+  // Wrap in HTML structure so downstream Readability has a document to parse.
   return {
-    contentCleaned,
-    excerpt: excerpt || null,
-    title: cleaned?.title || titleFromFilename(filename),
-    author: cleaned?.byline || null,
+    html: `<!DOCTYPE html><html><body>${result.value}</body></html>`,
+    markdownResult: null,
     fileType: "docx",
+    filename,
   };
 }
 
 /**
- * Processes an HTML file by cleaning with Readability.
+ * Converts Markdown to HTML using marked. Frontmatter title/description/author
+ * are extracted here and passed through as the markdown result so downstream
+ * treats it like a Markdown URL save (Readability skipped).
  */
-async function processHtml(content: string, filename: string): Promise<ProcessedFile> {
-  // Clean with Readability
-  const cleaned = await cleanContentAsync(content, { minCleanedLength: 10 });
-
-  if (cleaned) {
-    return {
-      contentCleaned: cleaned.content,
-      excerpt: summarizeCleanedContent(cleaned) || null,
-      title: cleaned.title || titleFromFilename(filename),
-      author: cleaned.byline || null,
-      fileType: "html",
-    };
-  }
-
-  // If Readability fails, return the raw HTML (sanitization happens on display)
+async function convertMarkdownFile(content: string, filename: string): Promise<ConvertedUpload> {
+  const { html, title, summary, author } = await convertMarkdown(content);
   return {
-    contentCleaned: content,
-    excerpt: generateSummary(content) || null,
-    title: titleFromFilename(filename),
-    author: null,
-    fileType: "html",
-  };
-}
-
-/**
- * Converts Markdown to HTML using marked.
- * Markdown content is kept as-is semantically, just rendered to HTML.
- * Supports YAML frontmatter for title, description, and author extraction.
- */
-async function processMarkdown(content: string, filename: string): Promise<ProcessedFile> {
-  // Convert markdown to HTML and extract title/summary/author from frontmatter or content
-  const {
-    html: contentCleaned,
-    title: extractedTitle,
-    summary: frontmatterSummary,
-    author,
-  } = await convertMarkdown(content);
-  const title = extractedTitle || titleFromFilename(filename);
-
-  // Prefer frontmatter description, fall back to generated summary from content
-  const excerpt = frontmatterSummary ?? generateSummary(contentCleaned);
-
-  return {
-    contentCleaned,
-    excerpt: excerpt || null,
-    title,
-    author,
+    html,
+    markdownResult: { html, title, summary, author },
     fileType: "markdown",
+    filename,
   };
 }
 
 // ============================================================================
-// Main Processing Function
+// Main Conversion Function
 // ============================================================================
 
 /**
- * Processes an uploaded file and converts it to HTML for storage.
+ * Converts an uploaded file to raw article content for `buildArticleFields`.
  *
  * @param content - The file content (Buffer for binary files, string for text)
  * @param filename - The original filename (used for type detection and title)
- * @returns Processed file with HTML content, or throws if unsupported type
- *
- * @example
- * ```typescript
- * // For a docx file
- * const result = await processUploadedFile(buffer, "document.docx");
- *
- * // For a markdown file
- * const result = await processUploadedFile(mdContent, "notes.md");
- * ```
+ * @returns The converted content, or throws if the type is unsupported
  */
-export async function processUploadedFile(
+export async function convertUploadedFile(
   content: Buffer | string,
   filename: string
-): Promise<ProcessedFile> {
+): Promise<ConvertedUpload> {
   const fileType = detectFileType(filename);
 
   if (!fileType) {
@@ -211,25 +163,25 @@ export async function processUploadedFile(
     );
   }
 
-  logger.info("Processing uploaded file", { filename, fileType });
+  logger.info("Converting uploaded file", { filename, fileType });
 
   switch (fileType) {
     case "docx": {
       // docx requires Buffer
       const buffer = typeof content === "string" ? Buffer.from(content, "base64") : content;
-      return processDocx(buffer, filename);
+      return convertDocx(buffer, filename);
     }
 
     case "html": {
-      // HTML should be string
+      // HTML should be string; Readability runs downstream.
       const htmlContent = typeof content === "string" ? content : content.toString("utf-8");
-      return processHtml(htmlContent, filename);
+      return { html: htmlContent, markdownResult: null, fileType: "html", filename };
     }
 
     case "markdown": {
       // Markdown should be string (also handles plain text files)
       const mdContent = typeof content === "string" ? content : content.toString("utf-8");
-      return processMarkdown(mdContent, filename);
+      return convertMarkdownFile(mdContent, filename);
     }
   }
 }

--- a/src/server/file/process-upload.ts
+++ b/src/server/file/process-upload.ts
@@ -10,7 +10,7 @@
 
 import * as mammoth from "mammoth";
 import { cleanContentAsync } from "@/server/feed/content-cleaner";
-import { generateSummary } from "@/server/html/strip-html";
+import { generateSummary, summarizeCleanedContent } from "@/server/html/strip-html";
 import { logger } from "@/lib/logger";
 import { processMarkdown as convertMarkdown } from "@/server/markdown";
 
@@ -114,7 +114,7 @@ async function processDocx(buffer: Buffer, filename: string): Promise<ProcessedF
 
   // Use cleaned content if available, otherwise use raw mammoth output
   const contentCleaned = cleaned?.content ?? rawHtml;
-  const excerpt = cleaned ? generateSummary(cleaned.content) : generateSummary(rawHtml);
+  const excerpt = cleaned ? summarizeCleanedContent(cleaned) : generateSummary(rawHtml);
 
   return {
     contentCleaned,
@@ -135,7 +135,7 @@ async function processHtml(content: string, filename: string): Promise<Processed
   if (cleaned) {
     return {
       contentCleaned: cleaned.content,
-      excerpt: cleaned.excerpt || generateSummary(cleaned.content) || null,
+      excerpt: summarizeCleanedContent(cleaned) || null,
       title: cleaned.title || titleFromFilename(filename),
       author: cleaned.byline || null,
       fileType: "html",

--- a/src/server/html/strip-html.ts
+++ b/src/server/html/strip-html.ts
@@ -155,3 +155,52 @@ export function stripHtml(html: string, maxLength?: number): string {
 export function generateSummary(html: string): string {
   return stripHtml(html, 300);
 }
+
+/**
+ * Truncates plain text to a maximum length at a word boundary, adding an
+ * ellipsis when it had to cut. (Operates on already-plain text, unlike
+ * `stripHtml`, which parses HTML first.)
+ */
+function truncateText(text: string, maxLength: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+
+  // Try to find a word boundary before the max length
+  let truncated = trimmed.slice(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(" ");
+  if (lastSpace > maxLength - 50) {
+    truncated = truncated.slice(0, lastSpace);
+  }
+
+  return truncated.trimEnd() + "...";
+}
+
+/**
+ * Builds a plain-text summary from already-cleaned (Readability) content.
+ *
+ * This is the single source of truth for turning cleaned content into an
+ * excerpt, shared by every surface that runs Readability then needs a preview
+ * (saved articles, uploaded HTML/docx). It prefers the extracted
+ * description/excerpt when it's substantial — that's usually a hand-written
+ * `og:description` / meta description and reads better than a truncated first
+ * paragraph — and only falls back to the article body text when the excerpt is
+ * missing or too short to be a real description. Both are truncated to
+ * `maxLength` at a word boundary.
+ *
+ * The ≥50-char guard keeps a junk/empty meta tag from winning; a page that sets
+ * a site-wide (rather than per-article) description is a site problem, not a bug
+ * to work around here — see the follow-up on smarter summary heuristics.
+ *
+ * Pure (no DB/network/native), so it can be unit-tested directly.
+ */
+export function summarizeCleanedContent(
+  cleaned: { excerpt: string; textContent: string },
+  maxLength = 300
+): string {
+  if (cleaned.excerpt && cleaned.excerpt.length >= 50) {
+    return truncateText(cleaned.excerpt, maxLength);
+  }
+  return truncateText(cleaned.textContent, maxLength);
+}

--- a/src/server/services/saved-excerpt.ts
+++ b/src/server/services/saved-excerpt.ts
@@ -1,4 +1,4 @@
-import { generateSummary } from "@/server/html/strip-html";
+import { generateSummary, summarizeCleanedContent } from "@/server/html/strip-html";
 
 /**
  * Choose the plain-text excerpt for a saved article.
@@ -15,6 +15,9 @@ import { generateSummary } from "@/server/html/strip-html";
  * (#1398). Plugins that skip Readability (Google Docs) leave `cleaned` null and
  * correctly fall through to their own HTML.
  *
+ * The cleaned branch defers to the shared `summarizeCleanedContent`, so saved
+ * articles and uploaded files derive excerpts identically (description-preferred).
+ *
  * Pure (no DB/network) so it can be unit-tested directly.
  */
 export function computeSavedArticleExcerpt(params: {
@@ -30,11 +33,7 @@ export function computeSavedArticleExcerpt(params: {
     return markdownResult.summary;
   }
   if (cleaned) {
-    let excerpt = cleaned.excerpt || cleaned.textContent.slice(0, 300).trim() || null;
-    if (excerpt && excerpt.length > 300) {
-      excerpt = excerpt.slice(0, 297) + "...";
-    }
-    return excerpt;
+    return summarizeCleanedContent(cleaned) || null;
   }
   if (pluginContent) {
     return generateSummary(pluginContent.html) || null;

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -22,6 +22,11 @@ import {
 } from "@/server/http/fetch";
 import { parseFeed } from "@/server/feed/parser";
 import { processMarkdown } from "@/server/markdown";
+import {
+  titleFromFilename,
+  type ConvertedUpload,
+  type SupportedFileType,
+} from "@/server/file/process-upload";
 import { usageLimitsConfig } from "@/server/config/env";
 import { absolutizeUrls, cleanContentAsync } from "@/server/feed/content-cleaner";
 import { sanitizeEntryHtmlAsync } from "@/server/html/sanitize";
@@ -242,6 +247,148 @@ function generateContentHash(title: string | null, content: string | null): stri
   return createHash("sha256").update(hashInput, "utf8").digest("hex");
 }
 
+/**
+ * Reserved-TLD base URL for uploaded content, which has no real origin. Relative
+ * URLs in uploads resolve against this instead of Lion Reader's own domain, so a
+ * stray relative link becomes an obviously-broken external URL rather than one
+ * that silently points back into the app. `.invalid` never resolves (RFC 6761).
+ */
+const UPLOAD_BASE_URL = "https://uploaded.invalid/";
+
+/**
+ * A unit of acquired content, however it was obtained. `saveArticle` fills it by
+ * fetching a URL; the upload paths fill it by converting a file/Markdown. This is
+ * the seam the "save vs. upload" difference collapses to: only acquisition (and a
+ * null URL for uploads) differs — everything downstream is shared.
+ */
+interface ArticleContentBundle {
+  /** Raw content HTML (stored as content_original). */
+  html: string;
+  /** Base URL for metadata + relative-URL resolution; null for uploads (no origin). */
+  contentUrl: string | null;
+  /** Plugin-supplied content that bypasses normal metadata/Readability sources. */
+  pluginContent: {
+    html: string;
+    title?: string | null;
+    author?: string | null;
+    siteName?: string;
+    skipReadability?: boolean;
+  } | null;
+  /** Markdown conversion result (Readability is skipped for Markdown). */
+  markdownResult: {
+    html: string;
+    title: string | null;
+    summary: string | null;
+    author: string | null;
+  } | null;
+}
+
+/** Caller-supplied hints that outrank (title) or backstop (filename) extraction. */
+interface ArticleFieldHints {
+  /** Explicit caller-provided title — highest precedence. */
+  providedTitle?: string | null;
+  /** Upload filename, used only as a last-resort title (below Readability). */
+  filename?: string | null;
+  /** Provided site name (uploads: "Uploaded Document", etc.). */
+  siteName?: string | null;
+}
+
+/** The stored article fields buildArticleFields derives, plus quality-guard text. */
+interface BuiltArticleFields {
+  title: string | null;
+  author: string | null;
+  siteName: string | null;
+  contentOriginal: string;
+  contentCleaned: string | null;
+  summary: string | null;
+  imageUrl: string | null;
+  contentHash: string;
+  /** Plain text of the new content, for the refetch quality guard. */
+  newTextContent: string;
+}
+
+/**
+ * Turn an acquired content bundle into the stored article fields — shared by the
+ * URL-save path and the file/Markdown upload paths, so both derive title, author,
+ * site name, excerpt, cleaned content, and image identically. The only thing that
+ * differs between "save" and "upload" is how the bundle was acquired (fetch vs.
+ * file conversion) and that uploads carry a null URL.
+ *
+ * Field precedence:
+ *  - title:  provided → source (plugin / Markdown frontmatter / OG or `<title>`) → Readability → filename
+ *  - author: source (plugin / frontmatter / OG) → Readability byline
+ *  - excerpt: see {@link computeSavedArticleExcerpt} (frontmatter → cleaned → plugin/Markdown HTML)
+ */
+async function buildArticleFields(
+  bundle: ArticleContentBundle,
+  hints: ArticleFieldHints = {},
+  // Uploads are trusted user content, so they pass a lower minCleanedLength than
+  // a web fetch (where a short extraction usually means a failed JS-heavy page).
+  cleanOptions: { minCleanedLength?: number } = {}
+): Promise<BuiltArticleFields> {
+  const { html, contentUrl, pluginContent, markdownResult } = bundle;
+  // Uploads have no origin; a guaranteed-broken base keeps relative URLs from
+  // resolving against Lion Reader itself.
+  const baseUrl = contentUrl ?? UPLOAD_BASE_URL;
+
+  // Extract metadata from Open Graph / meta tags.
+  const metadata = extractMetadata(html, baseUrl);
+
+  // Run Readability unless a plugin opted out or this is Markdown. Extraction
+  // runs on the libuv thread pool so large pages don't block the event loop.
+  const shouldSkipReadability = Boolean(pluginContent?.skipReadability) || markdownResult !== null;
+  const cleaned = shouldSkipReadability
+    ? null
+    : await cleanContentAsync(html, { url: baseUrl, ...cleanOptions });
+
+  // When Readability ran, its output already has absolutized URLs; when it was
+  // skipped for plugin/Markdown content, absolutize here. When neither produced
+  // anything (Readability failed on a plain page), store NULL rather than the raw
+  // full page — readers fall back to the sanitized original content.
+  const contentCleaned =
+    markdownResult?.html ??
+    cleaned?.content ??
+    (pluginContent ? absolutizeUrls(pluginContent.html, baseUrl) : null);
+
+  // Precedence: explicit caller value → direct-from-source (plugin, Markdown
+  // frontmatter, Open Graph/<title>) → Readability → filename (title only).
+  const title =
+    hints.providedTitle ||
+    pluginContent?.title ||
+    markdownResult?.title ||
+    metadata.title ||
+    cleaned?.title ||
+    (hints.filename ? titleFromFilename(hints.filename) || null : null) ||
+    null;
+  const author =
+    pluginContent?.author || markdownResult?.author || metadata.author || cleaned?.byline || null;
+  const siteName = hints.siteName || pluginContent?.siteName || metadata.siteName || null;
+
+  const summary = computeSavedArticleExcerpt({ markdownResult, cleaned, pluginContent, html });
+
+  const contentHash = generateContentHash(title, contentCleaned || html);
+
+  // Plain text for the refetch quality guard: prefer the raw plugin body, else
+  // Readability's text, else the raw HTML stripped.
+  const newTextContent = pluginContent
+    ? stripHtml(pluginContent.html)
+    : cleaned
+      ? cleaned.textContent
+      : stripHtml(html);
+
+  return {
+    title,
+    author,
+    siteName,
+    contentOriginal: html,
+    contentCleaned,
+    summary,
+    imageUrl: metadata.imageUrl,
+    contentHash,
+    newTextContent,
+  };
+}
+
 // ============================================================================
 // Shared Insert Helper
 // ============================================================================
@@ -264,8 +411,9 @@ interface InsertSavedEntryParams {
 /**
  * Insert a saved entry into the database and publish a new-entry event.
  *
- * Handles the shared boilerplate for both saveArticle and createUploadedArticle:
- * entry insert, user_entries insert, SSE publish, and SavedArticle construction.
+ * Handles the shared boilerplate for the URL-save path (saveArticle /
+ * savePlaceholderArticle) and the upload path (insertUploadedArticle): entry
+ * insert, user_entries insert, SSE publish, and SavedArticle construction.
  *
  * The entry and user_entries inserts run in one transaction so a crash can't
  * leave an entry with no user_entries row (which would make it invisible).
@@ -274,8 +422,8 @@ interface InsertSavedEntryParams {
  * `onConflictDoNothing` on `(feed_id, guid)`, so a concurrent duplicate save
  * (e.g. a double-click) is idempotent instead of surfacing a raw unique-violation
  * 500 (issue #952). The caller re-selects the existing article in that case.
- * `createUploadedArticle` uses a random `uploaded:{uuid}` guid, so it never
- * conflicts and always gets a row back.
+ * Uploads use a random `uploaded:{uuid}` guid, so they never conflict and always
+ * get a row back.
  */
 async function insertSavedEntry(
   db: typeof dbType,
@@ -366,6 +514,74 @@ async function insertSavedEntry(
     starred: false,
     savedAt: now,
   };
+}
+
+/** Display site name for an uploaded file, by type. */
+const UPLOAD_SITE_NAMES: Record<SupportedFileType, string> = {
+  docx: "Uploaded Document",
+  html: "Uploaded HTML",
+  markdown: "Uploaded Text",
+};
+
+/** The derived fields an uploaded (null-URL) article is stored with. */
+interface UploadedArticleFields {
+  title: string | null;
+  author: string | null;
+  siteName: string | null;
+  contentOriginal: string;
+  contentCleaned: string | null;
+  summary: string | null;
+  imageUrl: string | null;
+  contentHash: string;
+}
+
+/**
+ * Insert a null-URL (uploaded) saved article from already-derived fields.
+ *
+ * Uploaded articles have no URL, so — unlike {@link saveArticle} — there is no
+ * existing-by-URL lookup, refetch, quality guard, or placeholder heal: the guid
+ * is a fresh random `uploaded:{uuid}` that never conflicts. This is the shared
+ * tail for every upload path (file upload, Markdown, pre-cleaned HTML).
+ */
+async function insertUploadedArticle(
+  db: typeof dbType,
+  userId: string,
+  fields: UploadedArticleFields
+): Promise<SavedArticle> {
+  const maxSize = usageLimitsConfig.maxSavedArticleSizeBytes;
+  if (fields.contentOriginal.length > maxSize) {
+    throw errors.contentTooLarge("Uploaded article", maxSize);
+  }
+
+  const savedFeedId = await getOrCreateSavedFeed(db, userId);
+
+  // Fresh random guid → the insert can't conflict.
+  const guid = `uploaded:${generateUuidv7()}`;
+
+  const saved = await insertSavedEntry(db, userId, savedFeedId, {
+    guid,
+    url: null,
+    title: fields.title,
+    author: fields.author,
+    contentOriginal: fields.contentOriginal,
+    contentCleaned: fields.contentCleaned,
+    summary: fields.summary,
+    siteName: fields.siteName,
+    imageUrl: fields.imageUrl,
+    contentHash: fields.contentHash,
+  });
+
+  if (!saved) {
+    throw new Error("Uploaded article insert unexpectedly conflicted");
+  }
+
+  logger.info("Created uploaded article", {
+    entryId: saved.id,
+    title: fields.title,
+    siteName: fields.siteName,
+  });
+
+  return saved;
 }
 
 // ============================================================================
@@ -953,49 +1169,21 @@ export async function saveArticle(
     existingEntry = existing[0];
   }
 
-  const { html, contentUrl, pluginContent, markdownResult } = await acquireArticleContent(
-    userId,
-    params,
-    normalizedUrl
-  );
+  const bundle = await acquireArticleContent(userId, params, normalizedUrl);
+  const { html } = bundle;
 
-  // Extract metadata from Open Graph / meta tags
-  const metadata = extractMetadata(html, contentUrl);
-
-  // Run Readability for clean content (skip for plugins that request it, or
-  // for Markdown). Extraction runs on the libuv thread pool so large pages
-  // don't block the event loop.
-  const shouldSkipReadability = Boolean(pluginContent?.skipReadability) || markdownResult !== null;
-  const cleaned = shouldSkipReadability ? null : await cleanContentAsync(html, { url: contentUrl });
-
-  // Generate excerpt (see computeSavedArticleExcerpt for precedence rationale).
-  const excerpt = computeSavedArticleExcerpt({ markdownResult, cleaned, pluginContent, html });
-
-  // Build final values - prefer plugin/API data, then provided hint, then
-  // extracted metadata, then Readability
-  // When Readability ran, its output already has absolutized URLs; when it
-  // was skipped for plugin/API content, absolutize here.
-  // When neither produced anything (Readability failed on a plain page),
-  // store NULL rather than the raw full page — readers fall back to the
-  // sanitized original content.
-  const finalContentCleaned =
-    markdownResult?.html ??
-    cleaned?.content ??
-    (pluginContent ? absolutizeUrls(pluginContent.html, contentUrl) : null);
-
-  const finalTitle =
-    pluginContent?.title ||
-    params.title ||
-    markdownResult?.title ||
-    metadata.title ||
-    cleaned?.title ||
-    null;
-  const finalAuthor =
-    pluginContent?.author || markdownResult?.author || metadata.author || cleaned?.byline || null;
-  const finalSiteName = pluginContent?.siteName || metadata.siteName || null;
-
-  // Compute content hash for narration deduplication
-  const contentHash = generateContentHash(finalTitle, finalContentCleaned || html);
+  // Derive the stored fields from the acquired content. Shared with the upload
+  // paths (buildArticleFields) so save and upload stay in lockstep.
+  const {
+    title: finalTitle,
+    author: finalAuthor,
+    siteName: finalSiteName,
+    contentCleaned: finalContentCleaned,
+    summary: excerpt,
+    imageUrl,
+    contentHash,
+    newTextContent,
+  } = await buildArticleFields(bundle, { providedTitle: params.title ?? null });
 
   // Handle refetch: update the existing entry if quality is acceptable
   if (existingEntry) {
@@ -1013,11 +1201,7 @@ export async function saveArticle(
     if (!skipQualityGuard) {
       const oldTextLength = oldEntry.contentCleaned ? stripHtml(oldEntry.contentCleaned).length : 0;
 
-      const newTextLength = pluginContent
-        ? stripHtml(pluginContent.html).length
-        : cleaned
-          ? cleaned.textContent.length
-          : stripHtml(html).length;
+      const newTextLength = newTextContent.length;
 
       // Reject if new content is significantly shorter AND short in absolute terms
       // This catches error pages and access-denied pages while allowing legitimate edits
@@ -1055,7 +1239,7 @@ export async function saveArticle(
       contentCleaned: finalContentCleaned,
       summary: excerpt,
       siteName: finalSiteName,
-      imageUrl: metadata.imageUrl,
+      imageUrl,
       contentHash,
       updatedAt: now,
       // A successful real save clears the placeholder mark (no-op when the
@@ -1110,7 +1294,7 @@ export async function saveArticle(
       title: finalTitle,
       siteName: finalSiteName,
       author: finalAuthor,
-      imageUrl: metadata.imageUrl,
+      imageUrl,
       // Sanitize the body for the response (raw must not leave the service layer).
       contentCleaned: await sanitizeEntryHtmlAsync(finalContentCleaned),
       excerpt,
@@ -1130,7 +1314,7 @@ export async function saveArticle(
     contentCleaned: finalContentCleaned,
     summary: excerpt,
     siteName: finalSiteName,
-    imageUrl: metadata.imageUrl,
+    imageUrl,
     contentHash,
   });
 
@@ -1285,68 +1469,68 @@ export async function deleteSavedArticle(
 /**
  * Create a saved article from pre-processed HTML content.
  *
- * This is the core function for creating uploaded articles. It accepts
- * already-processed HTML content and handles the database insertion.
- * Used by both the MCP uploadArticle and tRPC uploadFile endpoints.
+ * Accepts already-cleaned HTML plus caller-supplied metadata and inserts it
+ * as-is (no Readability, no metadata extraction) — for callers that already hold
+ * final content. The file/Markdown upload entry points instead run their content
+ * through {@link buildArticleFields} (see {@link createSavedFromUpload} /
+ * {@link uploadArticle}).
  */
 export async function createUploadedArticle(
   db: typeof dbType,
   userId: string,
   params: CreateUploadedArticleParams
 ): Promise<SavedArticle> {
-  // Check content size
-  const maxSize = usageLimitsConfig.maxSavedArticleSizeBytes;
-  if (params.contentHtml.length > maxSize) {
-    throw errors.contentTooLarge("Uploaded article", maxSize);
-  }
-
-  // Get or create the user's saved feed
-  const savedFeedId = await getOrCreateSavedFeed(db, userId);
-
-  // Generate excerpt if not provided
-  const excerpt = params.excerpt ?? generateSummary(params.contentHtml) ?? null;
-
-  // Generate a unique guid for uploaded articles (no URL)
-  // Format: uploaded:{uuid} to distinguish from URL-based saved articles
-  const guid = `uploaded:${generateUuidv7()}`;
-
-  // Compute content hash for narration deduplication
-  const contentHash = generateContentHash(params.title, params.contentHtml);
-
   // Original and cleaned are the same string here; stored raw and sanitized per
   // read (issue #1282).
-  const saved = await insertSavedEntry(db, userId, savedFeedId, {
-    guid,
-    url: null,
+  return insertUploadedArticle(db, userId, {
     title: params.title,
     author: params.author ?? null,
+    siteName: params.siteName,
     contentOriginal: params.contentHtml,
     contentCleaned: params.contentHtml,
-    summary: excerpt,
-    siteName: params.siteName,
+    summary: params.excerpt ?? generateSummary(params.contentHtml) ?? null,
     imageUrl: null,
-    contentHash,
+    contentHash: generateContentHash(params.title, params.contentHtml),
   });
+}
 
-  // The guid is a fresh random `uploaded:{uuid}`, so the insert can't conflict.
-  if (!saved) {
-    throw new Error("Uploaded article insert unexpectedly conflicted");
-  }
-
-  logger.info("Created uploaded article", {
-    entryId: saved.id,
-    title: params.title,
-    siteName: params.siteName,
-  });
-
-  return saved;
+/**
+ * Create a saved article from an uploaded file (see `convertUploadedFile`).
+ *
+ * The converted content runs through the same {@link buildArticleFields} pipeline
+ * as a URL save — Readability, excerpt, and title/author/site-name precedence —
+ * with a null URL and the filename as a last-resort title.
+ */
+export async function createSavedFromUpload(
+  db: typeof dbType,
+  userId: string,
+  params: { converted: ConvertedUpload; title?: string | null }
+): Promise<SavedArticle> {
+  const { converted } = params;
+  const fields = await buildArticleFields(
+    {
+      html: converted.html,
+      contentUrl: null,
+      pluginContent: null,
+      markdownResult: converted.markdownResult,
+    },
+    {
+      providedTitle: params.title ?? null,
+      filename: converted.filename,
+      siteName: UPLOAD_SITE_NAMES[converted.fileType],
+    },
+    { minCleanedLength: 10 }
+  );
+  return insertUploadedArticle(db, userId, fields);
 }
 
 /**
  * Upload an article with Markdown content.
  *
  * Creates a saved article from Markdown content without requiring a URL.
- * Useful for AI assistants uploading content directly.
+ * Useful for AI assistants uploading content directly. Shares the same
+ * downstream processing as file uploads and URL saves via
+ * {@link buildArticleFields}.
  */
 export async function uploadArticle(
   db: typeof dbType,
@@ -1359,22 +1543,12 @@ export async function uploadArticle(
     throw errors.contentTooLarge("Uploaded article", maxSize);
   }
 
-  // Convert markdown to HTML and extract title/summary/author from frontmatter or content
-  const {
-    html: contentCleaned,
-    title: extractedTitle,
-    summary,
-    author,
-  } = await processMarkdown(params.content);
-
-  // Use provided title, falling back to extracted title
-  const finalTitle = params.title || extractedTitle;
-
-  return createUploadedArticle(db, userId, {
-    contentHtml: contentCleaned,
-    title: finalTitle,
-    excerpt: summary,
-    siteName: "Uploaded Article",
-    author,
-  });
+  // Convert markdown to HTML (with frontmatter title/summary/author); Readability
+  // is skipped downstream because markdownResult is set.
+  const markdownResult = await processMarkdown(params.content);
+  const fields = await buildArticleFields(
+    { html: markdownResult.html, contentUrl: null, pluginContent: null, markdownResult },
+    { providedTitle: params.title, siteName: "Uploaded Article" }
+  );
+  return insertUploadedArticle(db, userId, fields);
 }

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -350,19 +350,23 @@ async function buildArticleFields(
     cleaned?.content ??
     (pluginContent ? absolutizeUrls(pluginContent.html, baseUrl) : null);
 
-  // Precedence: explicit caller value → direct-from-source (plugin, Markdown
-  // frontmatter, Open Graph/<title> via extractMetadata) → Readability → filename
-  // (title only). `metadata.title` sits above `cleaned.title` and is also the
-  // fallback that survives a failed extraction (short/unparseable page, where
-  // Readability returns nothing). Our readability extractor (dom_smoothie) doesn't
-  // clean up the title beyond what the meta/<title> scrape already yields, so the
-  // two are equivalent when both are present.
+  // Precedence: explicit caller value → plugin/Markdown frontmatter → Readability
+  // → raw Open Graph/<title> → filename (title only).
+  //
+  // Readability sits above the raw `metadata.title` scrape because when it does
+  // produce a title it's the better one to prefer (it can strip a " | Site Name"
+  // suffix / pick a sensible heading). It only returns a title when it also
+  // extracted the body, so `metadata.title` (our own og:title/<title> scrape)
+  // stays just below it as the fallback that survives a failed extraction
+  // (short/unparseable page). Today our extractor (dom_smoothie) doesn't actually
+  // clean the title beyond the meta/<title> scrape, so the two are equivalent in
+  // practice — but this is the order we want if/when it improves.
   const title =
     hints.providedTitle ||
     pluginContent?.title ||
     markdownResult?.title ||
-    metadata.title ||
     cleaned?.title ||
+    metadata.title ||
     (hints.filename ? titleFromFilename(hints.filename) || null : null) ||
     null;
   const author =

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -351,7 +351,12 @@ async function buildArticleFields(
     (pluginContent ? absolutizeUrls(pluginContent.html, baseUrl) : null);
 
   // Precedence: explicit caller value → direct-from-source (plugin, Markdown
-  // frontmatter, Open Graph/<title>) → Readability → filename (title only).
+  // frontmatter, Open Graph/<title> via extractMetadata) → Readability → filename
+  // (title only). `metadata.title` sits above `cleaned.title` and is also the
+  // fallback that survives a failed extraction (short/unparseable page, where
+  // Readability returns nothing). Our readability extractor (dom_smoothie) doesn't
+  // clean up the title beyond what the meta/<title> scrape already yields, so the
+  // two are equivalent when both are present.
   const title =
     hints.providedTitle ||
     pluginContent?.title ||

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -33,7 +33,7 @@ import { logger } from "@/lib/logger";
 import * as countsService from "@/server/services/counts";
 import * as savedService from "@/server/services/saved";
 import {
-  processUploadedFile,
+  convertUploadedFile,
   detectFileType,
   getSupportedTypesDescription,
 } from "@/server/file/process-upload";
@@ -269,12 +269,14 @@ export const savedRouter = createTRPCRouter({
         throw errors.contentTooLarge("Uploaded file", usageLimitsConfig.maxSavedArticleSizeBytes);
       }
 
-      // Process the file
-      let processed;
+      // Convert the file to raw article content. Conversion failures are the
+      // user's problem (bad file) → BAD_REQUEST; the downstream save (Readability,
+      // metadata, insert) runs outside this catch so its errors surface as 500s.
+      let converted;
       try {
-        processed = await processUploadedFile(fileBuffer, input.filename);
+        converted = await convertUploadedFile(fileBuffer, input.filename);
       } catch (error) {
-        logger.warn("Failed to process uploaded file", {
+        logger.warn("Failed to convert uploaded file", {
           filename: input.filename,
           fileType,
           error: error instanceof Error ? error.message : String(error),
@@ -285,31 +287,18 @@ export const savedRouter = createTRPCRouter({
         });
       }
 
-      // Determine site name based on file type
-      const siteNameMap: Record<string, string> = {
-        docx: "Uploaded Document",
-        html: "Uploaded HTML",
-        markdown: "Uploaded Text",
-      };
-      const siteName = siteNameMap[processed.fileType] || "Uploaded File";
-
-      // Use provided title or extracted title
-      const finalTitle = input.title || processed.title;
-
-      // Create the uploaded article using the shared service
-      const article = await savedService.createUploadedArticle(ctx.db, userId, {
-        contentHtml: processed.contentCleaned,
-        title: finalTitle,
-        excerpt: processed.excerpt,
-        siteName,
-        author: processed.author,
+      // Save via the shared upload pipeline (title/author/excerpt/metadata
+      // derived identically to a URL save).
+      const article = await savedService.createSavedFromUpload(ctx.db, userId, {
+        converted,
+        title: input.title,
       });
 
       logger.info("Uploaded file saved", {
         entryId: article.id,
         filename: input.filename,
-        fileType: processed.fileType,
-        title: finalTitle,
+        fileType: converted.fileType,
+        title: article.title,
       });
 
       // Get counts after creating new entry

--- a/tests/integration/saved-uploads.test.ts
+++ b/tests/integration/saved-uploads.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Integration tests for the unified upload → save pipeline.
+ *
+ * File uploads (`createSavedFromUpload`) and Markdown uploads (`uploadArticle`)
+ * run their content through the same `buildArticleFields` pipeline as a URL save,
+ * so this covers the upload-specific behavior that pipeline adds: title/author
+ * precedence, the filename fallback, relative-URL handling against the dummy
+ * upload base, and Open Graph metadata extraction.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users, entries } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createSavedFromUpload, uploadArticle } from "../../src/server/services/saved";
+import { convertUploadedFile } from "../../src/server/file/process-upload";
+
+const createdUserIds: string[] = [];
+
+async function createTestUser(): Promise<string> {
+  const userId = generateUuidv7();
+  await db.insert(users).values({
+    id: userId,
+    email: `upload-${userId}@test.com`,
+    passwordHash: "test-hash",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  createdUserIds.push(userId);
+  return userId;
+}
+
+/** Reads the stored raw columns for a saved entry (bypassing the read-path sanitize). */
+async function readStored(entryId: string) {
+  const [row] = await db
+    .select({
+      contentOriginal: entries.contentOriginal,
+      contentCleaned: entries.contentCleaned,
+      title: entries.title,
+      author: entries.author,
+      siteName: entries.siteName,
+      summary: entries.summary,
+      imageUrl: entries.imageUrl,
+      url: entries.url,
+      guid: entries.guid,
+    })
+    .from(entries)
+    .where(eq(entries.id, entryId))
+    .limit(1);
+  return row;
+}
+
+// A substantial HTML article so Readability extracts a real body.
+const ARTICLE_BODY =
+  "<p>This is the opening paragraph of a genuinely substantial uploaded article. " +
+  "It has enough prose that the readability extractor treats it as real content " +
+  "rather than a boilerplate shell, so the cleaned body is produced.</p>" +
+  '<p>Here is a <a href="/relative/link">relative link</a> and an ' +
+  '<img src="images/pic.png" alt="pic"> relative image that should be rewritten.</p>' +
+  "<p>And a closing paragraph with still more text to comfortably clear the " +
+  "minimum content length thresholds the extractor enforces.</p>";
+
+afterAll(async () => {
+  for (const id of createdUserIds) {
+    await db.delete(users).where(eq(users.id, id));
+  }
+});
+
+describe("createSavedFromUpload (HTML)", () => {
+  it("stores a null URL and an uploaded: guid", async () => {
+    const userId = await createTestUser();
+    const converted = await convertUploadedFile(
+      `<html><head><title>Doc Title</title></head><body>${ARTICLE_BODY}</body></html>`,
+      "notes.html"
+    );
+    const article = await createSavedFromUpload(db, userId, { converted });
+
+    expect(article.url).toBeNull();
+    const stored = await readStored(article.id);
+    expect(stored.url).toBeNull();
+    expect(stored.guid.startsWith("uploaded:")).toBe(true);
+  });
+
+  it("prefers a provided title over the document title", async () => {
+    const userId = await createTestUser();
+    const converted = await convertUploadedFile(
+      `<html><head><title>Document Title</title></head><body>${ARTICLE_BODY}</body></html>`,
+      "notes.html"
+    );
+    const article = await createSavedFromUpload(db, userId, { converted, title: "Caller Title" });
+    expect(article.title).toBe("Caller Title");
+  });
+
+  it("falls back to the filename-derived title when content has none", async () => {
+    const userId = await createTestUser();
+    // No <title> and no heading Readability would pick up as a title.
+    const converted = await convertUploadedFile(
+      `<html><body>${ARTICLE_BODY}</body></html>`,
+      "My_Great-Notes.html"
+    );
+    const article = await createSavedFromUpload(db, userId, { converted });
+    expect(article.title).toBe("My Great Notes");
+  });
+
+  it("rewrites relative URLs against the dummy upload base (not Lion Reader)", async () => {
+    const userId = await createTestUser();
+    const converted = await convertUploadedFile(
+      `<html><body>${ARTICLE_BODY}</body></html>`,
+      "notes.html"
+    );
+    const article = await createSavedFromUpload(db, userId, { converted });
+
+    const stored = await readStored(article.id);
+    expect(stored.contentCleaned).toBeTruthy();
+    // Relative link/image resolved against uploaded.invalid, so nothing points
+    // back into the app.
+    expect(stored.contentCleaned).toContain("https://uploaded.invalid/relative/link");
+    expect(stored.contentCleaned).toContain("https://uploaded.invalid/images/pic.png");
+    expect(stored.contentCleaned).not.toContain('href="/relative/link"');
+  });
+
+  it("extracts Open Graph metadata (author, image) from uploaded HTML", async () => {
+    const userId = await createTestUser();
+    const html =
+      "<html><head>" +
+      '<meta property="og:image" content="https://cdn.example.com/cover.jpg">' +
+      '<meta name="author" content="Ada Lovelace">' +
+      "<title>OG Doc</title></head>" +
+      `<body>${ARTICLE_BODY}</body></html>`;
+    const converted = await convertUploadedFile(html, "og.html");
+    const article = await createSavedFromUpload(db, userId, { converted });
+
+    expect(article.author).toBe("Ada Lovelace");
+    const stored = await readStored(article.id);
+    expect(stored.imageUrl).toBe("https://cdn.example.com/cover.jpg");
+  });
+});
+
+describe("uploadArticle (Markdown)", () => {
+  it("uses frontmatter title/summary/author", async () => {
+    const userId = await createTestUser();
+    const md = [
+      "---",
+      "title: Frontmatter Title",
+      "description: A concise frontmatter summary of the piece.",
+      "author: Grace Hopper",
+      "---",
+      "",
+      "# Body Heading",
+      "",
+      "Some markdown body content here that is long enough to be meaningful.",
+    ].join("\n");
+
+    const article = await uploadArticle(db, userId, { content: md, title: "" });
+    expect(article.title).toBe("Frontmatter Title");
+    expect(article.author).toBe("Grace Hopper");
+    expect(article.excerpt).toBe("A concise frontmatter summary of the piece.");
+    expect(article.url).toBeNull();
+  });
+
+  it("prefers the provided title over frontmatter", async () => {
+    const userId = await createTestUser();
+    const md = ["---", "title: Frontmatter Title", "---", "", "Body text here."].join("\n");
+    const article = await uploadArticle(db, userId, { content: md, title: "Explicit Title" });
+    expect(article.title).toBe("Explicit Title");
+  });
+});

--- a/tests/integration/saved-uploads.test.ts
+++ b/tests/integration/saved-uploads.test.ts
@@ -120,6 +120,24 @@ describe("createSavedFromUpload (HTML)", () => {
     expect(stored.contentCleaned).not.toContain('href="/relative/link"');
   });
 
+  it("keeps the raw original when Readability fails (contentCleaned null, still readable)", async () => {
+    const userId = await createTestUser();
+    // Too short for Readability to extract → cleaned is null. Matches how a URL
+    // save behaves on a page Readability can't parse: store the original, serve
+    // `cleaned ?? original` on read.
+    const converted = await convertUploadedFile(
+      "<html><body><p>Too short.</p></body></html>",
+      "tiny.html"
+    );
+    const article = await createSavedFromUpload(db, userId, { converted });
+
+    expect(article.contentCleaned).toBeNull();
+    const stored = await readStored(article.id);
+    expect(stored.contentCleaned).toBeNull();
+    // The raw body survives as the original, so the read path still renders it.
+    expect(stored.contentOriginal).toContain("Too short.");
+  });
+
   it("extracts Open Graph metadata (author, image) from uploaded HTML", async () => {
     const userId = await createTestUser();
     const html =

--- a/tests/unit/content-cleaner.test.ts
+++ b/tests/unit/content-cleaner.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect } from "vitest";
 import {
   cleanContent,
-  generateCleanedSummary,
   absolutizeUrls,
   extractBaseHref,
   cleanLessWrongContent,
@@ -351,81 +350,6 @@ describe("cleanContent", () => {
       expect(result!.textContent).not.toMatch(/^\s/);
       expect(result!.textContent).not.toMatch(/\s$/);
     });
-  });
-});
-
-describe("generateCleanedSummary", () => {
-  it("should use excerpt when available and long enough", () => {
-    const cleaned = {
-      content: "<p>Full content here...</p>",
-      textContent: "Full content here...",
-      excerpt: "This is a meaningful excerpt that summarizes the article content well.",
-      title: "Test",
-      byline: null,
-    };
-
-    const summary = generateCleanedSummary(cleaned);
-
-    expect(summary).toBe(cleaned.excerpt);
-  });
-
-  it("should fall back to text content when excerpt is short", () => {
-    const cleaned = {
-      content: "<p>Full content here...</p>",
-      textContent: "This is the full text content that should be used for the summary.",
-      excerpt: "Too short",
-      title: "Test",
-      byline: null,
-    };
-
-    const summary = generateCleanedSummary(cleaned);
-
-    expect(summary).toContain("full text content");
-  });
-
-  it("should truncate long content", () => {
-    const longText = "A".repeat(500);
-    const cleaned = {
-      content: `<p>${longText}</p>`,
-      textContent: longText,
-      excerpt: "",
-      title: "Test",
-      byline: null,
-    };
-
-    const summary = generateCleanedSummary(cleaned, 300);
-
-    expect(summary.length).toBeLessThanOrEqual(303); // 300 + "..."
-    expect(summary.endsWith("...")).toBe(true);
-  });
-
-  it("should not truncate short content", () => {
-    const cleaned = {
-      content: "<p>Short content</p>",
-      textContent: "Short content",
-      excerpt: "",
-      title: "Test",
-      byline: null,
-    };
-
-    const summary = generateCleanedSummary(cleaned);
-
-    expect(summary).toBe("Short content");
-    expect(summary.endsWith("...")).toBe(false);
-  });
-
-  it("should handle empty content", () => {
-    const cleaned = {
-      content: "",
-      textContent: "",
-      excerpt: "",
-      title: "Test",
-      byline: null,
-    };
-
-    const summary = generateCleanedSummary(cleaned);
-
-    expect(summary).toBe("");
   });
 });
 

--- a/tests/unit/entry-summary.test.ts
+++ b/tests/unit/entry-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { stripHtml } from "@/server/html/strip-html";
+import { stripHtml, summarizeCleanedContent } from "@/server/html/strip-html";
 
 describe("stripHtml", () => {
   describe("basic text extraction", () => {
@@ -208,5 +208,44 @@ describe("stripHtml", () => {
       const html = "<a>X</a><p>Y</p>";
       expect(stripHtml(html, 300)).toBe("X Y");
     });
+  });
+});
+
+describe("summarizeCleanedContent", () => {
+  it("uses the excerpt when it is substantial (>= 50 chars)", () => {
+    const excerpt = "This is a meaningful excerpt that summarizes the article content well.";
+    expect(summarizeCleanedContent({ excerpt, textContent: "Full body text here." })).toBe(excerpt);
+  });
+
+  it("falls back to body text when the excerpt is too short", () => {
+    const summary = summarizeCleanedContent({
+      excerpt: "Too short",
+      textContent: "This is the full text content that should be used for the summary.",
+    });
+    expect(summary).toContain("full text content");
+  });
+
+  it("falls back to body text when there is no excerpt", () => {
+    expect(summarizeCleanedContent({ excerpt: "", textContent: "The article begins here." })).toBe(
+      "The article begins here."
+    );
+  });
+
+  it("truncates long content at a word boundary with an ellipsis", () => {
+    const longText = "word ".repeat(200).trim(); // 999 chars, spaces to break on
+    const summary = summarizeCleanedContent({ excerpt: "", textContent: longText });
+    expect(summary.length).toBeLessThanOrEqual(303); // 300 + "..."
+    expect(summary.endsWith("...")).toBe(true);
+    expect(summary.includes("wordword")).toBe(false); // broke on a space
+  });
+
+  it("does not truncate short content", () => {
+    const summary = summarizeCleanedContent({ excerpt: "", textContent: "Short content" });
+    expect(summary).toBe("Short content");
+    expect(summary.endsWith("...")).toBe(false);
+  });
+
+  it("returns an empty string for empty content", () => {
+    expect(summarizeCleanedContent({ excerpt: "", textContent: "" })).toBe("");
   });
 });

--- a/tests/unit/saved-article-excerpt.test.ts
+++ b/tests/unit/saved-article-excerpt.test.ts
@@ -35,16 +35,19 @@ describe("computeSavedArticleExcerpt", () => {
     expect(excerpt).not.toContain("Introduction");
   });
 
-  it("prefers the Readability excerpt when present, falling back to body text", () => {
+  it("delegates the cleaned branch to summarizeCleanedContent (description-preferred)", () => {
+    // A substantial excerpt (>= 50 chars) wins over the body text...
+    const excerpt = "A good, article-specific description that is clearly long enough.";
     expect(
       computeSavedArticleExcerpt({
         markdownResult: null,
-        cleaned: { excerpt: "A good article-specific excerpt.", textContent: "Body text here." },
+        cleaned: { excerpt, textContent: "Body text here." },
         pluginContent: null,
         html: "<p>Raw</p>",
       })
-    ).toBe("A good article-specific excerpt.");
+    ).toBe(excerpt);
 
+    // ...and the body text is used when there is no usable excerpt.
     expect(
       computeSavedArticleExcerpt({
         markdownResult: null,
@@ -55,28 +58,15 @@ describe("computeSavedArticleExcerpt", () => {
     ).toBe("The article begins here.");
   });
 
-  it("hard-truncates a long body-text fallback to <=300 chars (no ellipsis)", () => {
-    const long = "word ".repeat(200); // 1000 chars
-    const excerpt = computeSavedArticleExcerpt({
-      markdownResult: null,
-      cleaned: { excerpt: "", textContent: long },
-      pluginContent: null,
-      html: "",
-    });
-    expect(excerpt).not.toBeNull();
-    expect(excerpt!.length).toBeLessThanOrEqual(300);
-    expect(long.startsWith(excerpt!)).toBe(true);
-  });
-
-  it("truncates a long Readability excerpt to 297 chars + ellipsis", () => {
-    const long = "x".repeat(500);
-    const excerpt = computeSavedArticleExcerpt({
-      markdownResult: null,
-      cleaned: { excerpt: long, textContent: "body" },
-      pluginContent: null,
-      html: "",
-    });
-    expect(excerpt).toBe("x".repeat(297) + "...");
+  it("returns null when the cleaned content is empty", () => {
+    expect(
+      computeSavedArticleExcerpt({
+        markdownResult: null,
+        cleaned: { excerpt: "", textContent: "" },
+        pluginContent: null,
+        html: "<p>Raw</p>",
+      })
+    ).toBeNull();
   });
 
   it("summarizes raw plugin HTML only when Readability was skipped (cleaned is null)", () => {


### PR DESCRIPTION
## Motivation

Follow-up to the excerpt fixes (#1398) and the earlier dedup discussion in #1400. Save-from-URL and file/Markdown upload had grown into **parallel pipelines** that each derived title / author / excerpt / cleaned-content their own way — and had drifted (e.g. docx ignored the extracted description; uploads never ran OG metadata extraction and collapsed the original/cleaned body into one string).

As discussed: the only *essential* difference between save and upload is **how the content is acquired** (fetch vs. file conversion) and that **uploads carry a null URL** — which by itself disables plugin matching, existing-by-URL dedup, and refetch. Everything after acquisition is content-based and should be one path.

## Change

- **`buildArticleFields` (saved.ts)** — the shared "acquired content bundle → stored fields" step (metadata, Readability, excerpt, title/author/site-name precedence, content hash), used by `saveArticle` **and** both upload paths.
- **`process-upload.ts` is now a pure converter** (`convertUploadedFile`): docx→HTML (mammoth), .md→HTML (marked), .html passthrough. No Readability/excerpt/metadata there anymore — it all happens downstream, so uploads and URL saves are processed identically.
- **Fixed the drifted title precedence** to: provided → source (plugin / Markdown frontmatter / OG or `<title>`) → Readability → **filename** (passed as a hint, last resort). Author and site name follow the same shape.
- **Uploads now also get** OG metadata extraction and a distinct original-vs-cleaned body (the old path dropped both).
- **Relative URLs in uploads** resolve against a reserved-TLD dummy base (`https://uploaded.invalid/`, RFC 6761) instead of Lion Reader's own domain — so a stray relative link becomes an obviously-broken external URL, not one pointing back into the app.
- Uploads keep their lenient Readability threshold (`minCleanedLength: 10`) since they're trusted user content.

`createUploadedArticle` remains as the low-level "insert already-cleaned HTML" API; it, the file/Markdown uploads, and the placeholder path all funnel through `insertUploadedArticle` → `insertSavedEntry`.

## Behavior changes (intentional)

- A **provided title now beats a plugin title** for URL saves (previously plugin won). Matches the "explicit caller value first" precedence.
- **docx uploads now prefer the extracted description** for the excerpt (previously body-text only) and get OG metadata.
- Uploaded HTML with relative links now shows broken-external URLs rather than links resolving to `lionreader.com/...`.

## Scope / follow-ups

- Supersedes **#1402** — its `summarizeCleanedContent` consolidation is included here (this branch was built on it).
- The docx extraction quality (does mammoth→Readability produce garbage title/author/description tags?) is an edge case, tracked separately — see linked issue.

## Tests

New `tests/integration/saved-uploads.test.ts` covers title precedence (provided > content > filename), the filename fallback, the dummy-base relative-URL rewrite, OG metadata extraction, and Markdown frontmatter. Full unit (2555) + integration (709) suites, typecheck, lint, and knip all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)