### PR TITLE
docs: correct title-precedence comment in saved.ts

### DIFF
--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -373,8 +373,8 @@ async function buildArticleFields(
   // is skipped for Markdown (frontmatter wins) and for plugins that opt out
   // (`cleaned` is null), so those correctly prefer their own declared metadata.
   // dom_smoothie cleans up the title in some cases (e.g. stripping a
-  // " | Site Name" suffix) that our simpler raw scrape doesn't, so this ordering
-  // is load-bearing — it's not a no-op.
+  // " | Site Name" suffix) that our simpler raw scrape doesn't, so we prefer its
+  // output when it exists
   const title =
     hints.providedTitle ||
     pluginContent?.title ||

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -372,9 +372,9 @@ async function buildArticleFields(
   // (short/unparseable page). This ordering is HTML-only in practice: Readability
   // is skipped for Markdown (frontmatter wins) and for plugins that opt out
   // (`cleaned` is null), so those correctly prefer their own declared metadata.
-  // Today our extractor (dom_smoothie) doesn't clean the title beyond the
-  // meta/<title> scrape, so title is equivalent either way in practice — but this
-  // is the order we want if/when it improves.
+  // dom_smoothie cleans up the title in some cases (e.g. stripping a
+  // " | Site Name" suffix) that our simpler raw scrape doesn't, so this ordering
+  // is load-bearing — it's not a no-op.
   const title =
     hints.providedTitle ||
     pluginContent?.title ||


### PR DESCRIPTION
## Summary

Fixes an inaccurate code comment above the `const title =` precedence chain in `src/server/services/saved.ts`.

The comment claimed:

> Today our extractor (dom_smoothie) doesn't clean the title beyond the meta/\<title\> scrape, so title is equivalent either way in practice

That's not true. dom_smoothie ports Readability.js's `_getArticleTitle` and **does** clean the `<title>` — stripping " | Site Name"-style suffixes, colon suffixes, and falling back to a single `<h1>`. It applies this cleanup whenever a page has no `og:title`/meta title (dom_smoothie prefers a declared OG/meta title verbatim, and only falls back to the cleaned `<title>`).

Our own raw scrape (`extractMetadata`) sets `result.title = ogTitle || titleText` where `titleText` is the trimmed `<title>` with no cleanup. So on the common case of a page with only a cluttered `<title>` (e.g. `"Article | Site Name"`) and no `og:title`, the two paths diverge and preferring `cleaned.title` yields the cleaner result. The ordering is load-bearing, not a no-op — which is also exactly the " | Site Name" example the same comment cites two sentences earlier.

## Changes

Comment-only reword. No behavior change (the ordering was already the desired one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)