### PR TITLE
Reclassify Google Reader compat-API polling as API usage, not "last active"

### DIFF
--- a/src/server/auth/CLAUDE.md
+++ b/src/server/auth/CLAUDE.md
@@ -10,7 +10,9 @@ This file governs sessions, the session cookie, API-token/OAuth-token authorizat
 4. Validate: not revoked, not expired
 5. Update `last_active_at` asynchronously (on both the session row and, throttled, the denormalized `users.last_active_at` column)
 
-`users.last_active_at` is a denormalized copy of the most recent session activity. It exists so the admin "last active" view survives retention cleanup, which deletes expired sessions (see `runRetentionCleanup`); deriving activity from `MAX(sessions.last_active_at)` would blank out any user idle longer than the 30-day session lifetime. `updateLastActiveAt` refreshes it fire-and-forget, skipping the write when it was updated within the last minute to avoid write/index churn.
+`users.last_active_at` is a denormalized copy of the most recent **full-access (browser) session** activity. It exists so the admin "last active" view survives retention cleanup, which deletes expired sessions (see `runRetentionCleanup`); deriving activity from `MAX(sessions.last_active_at)` would blank out any user idle longer than the 30-day session lifetime. `updateLastActiveAt` refreshes it fire-and-forget, skipping the write when it was updated within the last minute to avoid write/index churn.
+
+A **scoped session** (`scopes IS NOT NULL` — today only the Google Reader compat token) is treated differently: it's a native app polling the sync API in the background, not a human using the reader, so `updateLastActiveAt` bumps **only its own `sessions.last_active_at`** and deliberately leaves `users.last_active_at` (and thus the admin "last active" column + the active-users stats) untouched. The admin user list instead folds `MAX(sessions.last_active_at)` over scoped rows into its `lastTokenUsedAt` ("last API usage") column alongside API-token and OAuth-token use, so compat-API sync shows up as API usage rather than session activity (`src/server/trpc/routers/admin.ts`).
 
 ## Session Cookie (`HttpOnly` + `Secure`)
 

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -364,7 +364,11 @@ export async function validateSession(
             return null;
           }
           // Update last_active_at asynchronously (fire and forget)
-          void updateLastActiveAt(data.session.id, data.session.userId);
+          void updateLastActiveAt(
+            data.session.id,
+            data.session.userId,
+            data.session.scopes !== null
+          );
           return data;
         }
 
@@ -431,7 +435,11 @@ export async function validateSession(
   }
 
   // Update last_active_at asynchronously (fire and forget)
-  void updateLastActiveAt(sessionData.session.id, sessionData.session.userId);
+  void updateLastActiveAt(
+    sessionData.session.id,
+    sessionData.session.userId,
+    sessionData.session.scopes !== null
+  );
 
   return sessionData;
 }
@@ -445,23 +453,42 @@ export async function validateSession(
 const USER_LAST_ACTIVE_REFRESH_MS = 60 * 1000;
 
 /**
- * Updates last_active_at for both the session and (throttled) the user row.
+ * Updates last_active_at for the session and (throttled) the user row.
  * Done asynchronously (fire-and-forget) so it never blocks the request.
  *
  * The user-row copy is denormalized so the admin "last active" view survives
  * session retention cleanup (expired sessions are deleted), rather than being
  * derived from MAX(sessions.last_active_at).
  *
- * This runs on every authenticated request, so it's a single round-trip via a
+ * `isScoped` is true for a restricted (compat-API) session — today only the
+ * Google Reader token, which a native app polls in the background. That polling
+ * isn't real user activity, so a scoped session bumps **only** its own session
+ * row (needed for the user's session list and as the admin "last API usage"
+ * source, MAX(sessions.last_active_at) over scoped rows) and deliberately leaves
+ * `users.last_active_at` alone — otherwise a native-app sync would keep a user
+ * looking perpetually "active" (and inflate the active-users stats) despite
+ * never opening the reader.
+ *
+ * For a full-access (browser) session this is a single round-trip via a
  * writable CTE rather than two sequential statements. The session row is always
  * touched; the user row is only touched when its timestamp is stale, so the
  * common case is a no-op on the users table (no row write, no index churn) while
  * still costing just one query.
  */
-async function updateLastActiveAt(sessionId: string, userId: string): Promise<void> {
+async function updateLastActiveAt(
+  sessionId: string,
+  userId: string,
+  isScoped: boolean
+): Promise<void> {
   const now = new Date();
-  const staleCutoff = new Date(now.getTime() - USER_LAST_ACTIVE_REFRESH_MS);
   try {
+    if (isScoped) {
+      await db.execute(sql`
+        UPDATE ${sessions} SET last_active_at = ${now} WHERE id = ${sessionId}
+      `);
+      return;
+    }
+    const staleCutoff = new Date(now.getTime() - USER_LAST_ACTIVE_REFRESH_MS);
     await db.execute(sql`
       WITH touched_session AS (
         UPDATE ${sessions} SET last_active_at = ${now} WHERE id = ${sessionId}

--- a/src/server/trpc/routers/admin.ts
+++ b/src/server/trpc/routers/admin.ts
@@ -6,7 +6,7 @@
  */
 
 import { z } from "zod";
-import { eq, and, isNull, sql, desc, asc, lt, gt, ilike, count, max } from "drizzle-orm";
+import { eq, and, isNull, isNotNull, sql, desc, asc, lt, gt, ilike, count, max } from "drizzle-orm";
 import crypto from "crypto";
 
 import { createTRPCRouter, adminProcedure } from "../trpc";
@@ -20,6 +20,7 @@ import {
   oauthAccounts,
   oauthAccessTokens,
   apiTokens,
+  sessions,
   userEntries,
 } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
@@ -553,10 +554,12 @@ const userEndpoints = {
             subscriptionCount: z.number(),
             entryCount: z.number(),
             lastActiveAt: z.date().nullable(),
-            // Most recent API-token / OAuth-MCP token use. Durable for
-            // long-lived API tokens (extension/integrations); for MCP OAuth
-            // access tokens it only reflects ~the last day, since those are
-            // short-lived and pruned by retention cleanup soon after expiry.
+            // Most recent programmatic (API) access: API-token / OAuth-MCP
+            // token use, or Google Reader compat-API polling (a scoped session).
+            // Durable for long-lived API tokens (extension/integrations); for
+            // MCP OAuth access tokens and Google Reader sessions it reflects
+            // only recent use, since those are pruned by retention cleanup soon
+            // after expiry.
             lastTokenUsedAt: z.date().nullable(),
           })
         ),
@@ -591,10 +594,19 @@ const userEndpoints = {
         .from(userEntries)
         .where(eq(userEntries.userId, users.id));
 
-      // Subqueries: most recent token use, tracked separately from session
-      // activity. API tokens (extension/integrations) are long-lived so this is
-      // durable; OAuth access tokens (remote MCP) are short-lived and pruned by
-      // retention, so they only contribute usage from ~the last day.
+      // Subqueries: most recent programmatic (API) access, tracked separately
+      // from human session activity. Three sources:
+      // - API tokens (extension/integrations) — long-lived, so durable.
+      // - OAuth access tokens (remote MCP) — short-lived and pruned by
+      //   retention, so they only contribute usage from ~the last day.
+      // - Scoped sessions — the Google Reader compat API mints one per login
+      //   (scopes IS NOT NULL). A native app polls it in the background, which
+      //   isn't real reader activity, so updateLastActiveAt bumps only
+      //   sessions.last_active_at for those and leaves users.last_active_at
+      //   alone. Surfacing MAX here reclassifies that polling as API usage.
+      //   Durable only while the session lives (retention deletes it ~a day
+      //   after its 30-day expiry), but an actively-syncing client keeps a live
+      //   session, so it stays current exactly when it matters.
       const apiTokenLastUsedSq = ctx.db
         .select({ max: max(apiTokens.lastUsedAt).as("max") })
         .from(apiTokens)
@@ -603,6 +615,10 @@ const userEndpoints = {
         .select({ max: max(oauthAccessTokens.lastUsedAt).as("max") })
         .from(oauthAccessTokens)
         .where(eq(oauthAccessTokens.userId, users.id));
+      const scopedSessionLastActiveSq = ctx.db
+        .select({ max: max(sessions.lastActiveAt).as("max") })
+        .from(sessions)
+        .where(and(eq(sessions.userId, users.id), isNotNull(sessions.scopes)));
 
       const conditions = [];
 
@@ -678,9 +694,9 @@ const userEndpoints = {
           subscriptionCount: sql<number>`(${subscriptionCountSq})`.as("subscription_count"),
           entryCount: sql<number>`(${entryCountSq})`.as("entry_count"),
           lastActiveAt: users.lastActiveAt,
-          // GREATEST ignores NULLs, so this is the newer of the two, or NULL.
+          // GREATEST ignores NULLs, so this is the newest of the three, or NULL.
           lastTokenUsedAt:
-            sql<Date | null>`GREATEST((${apiTokenLastUsedSq}), (${oauthTokenLastUsedSq}))`.as(
+            sql<Date | null>`GREATEST((${apiTokenLastUsedSq}), (${oauthTokenLastUsedSq}), (${scopedSessionLastActiveSq}))`.as(
               "last_token_used_at"
             ),
         })
@@ -762,6 +778,10 @@ const overviewEndpoints = {
 
         // Active users: single scan over the denormalized users.last_active_at
         // (durable across session retention cleanup, unlike a sessions scan).
+        // This counts real reader activity only — Google Reader compat-API
+        // polling is a scoped session that never bumps users.last_active_at, so
+        // native-app-only users don't inflate these counts (see
+        // updateLastActiveAt).
         ctx.db
           .select({
             active7d: sql<number>`COUNT(*) FILTER (WHERE ${users.lastActiveAt} > ${sevenDaysAgo})`,

--- a/tests/integration/admin.test.ts
+++ b/tests/integration/admin.test.ts
@@ -473,6 +473,57 @@ describe("Admin API", () => {
       expect(result.items[0].lastTokenUsedAt!.getTime()).toBe(tokenUsedTime.getTime());
     });
 
+    it("reports scoped (Google Reader) session activity as token use, not session activity", async () => {
+      // A native app polling the Google Reader compat API holds a scoped
+      // session (scopes IS NOT NULL). That polling bumps only
+      // sessions.last_active_at, never users.last_active_at, so it must surface
+      // as lastTokenUsedAt ("last API usage") and leave lastActiveAt untouched.
+      const ctx = createAdminContext();
+      const caller = createCaller(ctx);
+
+      const userId = await createTestUser("greader-user");
+
+      // No full-access session activity: users.last_active_at stays NULL.
+      const scopedActiveTime = new Date("2026-05-25T00:00:00Z");
+      await db.insert(sessions).values({
+        id: generateUuidv7(),
+        userId,
+        tokenHash: `greader-hash-${userId}`,
+        scopes: ["reader:full-access"],
+        expiresAt: new Date("2026-06-24T00:00:00Z"),
+        lastActiveAt: scopedActiveTime,
+      });
+
+      const result = await caller.admin.listUsers({ search: "greader-user" });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].lastActiveAt).toBeNull();
+      expect(result.items[0].lastTokenUsedAt).toBeInstanceOf(Date);
+      expect(result.items[0].lastTokenUsedAt!.getTime()).toBe(scopedActiveTime.getTime());
+    });
+
+    it("ignores full-access session rows when computing token use", async () => {
+      // A normal browser session (scopes NULL) must NOT count toward
+      // lastTokenUsedAt — only scoped sessions do.
+      const ctx = createAdminContext();
+      const caller = createCaller(ctx);
+
+      const userId = await createTestUser("browser-only-user");
+      await db.insert(sessions).values({
+        id: generateUuidv7(),
+        userId,
+        tokenHash: `browser-hash-${userId}`,
+        scopes: null,
+        expiresAt: new Date("2026-06-24T00:00:00Z"),
+        lastActiveAt: new Date("2026-05-25T00:00:00Z"),
+      });
+
+      const result = await caller.admin.listUsers({ search: "browser-only-user" });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].lastTokenUsedAt).toBeNull();
+    });
+
     it("returns null token use for users who never used a token", async () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);

--- a/tests/integration/google-reader-auth.test.ts
+++ b/tests/integration/google-reader-auth.test.ts
@@ -13,9 +13,9 @@
 
 import { describe, it, expect, afterAll } from "vitest";
 import * as argon2 from "argon2";
-import { inArray } from "drizzle-orm";
+import { inArray, eq } from "drizzle-orm";
 import { db } from "../../src/server/db";
-import { users } from "../../src/server/db/schema";
+import { users, sessions } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createSession, validateSession } from "../../src/server/auth/session";
 import { clientLogin, requireAuth } from "../../src/server/google-reader/auth";
@@ -159,5 +159,73 @@ describe("createSession scope validation", () => {
       scopes: [OAUTH_SCOPES.READER_FULL_ACCESS],
     });
     expect(token).toBeTruthy();
+  });
+});
+
+describe("last_active_at accounting for scoped vs full-access sessions", () => {
+  // updateLastActiveAt is fire-and-forget, so we poll for the DB write.
+  async function waitForSessionActiveAfter(sessionId: string, after: Date): Promise<Date> {
+    for (let i = 0; i < 100; i++) {
+      const [s] = await db
+        .select({ lastActiveAt: sessions.lastActiveAt })
+        .from(sessions)
+        .where(eq(sessions.id, sessionId));
+      if (s.lastActiveAt && s.lastActiveAt.getTime() > after.getTime()) return s.lastActiveAt;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    throw new Error("sessions.last_active_at was not bumped in time");
+  }
+
+  async function waitForUserActive(userId: string): Promise<Date> {
+    for (let i = 0; i < 100; i++) {
+      const [u] = await db
+        .select({ lastActiveAt: users.lastActiveAt })
+        .from(users)
+        .where(eq(users.id, userId));
+      if (u.lastActiveAt) return u.lastActiveAt;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    throw new Error("users.last_active_at was not bumped in time");
+  }
+
+  it("a scoped (Google Reader) session bumps its session row but never users.last_active_at", async () => {
+    const user = await createTestUser();
+    const login = await clientLogin(user.email, PASSWORD);
+    if (!login) throw new Error("unreachable");
+
+    // Resolve the session id (this first validation also fires a scoped bump).
+    const scoped = await validateSession(login.auth, { allowScoped: true });
+    const sessionId = scoped?.session.id;
+    if (!sessionId) throw new Error("unreachable");
+
+    // Reset to known markers: a compat-only user (NULL user activity) and an old
+    // session timestamp so the next bump is observably newer.
+    const marker = new Date("2020-01-01T00:00:00Z");
+    await db.update(users).set({ lastActiveAt: null }).where(eq(users.id, user.id));
+    await db.update(sessions).set({ lastActiveAt: marker }).where(eq(sessions.id, sessionId));
+
+    // Validate again — the scoped branch must bump only the session row.
+    await validateSession(login.auth, { allowScoped: true });
+    const bumped = await waitForSessionActiveAfter(sessionId, marker);
+    expect(bumped.getTime()).toBeGreaterThan(marker.getTime());
+
+    // Once the (single-statement) scoped bump has landed, the user row must
+    // still be untouched — a native app polling the sync API isn't "activity".
+    const [u] = await db
+      .select({ lastActiveAt: users.lastActiveAt })
+      .from(users)
+      .where(eq(users.id, user.id));
+    expect(u.lastActiveAt).toBeNull();
+  });
+
+  it("a full-access (browser) session bumps users.last_active_at", async () => {
+    const user = await createTestUser();
+    const { token } = await createSession(db, { userId: user.id });
+
+    await db.update(users).set({ lastActiveAt: null }).where(eq(users.id, user.id));
+
+    await validateSession(token);
+    const activeAt = await waitForUserActive(user.id);
+    expect(activeAt).toBeInstanceOf(Date);
   });
 });


### PR DESCRIPTION
## Problem

A user whose `last_active_at` updated constantly despite barely reading turned out to be syncing via a **native RSS app over the Google Reader compat API**. That path mints a *scoped session* (`scopes = ['reader:full-access']`), and `validateSession` bumps `users.last_active_at` on every successful validation — including scoped ones. So background polling from a native app kept the user looking perpetually "active" in the admin view and inflated the `active7d`/`active30d` stats, even though they never opened the reader.

`users.last_active_at` is only ever written by `updateLastActiveAt` (session validation). API tokens and OAuth/MCP tokens do **not** write it — they track their own `last_used_at`, which the admin list already surfaces as a separate `lastTokenUsedAt` ("last API usage") column. Google Reader was the odd one out because it's modeled as a session, not a token.

## Change (Option A — no schema change)

- `updateLastActiveAt` now takes `isScoped`. For a scoped session it bumps **only** `sessions.last_active_at` (still needed for the user's own session list) and leaves `users.last_active_at` untouched. Full-access (browser) sessions are unchanged.
- The admin user list folds `MAX(sessions.last_active_at)` over scoped rows into the existing `lastTokenUsedAt` column, next to API-token and OAuth-token use. So compat-API sync now shows up as **API usage** rather than session activity, and the active-users stats reflect real reader activity only.

Durable only while the scoped session lives (retention deletes it ~a day after its 30-day expiry), but an actively-syncing client always holds a live session, so the timestamp stays current exactly when it matters. Consistent with the OAuth-MCP token caveat already noted on that column.

## Tests

- **Write-side** (`google-reader-auth.test.ts`): a scoped validation bumps the session row but never `users.last_active_at`; a full-access validation still bumps the user row.
- **Read-side** (`admin.test.ts`): a scoped session surfaces as `lastTokenUsedAt`; full-access session rows are ignored when computing token use.

Docs updated: `src/server/auth/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)