### PR TITLE
Fix master CI: drop the phantom SANITIZER_VERSION re-export

### DIFF
--- a/native/sanitizer/index.js
+++ b/native/sanitizer/index.js
@@ -47,7 +47,6 @@ const nativeBinding = requireNative(binaryPath);
 // assignments — not the dynamic binding object above. Without these,
 // `import { sanitizeEntryHtml } from "@lion-reader/sanitizer"` fails to resolve
 // under the native ESM loader (e.g. the Playwright e2e harness).
-exports.SANITIZER_VERSION = nativeBinding.SANITIZER_VERSION;
 exports.sanitizeEntryHtml = nativeBinding.sanitizeEntryHtml;
 exports.sanitizeEntryHtmlAsync = nativeBinding.sanitizeEntryHtmlAsync;
 exports.embedCanonicalHostnames = nativeBinding.embedCanonicalHostnames;


### PR DESCRIPTION
All CI jobs on `master` have failed since #1415 merged. Unit tests (9 files), integration tests, and the e2e production build each died at module load:

```
Error: @lion-reader/sanitizer: re-exported "SANITIZER_VERSION" is undefined
— sanitizer.node has no such export.
```

## Root cause

A semantic merge conflict — neither side conflicted textually, so git merged it cleanly.

#1415 branched **before** 4803f448 ("Delete SANITIZER_VERSION") and was merged four days **after** it, without a rebase:

- **4803f448** removed `SANITIZER_VERSION` from the core crate, the `#[napi]` export, `index.d.ts`, and the TS re-export. It could not remove the `exports.SANITIZER_VERSION =` line in `native/sanitizer/index.js`, because that line only existed on the unmerged #1415 branch.
- **#1415** added that re-export back at a time when the symbol still existed, and in the same PR flipped the loader's drift guard to the dangerous direction (4da494ee): throw when a re-exported name is missing from the binary.

The guard did exactly its job. It converted what would otherwise have been a silent `undefined` on the security-critical sanitize path into a loud failure at import time. Because it runs on **every** import of `@lion-reader/sanitizer`, it took down essentially the whole suite at once.

The `Deploy` workflow was skipped on the failed run, so production was never affected.

## Fix

`SANITIZER_VERSION` has no remaining consumers anywhere in `src/`, `tests/`, or `scripts/`, so the phantom re-export is simply deleted. One line.

## Verification

All four failing CI jobs reproduced locally, then confirmed fixed:

- CJS `require` and ESM named imports both load; `sanitizeEntryHtml` still strips `<script>` and event-handler payloads
- `pnpm test:unit` — 145/145 files, 2626 tests (was 9 failed | 136 passed)
- `pnpm test:integration:local` — 50 passed | 2 skipped, 720 tests
- `pnpm typecheck` — clean
- `pnpm build && pnpm build:server` — completes (previously failed collecting page data for `/api/greader.php/reader/api/0/edit-tag`)

Sibling loaders `native/readability/index.js` and `native/feed-parser/index.js` were checked for the same drift; their re-export lists match their `#[napi]` exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)