### PR TITLE
Add author/summary overrides to upload_article MCP tool (#1420)

### DIFF
--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -212,6 +212,21 @@ const uploadArticleArgs = z.object({
         "& not &amp;, since the title is rendered as literal text and an entity like " +
         "&amp; would show up verbatim."
     ),
+  author: z
+    .string()
+    .optional()
+    .describe(
+      "Optional author/byline override. Plain text (NOT Markdown or HTML). Do NOT " +
+        "HTML-escape it — write & not &amp;, since it is rendered as literal text."
+    ),
+  summary: z
+    .string()
+    .optional()
+    .describe(
+      "Optional summary/excerpt override (e.g. an abstract you already have). Plain " +
+        "text (NOT Markdown or HTML). Do NOT HTML-escape it — write & not &amp;, since " +
+        "it is rendered as literal text. Clipped to ~300 characters."
+    ),
 });
 
 const listSubscriptionsArgs = z.object({
@@ -405,6 +420,8 @@ function buildTools(): Tool[] {
         return savedService.uploadArticle(db, userId, {
           content: params.content,
           title: params.title,
+          author: params.author,
+          excerpt: params.summary,
         });
       },
     },

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -123,6 +123,17 @@ export interface UploadArticleParams {
   content: string;
   /** Article title */
   title: string;
+  /**
+   * Optional author hint. Highest-precedence author source (above the Markdown
+   * frontmatter author). Plain text.
+   */
+  author?: string;
+  /**
+   * Optional excerpt/summary hint. Highest-precedence excerpt source (above the
+   * Markdown frontmatter summary / cleaned content). Plain text; clipped to the
+   * summary length like the other excerpt sources.
+   */
+  excerpt?: string;
 }
 
 export interface CreateUploadedArticleParams {
@@ -1619,7 +1630,12 @@ export async function uploadArticle(
       pluginContent: null,
       preCleanedContent: markdownResult,
     },
-    { providedTitle: params.title, siteName: "Uploaded Article" }
+    {
+      providedTitle: params.title,
+      providedAuthor: params.author ?? null,
+      providedExcerpt: params.excerpt ?? null,
+      siteName: "Uploaded Article",
+    }
   );
   return insertUploadedArticle(db, userId, fields);
 }

--- a/tests/integration/saved-uploads.test.ts
+++ b/tests/integration/saved-uploads.test.ts
@@ -261,4 +261,26 @@ describe("uploadArticle (Markdown)", () => {
     const article = await uploadArticle(db, userId, { content: md, title: "Explicit Title" });
     expect(article.title).toBe("Explicit Title");
   });
+
+  it("prefers the provided author/excerpt over frontmatter", async () => {
+    const userId = await createTestUser();
+    const md = [
+      "---",
+      "title: Frontmatter Title",
+      "description: A concise frontmatter summary of the piece.",
+      "author: Grace Hopper",
+      "---",
+      "",
+      "Some markdown body content here that is long enough to be meaningful.",
+    ].join("\n");
+
+    const article = await uploadArticle(db, userId, {
+      content: md,
+      title: "",
+      author: "Ada Lovelace",
+      excerpt: "An explicit summary override.",
+    });
+    expect(article.author).toBe("Ada Lovelace");
+    expect(article.excerpt).toBe("An explicit summary override.");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1420. The `upload_article` MCP tool (direct Markdown uploads) now accepts optional `author` and `summary` parameters, matching the semantics already available on `save_article`. Previously direct uploads could only set `title` and `content`, leaving `author: null` and an auto-derived excerpt.

## Changes

- `UploadArticleParams` gains optional `author` / `excerpt` fields, threaded through `buildArticleFields` as `providedAuthor` / `providedExcerpt` (highest precedence, above Markdown frontmatter).
- `upload_article` MCP schema gains `author` and `summary` params with descriptions mirroring `save_article` (plain text, not HTML-escaped, summary clipped to ~300 chars).
- Added an integration test asserting the provided author/excerpt override frontmatter values.

## Testing

- `pnpm typecheck`
- `pnpm test:integration:local` (720 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)