### PR TITLE
Fix broken images in saved GitHub Markdown files

### DIFF
--- a/src/server/feed/content-cleaner.ts
+++ b/src/server/feed/content-cleaner.ts
@@ -27,9 +27,17 @@ const decoder = new TextDecoder();
  *
  * @param html - The HTML content to process
  * @param baseUrl - The base URL for resolving relative URLs
+ * @param options.mediaBaseUrl - Separate base for the media attributes (src,
+ *   poster, srcset); defaults to `baseUrl`. Needed for sources that serve a
+ *   document and its embedded files from different origins — see
+ *   `absolutizeGitHubUrls` in `src/server/plugins/github.ts`.
  * @returns HTML with all relative URLs converted to absolute
  */
-export function absolutizeUrls(html: string, baseUrl: string): string {
+export function absolutizeUrls(
+  html: string,
+  baseUrl: string,
+  options: { mediaBaseUrl?: string } = {}
+): string {
   try {
     let output = "";
     const rewriter = new HTMLRewriter((chunk) => {
@@ -41,6 +49,7 @@ export function absolutizeUrls(html: string, baseUrl: string): string {
     // <base> in <head> will be seen before any body elements.
     // Per the HTML spec, only the first <base> with an href is used.
     let effectiveBaseUrl = baseUrl;
+    let effectiveMediaBaseUrl = options.mediaBaseUrl ?? baseUrl;
     let baseHrefSet = false;
 
     // Check for <base> tag and use its href as the base URL
@@ -54,7 +63,10 @@ export function absolutizeUrls(html: string, baseUrl: string): string {
           // in case <base href> itself is relative
           const resolved = resolveUrl(href, baseUrl);
           if (resolved) {
+            // Per the HTML spec <base href> governs every relative URL in the
+            // document, so an explicit tag overrides mediaBaseUrl too.
             effectiveBaseUrl = resolved;
+            effectiveMediaBaseUrl = resolved;
             baseHrefSet = true;
           }
         }
@@ -66,7 +78,7 @@ export function absolutizeUrls(html: string, baseUrl: string): string {
       element(el) {
         const value = el.getAttribute("src");
         if (value) {
-          const absolute = resolveUrl(value, effectiveBaseUrl);
+          const absolute = resolveUrl(value, effectiveMediaBaseUrl);
           if (absolute && absolute !== value) {
             el.setAttribute("src", absolute);
           }
@@ -92,7 +104,7 @@ export function absolutizeUrls(html: string, baseUrl: string): string {
       element(el) {
         const value = el.getAttribute("poster");
         if (value) {
-          const absolute = resolveUrl(value, effectiveBaseUrl);
+          const absolute = resolveUrl(value, effectiveMediaBaseUrl);
           if (absolute && absolute !== value) {
             el.setAttribute("poster", absolute);
           }
@@ -104,7 +116,7 @@ export function absolutizeUrls(html: string, baseUrl: string): string {
       element(el) {
         const value = el.getAttribute("srcset");
         if (value) {
-          el.setAttribute("srcset", absolutizeSrcset(value, effectiveBaseUrl));
+          el.setAttribute("srcset", absolutizeSrcset(value, effectiveMediaBaseUrl));
         }
       },
     });

--- a/src/server/feed/content-cleaner.ts
+++ b/src/server/feed/content-cleaner.ts
@@ -27,9 +27,10 @@ const decoder = new TextDecoder();
  *
  * @param html - The HTML content to process
  * @param baseUrl - The base URL for resolving relative URLs
- * @param options.mediaBaseUrl - Separate base for the media attributes (src,
- *   poster, srcset); defaults to `baseUrl`. Needed for sources that serve a
- *   document and its embedded files from different origins — see
+ * @param options.mediaBaseUrl - Separate base for the embedded-resource
+ *   attributes (`src`, `poster`, `srcset` — so `img`/`video`/`audio`, but also
+ *   `iframe`/`source`/`embed`); defaults to `baseUrl`. Needed for sources that
+ *   serve a document and the files it embeds from different origins — see
  *   `absolutizeGitHubUrls` in `src/server/plugins/github.ts`.
  * @returns HTML with all relative URLs converted to absolute
  */
@@ -63,8 +64,9 @@ export function absolutizeUrls(
           // in case <base href> itself is relative
           const resolved = resolveUrl(href, baseUrl);
           if (resolved) {
-            // Per the HTML spec <base href> governs every relative URL in the
-            // document, so an explicit tag overrides mediaBaseUrl too.
+            // <base href> governs both kinds of URL, so it replaces
+            // mediaBaseUrl too — but only for the elements that follow it,
+            // since this is a single streaming pass (see above).
             effectiveBaseUrl = resolved;
             effectiveMediaBaseUrl = resolved;
             baseHrefSet = true;

--- a/src/server/plugins/github.ts
+++ b/src/server/plugins/github.ts
@@ -344,12 +344,17 @@ export interface RepoFileLocation {
 
 /**
  * Absolutize the relative URLs in a rendered repo file against GitHub's *two*
- * bases: media (`src`) resolves to raw.githubusercontent.com, which serves the
- * file bytes, while links (`href`) resolve to the github.com blob view, which
- * serves a page a reader can actually follow. This has to happen here rather
- * than in the generic single-base absolutizer downstream, which resolves
+ * bases: embedded files (`src`) resolve to raw.githubusercontent.com, which
+ * serves the bytes, while links (`href`) resolve to the github.com blob view,
+ * which serves a page a reader can actually follow. This has to happen here
+ * rather than in the generic single-base absolutizer downstream, which resolves
  * everything against the article URL — that turns `images/foo.png` into a
  * `github.com/…/blob/…/images/foo.png` HTML page and renders a broken image.
+ *
+ * Both bases are the file's own URL, so paths resolve relative to its directory
+ * the way GitHub renders them. Root-relative paths (`/docs/logo.png`) are still
+ * wrong: GitHub reads them as repo-root-relative, but URL resolution sends them
+ * to the origin root, which no choice of base can fix (#1423).
  */
 function absolutizeGitHubUrls(html: string, file: RepoFileLocation): string {
   const { owner, repo, ref = "HEAD", path } = file;
@@ -373,8 +378,8 @@ function codeToHtml(content: string, language?: string): string {
  * For markdown files, also extracts the title from the first header.
  *
  * `location` is the repo file the content came from, so its relative URLs can be
- * resolved GitHub's way; pass null for gist files, whose flat file list has no
- * relative paths to resolve.
+ * resolved GitHub's way; pass null for gist files, whose sibling-file references
+ * we don't resolve (they'd need gist.githubusercontent.com raw URLs, #1424).
  */
 export function processFileContent(
   content: string,
@@ -382,7 +387,8 @@ export function processFileContent(
   language: string | null,
   location: RepoFileLocation | null
 ): { html: string; extractedTitle: string | null } {
-  const absolutize = (html: string) => (location ? absolutizeGitHubUrls(html, location) : html);
+  const absolutize = (html: string): string =>
+    location ? absolutizeGitHubUrls(html, location) : html;
 
   if (isMarkdownFile(filename) || isMarkdownLanguage(language)) {
     const { html, title } = processMarkdownContent(content);

--- a/src/server/plugins/github.ts
+++ b/src/server/plugins/github.ts
@@ -7,6 +7,7 @@ import { escapeHtml } from "@/server/http/html";
 import { githubConfig, usageLimitsConfig } from "@/server/config/env";
 import { marked } from "marked";
 import { extractAndStripTitleHeader } from "@/server/html/strip-title-header";
+import { absolutizeUrls } from "@/server/feed/content-cleaner";
 
 // ============================================================================
 // Types
@@ -330,6 +331,34 @@ function processMarkdownContent(content: string): { html: string; title: string 
 }
 
 /**
+ * A file's location in a repo, used to resolve the relative URLs in it.
+ * `ref` defaults to `HEAD` (accepted by both github.com and
+ * raw.githubusercontent.com) for the repo-root README, which we fetch without one.
+ */
+export interface RepoFileLocation {
+  owner: string;
+  repo: string;
+  ref?: string;
+  path: string;
+}
+
+/**
+ * Absolutize the relative URLs in a rendered repo file against GitHub's *two*
+ * bases: media (`src`) resolves to raw.githubusercontent.com, which serves the
+ * file bytes, while links (`href`) resolve to the github.com blob view, which
+ * serves a page a reader can actually follow. This has to happen here rather
+ * than in the generic single-base absolutizer downstream, which resolves
+ * everything against the article URL — that turns `images/foo.png` into a
+ * `github.com/…/blob/…/images/foo.png` HTML page and renders a broken image.
+ */
+function absolutizeGitHubUrls(html: string, file: RepoFileLocation): string {
+  const { owner, repo, ref = "HEAD", path } = file;
+  return absolutizeUrls(html, `https://github.com/${owner}/${repo}/blob/${ref}/${path}`, {
+    mediaBaseUrl: `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}`,
+  });
+}
+
+/**
  * Wrap code in a styled pre block.
  */
 function codeToHtml(content: string, language?: string): string {
@@ -342,22 +371,30 @@ function codeToHtml(content: string, language?: string): string {
 /**
  * Process a single file's content into HTML.
  * For markdown files, also extracts the title from the first header.
+ *
+ * `location` is the repo file the content came from, so its relative URLs can be
+ * resolved GitHub's way; pass null for gist files, whose flat file list has no
+ * relative paths to resolve.
  */
-function processFileContent(
+export function processFileContent(
   content: string,
   filename: string,
-  language: string | null
+  language: string | null,
+  location: RepoFileLocation | null
 ): { html: string; extractedTitle: string | null } {
+  const absolutize = (html: string) => (location ? absolutizeGitHubUrls(html, location) : html);
+
   if (isMarkdownFile(filename) || isMarkdownLanguage(language)) {
     const { html, title } = processMarkdownContent(content);
-    return { html, extractedTitle: title };
+    return { html: absolutize(html), extractedTitle: title };
   }
 
   if (isHtmlFile(filename)) {
-    return { html: content, extractedTitle: null };
+    return { html: absolutize(content), extractedTitle: null };
   }
 
-  // For other files, wrap in code block
+  // For other files, wrap in code block. The content is HTML-escaped, so there
+  // are no URL attributes left to absolutize.
   return { html: codeToHtml(content, language ?? undefined), extractedTitle: null };
 }
 
@@ -387,7 +424,8 @@ function buildGistHtml(
       const { html, extractedTitle } = processFileContent(
         matchedFile.content,
         matchedFile.filename,
-        matchedFile.language
+        matchedFile.language,
+        null
       );
       // Use extracted title from markdown, fall back to filename
       return { html, title: extractedTitle || matchedFile.filename };
@@ -397,7 +435,12 @@ function buildGistHtml(
   // Single file: return it directly
   if (files.length === 1) {
     const file = files[0];
-    const { html, extractedTitle } = processFileContent(file.content, file.filename, file.language);
+    const { html, extractedTitle } = processFileContent(
+      file.content,
+      file.filename,
+      file.language,
+      null
+    );
     // Use extracted title from markdown, fall back to filename
     return { html, title: extractedTitle || file.filename };
   }
@@ -406,7 +449,7 @@ function buildGistHtml(
   const parts: string[] = [];
   for (const file of files) {
     parts.push(`<h2>${escapeHtml(file.filename)}</h2>`);
-    const { html } = processFileContent(file.content, file.filename, file.language);
+    const { html } = processFileContent(file.content, file.filename, file.language, null);
     parts.push(html);
   }
 
@@ -456,7 +499,11 @@ async function fetchGitHubContent(url: URL): Promise<SavedArticleContent | null>
         return null;
       }
 
-      const { html, extractedTitle } = processFileContent(readme.content, readme.filename, null);
+      const { html, extractedTitle } = processFileContent(readme.content, readme.filename, null, {
+        owner: parsed.owner,
+        repo: parsed.repo,
+        path: readme.filename,
+      });
       // Use extracted title from README, fall back to repo name
       const title = extractedTitle || `${parsed.owner}/${parsed.repo}`;
 
@@ -481,7 +528,7 @@ async function fetchGitHubContent(url: URL): Promise<SavedArticleContent | null>
           return null;
         }
 
-        const { html, extractedTitle } = processFileContent(rawContent, parsed.path, null);
+        const { html, extractedTitle } = processFileContent(rawContent, parsed.path, null, parsed);
         const title = extractedTitle || filename;
         return {
           html,
@@ -493,7 +540,7 @@ async function fetchGitHubContent(url: URL): Promise<SavedArticleContent | null>
       }
 
       const content = Buffer.from(contents.content, "base64").toString("utf-8");
-      const { html, extractedTitle } = processFileContent(content, parsed.path, null);
+      const { html, extractedTitle } = processFileContent(content, parsed.path, null, parsed);
       const title = extractedTitle || filename;
 
       return {
@@ -513,7 +560,7 @@ async function fetchGitHubContent(url: URL): Promise<SavedArticleContent | null>
       }
 
       const filename = parsed.path.split("/").pop() ?? parsed.path;
-      const { html, extractedTitle } = processFileContent(content, parsed.path, null);
+      const { html, extractedTitle } = processFileContent(content, parsed.path, null, parsed);
       const title = extractedTitle || filename;
 
       return {

--- a/src/server/plugins/types.ts
+++ b/src/server/plugins/types.ts
@@ -151,6 +151,11 @@ export interface SavedArticleContent {
    */
   excerpt?: string | null;
   publishedAt?: Date | null;
-  /** Canonical URL (may differ from input URL) */
+  /**
+   * Canonical URL (may differ from input URL). It also doubles as the base the
+   * save and full-content paths absolutize `html`'s relative URLs against, so a
+   * plugin whose page and embedded files don't share an origin+directory has to
+   * resolve them itself before returning (see `github.ts`).
+   */
   canonicalUrl?: string;
 }

--- a/tests/unit/content-cleaner.test.ts
+++ b/tests/unit/content-cleaner.test.ts
@@ -599,6 +599,16 @@ describe("absolutizeUrls", () => {
       expect(result).toContain('src="https://example.com/docs/photo.jpg"');
     });
 
+    it("should keep honoring <base href> when no mediaBaseUrl is given", () => {
+      // The arXiv shape: a <base href> directory plus bare relative figure
+      // names. Media and page share an origin there, so it must keep resolving
+      // off <base> and not off the (unset) media base.
+      const html =
+        '<html><head><base href="/html/2503.09516v5/"></head><body><img src="x1.png"></body></html>';
+      const result = absolutizeUrls(html, "https://arxiv.org/html/2503.09516");
+      expect(result).toContain('src="https://arxiv.org/html/2503.09516v5/x1.png"');
+    });
+
     it("should let an explicit <base href> override mediaBaseUrl", () => {
       const html =
         '<html><head><base href="https://base.example.com/"></head><body><img src="photo.jpg"></body></html>';

--- a/tests/unit/content-cleaner.test.ts
+++ b/tests/unit/content-cleaner.test.ts
@@ -577,6 +577,38 @@ describe("absolutizeUrls", () => {
     });
   });
 
+  describe("mediaBaseUrl option", () => {
+    it("should resolve media attributes against mediaBaseUrl and links against baseUrl", () => {
+      const html = `<img src="images/photo.jpg">
+        <a href="other.html">Link</a>
+        <video poster="images/poster.jpg"></video>
+        <img srcset="images/small.jpg 1x, images/large.jpg 2x">`;
+      const result = absolutizeUrls(html, "https://example.com/docs/page.html", {
+        mediaBaseUrl: "https://cdn.example.com/docs/page.html",
+      });
+      expect(result).toContain('src="https://cdn.example.com/docs/images/photo.jpg"');
+      expect(result).toContain('poster="https://cdn.example.com/docs/images/poster.jpg"');
+      expect(result).toContain("https://cdn.example.com/docs/images/small.jpg 1x");
+      expect(result).toContain("https://cdn.example.com/docs/images/large.jpg 2x");
+      expect(result).toContain('href="https://example.com/docs/other.html"');
+    });
+
+    it("should default mediaBaseUrl to baseUrl", () => {
+      const html = '<img src="photo.jpg">';
+      const result = absolutizeUrls(html, "https://example.com/docs/page.html", {});
+      expect(result).toContain('src="https://example.com/docs/photo.jpg"');
+    });
+
+    it("should let an explicit <base href> override mediaBaseUrl", () => {
+      const html =
+        '<html><head><base href="https://base.example.com/"></head><body><img src="photo.jpg"></body></html>';
+      const result = absolutizeUrls(html, "https://example.com/page", {
+        mediaBaseUrl: "https://cdn.example.com/",
+      });
+      expect(result).toContain('src="https://base.example.com/photo.jpg"');
+    });
+  });
+
   describe("edge cases", () => {
     it("should handle empty HTML", () => {
       const html = "";

--- a/tests/unit/github-plugin.test.ts
+++ b/tests/unit/github-plugin.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeFilenameForFragment,
   isMarkdownFile,
   isHtmlFile,
+  processFileContent,
 } from "../../src/server/plugins/github";
 
 describe("GitHub plugin URL parsing", () => {
@@ -308,6 +309,108 @@ describe("File type detection", () => {
       expect(isHtmlFile("script.js")).toBe(false);
       expect(isHtmlFile("style.css")).toBe(false);
       expect(isHtmlFile("README.md")).toBe(false);
+    });
+  });
+});
+
+describe("processFileContent", () => {
+  const repoFile = {
+    owner: "humanlayer",
+    repo: "advanced-context-engineering-for-coding-agents",
+    ref: "main",
+    path: "wsff.md",
+  };
+  const rawBase = `https://raw.githubusercontent.com/${repoFile.owner}/${repoFile.repo}/main`;
+  const blobBase = `https://github.com/${repoFile.owner}/${repoFile.repo}/blob/main`;
+
+  describe("relative URL resolution", () => {
+    it("resolves relative Markdown image paths to raw.githubusercontent.com", () => {
+      const { html } = processFileContent(
+        "![A chart](images/chart.png)",
+        "wsff.md",
+        null,
+        repoFile
+      );
+      expect(html).toContain(`src="${rawBase}/images/chart.png"`);
+    });
+
+    it("resolves ./-prefixed image paths the same way", () => {
+      const { html } = processFileContent(
+        "![A chart](./images/chart.png)",
+        "wsff.md",
+        null,
+        repoFile
+      );
+      expect(html).toContain(`src="${rawBase}/images/chart.png"`);
+    });
+
+    it("resolves images in raw HTML blocks embedded in Markdown", () => {
+      // GitHub Markdown commonly centers figures with a raw <div><img>.
+      const { html } = processFileContent(
+        '<div align="center"><img src="images/chart.png" width="50%" alt="A chart"></div>',
+        "wsff.md",
+        null,
+        repoFile
+      );
+      expect(html).toContain(`src="${rawBase}/images/chart.png"`);
+    });
+
+    it("resolves images relative to the file's own directory, not the repo root", () => {
+      const { html } = processFileContent("![Chart](charts/one.png)", "where.md", null, {
+        ...repoFile,
+        path: "side-quests/where.md",
+      });
+      expect(html).toContain(`src="${rawBase}/side-quests/charts/one.png"`);
+    });
+
+    it("resolves relative links to the github.com blob view, not raw", () => {
+      const { html } = processFileContent(
+        "[Side quest](./side-quests/where.md)",
+        "wsff.md",
+        null,
+        repoFile
+      );
+      expect(html).toContain(`href="${blobBase}/side-quests/where.md"`);
+    });
+
+    it("leaves absolute URLs alone", () => {
+      const { html } = processFileContent(
+        "![Thumb](https://img.youtube.com/vi/abc/hqdefault.jpg)",
+        "wsff.md",
+        null,
+        repoFile
+      );
+      expect(html).toContain('src="https://img.youtube.com/vi/abc/hqdefault.jpg"');
+    });
+
+    it("defaults to the HEAD ref when the file was fetched without one", () => {
+      const { html } = processFileContent("![Logo](logo.png)", "README.md", null, {
+        owner: "brendanlong",
+        repo: "lion-reader",
+        path: "README.md",
+      });
+      expect(html).toContain(
+        'src="https://raw.githubusercontent.com/brendanlong/lion-reader/HEAD/logo.png"'
+      );
+    });
+
+    it("leaves gist content relative (no repo path to resolve against)", () => {
+      const { html } = processFileContent("![Chart](images/chart.png)", "notes.md", null, null);
+      expect(html).toContain('src="images/chart.png"');
+    });
+  });
+
+  describe("non-Markdown files", () => {
+    it("resolves relative URLs in HTML files", () => {
+      const { html } = processFileContent('<img src="logo.png">', "index.html", null, repoFile);
+      expect(html).toContain(`src="${rawBase}/logo.png"`);
+    });
+
+    it("escapes other files into a code block without rewriting URLs", () => {
+      const { html } = processFileContent('const src = "images/a.png";', "app.js", null, repoFile);
+      expect(html).toContain("<pre><code>");
+      expect(html).toContain("images/a.png");
+      expect(html).not.toContain(rawBase);
     });
   });
 });

--- a/tests/unit/github-plugin.test.ts
+++ b/tests/unit/github-plugin.test.ts
@@ -394,9 +394,50 @@ describe("processFileContent", () => {
       );
     });
 
-    it("leaves gist content relative (no repo path to resolve against)", () => {
+    it("leaves content untouched when given no repo location (gists)", () => {
       const { html } = processFileContent("![Chart](images/chart.png)", "notes.md", null, null);
       expect(html).toContain('src="images/chart.png"');
+    });
+
+    it("resolves srcset candidates and video posters against the raw base", () => {
+      const { html } = processFileContent(
+        '<img srcset="images/small.png 1x, images/large.png 2x">' +
+          '<video poster="images/poster.png"></video>',
+        "wsff.md",
+        null,
+        repoFile
+      );
+      expect(html).toContain(`${rawBase}/images/small.png 1x`);
+      expect(html).toContain(`${rawBase}/images/large.png 2x`);
+      expect(html).toContain(`poster="${rawBase}/images/poster.png"`);
+    });
+
+    it("resolves links against the blob view at the default HEAD ref", () => {
+      const { html } = processFileContent("[Docs](docs/guide.md)", "README.md", null, {
+        owner: "brendanlong",
+        repo: "lion-reader",
+        path: "README.md",
+      });
+      expect(html).toContain(
+        'href="https://github.com/brendanlong/lion-reader/blob/HEAD/docs/guide.md"'
+      );
+    });
+
+    // GitHub reads a leading slash as repo-root-relative, but URL resolution
+    // sends it to the origin root instead. Un-skip with the fix.
+    it.skip("resolves root-relative image paths against the repo root (#1423)", () => {
+      const { html } = processFileContent(
+        '<img src="/docs/images/chart.png">',
+        "wsff.md",
+        null,
+        repoFile
+      );
+      expect(html).toContain(`src="${rawBase}/docs/images/chart.png"`);
+    });
+
+    it.skip("resolves root-relative links against the repo root (#1423)", () => {
+      const { html } = processFileContent("[Docs](/docs/guide.md)", "wsff.md", null, repoFile);
+      expect(html).toContain(`href="${blobBase}/docs/guide.md"`);
     });
   });
 


### PR DESCRIPTION
## The bug

Images in saved GitHub Markdown files (e.g. [Why Software Factories Fail](https://github.com/humanlayer/advanced-context-engineering-for-coding-agents/blob/main/wsff.md)) all render broken. 32 of 32 images in that post were dead.

GitHub resolves a Markdown file's relative URLs against **two different bases**:

- `src` (images) → `raw.githubusercontent.com/{owner}/{repo}/{ref}/…` — the file bytes
- `href` (links) → `github.com/{owner}/{repo}/blob/{ref}/…` — a page a reader can follow

We had no GitHub-specific resolution at all. The plugin's HTML kept its relative `images/foo.png` URLs, and the generic single-base absolutizer downstream (`buildArticleFields` in `saved.ts`) resolved them against the article URL, producing `github.com/{owner}/{repo}/blob/{ref}/images/foo.png` — a valid URL that serves `text/html`, not a PNG. Hence a broken image for every relative reference.

(Only relative references were affected; the post's absolute `img.youtube.com` thumbnails worked fine, which is why this wasn't obvious.)

## The fix

- `absolutizeUrls` takes an optional `mediaBaseUrl` for the media attributes (`src`, `poster`, `srcset`), defaulting to `baseUrl`. An explicit `<base href>` still overrides both, per the HTML spec.
- The GitHub plugin resolves each repo file with the raw base for media and the blob base for links, defaulting to the `HEAD` ref for the repo-root README (which we fetch without one).
- The absolutizing happens inside `processFileContent`, which now takes the file's repo location (or `null` for gists, whose flat file list has no relative paths to resolve), so a new URL type can't silently skip the step.

## Verification

Ran the real plugin against the real post: all 32 images now resolve, and a `HEAD` on each returns `200` with an `image/*` content type (0 failures). Relative links resolve to the blob view. Confirmed the 32 images also survive the read-path sanitizer, and CSP already allows any `https:` image.

New unit tests cover the dual-base resolution (`images/x.png`, `./images/x.png`, raw `<div><img>` blocks GitHub Markdown commonly uses for centered figures, nested file paths, absolute URLs, the `HEAD` default, gists, HTML files, and code blocks) plus the `mediaBaseUrl` option itself. Full unit suite passes (2588 tests); `pnpm typecheck` clean.

## Note

This fixes new saves. Articles already saved keep their broken URLs until refetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)