### PR TITLE
Fix flaky SSE-event tests racing their own setup publish (#1427)

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -27,7 +27,7 @@ Key design points:
 
 ## Asserting on Redis pub/sub events
 
-Integration tests that assert on published events use the shared helpers in `tests/utils/pubsub.ts` — don't hand-roll listeners per file. Because all SSE publishing is fire-and-forget (a service call's `await` returns before its PUBLISH reaches Redis), a test whose **setup** mutates through a service or tRPC caller must use `subscribeAndDrain` rather than subscribing afterwards: otherwise the setup's own event can arrive inside the window under test and be mistaken for one the action published (issue #1427).
+Integration tests that assert on published events use the shared helpers in `tests/utils/pubsub.ts` — don't hand-roll listeners per file. A test whose **setup** mutates through a service or tRPC caller must establish that state with `subscribeAndDrain`, never by subscribing afterwards (publishing is fire-and-forget, so the setup's own event can land inside the window under test — see the file header and issue #1427).
 
 ## Manual verification
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -25,6 +25,10 @@ Key design points:
 - **Minimal-request assertions**: `recordTrpcProcedures(page)` records every tRPC procedure the page calls. Tests assert that SSE events update the UI with _zero_ `entries.*` refetches — this encodes the delta-update invariant documented in `src/FRONTEND_STATE.md` as a regression test instead of a code-review concern.
 - **Isolation**: each test creates its own user and feeds (unique IDs), so tests don't interfere with each other or with leftover data; the suite runs serially against one shared server.
 
+## Asserting on Redis pub/sub events
+
+Integration tests that assert on published events use the shared helpers in `tests/utils/pubsub.ts` — don't hand-roll listeners per file. Because all SSE publishing is fire-and-forget (a service call's `await` returns before its PUBLISH reaches Redis), a test whose **setup** mutates through a service or tRPC caller must use `subscribeAndDrain` rather than subscribing afterwards: otherwise the setup's own event can arrive inside the window under test and be mistaken for one the action published (issue #1427).
+
 ## Manual verification
 
 Use the Playwright MCP browser tools (`mcp__Playwright__browser_*`) if available — navigate, take accessibility snapshots, click, and screenshot interactively against a dev server (or https://lionreader.com/demo for auth-free checks). `pnpm test:e2e` starts the app server on port 4983 against the test database; you can also seed data with the helpers and inspect pages with Playwright directly.

--- a/tests/integration/entry-state-events.test.ts
+++ b/tests/integration/entry-state-events.test.ts
@@ -28,7 +28,12 @@ import { users, feeds, entries, subscriptions, userEntries } from "../../src/ser
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import * as entriesService from "../../src/server/services/entries";
 import { getUserEventsChannel } from "../../src/server/redis/pubsub";
-import { expectNoMessage, subscribeAndDrain, waitForMessage } from "../utils/pubsub";
+import {
+  expectNoMessage,
+  subscribeAndDrain,
+  waitForMessage,
+  waitForMessages,
+} from "../utils/pubsub";
 
 let subscriber: Redis;
 
@@ -450,7 +455,8 @@ describe("updateEntriesStarred (bulk) SSE publishing", () => {
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
-    const first = waitForMessage(subscriber, channel);
+    // One event per flipped entry, so wait for both.
+    const bothEvents = waitForMessages(subscriber, channel, 2);
 
     const {
       entries: state,
@@ -462,11 +468,11 @@ describe("updateEntriesStarred (bulk) SSE publishing", () => {
     // Both entries are now starred, so the starred badge reflects both.
     expect(counts?.starred.unread).toBe(2);
 
-    const event = JSON.parse(await first);
-    expect(event.type).toBe("entry_state_changed");
-    expect([entryA, entryB]).toContain(event.entryId);
-    expect(event.starred).toBe(true);
-    expect(event.counts.starred.unread).toBe(2);
+    const events = (await bothEvents).map((message) => JSON.parse(message));
+    expect(events.map((e) => e.type)).toEqual(["entry_state_changed", "entry_state_changed"]);
+    expect(events.map((e) => e.entryId).sort()).toEqual([entryA, entryB].sort());
+    expect(events.every((e) => e.starred)).toBe(true);
+    expect(events.every((e) => e.counts.starred.unread === 2)).toBe(true);
 
     // Both rows were actually written.
     expect((await getUserEntryRow(userId, entryA)).starred).toBe(true);

--- a/tests/integration/entry-state-events.test.ts
+++ b/tests/integration/entry-state-events.test.ts
@@ -28,6 +28,7 @@ import { users, feeds, entries, subscriptions, userEntries } from "../../src/ser
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import * as entriesService from "../../src/server/services/entries";
 import { getUserEventsChannel } from "../../src/server/redis/pubsub";
+import { expectNoMessage, subscribeAndDrain, waitForMessage } from "../utils/pubsub";
 
 let subscriber: Redis;
 
@@ -127,27 +128,6 @@ async function seedEntry(
   return entryId;
 }
 
-// Resolves with the first message on `channel`. Always removes its own listener
-// (on match or timeout) so listeners don't accumulate on the shared subscriber.
-function waitForMessage(channel: string, timeoutMs = 5000): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const listener = (ch: string, message: string) => {
-      if (ch !== channel) return;
-      cleanup();
-      resolve(message);
-    };
-    const timer = setTimeout(() => {
-      cleanup();
-      reject(new Error("Timed out waiting for message"));
-    }, timeoutMs);
-    const cleanup = () => {
-      clearTimeout(timer);
-      subscriber.off("message", listener);
-    };
-    subscriber.on("message", listener);
-  });
-}
-
 // Reads the user_entries state row directly, for asserting on the LWW
 // watermark columns that the service return value doesn't expose.
 async function getUserEntryRow(userId: string, entryId: string) {
@@ -164,26 +144,6 @@ async function getUserEntryRow(userId: string, entryId: string) {
   return row;
 }
 
-// Runs `action`, then waits `quietMs` and asserts no message arrived on `channel`.
-async function expectNoMessage(
-  channel: string,
-  action: () => Promise<unknown>,
-  quietMs = 200
-): Promise<void> {
-  let received = false;
-  const listener = (ch: string) => {
-    if (ch === channel) received = true;
-  };
-  subscriber.on("message", listener);
-  try {
-    await action();
-    await new Promise((resolve) => setTimeout(resolve, quietMs));
-    expect(received).toBe(false);
-  } finally {
-    subscriber.off("message", listener);
-  }
-}
-
 describe("markEntriesRead SSE publishing", () => {
   it("publishes entry_state_changed with absolute counts when an entry changes", async () => {
     const userId = await seedUser();
@@ -191,7 +151,7 @@ describe("markEntriesRead SSE publishing", () => {
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
-    const messagePromise = waitForMessage(channel);
+    const messagePromise = waitForMessage(subscriber, channel);
 
     const { entries: result, counts } = await entriesService.markEntriesRead(
       db,
@@ -216,7 +176,7 @@ describe("markEntriesRead SSE publishing", () => {
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
-    const messagePromise = waitForMessage(channel);
+    const messagePromise = waitForMessage(subscriber, channel);
 
     await entriesService.markEntriesRead(db, userId, [{ id: entryId }], true);
 
@@ -230,11 +190,14 @@ describe("markEntriesRead SSE publishing", () => {
   it("attaches the entry list payload when an entry flips to unread (#1237)", async () => {
     const userId = await seedUser();
     const entryId = await seedEntry(userId);
-    await entriesService.markEntriesRead(db, userId, [{ id: entryId }], true);
 
+    // Setup mutates through the service, which publishes fire-and-forget — so
+    // subscribe first and drain that event rather than racing it (issue #1427).
     const channel = getUserEventsChannel(userId);
-    await subscriber.subscribe(channel);
-    const messagePromise = waitForMessage(channel);
+    await subscribeAndDrain(subscriber, channel, () =>
+      entriesService.markEntriesRead(db, userId, [{ id: entryId }], true)
+    );
+    const messagePromise = waitForMessage(subscriber, channel);
 
     await entriesService.markEntriesRead(db, userId, [{ id: entryId }], false);
 
@@ -257,11 +220,12 @@ describe("markEntriesRead SSE publishing", () => {
   it("omits the payload for a spam entry flipping to unread", async () => {
     const userId = await seedUser();
     const entryId = await seedEntry(userId, { isSpam: true });
-    await entriesService.markEntriesRead(db, userId, [{ id: entryId }], true);
 
     const channel = getUserEventsChannel(userId);
-    await subscriber.subscribe(channel);
-    const messagePromise = waitForMessage(channel);
+    await subscribeAndDrain(subscriber, channel, () =>
+      entriesService.markEntriesRead(db, userId, [{ id: entryId }], true)
+    );
+    const messagePromise = waitForMessage(subscriber, channel);
 
     await entriesService.markEntriesRead(db, userId, [{ id: entryId }], false);
 
@@ -277,14 +241,14 @@ describe("markEntriesRead SSE publishing", () => {
     const entryId = await seedEntry(userId);
 
     // Establish a recent read_changed_at.
-    await entriesService.markEntriesRead(db, userId, [{ id: entryId }], true, {});
-
     const channel = getUserEventsChannel(userId);
-    await subscriber.subscribe(channel);
+    await subscribeAndDrain(subscriber, channel, () =>
+      entriesService.markEntriesRead(db, userId, [{ id: entryId }], true, {})
+    );
 
     // Replaying an older action loses the read_changed_at <= changedAt guard, so
     // no row updates and nothing is published.
-    await expectNoMessage(channel, () =>
+    await expectNoMessage(subscriber, channel, () =>
       entriesService.markEntriesRead(db, userId, [{ id: entryId, changedAt: new Date(0) }], false)
     );
   });
@@ -295,19 +259,19 @@ describe("markEntriesRead SSE publishing", () => {
 
     const t1 = new Date("2026-01-01T00:00:01Z");
     const t2 = new Date("2026-01-01T00:00:05Z");
-    await entriesService.markEntriesRead(db, userId, [{ id: entryId, changedAt: t1 }], true);
+    const channel = getUserEventsChannel(userId);
+    await subscribeAndDrain(subscriber, channel, () =>
+      entriesService.markEntriesRead(db, userId, [{ id: entryId, changedAt: t1 }], true)
+    );
 
     // Capture updated_at (the delta-sync "meaningful change" timestamp) after
     // the real flip so we can assert the re-assert leaves it untouched.
     const before = await getUserEntryRow(userId, entryId);
 
-    const channel = getUserEventsChannel(userId);
-    await subscriber.subscribe(channel);
-
     // A FRESH changedAt wins the guard and writes the row (the watermark must
     // advance), but the read value doesn't flip — so nothing is published,
     // `changed` is empty, and no counts are computed.
-    await expectNoMessage(channel, async () => {
+    await expectNoMessage(subscriber, channel, async () => {
       const result = await entriesService.markEntriesRead(
         db,
         userId,
@@ -361,11 +325,12 @@ describe("markEntriesRead SSE publishing", () => {
     const userId = await seedUser();
     const unreadEntryId = await seedEntry(userId);
     const readEntryId = await seedEntry(userId);
-    await entriesService.markEntriesRead(db, userId, [{ id: readEntryId }], true);
 
     const channel = getUserEventsChannel(userId);
-    await subscriber.subscribe(channel);
-    const messagePromise = waitForMessage(channel);
+    await subscribeAndDrain(subscriber, channel, () =>
+      entriesService.markEntriesRead(db, userId, [{ id: readEntryId }], true)
+    );
+    const messagePromise = waitForMessage(subscriber, channel);
 
     // One entry flips unread→read, the other is a same-value re-assert.
     const result = await entriesService.markEntriesRead(
@@ -392,7 +357,7 @@ describe("updateEntryStarred SSE publishing", () => {
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
-    const messagePromise = waitForMessage(channel);
+    const messagePromise = waitForMessage(subscriber, channel);
 
     const { entry, counts } = await entriesService.updateEntryStarred(db, userId, entryId, true);
     expect(entry.starred).toBe(true);
@@ -410,13 +375,13 @@ describe("updateEntryStarred SSE publishing", () => {
     const entryId = await seedEntry(userId);
 
     // Establish a recent starred_changed_at.
-    await entriesService.updateEntryStarred(db, userId, entryId, true, new Date());
-
     const channel = getUserEventsChannel(userId);
-    await subscriber.subscribe(channel);
+    await subscribeAndDrain(subscriber, channel, () =>
+      entriesService.updateEntryStarred(db, userId, entryId, true, new Date())
+    );
 
     // Replaying an older action loses the starred_changed_at <= changedAt guard.
-    await expectNoMessage(channel, () =>
+    await expectNoMessage(subscriber, channel, () =>
       entriesService.updateEntryStarred(db, userId, entryId, false, new Date(0))
     );
   });
@@ -427,19 +392,19 @@ describe("updateEntryStarred SSE publishing", () => {
 
     const t1 = new Date("2026-01-01T00:00:01Z");
     const t2 = new Date("2026-01-01T00:00:05Z");
-    await entriesService.updateEntryStarred(db, userId, entryId, true, t1);
+    const channel = getUserEventsChannel(userId);
+    await subscribeAndDrain(subscriber, channel, () =>
+      entriesService.updateEntryStarred(db, userId, entryId, true, t1)
+    );
 
     // Capture updated_at (the delta-sync "meaningful change" timestamp) after
     // the real flip so we can assert the re-assert leaves it untouched.
     const before = await getUserEntryRow(userId, entryId);
 
-    const channel = getUserEventsChannel(userId);
-    await subscriber.subscribe(channel);
-
     // A FRESH changedAt wins the guard and writes the row (the watermark must
     // advance), but the starred value doesn't flip — so nothing is published
     // and no counts are computed.
-    await expectNoMessage(channel, async () => {
+    await expectNoMessage(subscriber, channel, async () => {
       const result = await entriesService.updateEntryStarred(db, userId, entryId, true, t2);
       expect(result.entry.starred).toBe(true);
       expect(result.counts).toBeUndefined();
@@ -485,7 +450,7 @@ describe("updateEntriesStarred (bulk) SSE publishing", () => {
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
-    const first = waitForMessage(channel);
+    const first = waitForMessage(subscriber, channel);
 
     const {
       entries: state,
@@ -522,16 +487,16 @@ describe("updateEntriesStarred (bulk) SSE publishing", () => {
 
     const t1 = new Date("2026-01-01T00:00:01Z");
     const t2 = new Date("2026-01-01T00:00:05Z");
-    await entriesService.updateEntriesStarred(db, userId, [entryId], true, t1);
+    const channel = getUserEventsChannel(userId);
+    await subscribeAndDrain(subscriber, channel, () =>
+      entriesService.updateEntriesStarred(db, userId, [entryId], true, t1)
+    );
 
     const before = await getUserEntryRow(userId, entryId);
 
-    const channel = getUserEventsChannel(userId);
-    await subscriber.subscribe(channel);
-
     // A fresh changedAt advances the watermark, but the value doesn't flip, so
     // nothing is published and no counts are computed.
-    await expectNoMessage(channel, async () => {
+    await expectNoMessage(subscriber, channel, async () => {
       const result = await entriesService.updateEntriesStarred(db, userId, [entryId], true, t2);
       expect(result.changed).toHaveLength(0);
       expect(result.counts).toBeUndefined();

--- a/tests/integration/mark-all-read-events.test.ts
+++ b/tests/integration/mark-all-read-events.test.ts
@@ -19,6 +19,7 @@ import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import { getUserEventsChannel } from "../../src/server/redis/pubsub";
 import type { Context } from "../../src/server/trpc/context";
+import { expectNoMessage, waitForMessage } from "../utils/pubsub";
 
 let subscriber: Redis;
 
@@ -150,27 +151,6 @@ async function seedUnreadEntries(userId: string, count: number): Promise<string[
   return entryIds;
 }
 
-// Resolves with the first message on `channel`. Always removes its own listener
-// (on match or timeout) so listeners don't accumulate on the shared subscriber.
-function waitForMessage(channel: string, timeoutMs = 5000): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const listener = (ch: string, message: string) => {
-      if (ch !== channel) return;
-      cleanup();
-      resolve(message);
-    };
-    const timer = setTimeout(() => {
-      cleanup();
-      reject(new Error("Timed out waiting for message"));
-    }, timeoutMs);
-    const cleanup = () => {
-      clearTimeout(timer);
-      subscriber.off("message", listener);
-    };
-    subscriber.on("message", listener);
-  });
-}
-
 describe("entries.markAllRead SSE publishing", () => {
   it("publishes a mark_all_read signal carrying a cursor timestamp and the max marked id", async () => {
     const userId = generateUuidv7();
@@ -185,7 +165,7 @@ describe("entries.markAllRead SSE publishing", () => {
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
-    const messagePromise = waitForMessage(channel);
+    const messagePromise = waitForMessage(subscriber, channel);
 
     const caller = createCaller(createAuthContext(userId));
     const result = await caller.entries.markAllRead({});
@@ -214,22 +194,11 @@ describe("entries.markAllRead SSE publishing", () => {
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
-    let received = false;
-    const listener = (ch: string) => {
-      if (ch === channel) received = true;
-    };
-    subscriber.on("message", listener);
 
-    try {
+    await expectNoMessage(subscriber, channel, async () => {
       const caller = createCaller(createAuthContext(userId));
       const result = await caller.entries.markAllRead({});
       expect(result.count).toBe(0);
-
-      // Give any (erroneous) publish a chance to arrive.
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      expect(received).toBe(false);
-    } finally {
-      subscriber.off("message", listener);
-    }
+    });
   });
 });

--- a/tests/integration/subscription-update-events.test.ts
+++ b/tests/integration/subscription-update-events.test.ts
@@ -30,6 +30,7 @@ import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
 import { getUserEventsChannel } from "../../src/server/redis/pubsub";
+import { expectNoMessage, subscribeAndDrain, waitForMessage } from "../utils/pubsub";
 
 let subscriber: Redis;
 
@@ -179,47 +180,6 @@ async function getSubscriptionUpdatedAt(subscriptionId: string): Promise<Date> {
   return row.updatedAt;
 }
 
-// Resolves with the first message on `channel`. Always removes its own listener
-// (on match or timeout) so listeners don't accumulate on the shared subscriber.
-function waitForMessage(channel: string, timeoutMs = 5000): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const listener = (ch: string, message: string) => {
-      if (ch !== channel) return;
-      cleanup();
-      resolve(message);
-    };
-    const timer = setTimeout(() => {
-      cleanup();
-      reject(new Error("Timed out waiting for message"));
-    }, timeoutMs);
-    const cleanup = () => {
-      clearTimeout(timer);
-      subscriber.off("message", listener);
-    };
-    subscriber.on("message", listener);
-  });
-}
-
-// Runs `action`, then waits `quietMs` and asserts no message arrived on `channel`.
-async function expectNoMessage(
-  channel: string,
-  action: () => Promise<unknown>,
-  quietMs = 200
-): Promise<void> {
-  let received = false;
-  const listener = (ch: string) => {
-    if (ch === channel) received = true;
-  };
-  subscriber.on("message", listener);
-  try {
-    await action();
-    await new Promise((resolve) => setTimeout(resolve, quietMs));
-    expect(received).toBe(false);
-  } finally {
-    subscriber.off("message", listener);
-  }
-}
-
 // ============================================================================
 // Tests
 // ============================================================================
@@ -233,7 +193,7 @@ describe("subscriptions.update meaningful-change gating (issue #1160)", () => {
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
-    const messagePromise = waitForMessage(channel);
+    const messagePromise = waitForMessage(subscriber, channel);
 
     const result = await caller.subscriptions.update({
       id: subscriptionId,
@@ -261,7 +221,7 @@ describe("subscriptions.update meaningful-change gating (issue #1160)", () => {
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
 
-    await expectNoMessage(channel, async () => {
+    await expectNoMessage(subscriber, channel, async () => {
       // The full-form re-save pattern: every field sent, none changed.
       const result = await caller.subscriptions.update({
         id: subscriptionId,
@@ -286,7 +246,7 @@ describe("subscriptions.update meaningful-change gating (issue #1160)", () => {
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
 
-    await expectNoMessage(channel, () =>
+    await expectNoMessage(subscriber, channel, () =>
       caller.subscriptions.update({ id: subscriptionId, customTitle: null })
     );
 
@@ -303,7 +263,9 @@ describe("subscriptions.update meaningful-change gating (issue #1160)", () => {
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
 
-    await expectNoMessage(channel, () => caller.subscriptions.update({ id: subscriptionId }));
+    await expectNoMessage(subscriber, channel, () =>
+      caller.subscriptions.update({ id: subscriptionId })
+    );
 
     const after = await getSubscriptionUpdatedAt(subscriptionId);
     expect(after).toEqual(before);
@@ -320,7 +282,7 @@ describe("subscriptions.update meaningful-change gating (issue #1160)", () => {
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
-    const messagePromise = waitForMessage(channel);
+    const messagePromise = waitForMessage(subscriber, channel);
 
     const result = await caller.subscriptions.update({
       id: subscriptionId,
@@ -347,7 +309,7 @@ describe("subscriptions.setTags meaningful-change gating (issue #1160)", () => {
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
-    const messagePromise = waitForMessage(channel);
+    const messagePromise = waitForMessage(subscriber, channel);
 
     await caller.subscriptions.setTags({ id: subscriptionId, tagIds: [tagId] });
 
@@ -366,14 +328,16 @@ describe("subscriptions.setTags meaningful-change gating (issue #1160)", () => {
     const tagB = await createTestTag(userId, "News");
     const caller = createCaller(createAuthContext(userId));
 
-    await caller.subscriptions.setTags({ id: subscriptionId, tagIds: [tagA, tagB] });
+    // Setup mutates through the API, which publishes fire-and-forget — so
+    // subscribe first and drain that event rather than racing it (issue #1427).
+    const channel = getUserEventsChannel(userId);
+    await subscribeAndDrain(subscriber, channel, () =>
+      caller.subscriptions.setTags({ id: subscriptionId, tagIds: [tagA, tagB] })
+    );
     const before = await getSubscriptionUpdatedAt(subscriptionId);
 
-    const channel = getUserEventsChannel(userId);
-    await subscriber.subscribe(channel);
-
     // Same set, different order — still identical.
-    await expectNoMessage(channel, () =>
+    await expectNoMessage(subscriber, channel, () =>
       caller.subscriptions.setTags({ id: subscriptionId, tagIds: [tagB, tagA] })
     );
 
@@ -395,12 +359,12 @@ describe("subscriptions.setTags meaningful-change gating (issue #1160)", () => {
     const tagB = await createTestTag(userId, "News");
     const caller = createCaller(createAuthContext(userId));
 
-    await caller.subscriptions.setTags({ id: subscriptionId, tagIds: [tagA] });
-    const before = await getSubscriptionUpdatedAt(subscriptionId);
-
     const channel = getUserEventsChannel(userId);
-    await subscriber.subscribe(channel);
-    const messagePromise = waitForMessage(channel);
+    await subscribeAndDrain(subscriber, channel, () =>
+      caller.subscriptions.setTags({ id: subscriptionId, tagIds: [tagA] })
+    );
+    const before = await getSubscriptionUpdatedAt(subscriptionId);
+    const messagePromise = waitForMessage(subscriber, channel);
 
     await caller.subscriptions.setTags({ id: subscriptionId, tagIds: [tagA, tagB] });
 
@@ -417,12 +381,12 @@ describe("subscriptions.setTags meaningful-change gating (issue #1160)", () => {
     const tagId = await createTestTag(userId, "Tech");
     const caller = createCaller(createAuthContext(userId));
 
-    await caller.subscriptions.setTags({ id: subscriptionId, tagIds: [tagId] });
-    const before = await getSubscriptionUpdatedAt(subscriptionId);
-
     const channel = getUserEventsChannel(userId);
-    await subscriber.subscribe(channel);
-    const messagePromise = waitForMessage(channel);
+    await subscribeAndDrain(subscriber, channel, () =>
+      caller.subscriptions.setTags({ id: subscriptionId, tagIds: [tagId] })
+    );
+    const before = await getSubscriptionUpdatedAt(subscriptionId);
+    const messagePromise = waitForMessage(subscriber, channel);
 
     await caller.subscriptions.setTags({ id: subscriptionId, tagIds: [] });
 
@@ -443,7 +407,7 @@ describe("subscriptions.setTags meaningful-change gating (issue #1160)", () => {
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
 
-    await expectNoMessage(channel, () =>
+    await expectNoMessage(subscriber, channel, () =>
       caller.subscriptions.setTags({ id: subscriptionId, tagIds: [] })
     );
 

--- a/tests/utils/pubsub.ts
+++ b/tests/utils/pubsub.ts
@@ -63,6 +63,10 @@ export async function waitForMessage(
  * `expectedEvents` events, and returns only once all of them have arrived — so
  * a late fire-and-forget publish from setup can't be mistaken for an event from
  * the action the test is actually asserting on (issue #1427).
+ *
+ * Count the events setup really publishes: the bulk mark-read/star paths emit
+ * one entry_state_changed per *changed* entry, so a setup that flips two entries
+ * publishes two. Draining too few leaves a straggler and re-opens the race.
  */
 export async function subscribeAndDrain(
   subscriber: Redis,
@@ -72,8 +76,9 @@ export async function subscribeAndDrain(
 ): Promise<void> {
   await subscriber.subscribe(channel);
   const drained = waitForMessages(subscriber, channel, expectedEvents);
-  await setup();
-  await drained;
+  // Both awaited together so a throwing `setup` doesn't leave `drained` to
+  // reject unhandled (vitest would attribute it to an unrelated later test).
+  await Promise.all([drained, setup()]);
 }
 
 /** Runs `action`, then waits `quietMs` and asserts no message arrived on `channel`. */

--- a/tests/utils/pubsub.ts
+++ b/tests/utils/pubsub.ts
@@ -1,0 +1,98 @@
+/**
+ * Helpers for asserting on the Redis pub/sub events our services publish.
+ *
+ * All SSE publishing is deliberately fire-and-forget (issue #1082): a service
+ * call's `await` resolves before its PUBLISH reaches Redis. Any test that
+ * mutates state during setup and *then* subscribes is therefore racing its own
+ * setup event — if the publish lands after the SUBSCRIBE, the setup event is
+ * indistinguishable from one the action under test produced (issue #1427).
+ * Use `subscribeAndDrain` for that setup instead of a bare `subscribe`.
+ */
+
+import { expect } from "vitest";
+import type Redis from "ioredis";
+
+/**
+ * Resolves with the first `count` messages on `channel`. Always removes its own
+ * listener (on match or timeout) so listeners don't accumulate on the shared
+ * subscriber.
+ */
+export function waitForMessages(
+  subscriber: Redis,
+  channel: string,
+  count: number,
+  timeoutMs = 5000
+): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const messages: string[] = [];
+    const listener = (ch: string, message: string) => {
+      if (ch !== channel) return;
+      messages.push(message);
+      if (messages.length < count) return;
+      cleanup();
+      resolve(messages);
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `Timed out waiting for ${count} message(s) on ${channel} (received ${messages.length})`
+        )
+      );
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      subscriber.off("message", listener);
+    };
+    subscriber.on("message", listener);
+  });
+}
+
+/** Resolves with the first message on `channel`. */
+export async function waitForMessage(
+  subscriber: Redis,
+  channel: string,
+  timeoutMs = 5000
+): Promise<string> {
+  const [message] = await waitForMessages(subscriber, channel, 1, timeoutMs);
+  return message;
+}
+
+/**
+ * Subscribes to `channel`, runs a `setup` mutation expected to publish
+ * `expectedEvents` events, and returns only once all of them have arrived — so
+ * a late fire-and-forget publish from setup can't be mistaken for an event from
+ * the action the test is actually asserting on (issue #1427).
+ */
+export async function subscribeAndDrain(
+  subscriber: Redis,
+  channel: string,
+  setup: () => Promise<unknown>,
+  expectedEvents = 1
+): Promise<void> {
+  await subscriber.subscribe(channel);
+  const drained = waitForMessages(subscriber, channel, expectedEvents);
+  await setup();
+  await drained;
+}
+
+/** Runs `action`, then waits `quietMs` and asserts no message arrived on `channel`. */
+export async function expectNoMessage(
+  subscriber: Redis,
+  channel: string,
+  action: () => Promise<unknown>,
+  quietMs = 200
+): Promise<void> {
+  let received = false;
+  const listener = (ch: string) => {
+    if (ch === channel) received = true;
+  };
+  subscriber.on("message", listener);
+  try {
+    await action();
+    await new Promise((resolve) => setTimeout(resolve, quietMs));
+    expect(received).toBe(false);
+  } finally {
+    subscriber.off("message", listener);
+  }
+}


### PR DESCRIPTION
Fixes #1427.

## The race

Several `tests/integration/*-events.test.ts` tests established prior state by calling the service (or a tRPC caller) and *then* subscribed to the user's Redis channel:

```ts
await entriesService.updateEntryStarred(db, userId, entryId, true, new Date()); // real flip → publishes
await subscriber.subscribe(channel);
await expectNoMessage(channel, () => /* idempotent replay */);
```

SSE publishing is deliberately fire-and-forget (`void publishEntryStateChanged(...)`, #1082), so the setup call's `PUBLISH` can reach Redis *after* its `await` resolves. If it lands after the SUBSCRIBE, the setup event falls inside the window the test attributes to the action under test. It usually passes only because Redis drops messages published before a SUBSCRIBE — a scheduling race that shows up under CI load.

The reported test isn't the only one with this shape: the same pattern appears in the positive tests too (e.g. "attaches the entry list payload when an entry flips to unread" would see the setup's `read: true` event), and in `subscription-update-events.test.ts`'s `setTags` tests.

## The fix

- New shared `tests/utils/pubsub.ts` with `waitForMessage` / `waitForMessages` / `expectNoMessage` (three near-identical copies previously lived in three test files) plus **`subscribeAndDrain`**: subscribe first, run the setup mutation, and wait until its expected event(s) have been delivered before the assertion window opens.
- Converted every setup-mutates-through-the-service site in `entry-state-events`, `subscription-update-events`, and `mark-all-read-events` to it.
- Documented the rule in `tests/CLAUDE.md` so the pattern isn't reintroduced.

No product code changed.

## Verification

To prove the fix actually removes the race (rather than just re-passing a usually-green test), I temporarily added a 50 ms delay inside `publishEntryStateChanged` / `publishSubscriptionUpdated` to force the publish to land after the setup call returns:

- old tests + delay: **10 failed**, 17 passed
- new tests + delay: **27 passed**

The delay was reverted. Full local integration suite: **720 passed | 15 skipped**, plus 5 consecutive clean runs of the three affected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)