### PR TITLE
Add caller-provided author/excerpt hints to saveArticle (#1413)

### DIFF
--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -165,7 +165,30 @@ const countEntriesArgs = z.object({
 
 const saveArticleArgs = z.object({
   url: z.url().describe("The URL to save"),
-  title: z.string().optional().describe("Optional title override (useful if page title is poor)"),
+  title: z
+    .string()
+    .optional()
+    .describe(
+      "Optional title override (useful if page title is poor). Plain text (NOT " +
+        "Markdown or HTML). Do NOT HTML-escape it — write & not &amp;, since it is " +
+        "rendered as literal text and an entity like &amp; would show up verbatim."
+    ),
+  author: z
+    .string()
+    .optional()
+    .describe(
+      "Optional author/byline override (useful if you already know it better than " +
+        "the page). Plain text (NOT Markdown or HTML). Do NOT HTML-escape it — write " +
+        "& not &amp;, since it is rendered as literal text."
+    ),
+  summary: z
+    .string()
+    .optional()
+    .describe(
+      "Optional summary/excerpt override (e.g. an abstract you already have). Plain " +
+        "text (NOT Markdown or HTML). Do NOT HTML-escape it — write & not &amp;, since " +
+        "it is rendered as literal text. Clipped to ~300 characters."
+    ),
 });
 
 const deleteSavedArticleArgs = z.object({
@@ -350,6 +373,8 @@ function buildTools(): Tool[] {
         return savedService.saveArticle(db, userId, {
           url: params.url,
           title: params.title,
+          author: params.author,
+          excerpt: params.summary,
           // Use the user's stored Google credentials for private Google Docs
           // when already linked/granted; otherwise throw a clear error telling
           // them to authorize Google Docs access in the web app (an MCP client

--- a/src/server/services/saved-excerpt.ts
+++ b/src/server/services/saved-excerpt.ts
@@ -6,14 +6,19 @@ const MAX_EXCERPT_LENGTH = 300;
 /**
  * Choose the plain-text excerpt for a saved article.
  *
- * Precedence: explicit plugin excerpt → pre-cleaned source summary (Markdown
- * frontmatter / docx `dc:description`) → Readability's cleaned extraction → raw
- * plugin HTML → raw pre-cleaned HTML.
+ * Precedence: caller-provided excerpt → explicit plugin excerpt → pre-cleaned
+ * source summary (Markdown frontmatter / docx `dc:description`) → Readability's
+ * cleaned extraction → raw plugin HTML → raw pre-cleaned HTML.
+ *
+ * A caller-provided excerpt (e.g. an MCP client that already read the page and
+ * has a clean abstract in hand) is authoritative and outranks every extracted
+ * source — the same top tier a caller-provided title occupies for the title. Like
+ * the plugin excerpt it's plain text, so it's just clipped to the summary length.
  *
  * A plugin-supplied `excerpt` (e.g. the arXiv API abstract) is authoritative and
- * outranks everything, including Readability — the whole point of fetching it is
- * that it beats any scrape of the HTML render. It's plain text, so it's just
- * clipped to the summary length (arXiv abstracts run long — see #1399).
+ * outranks everything extracted, including Readability — the whole point of
+ * fetching it is that it beats any scrape of the HTML render. It's plain text, so
+ * it's just clipped to the summary length (arXiv abstracts run long — see #1399).
  *
  * Otherwise the `cleaned` (Readability) branch must be checked **before** the
  * plugin-HTML branch. When Readability ran, its output is what we store and
@@ -30,13 +35,19 @@ const MAX_EXCERPT_LENGTH = 300;
  * Pure (no DB/network) so it can be unit-tested directly.
  */
 export function computeSavedArticleExcerpt(params: {
+  /** Explicit caller-provided excerpt — highest precedence. */
+  providedExcerpt?: string | null;
   preCleanedContent: { summary: string | null } | null;
   cleaned: { excerpt: string; textContent: string } | null;
   pluginContent: { html: string; excerpt?: string | null } | null;
   html: string;
 }): string | null {
-  const { preCleanedContent, cleaned, pluginContent, html } = params;
+  const { providedExcerpt, preCleanedContent, cleaned, pluginContent, html } = params;
 
+  if (providedExcerpt) {
+    // Explicit caller override: authoritative, just clip it.
+    return truncateText(providedExcerpt, MAX_EXCERPT_LENGTH) || null;
+  }
   if (pluginContent?.excerpt) {
     // Explicit plugin excerpt (arXiv abstract): authoritative, just clip it.
     return truncateText(pluginContent.excerpt, MAX_EXCERPT_LENGTH) || null;

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -63,6 +63,19 @@ export interface SaveArticleParams {
   /** Optional title hint (useful when page title is poor) */
   title?: string;
   /**
+   * Optional author hint. Highest-precedence author source (above plugin /
+   * frontmatter / Readability / OG-meta), for a caller that already knows the
+   * byline better than our extraction. Plain text (rendered escaped).
+   */
+  author?: string;
+  /**
+   * Optional excerpt/summary hint. Highest-precedence excerpt source (above the
+   * plugin excerpt / frontmatter / Readability), for a caller that already has a
+   * clean summary in hand. Plain text (rendered escaped); clipped to the summary
+   * length like the other excerpt sources.
+   */
+  excerpt?: string;
+  /**
    * Pre-fetched HTML (e.g. a bookmarklet capturing the rendered DOM). Used
    * instead of fetching the URL — useful for JavaScript-rendered pages where
    * a server-side fetch would miss content.
@@ -294,6 +307,10 @@ interface ArticleContentBundle {
 interface ArticleFieldHints {
   /** Explicit caller-provided title — highest precedence. */
   providedTitle?: string | null;
+  /** Explicit caller-provided author — highest precedence. */
+  providedAuthor?: string | null;
+  /** Explicit caller-provided excerpt/summary — highest precedence. */
+  providedExcerpt?: string | null;
   /** Upload filename, used only as a last-resort title (below Readability). */
   filename?: string | null;
   /** Provided site name (uploads: "Uploaded Document", etc.). */
@@ -323,8 +340,8 @@ interface BuiltArticleFields {
  *
  * Field precedence:
  *  - title:  provided → plugin / Markdown frontmatter / docx core.xml → Readability → OG or `<title>` → filename
- *  - author: plugin / frontmatter / docx core.xml → Readability byline → OG/meta author
- *  - excerpt: see {@link computeSavedArticleExcerpt} (plugin excerpt → source metadata → cleaned → plugin/pre-cleaned HTML)
+ *  - author: provided → plugin / frontmatter / docx core.xml → Readability byline → OG/meta author
+ *  - excerpt: see {@link computeSavedArticleExcerpt} (provided → plugin excerpt → source metadata → cleaned → plugin/pre-cleaned HTML)
  */
 async function buildArticleFields(
   bundle: ArticleContentBundle,
@@ -384,6 +401,7 @@ async function buildArticleFields(
     (hints.filename ? titleFromFilename(hints.filename) || null : null) ||
     null;
   const author =
+    hints.providedAuthor ||
     pluginContent?.author ||
     preCleanedContent?.author ||
     cleaned?.byline ||
@@ -391,7 +409,13 @@ async function buildArticleFields(
     null;
   const siteName = hints.siteName || pluginContent?.siteName || metadata.siteName || null;
 
-  const summary = computeSavedArticleExcerpt({ preCleanedContent, cleaned, pluginContent, html });
+  const summary = computeSavedArticleExcerpt({
+    providedExcerpt: hints.providedExcerpt,
+    preCleanedContent,
+    cleaned,
+    pluginContent,
+    html,
+  });
 
   const contentHash = generateContentHash(title, contentCleaned || html);
 
@@ -1221,7 +1245,11 @@ export async function saveArticle(
     imageUrl,
     contentHash,
     newTextContent,
-  } = await buildArticleFields(bundle, { providedTitle: params.title ?? null });
+  } = await buildArticleFields(bundle, {
+    providedTitle: params.title ?? null,
+    providedAuthor: params.author ?? null,
+    providedExcerpt: params.excerpt ?? null,
+  });
 
   // Handle refetch: update the existing entry if quality is acceptable
   if (existingEntry) {

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -131,6 +131,10 @@ export const savedRouter = createTRPCRouter({
           )
           .optional(),
         title: z.string().optional(),
+        /** Optional author hint (highest-precedence author source); plain text. */
+        author: z.string().optional(),
+        /** Optional excerpt/summary hint (highest-precedence); plain text, clipped. */
+        excerpt: z.string().optional(),
         /** When true (default), re-fetch and update if URL is already saved */
         refetch: z.boolean().default(true),
         /** When true with refetch, update even if new content appears lower quality */
@@ -145,6 +149,8 @@ export const savedRouter = createTRPCRouter({
         url: input.url,
         html: input.html,
         title: input.title,
+        author: input.author,
+        excerpt: input.excerpt,
         refetch: input.refetch,
         force: input.force,
         // The web UI can walk the user through Google sign-in / consent, so it

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -1157,6 +1157,40 @@ describe("Saved Articles API", () => {
       expect(result.article.title).toBe("Title from Bookmarklet");
     });
 
+    it("uses provided author and excerpt parameters over extracted metadata", async () => {
+      const userId = await createTestUser();
+      const ctx = createAuthContext(userId);
+      const caller = createCaller(ctx);
+
+      const testHtml = `
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <title>Page Title</title>
+            <meta name="author" content="Scraped Author" />
+            <meta property="og:description" content="Scraped description from the page." />
+          </head>
+          <body>
+            <article>
+              <p>This is the article content that should be extracted by Readability.</p>
+              <p>It has multiple paragraphs to ensure proper extraction.</p>
+            </article>
+          </body>
+        </html>
+      `;
+
+      const result = await caller.saved.save({
+        url: "https://example.com/with-author-excerpt",
+        html: testHtml,
+        author: "Caller Author",
+        excerpt: "Caller-supplied summary.",
+      });
+
+      // Caller-provided values win over anything extracted from the page.
+      expect(result.article.author).toBe("Caller Author");
+      expect(result.article.excerpt).toBe("Caller-supplied summary.");
+    });
+
     it("falls back to og:title when title parameter is not provided", async () => {
       const userId = await createTestUser();
       const ctx = createAuthContext(userId);

--- a/tests/unit/saved-article-excerpt.test.ts
+++ b/tests/unit/saved-article-excerpt.test.ts
@@ -17,6 +17,42 @@ describe("computeSavedArticleExcerpt", () => {
     expect(excerpt).toBe("Mitigating reward hacking remains a key challenge in aligned models.");
   });
 
+  it("prefers a caller-provided excerpt above everything, including the plugin excerpt", () => {
+    const excerpt = computeSavedArticleExcerpt({
+      providedExcerpt: "Caller-supplied abstract wins.",
+      preCleanedContent: { summary: "Frontmatter" },
+      cleaned: { excerpt: "Readability excerpt", textContent: "Body text" },
+      pluginContent: { html: "<p>Body</p>", excerpt: "arXiv abstract" },
+      html: "<p>Raw</p>",
+    });
+    expect(excerpt).toBe("Caller-supplied abstract wins.");
+  });
+
+  it("clips a long caller-provided excerpt to the summary length at a word boundary", () => {
+    const longSummary = "Reward hacking ".repeat(40).trim(); // > 300 chars
+    const excerpt = computeSavedArticleExcerpt({
+      providedExcerpt: longSummary,
+      preCleanedContent: null,
+      cleaned: null,
+      pluginContent: null,
+      html: "<p>Raw</p>",
+    });
+    expect(excerpt).not.toBeNull();
+    expect(excerpt!.length).toBeLessThanOrEqual(303); // 300 + "..."
+    expect(excerpt!.endsWith("...")).toBe(true);
+  });
+
+  it("ignores an empty caller-provided excerpt and falls through to the next source", () => {
+    const excerpt = computeSavedArticleExcerpt({
+      providedExcerpt: "",
+      preCleanedContent: null,
+      cleaned: null,
+      pluginContent: { html: "<p>Body</p>", excerpt: "arXiv abstract" },
+      html: "<p>Raw</p>",
+    });
+    expect(excerpt).toBe("arXiv abstract");
+  });
+
   it("clips a long plugin excerpt to the summary length at a word boundary", () => {
     const longAbstract = "Reward hacking ".repeat(40).trim(); // > 300 chars
     const excerpt = computeSavedArticleExcerpt({


### PR DESCRIPTION
Fixes #1413.

## What

`saveArticle` previously accepted only a `title` metadata hint. This extends the same **highest-precedence** caller override to **author** and **excerpt/summary**, so a caller that already knows the byline/abstract better than our extraction (primarily the MCP `save_article` tool) can override it.

## Changes

- **`SaveArticleParams`** gains optional `author` and `excerpt`; **`ArticleFieldHints`** gains `providedAuthor`/`providedExcerpt`, threaded as the top tier in `buildArticleFields` (above plugin / frontmatter / Readability / OG-meta) — the same tier `providedTitle` occupies for title.
- **`computeSavedArticleExcerpt`** takes `providedExcerpt` as its highest-precedence source, clipped to the summary length (300 chars) like the plugin excerpt.
- **MCP `save_article`** exposes `author` and `summary` args. describe() text mirrors the existing `title` warning to pass plain, un-escaped text (rendered as escaped text).
- **tRPC/REST `saved.save`** input gains `author` and `excerpt`.

Precedence now:
- author: **provided** → plugin / frontmatter / docx core.xml → Readability byline → OG/meta author
- excerpt: **provided** → plugin excerpt → source metadata → cleaned → plugin/pre-cleaned HTML

## Tests

- Unit (`saved-article-excerpt`): caller-provided excerpt beats plugin/frontmatter/Readability; long excerpt is clipped at a word boundary; empty excerpt falls through.
- Integration (`saved-articles`): caller-provided `author`/`excerpt` win over scraped `meta[name=author]` / `og:description`.

All unit + integration tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)