### PR TITLE
Narrate a list item once when it wraps block children (#1441)

### DIFF
--- a/src/lib/narration/client-paragraph-ids.ts
+++ b/src/lib/narration/client-paragraph-ids.ts
@@ -233,6 +233,25 @@ function processInlineContent(el: Element): string {
 }
 
 /**
+ * The first matching descendant an element speaks for itself — one no block in
+ * between has already claimed.
+ */
+function ownDescendant(el: Element, selector: string): Element | null {
+  for (const candidate of Array.from(el.querySelectorAll(selector))) {
+    let owner: Element | null = null;
+    for (let parent = candidate.parentElement; parent; parent = parent.parentElement) {
+      const tagName = parent.tagName.toLowerCase();
+      if (tagName !== "img" && BLOCK_ELEMENT_SET.has(tagName)) {
+        owner = parent;
+        break;
+      }
+    }
+    if (owner === el) return candidate;
+  }
+  return null;
+}
+
+/**
  * Everything inside an element, block children included, with the blocks kept
  * apart by a space.
  *
@@ -241,6 +260,14 @@ function processInlineContent(el: Element): string {
  * come from here — and `textContent` won't do, since it drops image alt text.
  */
 function subtreeNarrationText(el: Element): string {
+  return subtreeText(el).replace(/\s+/g, " ").trim();
+}
+
+/**
+ * The subtree's text, untrimmed — trimming at every level of the walk swallows
+ * the space in `<b>Total:</b><span> 42</span>`.
+ */
+function subtreeText(el: Element): string {
   let text = "";
 
   el.childNodes.forEach((node) => {
@@ -261,12 +288,12 @@ function subtreeNarrationText(el: Element): string {
       }
       return;
     }
-    const inner = subtreeNarrationText(childEl);
+    const inner = subtreeText(childEl);
     // Inline markup continues the run of text; a block starts a new one.
     text += BLOCK_ELEMENT_SET.has(childTag) ? ` ${inner} ` : inner;
   });
 
-  return text.replace(/\s+/g, " ").trim();
+  return text;
 }
 
 /**
@@ -320,31 +347,42 @@ function getElementNarrationText(el: Element): string {
     return processInlineContent(el);
   }
 
-  // Handle figures
+  // Handle figures. Only what the figure itself holds: an image inside a
+  // nested block (a table, a list) is spoken by that block instead — and a
+  // figure around one of those is not an image at all, so it announces none.
   if (tagName === "figure") {
-    const img = el.querySelector("img");
-    const figcaption = el.querySelector("figcaption");
-    const alt = img?.getAttribute("alt") || figcaption?.textContent?.trim();
-    if (alt) {
-      return `Image: ${alt}`;
+    const img = ownDescendant(el, "img");
+    if (!img) {
+      return processInlineContent(el);
     }
-    return "";
+    const figcaption = ownDescendant(el, "figcaption");
+    const alt = img.getAttribute("alt") || figcaption?.textContent?.trim();
+    return alt ? `Image: ${alt}` : "";
   }
 
   // Handle tables
   if (tagName === "table") {
-    // Extract table content in a readable format
-    const rows: string[] = [];
+    // Extract table content in a readable format. The caption counts: like the
+    // cells, the blocks inside it stay silent for the table's sake, so if the
+    // table doesn't say it, nothing does (issue #1445).
+    const parts: string[] = [];
+    const caption = el.querySelector("caption");
+    if (caption?.closest("table") === el) {
+      parts.push(subtreeNarrationText(caption));
+    }
     el.querySelectorAll("tr").forEach((tr) => {
+      // A nested table narrates its own rows — as a cell of this one.
+      if (tr.closest("table") !== el) return;
       const cells: string[] = [];
       tr.querySelectorAll("th, td").forEach((cell) => {
+        if (cell.closest("tr") !== tr) return;
         cells.push(subtreeNarrationText(cell));
       });
       if (cells.length > 0 && cells.some((c) => c.length > 0)) {
-        rows.push(cells.join(", "));
+        parts.push(cells.join(", "));
       }
     });
-    return rows.join(". ");
+    return parts.filter(Boolean).join(". ");
   }
 
   // Handle standalone images

--- a/src/lib/narration/client-paragraph-ids.ts
+++ b/src/lib/narration/client-paragraph-ids.ts
@@ -233,6 +233,43 @@ function processInlineContent(el: Element): string {
 }
 
 /**
+ * Everything inside an element, block children included, with the blocks kept
+ * apart by a space.
+ *
+ * `processInlineContent` stops at block children because each narrates itself;
+ * a table cell's blocks don't (the table speaks for them), so their text has to
+ * come from here — and `textContent` won't do, since it drops image alt text.
+ */
+function subtreeNarrationText(el: Element): string {
+  let text = "";
+
+  el.childNodes.forEach((node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      text += node.textContent || "";
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+    const childEl = node as Element;
+    const childTag = childEl.tagName.toLowerCase();
+    if (childTag === "img") {
+      const alt = childEl.getAttribute("alt");
+      if (alt && alt.trim()) {
+        // Padded: nothing here guarantees whitespace around an image the way
+        // the text around an inline one does (a caption butts right up to it).
+        text += ` Image: ${alt.trim()} `;
+      }
+      return;
+    }
+    const inner = subtreeNarrationText(childEl);
+    // Inline markup continues the run of text; a block starts a new one.
+    text += BLOCK_ELEMENT_SET.has(childTag) ? ` ${inner} ` : inner;
+  });
+
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/**
  * Blocks whose narration already accounts for everything inside them: a table
  * speaks all of its cells, and a code block is deliberately not spoken at all.
  * A block nested in one of those has to stay silent, or its text comes back —
@@ -301,7 +338,7 @@ function getElementNarrationText(el: Element): string {
     el.querySelectorAll("tr").forEach((tr) => {
       const cells: string[] = [];
       tr.querySelectorAll("th, td").forEach((cell) => {
-        cells.push(cell.textContent?.trim() || "");
+        cells.push(subtreeNarrationText(cell));
       });
       if (cells.length > 0 && cells.some((c) => c.length > 0)) {
         rows.push(cells.join(", "));

--- a/src/lib/narration/client-paragraph-ids.ts
+++ b/src/lib/narration/client-paragraph-ids.ts
@@ -233,10 +233,25 @@ function processInlineContent(el: Element): string {
 }
 
 /**
+ * Blocks whose narration already accounts for everything inside them: a table
+ * speaks all of its cells, and a code block is deliberately not spoken at all.
+ * A block nested in one of those has to stay silent, or its text comes back —
+ * a second time for the table, and at all for the code block (issue #1445).
+ *
+ * A blockquote is not one of these: it speaks only its own text, so the
+ * paragraphs inside it are the ones that narrate the quote.
+ */
+const SUBTREE_SPEAKERS = new Set(["pre", "table"]);
+
+/**
  * Gets narration text for an element.
  * Handles special elements like images, code blocks, headings, etc.
  */
 function getElementNarrationText(el: Element): string {
+  for (let parent = el.parentElement; parent; parent = parent.parentElement) {
+    if (SUBTREE_SPEAKERS.has(parent.tagName.toLowerCase())) return "";
+  }
+
   const tagName = el.tagName.toLowerCase();
 
   // Handle headings - process inline content to capture any images

--- a/src/lib/narration/client-paragraph-ids.ts
+++ b/src/lib/narration/client-paragraph-ids.ts
@@ -19,6 +19,9 @@ import {
 export { BLOCK_ELEMENTS };
 export type { ParagraphMapEntry };
 
+/** Set version of `BLOCK_ELEMENTS` for efficient lookup. */
+const BLOCK_ELEMENT_SET = new Set<string>(BLOCK_ELEMENTS);
+
 /**
  * Result of adding paragraph IDs to HTML content.
  */
@@ -81,7 +84,6 @@ export function addParagraphIdsToHtml(html: string): AddParagraphIdsResult {
 
   // Find standalone images (not nested inside other block elements)
   // An image is standalone if none of its ancestors are block elements
-  const blockElementSet = new Set(BLOCK_ELEMENTS);
   const standaloneImages: Element[] = [];
   container.querySelectorAll("img").forEach((img) => {
     let parent = img.parentElement;
@@ -89,7 +91,7 @@ export function addParagraphIdsToHtml(html: string): AddParagraphIdsResult {
 
     while (parent && parent !== container) {
       const parentTag = parent.tagName.toLowerCase();
-      if (blockElementSet.has(parentTag as (typeof BLOCK_ELEMENTS)[number])) {
+      if (BLOCK_ELEMENT_SET.has(parentTag)) {
         isStandalone = false;
         break;
       }
@@ -195,6 +197,11 @@ export interface ClientNarrationResult {
 /**
  * Process inline content, handling images and other inline elements.
  * Recursively walks through child nodes to preserve image alt text.
+ *
+ * Block children are skipped: each one is its own paragraph in the list below,
+ * so including their text here would narrate it twice — once for the wrapper
+ * and once for the child (issue #1441). Images are the exception, since a
+ * nested image never gets a paragraph of its own.
  */
 function processInlineContent(el: Element): string {
   let text = "";
@@ -215,7 +222,7 @@ function processInlineContent(el: Element): string {
         if (alt && alt.trim()) {
           text += `Image: ${alt.trim()}`;
         }
-      } else {
+      } else if (!BLOCK_ELEMENT_SET.has(childTag)) {
         // Recurse for other inline elements (strong, em, span, a, etc.)
         text += processInlineContent(childEl);
       }
@@ -350,7 +357,6 @@ export function htmlToClientNarration(html: string): ClientNarrationResult {
   const allElements = container.querySelectorAll(selector);
 
   // Find standalone images (not nested inside other block elements)
-  const blockElementSet = new Set(BLOCK_ELEMENTS);
   const standaloneImages: Element[] = [];
   container.querySelectorAll("img").forEach((img) => {
     let parent = img.parentElement;
@@ -358,7 +364,7 @@ export function htmlToClientNarration(html: string): ClientNarrationResult {
 
     while (parent && parent !== container) {
       const parentTag = parent.tagName.toLowerCase();
-      if (blockElementSet.has(parentTag as (typeof BLOCK_ELEMENTS)[number])) {
+      if (BLOCK_ELEMENT_SET.has(parentTag)) {
         isStandalone = false;
         break;
       }

--- a/src/lib/narration/client-paragraph-ids.ts
+++ b/src/lib/narration/client-paragraph-ids.ts
@@ -195,6 +195,18 @@ export interface ClientNarrationResult {
 }
 
 /**
+ * How deep the walks below descend before flattening what is left. The markup
+ * is feed-controlled and nests as deeply as it likes; the walks are recursive.
+ */
+const MAX_CONTENT_DEPTH = 64;
+
+/** An image's spoken text, padded — nothing else guarantees a gap around it. */
+function imageText(img: Element): string {
+  const alt = img.getAttribute("alt");
+  return alt && alt.trim() ? ` Image: ${alt.trim()} ` : "";
+}
+
+/**
  * Process inline content, handling images and other inline elements.
  * Recursively walks through child nodes to preserve image alt text.
  *
@@ -204,32 +216,42 @@ export interface ClientNarrationResult {
  * nested image never gets a paragraph of its own.
  */
 function processInlineContent(el: Element): string {
-  let text = "";
+  // Horizontal whitespace only: a blank line in the source is how a block with
+  // `<br><br>` in it becomes two spoken paragraphs (see `./paragraph-map`).
+  return inlineText(el)
+    .replace(/[^\S\n]+/g, " ")
+    .trim();
+}
 
-  // Walk through child nodes
+/**
+ * The inline text of an element's children, untrimmed — trimming at every level
+ * of the walk swallows the space in `<b>Total:</b><span> 42</span>`.
+ */
+function inlineText(el: Element, depth = 0): string {
+  if (depth >= MAX_CONTENT_DEPTH) {
+    return el.textContent || "";
+  }
+
+  let text = "";
   el.childNodes.forEach((node) => {
     if (node.nodeType === Node.TEXT_NODE) {
-      // Text node
       text += node.textContent || "";
-    } else if (node.nodeType === Node.ELEMENT_NODE) {
-      // Element node
-      const childEl = node as Element;
-      const childTag = childEl.tagName.toLowerCase();
-
-      if (childTag === "img") {
-        // Inline image - include alt text
-        const alt = childEl.getAttribute("alt");
-        if (alt && alt.trim()) {
-          text += `Image: ${alt.trim()}`;
-        }
-      } else if (!BLOCK_ELEMENT_SET.has(childTag)) {
-        // Recurse for other inline elements (strong, em, span, a, etc.)
-        text += processInlineContent(childEl);
-      }
+      return;
     }
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+    const childEl = node as Element;
+    const childTag = childEl.tagName.toLowerCase();
+    if (childTag === "img") {
+      text += imageText(childEl);
+      return;
+    }
+    if (BLOCK_ELEMENT_SET.has(childTag)) return;
+    // Recurse for other inline elements (strong, em, span, a, etc.)
+    text += inlineText(childEl, depth + 1);
   });
 
-  return text.trim();
+  return text;
 }
 
 /**
@@ -267,9 +289,12 @@ function subtreeNarrationText(el: Element): string {
  * The subtree's text, untrimmed — trimming at every level of the walk swallows
  * the space in `<b>Total:</b><span> 42</span>`.
  */
-function subtreeText(el: Element): string {
-  let text = "";
+function subtreeText(el: Element, depth = 0): string {
+  if (depth >= MAX_CONTENT_DEPTH) {
+    return el.textContent || "";
+  }
 
+  let text = "";
   el.childNodes.forEach((node) => {
     if (node.nodeType === Node.TEXT_NODE) {
       text += node.textContent || "";
@@ -280,20 +305,70 @@ function subtreeText(el: Element): string {
     const childEl = node as Element;
     const childTag = childEl.tagName.toLowerCase();
     if (childTag === "img") {
-      const alt = childEl.getAttribute("alt");
-      if (alt && alt.trim()) {
-        // Padded: nothing here guarantees whitespace around an image the way
-        // the text around an inline one does (a caption butts right up to it).
-        text += ` Image: ${alt.trim()} `;
-      }
+      text += imageText(childEl);
       return;
     }
-    const inner = subtreeText(childEl);
+    if (childTag === "table") {
+      // A table in a cell reads as a table, not as its cells glued together.
+      text += ` ${tableNarrationText(childEl)} `;
+      return;
+    }
+    if (childTag === "figure" && ownDescendant(childEl, "img")) {
+      text += ` ${figureNarrationText(childEl)} `;
+      return;
+    }
+    const inner = subtreeText(childEl, depth + 1);
     // Inline markup continues the run of text; a block starts a new one.
     text += BLOCK_ELEMENT_SET.has(childTag) ? ` ${inner} ` : inner;
   });
 
   return text;
+}
+
+/**
+ * A figure's image, with the caption that nothing else narrates: the caption is
+ * the description when there is no alt text, and extra detail when there is.
+ *
+ * A figure that holds no image of its own — one around a table or a list, or
+ * one whose image a nested block already speaks — is not an image at all, so it
+ * announces none and narrates whatever text it does hold.
+ */
+function figureNarrationText(el: Element): string {
+  const img = ownDescendant(el, "img");
+  if (!img) {
+    return processInlineContent(el);
+  }
+  const alt = img.getAttribute("alt")?.trim();
+  const caption = ownDescendant(el, "figcaption")?.textContent?.trim();
+  if (!alt) {
+    return caption ? `Image: ${caption}` : "";
+  }
+  return caption ? `Image: ${alt}. ${caption}` : `Image: ${alt}`;
+}
+
+/**
+ * A table's rows, and the caption that no one else will narrate (issue #1445):
+ * like the cells, the blocks inside it stay silent for the table's sake.
+ */
+function tableNarrationText(el: Element): string {
+  const parts: string[] = [];
+  const caption = el.querySelector("caption");
+  if (caption?.closest("table") === el) {
+    parts.push(subtreeNarrationText(caption));
+  }
+  el.querySelectorAll("tr").forEach((tr) => {
+    // A nested table narrates its own rows — as a cell of this one.
+    if (tr.closest("table") !== el) return;
+    const cells: string[] = [];
+    tr.querySelectorAll("th, td").forEach((cell) => {
+      if (cell.closest("tr") !== tr) return;
+      cells.push(subtreeNarrationText(cell));
+    });
+    if (cells.length > 0 && cells.some((c) => c.length > 0)) {
+      parts.push(cells.join(", "));
+    }
+  });
+  return parts.filter(Boolean).join(". ");
 }
 
 /**
@@ -351,38 +426,12 @@ function getElementNarrationText(el: Element): string {
   // nested block (a table, a list) is spoken by that block instead — and a
   // figure around one of those is not an image at all, so it announces none.
   if (tagName === "figure") {
-    const img = ownDescendant(el, "img");
-    if (!img) {
-      return processInlineContent(el);
-    }
-    const figcaption = ownDescendant(el, "figcaption");
-    const alt = img.getAttribute("alt") || figcaption?.textContent?.trim();
-    return alt ? `Image: ${alt}` : "";
+    return figureNarrationText(el);
   }
 
   // Handle tables
   if (tagName === "table") {
-    // Extract table content in a readable format. The caption counts: like the
-    // cells, the blocks inside it stay silent for the table's sake, so if the
-    // table doesn't say it, nothing does (issue #1445).
-    const parts: string[] = [];
-    const caption = el.querySelector("caption");
-    if (caption?.closest("table") === el) {
-      parts.push(subtreeNarrationText(caption));
-    }
-    el.querySelectorAll("tr").forEach((tr) => {
-      // A nested table narrates its own rows — as a cell of this one.
-      if (tr.closest("table") !== el) return;
-      const cells: string[] = [];
-      tr.querySelectorAll("th, td").forEach((cell) => {
-        if (cell.closest("tr") !== tr) return;
-        cells.push(subtreeNarrationText(cell));
-      });
-      if (cells.length > 0 && cells.some((c) => c.length > 0)) {
-        parts.push(cells.join(", "));
-      }
-    });
-    return parts.filter(Boolean).join(". ");
+    return tableNarrationText(el);
   }
 
   // Handle standalone images

--- a/src/lib/narration/html-to-narration-input.ts
+++ b/src/lib/narration/html-to-narration-input.ts
@@ -163,12 +163,36 @@ function insideSubtreeSpeaker(el: Element): boolean {
   return false;
 }
 
+/** Selector matching the blocks that break a run of inline text. */
+const BLOCK_SELECTOR = BLOCK_ELEMENTS.filter((tagName) => tagName !== "img").join(", ");
+
+/**
+ * Blocks that already speak for their whole subtree when they turn up inside
+ * one — `SUBTREE_SPEAKERS` plus `figure`, which speaks its image rather than
+ * its markup and so must not be walked into like a generic wrapper.
+ */
+const SELF_CONTAINED = new Set([...SUBTREE_SPEAKERS, "figure"]);
+
+/**
+ * How deep the content walk descends before flattening what is left.
+ *
+ * Nothing a listener can follow nests this far, and the walk is recursive over
+ * feed-controlled markup — a document nesting thousands of quotes deep would
+ * otherwise overflow the stack instead of being narrated.
+ */
+const MAX_CONTENT_DEPTH = 64;
+
 /**
  * The paragraphs an element's content narrates as, in document order: inline
  * runs and block children interleaved the way they appear, so an attribution
  * that trails a quote is read after it rather than before it.
  */
-function contentParagraphs(el: Element): string[] {
+function contentParagraphs(el: Element, depth = 0): string[] {
+  if (depth >= MAX_CONTENT_DEPTH) {
+    const text = el.textContent?.trim();
+    return text ? [text] : [];
+  }
+
   const paragraphs: string[] = [];
   let inline = "";
 
@@ -180,21 +204,23 @@ function contentParagraphs(el: Element): string[] {
   el.childNodes.forEach((node) => {
     const child = node.nodeType === ELEMENT_NODE ? (node as Element) : null;
     const tagName = child?.tagName.toLowerCase() ?? "";
-    // An image belongs to the run of text around it — it gets no paragraph.
-    if (!child || tagName === "img" || !BLOCK_ELEMENTS_SET.has(tagName)) {
+    const isBlock = tagName !== "img" && BLOCK_ELEMENTS_SET.has(tagName);
+    // A `<div>`/`<section>` around the blocks is transparent, but one that only
+    // wraps text is part of the run around it — as is an image, always.
+    if (!child || (!isBlock && !child.querySelector(BLOCK_SELECTOR))) {
       inline += inlineNodeText(node);
       return;
     }
 
     flushInline();
-    if (SUBTREE_SPEAKERS.has(tagName)) {
+    if (SELF_CONTAINED.has(tagName)) {
       // Already speaks for everything below it, so don't descend twice.
-      const text = getOwnNarrationText(child);
+      const text = getOwnNarrationText(child, depth + 1);
       if (text) paragraphs.push(text);
       return;
     }
 
-    const inner = contentParagraphs(child);
+    const inner = contentParagraphs(child, depth + 1);
     if (tagName === "li" && inner.length > 0) {
       inner[0] = `${listItemMarker(child)}${inner[0]}`;
     }
@@ -223,9 +249,10 @@ function getElementNarrationText(el: Element): string {
 
 /**
  * The element's own narration text, before any marker it inherits from an
- * enclosing list item.
+ * enclosing list item. `depth` is how far a wrapper's content walk has already
+ * descended to reach this element (see `contentParagraphs`).
  */
-function getOwnNarrationText(el: Element): string {
+function getOwnNarrationText(el: Element, depth = 0): string {
   const tagName = el.tagName.toLowerCase();
 
   // Handle headings - just return the text (no marker)
@@ -250,7 +277,7 @@ function getOwnNarrationText(el: Element): string {
   // lines rather than run together, and the player speaks each of them as its
   // own paragraph (all highlighting this blockquote).
   if (tagName === "blockquote") {
-    const quoted = contentParagraphs(el);
+    const quoted = contentParagraphs(el, depth);
     return quoted.length > 0 ? `Quote: ${quoted.join("\n\n")} End quote.` : "";
   }
 
@@ -277,12 +304,15 @@ function getOwnNarrationText(el: Element): string {
 
   // Handle tables
   if (tagName === "table") {
-    // Extract table content in a readable format
+    // Extract table content in a readable format. Cells narrate the same way
+    // anything else does rather than through `textContent`, because the blocks
+    // inside them stay silent for the table's sake — so whatever they would
+    // have said (an image's alt text, a list's bullets) has to be said here.
     const rows: string[] = [];
     el.querySelectorAll("tr").forEach((tr) => {
       const cells: string[] = [];
       tr.querySelectorAll("th, td").forEach((cell) => {
-        cells.push(cell.textContent?.trim() || "");
+        cells.push(contentParagraphs(cell, depth + 1).join(" "));
       });
       if (cells.length > 0) {
         rows.push(cells.join(", "));

--- a/src/lib/narration/html-to-narration-input.ts
+++ b/src/lib/narration/html-to-narration-input.ts
@@ -77,18 +77,6 @@ function leadingTaskCheckbox(li: Element): Element | null {
 }
 
 /**
- * Whether an element narrates itself, so an enclosing block must leave its text
- * out — otherwise the same words are spoken twice (issue #1441).
- *
- * `img` is the exception: an image nested inside a block element is dropped from
- * the paragraph list below, so the enclosing block is what speaks its alt text.
- */
-function narratesItself(el: Element): boolean {
-  const tagName = el.tagName.toLowerCase();
-  return tagName !== "img" && BLOCK_ELEMENTS_SET.has(tagName);
-}
-
-/**
  * The bullet a list item is read with, plus its task-list state when it leads
  * with a checkbox. A task list carries that state in the checkbox, which
  * contributes no text — so read aloud, a done item would be indistinguishable
@@ -103,21 +91,59 @@ function listItemMarker(li: Element): string {
 }
 
 /**
+ * The list item a block belongs to, if any. Elements that aren't block-level —
+ * a `<div>` or `<section>` wrapper — are transparent, since they get no
+ * paragraph of their own; another block element does own its descendants.
+ */
+function enclosingListItem(el: Element): Element | null {
+  for (let parent = el.parentElement; parent; parent = parent.parentElement) {
+    const tagName = parent.tagName.toLowerCase();
+    if (tagName === "li") return parent;
+    if (BLOCK_ELEMENTS_SET.has(tagName)) return null;
+  }
+  return null;
+}
+
+/**
+ * The block a list item hands its marker to, or null if nothing in it speaks.
+ *
+ * The *first* child is not good enough: a leading empty `<p>` narrates nothing,
+ * and a nested list narrates only through its own items (which mark
+ * themselves), so a marker parked on either is a marker lost — including the
+ * task-list state from #1439, which is the item's only cue that it is done.
+ */
+function markerCarrier(li: Element): Element | null {
+  for (const child of Array.from(li.children)) {
+    const tagName = child.tagName.toLowerCase();
+    // A nested list's items carry their own markers, and a nested image is
+    // spoken by the block around it rather than getting a paragraph.
+    if (tagName === "ul" || tagName === "ol" || tagName === "img") continue;
+    if (!BLOCK_ELEMENTS_SET.has(tagName)) {
+      // A wrapper is transparent — the block that speaks may be inside it.
+      const nested = markerCarrier(child);
+      if (nested) return nested;
+      continue;
+    }
+    if (getOwnNarrationText(child).trim() !== "") return child;
+  }
+  return null;
+}
+
+/**
  * The list marker a block inherits from the item that wraps it, if any.
  *
  * A loose list item (`<li><p>…</p></li>` — what cmark-gfm/GitHub emit for any
  * list with blank lines between items, so it is common in feed HTML) has no
  * text of its own; its children narrate themselves. The bullet and the spoken
- * checkbox state therefore ride along on the first of those children instead of
- * on the item (issue #1441). An item that does have its own text speaks its own
+ * checkbox state therefore ride along on one of those children instead of on
+ * the item (issue #1441). An item that does have its own text speaks its own
  * marker, so its children inherit nothing.
  */
 function inheritedListMarker(el: Element): string {
-  const li = el.parentElement;
-  if (!li || li.tagName.toLowerCase() !== "li") return "";
-  if (leadingElement(li) !== el) return "";
+  const li = enclosingListItem(el);
+  if (!li) return "";
   if (processInlineContent(li) !== "") return "";
-  return listItemMarker(li);
+  return markerCarrier(li) === el ? listItemMarker(li) : "";
 }
 
 /**
@@ -210,7 +236,9 @@ function getOwnNarrationText(el: Element): string {
 /**
  * Process inline content, handling links and other inline elements.
  *
- * Block children are left out — see `narratesItself`.
+ * Block children are left out: each narrates itself, so speaking them here too
+ * would say the same words twice (issue #1441). An image is the exception — a
+ * nested one gets no paragraph of its own, so the block around it speaks it.
  */
 function processInlineContent(el: Element): string {
   let text = "";
@@ -230,7 +258,11 @@ function processInlineContent(el: Element): string {
         const href = childEl.getAttribute("href");
         const linkText = childEl.textContent?.trim() || "";
 
-        if (!linkText || linkText === href) {
+        if (!href) {
+          // A link target (`<a id="fn1">`), not a link: it goes nowhere, so
+          // announcing one would be noise — speak whatever text it wraps.
+          text += linkText;
+        } else if (!linkText || linkText === href) {
           try {
             const domain = new URL(href || "").hostname;
             text += `[link to ${domain}]`;
@@ -241,13 +273,16 @@ function processInlineContent(el: Element): string {
           text += linkText;
         }
       } else if (childTag === "code") {
-        // Inline code
-        text += `\`${childEl.textContent || ""}\``;
+        // Inline code (empty markup is not worth speaking a pair of backticks)
+        const code = childEl.textContent || "";
+        if (code) {
+          text += `\`${code}\``;
+        }
       } else if (childTag === "img") {
         // Inline image
         const alt = childEl.getAttribute("alt") || "image";
         text += `Image: ${alt}`;
-      } else if (!narratesItself(childEl)) {
+      } else if (!BLOCK_ELEMENTS_SET.has(childTag)) {
         // Recurse for other inline elements (strong, em, span, etc.)
         text += processInlineContent(childEl);
       }

--- a/src/lib/narration/html-to-narration-input.ts
+++ b/src/lib/narration/html-to-narration-input.ts
@@ -167,11 +167,23 @@ function insideSubtreeSpeaker(el: Element): boolean {
 const BLOCK_SELECTOR = BLOCK_ELEMENTS.filter((tagName) => tagName !== "img").join(", ");
 
 /**
- * Blocks that already speak for their whole subtree when they turn up inside
- * one — `SUBTREE_SPEAKERS` plus `figure`, which speaks its image rather than
- * its markup and so must not be walked into like a generic wrapper.
+ * The first matching descendant an element speaks for itself — one no block in
+ * between has already claimed.
  */
-const SELF_CONTAINED = new Set([...SUBTREE_SPEAKERS, "figure"]);
+function ownDescendant(el: Element, selector: string): Element | null {
+  for (const candidate of Array.from(el.querySelectorAll(selector))) {
+    let owner: Element | null = null;
+    for (let parent = candidate.parentElement; parent; parent = parent.parentElement) {
+      const tagName = parent.tagName.toLowerCase();
+      if (tagName !== "img" && BLOCK_ELEMENTS_SET.has(tagName)) {
+        owner = parent;
+        break;
+      }
+    }
+    if (owner === el) return candidate;
+  }
+  return null;
+}
 
 /**
  * How deep the content walk descends before flattening what is left.
@@ -213,7 +225,7 @@ function contentParagraphs(el: Element, depth = 0): string[] {
     }
 
     flushInline();
-    if (SELF_CONTAINED.has(tagName)) {
+    if (SUBTREE_SPEAKERS.has(tagName)) {
       // Already speaks for everything below it, so don't descend twice.
       const text = getOwnNarrationText(child, depth + 1);
       if (text) paragraphs.push(text);
@@ -294,31 +306,43 @@ function getOwnNarrationText(el: Element, depth = 0): string {
     return text ? `${listItemMarker(el)}${text}` : "";
   }
 
-  // Handle figures
+  // Handle figures. Only what the figure itself holds: an image inside a
+  // nested block (a table, a list) is spoken by that block instead — and a
+  // figure around one of those is not an image at all, so it announces none.
   if (tagName === "figure") {
-    const img = el.querySelector("img");
-    const figcaption = el.querySelector("figcaption");
-    const alt = img?.getAttribute("alt") || figcaption?.textContent?.trim() || "no description";
-    return `Image: ${alt}`;
+    const img = ownDescendant(el, "img");
+    if (!img) {
+      return processInlineContent(el);
+    }
+    const figcaption = ownDescendant(el, "figcaption");
+    return `Image: ${img.getAttribute("alt") || figcaption?.textContent?.trim() || "no description"}`;
   }
 
   // Handle tables
   if (tagName === "table") {
-    // Extract table content in a readable format. Cells narrate the same way
-    // anything else does rather than through `textContent`, because the blocks
-    // inside them stay silent for the table's sake — so whatever they would
-    // have said (an image's alt text, a list's bullets) has to be said here.
-    const rows: string[] = [];
+    // Extract table content in a readable format. The caption and the cells
+    // narrate the same way anything else does rather than through
+    // `textContent`, because the blocks inside them stay silent for the
+    // table's sake — so whatever they would have said (an image's alt text, a
+    // list's bullets) has to be said here or it is said nowhere.
+    const parts: string[] = [];
+    const caption = el.querySelector("caption");
+    if (caption?.closest("table") === el) {
+      parts.push(contentParagraphs(caption, depth + 1).join(" "));
+    }
     el.querySelectorAll("tr").forEach((tr) => {
+      // A nested table narrates its own rows — as a cell of this one.
+      if (tr.closest("table") !== el) return;
       const cells: string[] = [];
       tr.querySelectorAll("th, td").forEach((cell) => {
+        if (cell.closest("tr") !== tr) return;
         cells.push(contentParagraphs(cell, depth + 1).join(" "));
       });
       if (cells.length > 0) {
-        rows.push(cells.join(", "));
+        parts.push(cells.join(", "));
       }
     });
-    return `Table: ${rows.join(". ")} End table.`;
+    return `Table: ${parts.filter(Boolean).join(". ")} End table.`;
   }
 
   // Handle standalone images
@@ -339,11 +363,19 @@ function getOwnNarrationText(el: Element, depth = 0): string {
  * nested one gets no paragraph of its own, so the block around it speaks it.
  */
 function processInlineContent(el: Element): string {
+  return inlineChildrenText(el).trim();
+}
+
+/**
+ * The inline text of an element's children, untrimmed — trimming at every level
+ * of the walk swallows the space in `<b>Total:</b><span> 42</span>`.
+ */
+function inlineChildrenText(el: Element): string {
   let text = "";
   el.childNodes.forEach((node) => {
     text += inlineNodeText(node);
   });
-  return text.trim();
+  return text;
 }
 
 /**
@@ -361,14 +393,16 @@ function inlineNodeText(node: Node): string {
   const tagName = el.tagName.toLowerCase();
 
   if (tagName === "a") {
-    // Handle links
+    // Handle links. Spoken untrimmed, so the space in `a<a href> b </a>c`
+    // survives; the trimmed form is only for deciding what to say.
     const href = el.getAttribute("href");
-    const linkText = el.textContent?.trim() || "";
+    const raw = el.textContent || "";
+    const linkText = raw.trim();
 
     if (!href) {
       // A link target (`<a id="fn1">`), not a link: it goes nowhere, so
       // announcing one would be noise — speak whatever text it wraps.
-      return linkText;
+      return raw;
     }
     if (!linkText || linkText === href) {
       try {
@@ -377,7 +411,7 @@ function inlineNodeText(node: Node): string {
         return `[link to ${href}]`;
       }
     }
-    return linkText;
+    return raw;
   }
 
   if (tagName === "code") {
@@ -387,8 +421,9 @@ function inlineNodeText(node: Node): string {
   }
 
   if (tagName === "img") {
-    // Inline image
-    return `Image: ${el.getAttribute("alt") || "image"}`;
+    // Inline image. Padded because nothing guarantees whitespace around it —
+    // a caption or a cell's text can butt right up against the alt text.
+    return ` Image: ${el.getAttribute("alt") || "image"} `;
   }
 
   if (BLOCK_ELEMENTS_SET.has(tagName)) {
@@ -396,7 +431,7 @@ function inlineNodeText(node: Node): string {
   }
 
   // Recurse for other inline elements (strong, em, span, etc.)
-  return processInlineContent(el);
+  return inlineChildrenText(el);
 }
 
 /**

--- a/src/lib/narration/html-to-narration-input.ts
+++ b/src/lib/narration/html-to-narration-input.ts
@@ -99,9 +99,18 @@ function enclosingListItem(el: Element): Element | null {
   for (let parent = el.parentElement; parent; parent = parent.parentElement) {
     const tagName = parent.tagName.toLowerCase();
     if (tagName === "li") return parent;
-    if (BLOCK_ELEMENTS_SET.has(tagName)) return null;
+    if (tagName === "ul" || tagName === "ol") return null;
+    if (BLOCK_ELEMENTS_SET.has(tagName) && !isTransparentWrapper(parent)) return null;
   }
   return null;
+}
+
+/**
+ * Whether a block says nothing of its own, so it owns none of its descendants:
+ * a `<figure>` around a table announces no image, and the table is what speaks.
+ */
+function isTransparentWrapper(el: Element): boolean {
+  return el.tagName.toLowerCase() === "figure" && getOwnNarrationText(el).trim() === "";
 }
 
 /**
@@ -112,19 +121,21 @@ function enclosingListItem(el: Element): Element | null {
  * themselves), so a marker parked on either is a marker lost — including the
  * task-list state from #1439, which is the item's only cue that it is done.
  */
-function markerCarrier(li: Element): Element | null {
+function markerCarrier(li: Element, depth = 0): Element | null {
+  if (depth >= MAX_CONTENT_DEPTH) return null;
+
   for (const child of Array.from(li.children)) {
     const tagName = child.tagName.toLowerCase();
     // A nested list's items carry their own markers, and a nested image is
     // spoken by the block around it rather than getting a paragraph.
     if (tagName === "ul" || tagName === "ol" || tagName === "img") continue;
-    if (!BLOCK_ELEMENTS_SET.has(tagName)) {
-      // A wrapper is transparent — the block that speaks may be inside it.
-      const nested = markerCarrier(child);
-      if (nested) return nested;
-      continue;
+    if (BLOCK_ELEMENTS_SET.has(tagName)) {
+      if (getOwnNarrationText(child).trim() !== "") return child;
+      if (!isTransparentWrapper(child)) continue;
     }
-    if (getOwnNarrationText(child).trim() !== "") return child;
+    // A wrapper is transparent — the block that speaks may be inside it.
+    const nested = markerCarrier(child, depth + 1);
+    if (nested) return nested;
   }
   return null;
 }
@@ -142,9 +153,23 @@ function markerCarrier(li: Element): Element | null {
 function inheritedListMarker(el: Element): string {
   const li = enclosingListItem(el);
   if (!li) return "";
-  if (processInlineContent(li) !== "") return "";
-  return markerCarrier(li) === el ? listItemMarker(li) : "";
+
+  // Memoized: the answer depends only on the item, but the question is asked
+  // once per block inside it, and answering walks the item — an item with a
+  // few thousand paragraphs took seconds to narrate without this.
+  let handoff = markerHandoffs.get(li);
+  if (!handoff) {
+    handoff =
+      processInlineContent(li) !== ""
+        ? { carrier: null, marker: "" }
+        : { carrier: markerCarrier(li), marker: listItemMarker(li) };
+    markerHandoffs.set(li, handoff);
+  }
+  return handoff.carrier === el ? handoff.marker : "";
 }
+
+/** Which block each list item hands its marker to — see `inheritedListMarker`. */
+const markerHandoffs = new WeakMap<Element, { carrier: Element | null; marker: string }>();
 
 /**
  * Blocks whose narration covers everything inside them, because their markers
@@ -165,6 +190,14 @@ function insideSubtreeSpeaker(el: Element): boolean {
 
 /** Selector matching the blocks that break a run of inline text. */
 const BLOCK_SELECTOR = BLOCK_ELEMENTS.filter((tagName) => tagName !== "img").join(", ");
+
+/**
+ * Whether a figure narrates as the image it holds — as opposed to one around a
+ * table or a list, which announces no image and is walked into like a wrapper.
+ */
+function speaksAsImage(el: Element): boolean {
+  return el.tagName.toLowerCase() === "figure" && ownDescendant(el, "img") !== null;
+}
 
 /**
  * The first matching descendant an element speaks for itself — one no block in
@@ -225,7 +258,7 @@ function contentParagraphs(el: Element, depth = 0): string[] {
     }
 
     flushInline();
-    if (SUBTREE_SPEAKERS.has(tagName)) {
+    if (SUBTREE_SPEAKERS.has(tagName) || speaksAsImage(child)) {
       // Already speaks for everything below it, so don't descend twice.
       const text = getOwnNarrationText(child, depth + 1);
       if (text) paragraphs.push(text);
@@ -310,12 +343,16 @@ function getOwnNarrationText(el: Element, depth = 0): string {
   // nested block (a table, a list) is spoken by that block instead — and a
   // figure around one of those is not an image at all, so it announces none.
   if (tagName === "figure") {
-    const img = ownDescendant(el, "img");
-    if (!img) {
+    if (!speaksAsImage(el)) {
       return processInlineContent(el);
     }
-    const figcaption = ownDescendant(el, "figcaption");
-    return `Image: ${img.getAttribute("alt") || figcaption?.textContent?.trim() || "no description"}`;
+    const alt = ownDescendant(el, "img")?.getAttribute("alt")?.trim();
+    const caption = ownDescendant(el, "figcaption")?.textContent?.trim();
+    if (!alt) {
+      // The caption is the only description there is.
+      return `Image: ${caption || "no description"}`;
+    }
+    return caption ? `Image: ${alt}. ${caption}` : `Image: ${alt}`;
   }
 
   // Handle tables
@@ -369,11 +406,18 @@ function processInlineContent(el: Element): string {
 /**
  * The inline text of an element's children, untrimmed — trimming at every level
  * of the walk swallows the space in `<b>Total:</b><span> 42</span>`.
+ *
+ * Depth-capped like the content walk, and for the same reason: the markup is
+ * feed-controlled and nests as deeply as it likes.
  */
-function inlineChildrenText(el: Element): string {
+function inlineChildrenText(el: Element, depth = 0): string {
+  if (depth >= MAX_CONTENT_DEPTH) {
+    return el.textContent ?? "";
+  }
+
   let text = "";
   el.childNodes.forEach((node) => {
-    text += inlineNodeText(node);
+    text += inlineNodeText(node, depth);
   });
   return text;
 }
@@ -381,7 +425,7 @@ function inlineChildrenText(el: Element): string {
 /**
  * What a node contributes to the inline run of text around it.
  */
-function inlineNodeText(node: Node): string {
+function inlineNodeText(node: Node, depth = 0): string {
   if (node.nodeType === TEXT_NODE) {
     return node.textContent || "";
   }
@@ -431,7 +475,7 @@ function inlineNodeText(node: Node): string {
   }
 
   // Recurse for other inline elements (strong, em, span, etc.)
-  return inlineChildrenText(el);
+  return inlineChildrenText(el, depth + 1);
 }
 
 /**

--- a/src/lib/narration/html-to-narration-input.ts
+++ b/src/lib/narration/html-to-narration-input.ts
@@ -77,11 +77,64 @@ function leadingTaskCheckbox(li: Element): Element | null {
 }
 
 /**
+ * Whether an element narrates itself, so an enclosing block must leave its text
+ * out — otherwise the same words are spoken twice (issue #1441).
+ *
+ * `img` is the exception: an image nested inside a block element is dropped from
+ * the paragraph list below, so the enclosing block is what speaks its alt text.
+ */
+function narratesItself(el: Element): boolean {
+  const tagName = el.tagName.toLowerCase();
+  return tagName !== "img" && BLOCK_ELEMENTS_SET.has(tagName);
+}
+
+/**
+ * The bullet a list item is read with, plus its task-list state when it leads
+ * with a checkbox. A task list carries that state in the checkbox, which
+ * contributes no text — so read aloud, a done item would be indistinguishable
+ * from a not-done one (the narration half of issue #1439). Speak the state.
+ */
+function listItemMarker(li: Element): string {
+  const checkbox = leadingTaskCheckbox(li);
+  if (!checkbox) {
+    return "- ";
+  }
+  return `- ${checkbox.hasAttribute("checked") ? "Done" : "Not done"}: `;
+}
+
+/**
+ * The list marker a block inherits from the item that wraps it, if any.
+ *
+ * A loose list item (`<li><p>…</p></li>` — what cmark-gfm/GitHub emit for any
+ * list with blank lines between items, so it is common in feed HTML) has no
+ * text of its own; its children narrate themselves. The bullet and the spoken
+ * checkbox state therefore ride along on the first of those children instead of
+ * on the item (issue #1441). An item that does have its own text speaks its own
+ * marker, so its children inherit nothing.
+ */
+function inheritedListMarker(el: Element): string {
+  const li = el.parentElement;
+  if (!li || li.tagName.toLowerCase() !== "li") return "";
+  if (leadingElement(li) !== el) return "";
+  if (processInlineContent(li) !== "") return "";
+  return listItemMarker(li);
+}
+
+/**
  * Converts an element's text content for narration.
  * Returns text in speakable form (no structural markers like [HEADING]).
  * Handles special elements like images, code blocks, etc.
  */
 function getElementNarrationText(el: Element): string {
+  const text = getOwnNarrationText(el);
+  return text ? `${inheritedListMarker(el)}${text}` : "";
+}
+
+/**
+ * The element's own narration text, before any marker it inherits from an
+ * enclosing list item.
+ */
+function getOwnNarrationText(el: Element): string {
   const tagName = el.tagName.toLowerCase();
 
   // Handle headings - just return the text (no marker)
@@ -112,17 +165,12 @@ function getElementNarrationText(el: Element): string {
     return "";
   }
 
-  // Handle list items
+  // Handle list items. Only the item's own text: block children (a loose list's
+  // paragraphs, a nested list) narrate themselves, and one of them carries the
+  // marker when the item has no text of its own — see `inheritedListMarker`.
   if (tagName === "li") {
-    const text = el.textContent?.trim() || "";
-    // A task list carries its state in a leading checkbox, which contributes no
-    // text — so read aloud, a done item would be indistinguishable from a
-    // not-done one (the narration half of issue #1439). Speak the state.
-    const checkbox = leadingTaskCheckbox(el);
-    if (checkbox) {
-      return `- ${checkbox.hasAttribute("checked") ? "Done" : "Not done"}: ${text}`;
-    }
-    return `- ${text}`;
+    const text = processInlineContent(el);
+    return text ? `${listItemMarker(el)}${text}` : "";
   }
 
   // Handle figures
@@ -161,6 +209,8 @@ function getElementNarrationText(el: Element): string {
 
 /**
  * Process inline content, handling links and other inline elements.
+ *
+ * Block children are left out — see `narratesItself`.
  */
 function processInlineContent(el: Element): string {
   let text = "";
@@ -197,7 +247,7 @@ function processInlineContent(el: Element): string {
         // Inline image
         const alt = childEl.getAttribute("alt") || "image";
         text += `Image: ${alt}`;
-      } else {
+      } else if (!narratesItself(childEl)) {
         // Recurse for other inline elements (strong, em, span, etc.)
         text += processInlineContent(childEl);
       }

--- a/src/lib/narration/html-to-narration-input.ts
+++ b/src/lib/narration/html-to-narration-input.ts
@@ -147,11 +147,76 @@ function inheritedListMarker(el: Element): string {
 }
 
 /**
+ * Blocks whose narration covers everything inside them, because their markers
+ * wrap the text (`Quote: … End quote.`) and can't be split across children the
+ * way a list item's bullet can.
+ */
+const SUBTREE_SPEAKERS = new Set(["blockquote", "pre", "table"]);
+
+/**
+ * Whether a block sits inside one that already speaks for it (issue #1445).
+ */
+function insideSubtreeSpeaker(el: Element): boolean {
+  for (let parent = el.parentElement; parent; parent = parent.parentElement) {
+    if (SUBTREE_SPEAKERS.has(parent.tagName.toLowerCase())) return true;
+  }
+  return false;
+}
+
+/**
+ * The paragraphs an element's content narrates as, in document order: inline
+ * runs and block children interleaved the way they appear, so an attribution
+ * that trails a quote is read after it rather than before it.
+ */
+function contentParagraphs(el: Element): string[] {
+  const paragraphs: string[] = [];
+  let inline = "";
+
+  const flushInline = () => {
+    if (inline.trim()) paragraphs.push(inline.trim());
+    inline = "";
+  };
+
+  el.childNodes.forEach((node) => {
+    const child = node.nodeType === ELEMENT_NODE ? (node as Element) : null;
+    const tagName = child?.tagName.toLowerCase() ?? "";
+    // An image belongs to the run of text around it — it gets no paragraph.
+    if (!child || tagName === "img" || !BLOCK_ELEMENTS_SET.has(tagName)) {
+      inline += inlineNodeText(node);
+      return;
+    }
+
+    flushInline();
+    if (SUBTREE_SPEAKERS.has(tagName)) {
+      // Already speaks for everything below it, so don't descend twice.
+      const text = getOwnNarrationText(child);
+      if (text) paragraphs.push(text);
+      return;
+    }
+
+    const inner = contentParagraphs(child);
+    if (tagName === "li" && inner.length > 0) {
+      inner[0] = `${listItemMarker(child)}${inner[0]}`;
+    }
+    paragraphs.push(...inner);
+  });
+
+  flushInline();
+  return paragraphs;
+}
+
+/**
  * Converts an element's text content for narration.
  * Returns text in speakable form (no structural markers like [HEADING]).
  * Handles special elements like images, code blocks, etc.
  */
 function getElementNarrationText(el: Element): string {
+  // A block inside a quote or a table was narrated by that wrapper already;
+  // narrating it again would speak the same words twice (issue #1445). It keeps
+  // its paragraph index — which is what the client highlights by — and simply
+  // contributes no paragraph, exactly like an empty element does.
+  if (insideSubtreeSpeaker(el)) return "";
+
   const text = getOwnNarrationText(el);
   return text ? `${inheritedListMarker(el)}${text}` : "";
 }
@@ -181,9 +246,12 @@ function getOwnNarrationText(el: Element): string {
     return `Code block: ${codeContent} End code block.`;
   }
 
-  // Handle blockquotes
+  // Handle blockquotes. Paragraphs inside the quote are kept apart by blank
+  // lines rather than run together, and the player speaks each of them as its
+  // own paragraph (all highlighting this blockquote).
   if (tagName === "blockquote") {
-    return `Quote: ${el.textContent?.trim() || ""} End quote.`;
+    const quoted = contentParagraphs(el);
+    return quoted.length > 0 ? `Quote: ${quoted.join("\n\n")} End quote.` : "";
   }
 
   // Handle lists (ul/ol don't have their own text - skip)
@@ -242,54 +310,63 @@ function getOwnNarrationText(el: Element): string {
  */
 function processInlineContent(el: Element): string {
   let text = "";
-
-  // Walk through child nodes
   el.childNodes.forEach((node) => {
-    if (node.nodeType === 3) {
-      // Text node
-      text += node.textContent || "";
-    } else if (node.nodeType === 1) {
-      // Element node
-      const childEl = node as Element;
-      const childTag = childEl.tagName.toLowerCase();
+    text += inlineNodeText(node);
+  });
+  return text.trim();
+}
 
-      if (childTag === "a") {
-        // Handle links
-        const href = childEl.getAttribute("href");
-        const linkText = childEl.textContent?.trim() || "";
+/**
+ * What a node contributes to the inline run of text around it.
+ */
+function inlineNodeText(node: Node): string {
+  if (node.nodeType === TEXT_NODE) {
+    return node.textContent || "";
+  }
+  if (node.nodeType !== ELEMENT_NODE) {
+    return "";
+  }
 
-        if (!href) {
-          // A link target (`<a id="fn1">`), not a link: it goes nowhere, so
-          // announcing one would be noise — speak whatever text it wraps.
-          text += linkText;
-        } else if (!linkText || linkText === href) {
-          try {
-            const domain = new URL(href || "").hostname;
-            text += `[link to ${domain}]`;
-          } catch {
-            text += `[link to ${href}]`;
-          }
-        } else {
-          text += linkText;
-        }
-      } else if (childTag === "code") {
-        // Inline code (empty markup is not worth speaking a pair of backticks)
-        const code = childEl.textContent || "";
-        if (code) {
-          text += `\`${code}\``;
-        }
-      } else if (childTag === "img") {
-        // Inline image
-        const alt = childEl.getAttribute("alt") || "image";
-        text += `Image: ${alt}`;
-      } else if (!BLOCK_ELEMENTS_SET.has(childTag)) {
-        // Recurse for other inline elements (strong, em, span, etc.)
-        text += processInlineContent(childEl);
+  const el = node as Element;
+  const tagName = el.tagName.toLowerCase();
+
+  if (tagName === "a") {
+    // Handle links
+    const href = el.getAttribute("href");
+    const linkText = el.textContent?.trim() || "";
+
+    if (!href) {
+      // A link target (`<a id="fn1">`), not a link: it goes nowhere, so
+      // announcing one would be noise — speak whatever text it wraps.
+      return linkText;
+    }
+    if (!linkText || linkText === href) {
+      try {
+        return `[link to ${new URL(href).hostname}]`;
+      } catch {
+        return `[link to ${href}]`;
       }
     }
-  });
+    return linkText;
+  }
 
-  return text.trim();
+  if (tagName === "code") {
+    // Inline code (empty markup is not worth speaking a pair of backticks)
+    const code = el.textContent || "";
+    return code ? `\`${code}\`` : "";
+  }
+
+  if (tagName === "img") {
+    // Inline image
+    return `Image: ${el.getAttribute("alt") || "image"}`;
+  }
+
+  if (BLOCK_ELEMENTS_SET.has(tagName)) {
+    return "";
+  }
+
+  // Recurse for other inline elements (strong, em, span, etc.)
+  return processInlineContent(el);
 }
 
 /**

--- a/src/lib/narration/html-to-narration-input.ts
+++ b/src/lib/narration/html-to-narration-input.ts
@@ -108,10 +108,21 @@ function enclosingListItem(el: Element): Element | null {
 /**
  * Whether a block says nothing of its own, so it owns none of its descendants:
  * a `<figure>` around a table announces no image, and the table is what speaks.
+ *
+ * Memoized for the same reason the marker handoff is: every block under a
+ * figure asks this about it, and answering walks the figure.
  */
 function isTransparentWrapper(el: Element): boolean {
-  return el.tagName.toLowerCase() === "figure" && getOwnNarrationText(el).trim() === "";
+  const cached = transparentWrappers.get(el);
+  if (cached !== undefined) return cached;
+
+  const transparent =
+    el.tagName.toLowerCase() === "figure" && getOwnNarrationText(el).trim() === "";
+  transparentWrappers.set(el, transparent);
+  return transparent;
 }
+
+const transparentWrappers = new WeakMap<Element, boolean>();
 
 /**
  * The block a list item hands its marker to, or null if nothing in it speaks.

--- a/tests/unit/client-paragraph-ids.test.ts
+++ b/tests/unit/client-paragraph-ids.test.ts
@@ -625,6 +625,20 @@ describe("htmlToClientNarration", () => {
         { n: 1, o: 2 },
       ]);
     });
+
+    it("skips a code block wrapped in a list item or blockquote too", () => {
+      // The wrapper used to read the code out on the <pre>'s behalf, which the
+      // skip above exists to prevent.
+      for (const html of [
+        "<ul><li><pre>const x = 1;</pre></li></ul>",
+        "<blockquote><pre>const x = 1;</pre></blockquote>",
+      ]) {
+        const result = htmlToClientNarration(html);
+
+        expect(result.narrationText).toBe("");
+        expect(result.paragraphMap).toEqual([]);
+      }
+    });
   });
 
   describe("list handling", () => {

--- a/tests/unit/client-paragraph-ids.test.ts
+++ b/tests/unit/client-paragraph-ids.test.ts
@@ -853,5 +853,27 @@ describe("htmlToClientNarration", () => {
       expect(result.narrationText).toBe("A, B. C, D");
       expect(result.paragraphMap).toEqual([{ n: 0, o: 0 }]);
     });
+
+    it("narrates a cell's paragraph only as part of the table (issue #1445)", () => {
+      const html =
+        "<p>before</p><table><tr><td><p>Cell 1</p></td><td>B</td></tr></table><p>after</p>";
+      const result = htmlToClientNarration(html);
+
+      // The cell's <p> is para-2 and stays silent; "after" is still para-3.
+      expect(result.narrationText).toBe("before\n\nCell 1, B\n\nafter");
+      expect(result.paragraphMap).toEqual([
+        { n: 0, o: 0 },
+        { n: 1, o: 1 },
+        { n: 2, o: 3 },
+      ]);
+    });
+
+    it("does not let a code block's children narrate it back", () => {
+      const html = "<pre><p>const x = 1;</p></pre>";
+      const result = htmlToClientNarration(html);
+
+      expect(result.narrationText).toBe("");
+      expect(result.paragraphMap).toEqual([]);
+    });
   });
 });

--- a/tests/unit/client-paragraph-ids.test.ts
+++ b/tests/unit/client-paragraph-ids.test.ts
@@ -886,6 +886,33 @@ describe("htmlToClientNarration", () => {
       expect(result.narrationText).toBe("50th");
     });
 
+    it("keeps the space inside a cell's inline markup", () => {
+      const html = "<table><tr><td><b>Name:</b><span> John</span></td></tr></table>";
+      const result = htmlToClientNarration(html);
+
+      expect(result.narrationText).toBe("Name: John");
+    });
+
+    it("narrates the caption, which no one else will (issue #1445)", () => {
+      // `<caption>` is outside the row walk, and its blocks are silenced for
+      // the table's sake — so if the table skips it, it is narrated nowhere.
+      const html =
+        "<table><caption><p>Table 1. Revenue by quarter</p></caption>" +
+        "<tr><th>Q</th></tr><tr><td>1</td></tr></table>";
+      const result = htmlToClientNarration(html);
+
+      expect(result.narrationText).toBe("Table 1. Revenue by quarter. Q. 1");
+      expect(result.paragraphMap).toEqual([{ n: 0, o: 0 }]);
+    });
+
+    it("reads a nested table as a cell of the outer one, once", () => {
+      const html = "<table><tr><td><table><tr><td>inner</td></tr></table></td></tr></table>";
+      const result = htmlToClientNarration(html);
+
+      expect(result.narrationText).toBe("inner");
+      expect(result.paragraphMap).toEqual([{ n: 0, o: 0 }]);
+    });
+
     it("does not let a code block's children narrate it back", () => {
       const html = "<pre><p>const x = 1;</p></pre>";
       const result = htmlToClientNarration(html);

--- a/tests/unit/client-paragraph-ids.test.ts
+++ b/tests/unit/client-paragraph-ids.test.ts
@@ -593,7 +593,8 @@ describe("htmlToClientNarration", () => {
       const html = '<p>Text before <img src="test.jpg"> text after</p>';
       const result = htmlToClientNarration(html);
 
-      expect(result.narrationText).toBe("Text before  text after");
+      // The gap the image left is collapsed away, not spoken as a double space.
+      expect(result.narrationText).toBe("Text before text after");
     });
 
     it("handles inline images in list items", () => {
@@ -826,6 +827,29 @@ describe("htmlToClientNarration", () => {
     });
   });
 
+  describe("paragraph text", () => {
+    it("keeps the space inside a paragraph's inline markup", () => {
+      const html = "<p><b>Name:</b><span> John</span></p>";
+      const result = htmlToClientNarration(html);
+
+      expect(result.narrationText).toBe("Name: John");
+    });
+
+    it("keeps an inline image's alt text apart from the words around it", () => {
+      const html = '<p>see<img alt="a cat">now</p>';
+      const result = htmlToClientNarration(html);
+
+      expect(result.narrationText).toBe("see Image: a cat now");
+    });
+
+    it("narrates a figure's caption, which nothing else does", () => {
+      const html = '<figure><img alt="A cat"><figcaption>My cat</figcaption></figure>';
+      const result = htmlToClientNarration(html);
+
+      expect(result.narrationText).toBe("Image: A cat. My cat");
+    });
+  });
+
   describe("blockquote handling", () => {
     it("includes blockquote text in narration", () => {
       const html = "<blockquote>A famous quote goes here.</blockquote>";
@@ -875,7 +899,7 @@ describe("htmlToClientNarration", () => {
         "<td>B</td></tr></table>";
       const result = htmlToClientNarration(html);
 
-      expect(result.narrationText).toBe("Image: Sales chart Fig 1, B");
+      expect(result.narrationText).toBe("Image: Sales chart. Fig 1, B");
       expect(result.paragraphMap).toEqual([{ n: 0, o: 0 }]);
     });
 
@@ -906,10 +930,14 @@ describe("htmlToClientNarration", () => {
     });
 
     it("reads a nested table as a cell of the outer one, once", () => {
-      const html = "<table><tr><td><table><tr><td>inner</td></tr></table></td></tr></table>";
+      // More than one inner cell, so cells run together rather than being
+      // separated would fail this too.
+      const html =
+        "<table><tr><td><table><tr><td>A</td><td>B</td></tr><tr><td>C</td></tr></table>" +
+        "</td></tr></table>";
       const result = htmlToClientNarration(html);
 
-      expect(result.narrationText).toBe("inner");
+      expect(result.narrationText).toBe("A, B. C");
       expect(result.paragraphMap).toEqual([{ n: 0, o: 0 }]);
     });
 

--- a/tests/unit/client-paragraph-ids.test.ts
+++ b/tests/unit/client-paragraph-ids.test.ts
@@ -640,6 +640,31 @@ describe("htmlToClientNarration", () => {
         { n: 1, o: 2 },
       ]);
     });
+
+    it("narrates a loose list item once, not once per wrapper (issue #1441)", () => {
+      // The <li>/<p> shape cmark-gfm and GitHub emit for any list with blank
+      // lines between items, so it is common in feed HTML.
+      const html = "<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>";
+      const result = htmlToClientNarration(html);
+
+      // Only the paragraphs speak; ul (0) and both li (1, 3) are containers.
+      expect(result.narrationText).toBe("Item 1\n\nItem 2");
+      expect(result.paragraphMap).toEqual([
+        { n: 0, o: 2 },
+        { n: 1, o: 4 },
+      ]);
+    });
+
+    it("does not repeat a nested list's items in its parent item", () => {
+      const html = "<ul><li>Parent<ul><li>Child</li></ul></li></ul>";
+      const result = htmlToClientNarration(html);
+
+      expect(result.narrationText).toBe("Parent\n\nChild");
+      expect(result.paragraphMap).toEqual([
+        { n: 0, o: 1 },
+        { n: 1, o: 3 },
+      ]);
+    });
   });
 
   describe("heading handling", () => {
@@ -794,6 +819,15 @@ describe("htmlToClientNarration", () => {
 
       expect(result.narrationText).toBe("A famous quote goes here.");
       expect(result.paragraphMap).toEqual([{ n: 0, o: 0 }]);
+    });
+
+    it("narrates a quoted paragraph once, not once per wrapper (issue #1441)", () => {
+      const html = "<blockquote><p>A famous quote goes here.</p></blockquote>";
+      const result = htmlToClientNarration(html);
+
+      // The <p> (para-1) speaks; the blockquote wrapping it has no text of its own.
+      expect(result.narrationText).toBe("A famous quote goes here.");
+      expect(result.paragraphMap).toEqual([{ n: 0, o: 1 }]);
     });
   });
 

--- a/tests/unit/client-paragraph-ids.test.ts
+++ b/tests/unit/client-paragraph-ids.test.ts
@@ -868,6 +868,24 @@ describe("htmlToClientNarration", () => {
       ]);
     });
 
+    it("says what a silenced cell block would have said", () => {
+      // `textContent` would drop the alt text the cell's figure used to speak.
+      const html =
+        '<table><tr><td><figure><img alt="Sales chart"><figcaption>Fig 1</figcaption></figure></td>' +
+        "<td>B</td></tr></table>";
+      const result = htmlToClientNarration(html);
+
+      expect(result.narrationText).toBe("Image: Sales chart Fig 1, B");
+      expect(result.paragraphMap).toEqual([{ n: 0, o: 0 }]);
+    });
+
+    it("keeps inline markup in a cell glued to the text around it", () => {
+      const html = "<table><tr><td>50<sup>th</sup></td></tr></table>";
+      const result = htmlToClientNarration(html);
+
+      expect(result.narrationText).toBe("50th");
+    });
+
     it("does not let a code block's children narrate it back", () => {
       const html = "<pre><p>const x = 1;</p></pre>";
       const result = htmlToClientNarration(html);

--- a/tests/unit/html-to-narration-input.test.ts
+++ b/tests/unit/html-to-narration-input.test.ts
@@ -192,18 +192,32 @@ describe("htmlToNarrationInput", () => {
       expect(result.paragraphs).toEqual([{ id: 0, text: "Quote: Hello world again End quote." }]);
     });
 
-    it("speaks a quoted image rather than walking into the figure", () => {
+    it("keeps a quoted figure's caption as well as its image", () => {
       const html =
         '<blockquote><figure><img alt="A cat"><figcaption>My cat</figcaption></figure></blockquote>';
       const result = htmlToNarrationInput(html);
 
-      expect(result.paragraphs).toEqual([{ id: 0, text: "Quote: Image: A cat End quote." }]);
+      expect(result.paragraphs).toEqual([{ id: 0, text: "Quote: Image: A cat My cat End quote." }]);
+    });
+
+    it("keeps what a quoted figure wraps when it is not an image", () => {
+      // A figure around a table announces no image — the table speaks instead.
+      const html =
+        "<blockquote><figure><table><tr><td>Cell A</td></tr></table>" +
+        "<figcaption>Data</figcaption></figure></blockquote>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([
+        { id: 0, text: "Quote: Table: Cell A End table.\n\nData End quote." },
+      ]);
     });
 
     it("narrates absurdly nested quotes instead of overflowing the stack", () => {
       // Feed HTML is not depth-limited and the content walk is recursive, so
       // past a point it flattens what is left rather than descending further.
-      const depth = 500;
+      // Deep enough that an uncapped walk would overflow (measured: 2000 is
+      // fine, 5000 throws), so removing the cap fails this test.
+      const depth = 5000;
       const html = `${"<blockquote>".repeat(depth)}<p>the text</p>${"</blockquote>".repeat(depth)}`;
       const result = htmlToNarrationInput(html);
 
@@ -433,13 +447,42 @@ describe("htmlToNarrationInput", () => {
       // would have narrated — an image's alt text, a list's bullets — has to
       // come through in the cell instead of being lost.
       const html =
-        '<table><tr><td><figure><img alt="Sales chart"></figure></td>' +
+        '<table><tr><td><figure><img alt="Sales chart"><figcaption>Fig 1</figcaption></figure></td>' +
         "<td><ul><li>a</li><li>b</li></ul></td></tr></table>";
       const result = htmlToNarrationInput(html);
 
       expect(result.paragraphs).toEqual([
-        { id: 0, text: "Table: Image: Sales chart, - a - b End table." },
+        { id: 0, text: "Table: Image: Sales chart Fig 1, - a - b End table." },
       ]);
+    });
+
+    it("narrates the caption, which no one else will (issue #1445)", () => {
+      // `<caption>` is outside the row walk, and its blocks are silenced for
+      // the table's sake — so if the table skips it, it is narrated nowhere.
+      const html =
+        "<table><caption><p>Table 1. Revenue by quarter</p></caption>" +
+        "<tr><th>Q</th></tr><tr><td>1</td></tr></table>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([
+        { id: 0, text: "Table: Table 1. Revenue by quarter. Q. 1 End table." },
+      ]);
+    });
+
+    it("reads a nested table as a cell of the outer one, once", () => {
+      const html = "<table><tr><td><table><tr><td>inner</td></tr></table></td></tr></table>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([
+        { id: 0, text: "Table: Table: inner End table. End table." },
+      ]);
+    });
+
+    it("keeps the space inside a cell's inline markup", () => {
+      const html = "<table><tr><td><b>Name:</b><span> John</span></td></tr></table>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 0, text: "Table: Name: John End table." }]);
     });
   });
 

--- a/tests/unit/html-to-narration-input.test.ts
+++ b/tests/unit/html-to-narration-input.test.ts
@@ -112,6 +112,15 @@ describe("htmlToNarrationInput", () => {
 
       expect(result.paragraphs).toEqual([{ id: 0, text: "Quote: A famous quote. End quote." }]);
     });
+
+    // Same double-narration as issue #1441, in the wrapper that needs its
+    // markers split across the children rather than dropped. See issue #1445.
+    it.skip("narrates a quoted paragraph once, not once per wrapper", () => {
+      const html = "<blockquote><p>A famous quote.</p></blockquote>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 1, text: "Quote: A famous quote. End quote." }]);
+    });
   });
 
   describe("image handling", () => {
@@ -189,14 +198,62 @@ describe("htmlToNarrationInput", () => {
     });
 
     it("speaks task-list state for loose lists (checkbox inside the item's <p>)", () => {
-      // cmark-gfm/GitHub shape, which arrives via feed HTML.
+      // cmark-gfm/GitHub shape, which arrives via feed HTML. The item has no
+      // text of its own, so the marker rides along on its <p> (issue #1441).
       const html = '<ul><li><p><input type="checkbox" checked="" disabled=""> done</p></li></ul>';
       const result = htmlToNarrationInput(html);
 
-      // The <p> is also narrated on its own — an <li> wrapping block children is
-      // double-narrated, which predates this (issue #1441). What
-      // matters here is that the item itself carries the state.
-      expect(result.paragraphs[0]).toEqual({ id: 1, text: "- Done: done" });
+      expect(result.paragraphs).toEqual([{ id: 2, text: "- Done: done" }]);
+    });
+
+    it("narrates a loose list item once, not once per wrapper (issue #1441)", () => {
+      // Any list with blank lines between items comes out of cmark-gfm/GitHub
+      // in this shape, so it is common in feed HTML.
+      const html = "<ul><li><p>hello</p></li></ul>";
+      const result = htmlToNarrationInput(html);
+
+      // ul is 0 and li is 1; both are containers here, so only the <p> speaks.
+      expect(result.paragraphs).toEqual([{ id: 2, text: "- hello" }]);
+    });
+
+    it("keeps a multi-paragraph item's paragraphs separate", () => {
+      const html = "<ul><li><p>a</p><p>b</p></li></ul>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([
+        { id: 2, text: "- a" },
+        { id: 3, text: "b" },
+      ]);
+    });
+
+    it("narrates an item's own text and its block children separately", () => {
+      const html = "<ul><li>intro<p>more</p></li></ul>";
+      const result = htmlToNarrationInput(html);
+
+      // The item speaks its own marker, so the <p> inherits none.
+      expect(result.paragraphs).toEqual([
+        { id: 1, text: "- intro" },
+        { id: 2, text: "more" },
+      ]);
+    });
+
+    it("does not repeat a nested list's items in its parent item", () => {
+      const html = "<ul><li>Parent<ul><li>Child</li></ul></li></ul>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([
+        { id: 1, text: "- Parent" },
+        { id: 3, text: "- Child" },
+      ]);
+    });
+
+    it("keeps an inline image in the item that contains it", () => {
+      // A nested image gets no paragraph of its own, so its alt text has to
+      // come from the enclosing block.
+      const html = '<ul><li>Item with <img alt="icon"> image</li></ul>';
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 1, text: "- Item with Image: icon image" }]);
     });
 
     it("leaves a checkbox mid-item alone (not a task list)", () => {
@@ -215,6 +272,14 @@ describe("htmlToNarrationInput", () => {
       const result = htmlToNarrationInput(html);
 
       expect(result.paragraphs).toEqual([{ id: 0, text: "Table: Cell 1, Cell 2 End table." }]);
+    });
+
+    // The cell's <p> is narrated again on its own — issue #1445.
+    it.skip("narrates a cell's paragraph only as part of the table", () => {
+      const html = "<table><tr><td><p>Cell 1</p></td></tr></table>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 0, text: "Table: Cell 1 End table." }]);
     });
   });
 

--- a/tests/unit/html-to-narration-input.test.ts
+++ b/tests/unit/html-to-narration-input.test.ts
@@ -113,13 +113,70 @@ describe("htmlToNarrationInput", () => {
       expect(result.paragraphs).toEqual([{ id: 0, text: "Quote: A famous quote. End quote." }]);
     });
 
-    // Same double-narration as issue #1441, in the wrapper that needs its
-    // markers split across the children rather than dropped. See issue #1445.
-    it.skip("narrates a quoted paragraph once, not once per wrapper", () => {
+    it("narrates a quoted paragraph once, not once per wrapper (issue #1445)", () => {
+      // Every Markdown renderer emits a `>` quote in this shape.
       const html = "<blockquote><p>A famous quote.</p></blockquote>";
       const result = htmlToNarrationInput(html);
 
-      expect(result.paragraphs).toEqual([{ id: 1, text: "Quote: A famous quote. End quote." }]);
+      // The quote speaks for the paragraph inside it, which keeps its own
+      // paragraph index (1) but contributes no narration.
+      expect(result.paragraphs).toEqual([{ id: 0, text: "Quote: A famous quote. End quote." }]);
+    });
+
+    it("keeps a multi-paragraph quote's paragraphs apart", () => {
+      // Blank lines, so the player speaks two paragraphs instead of "ab".
+      const html = "<blockquote><p>a</p><p>b</p></blockquote>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 0, text: "Quote: a\n\nb End quote." }]);
+    });
+
+    it("reads an attribution after the quote it follows", () => {
+      const html = "<blockquote><p>Quote text</p><footer>— Author</footer></blockquote>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([
+        { id: 0, text: "Quote: Quote text\n\n— Author End quote." },
+      ]);
+    });
+
+    it("keeps structure the quote wraps", () => {
+      // Descending rather than flattening to textContent, so a list inside a
+      // quote keeps its bullets and a table keeps its markers.
+      const html =
+        "<blockquote><ul><li>a</li><li>b</li></ul></blockquote>" +
+        "<blockquote><table><tr><td>A</td><td>B</td></tr></table></blockquote>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([
+        { id: 0, text: "Quote: - a\n\n- b End quote." },
+        { id: 4, text: "Quote: Table: A, B End table. End quote." },
+      ]);
+    });
+
+    it("still numbers the blocks that follow a quote", () => {
+      // The suppressed <p> keeps its index — the client highlights by it.
+      const html = "<blockquote><p>q</p></blockquote><p>after</p>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([
+        { id: 0, text: "Quote: q End quote." },
+        { id: 2, text: "after" },
+      ]);
+    });
+
+    it("marks a quote that is a list item's only content", () => {
+      const html = "<ul><li><blockquote><p>x</p></blockquote></li></ul>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 2, text: "- Quote: x End quote." }]);
+    });
+
+    it("drops an empty quote instead of speaking bare markers", () => {
+      const html = "<blockquote></blockquote><p>after</p>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 1, text: "after" }]);
     });
   });
 
@@ -325,12 +382,11 @@ describe("htmlToNarrationInput", () => {
       expect(result.paragraphs).toEqual([{ id: 0, text: "Table: Cell 1, Cell 2 End table." }]);
     });
 
-    // The cell's <p> is narrated again on its own — issue #1445.
-    it.skip("narrates a cell's paragraph only as part of the table", () => {
-      const html = "<table><tr><td><p>Cell 1</p></td></tr></table>";
+    it("narrates a cell's paragraph only as part of the table (issue #1445)", () => {
+      const html = "<table><tr><td><p>Cell 1</p></td><td>Cell 2</td></tr></table>";
       const result = htmlToNarrationInput(html);
 
-      expect(result.paragraphs).toEqual([{ id: 0, text: "Table: Cell 1 End table." }]);
+      expect(result.paragraphs).toEqual([{ id: 0, text: "Table: Cell 1, Cell 2 End table." }]);
     });
   });
 

--- a/tests/unit/html-to-narration-input.test.ts
+++ b/tests/unit/html-to-narration-input.test.ts
@@ -160,6 +160,14 @@ describe("htmlToNarrationInput", () => {
 
       expect(result.paragraphs).toEqual([{ id: 0, text: "Visit [link to example.com] for more." }]);
     });
+
+    it("does not announce an anchor that has no href", () => {
+      // `<a id="fn1">` is a link target, not a link — it goes nowhere.
+      const html = '<p><a id="fn1"></a>Footnote text</p>';
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 0, text: "Footnote text" }]);
+    });
   });
 
   describe("list handling", () => {
@@ -235,6 +243,49 @@ describe("htmlToNarrationInput", () => {
         { id: 1, text: "- intro" },
         { id: 2, text: "more" },
       ]);
+    });
+
+    it("hands the marker to the first child that actually speaks", () => {
+      // Parking it on a leading empty <p> would lose it altogether.
+      const html = "<ul><li><p></p><p>text</p></li></ul>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 3, text: "- text" }]);
+    });
+
+    it("keeps the task-list state when the item leads with an empty block", () => {
+      // The checkbox is the item's only cue that it is done (#1439), so losing
+      // the marker here would lose the state with it.
+      const html = '<ul><li><p><input type="checkbox" checked=""></p><p>Ship it</p></li></ul>';
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 3, text: "- Done: Ship it" }]);
+    });
+
+    it("marks the item's own paragraph when it opens with a sublist", () => {
+      // A nested list narrates only through its items, which mark themselves.
+      const html = "<ul><li><ul><li>sub</li></ul><p>after</p></li></ul>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([
+        { id: 3, text: "- sub" },
+        { id: 4, text: "- after" },
+      ]);
+    });
+
+    it("marks through a non-block wrapper inside the item", () => {
+      // <div>/<section> get no paragraph of their own, so they are transparent.
+      const html = "<ul><li><div><p>x</p></div></li></ul>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 2, text: "- x" }]);
+    });
+
+    it("does not let an empty link target take the item's marker", () => {
+      const html = '<ul><li><a id="fn1"></a><p>Footnote text</p></li></ul>';
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 2, text: "- Footnote text" }]);
     });
 
     it("does not repeat a nested list's items in its parent item", () => {

--- a/tests/unit/html-to-narration-input.test.ts
+++ b/tests/unit/html-to-narration-input.test.ts
@@ -430,18 +430,23 @@ describe("htmlToNarrationInput", () => {
       expect(result.paragraphs).toEqual([{ id: 3, text: "- Table: x End table." }]);
     });
 
-    it("narrates a list item with thousands of paragraphs in reasonable time", () => {
-      // Answering "which of my blocks carries the marker?" walks the item, and
-      // it is asked once per block — quadratic without memoization, which took
-      // seconds on an item this size.
-      const html = `<ul><li>${"<p>text here</p>".repeat(3000)}</li></ul>`;
+    it("narrates thousands of blocks under a wrapper in reasonable time", () => {
+      // Two questions are asked of a wrapper by every block inside it — which
+      // of my blocks carries the marker, and does this figure say anything of
+      // its own — and answering either one walks the wrapper. Unmemoized that
+      // is quadratic: these took 1.4s and 1.3s, and 4× the blocks took 16×.
+      // Both run in tens of milliseconds, so the bound has plenty of slack.
+      for (const [html, first] of [
+        [`<ul><li>${"<p>text here</p>".repeat(3000)}</li></ul>`, "- text here"],
+        [`<figure>${"<p>text here</p>".repeat(3000)}</figure>`, "text here"],
+      ] as const) {
+        const started = performance.now();
+        const result = htmlToNarrationInput(html);
 
-      const started = performance.now();
-      const result = htmlToNarrationInput(html);
-
-      expect(performance.now() - started).toBeLessThan(2000);
-      expect(result.paragraphs).toHaveLength(3000);
-      expect(result.paragraphs[0].text).toBe("- text here");
+        expect(performance.now() - started).toBeLessThan(500);
+        expect(result.paragraphs).toHaveLength(3000);
+        expect(result.paragraphs[0].text).toBe(first);
+      }
     });
 
     it("does not repeat a nested list's items in its parent item", () => {

--- a/tests/unit/html-to-narration-input.test.ts
+++ b/tests/unit/html-to-narration-input.test.ts
@@ -172,6 +172,45 @@ describe("htmlToNarrationInput", () => {
       expect(result.paragraphs).toEqual([{ id: 2, text: "- Quote: x End quote." }]);
     });
 
+    it("reads through a wrapper between the quote and its paragraphs", () => {
+      // The pull-quote markup WordPress-style editors emit. `<div>`/`<section>`
+      // get no paragraph of their own, so the quote has to walk through them or
+      // its text is narrated nowhere at all.
+      const html =
+        '<blockquote><div class="quote-body"><p>Be excellent.</p></div><cite>Bill</cite></blockquote>';
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([
+        { id: 0, text: "Quote: Be excellent.\n\nBill End quote." },
+      ]);
+    });
+
+    it("keeps a wrapper that only holds text in the run around it", () => {
+      const html = "<blockquote>Hello <span>world</span> again</blockquote>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 0, text: "Quote: Hello world again End quote." }]);
+    });
+
+    it("speaks a quoted image rather than walking into the figure", () => {
+      const html =
+        '<blockquote><figure><img alt="A cat"><figcaption>My cat</figcaption></figure></blockquote>';
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 0, text: "Quote: Image: A cat End quote." }]);
+    });
+
+    it("narrates absurdly nested quotes instead of overflowing the stack", () => {
+      // Feed HTML is not depth-limited and the content walk is recursive, so
+      // past a point it flattens what is left rather than descending further.
+      const depth = 500;
+      const html = `${"<blockquote>".repeat(depth)}<p>the text</p>${"</blockquote>".repeat(depth)}`;
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toHaveLength(1);
+      expect(result.paragraphs[0].text).toContain("the text");
+    });
+
     it("drops an empty quote instead of speaking bare markers", () => {
       const html = "<blockquote></blockquote><p>after</p>";
       const result = htmlToNarrationInput(html);
@@ -387,6 +426,20 @@ describe("htmlToNarrationInput", () => {
       const result = htmlToNarrationInput(html);
 
       expect(result.paragraphs).toEqual([{ id: 0, text: "Table: Cell 1, Cell 2 End table." }]);
+    });
+
+    it("says what a silenced cell block would have said", () => {
+      // The blocks in a cell stay silent for the table's sake, so anything they
+      // would have narrated — an image's alt text, a list's bullets — has to
+      // come through in the cell instead of being lost.
+      const html =
+        '<table><tr><td><figure><img alt="Sales chart"></figure></td>' +
+        "<td><ul><li>a</li><li>b</li></ul></td></tr></table>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([
+        { id: 0, text: "Table: Image: Sales chart, - a - b End table." },
+      ]);
     });
   });
 

--- a/tests/unit/html-to-narration-input.test.ts
+++ b/tests/unit/html-to-narration-input.test.ts
@@ -197,7 +197,9 @@ describe("htmlToNarrationInput", () => {
         '<blockquote><figure><img alt="A cat"><figcaption>My cat</figcaption></figure></blockquote>';
       const result = htmlToNarrationInput(html);
 
-      expect(result.paragraphs).toEqual([{ id: 0, text: "Quote: Image: A cat My cat End quote." }]);
+      expect(result.paragraphs).toEqual([
+        { id: 0, text: "Quote: Image: A cat. My cat End quote." },
+      ]);
     });
 
     it("keeps what a quoted figure wraps when it is not an image", () => {
@@ -239,6 +241,27 @@ describe("htmlToNarrationInput", () => {
       const result = htmlToNarrationInput(html);
 
       expect(result.paragraphs).toEqual([{ id: 0, text: "Image: A beautiful sunset" }]);
+    });
+
+    it("narrates a figure's caption, which nothing else does", () => {
+      // The caption is the description when there is no alt text, and extra
+      // detail when there is — and `<figcaption>` gets no paragraph of its own.
+      const html = '<figure><img alt="A cat"><figcaption>My cat</figcaption></figure>';
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 0, text: "Image: A cat. My cat" }]);
+    });
+
+    it("does not announce an image for a figure that holds none", () => {
+      // A figure around a table is not an image; the table speaks for itself.
+      const html =
+        "<figure><table><tr><td>Cell</td></tr></table><figcaption>Data</figcaption></figure>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([
+        { id: 0, text: "Data" },
+        { id: 1, text: "Table: Cell End table." },
+      ]);
     });
 
     it("handles inline images within paragraphs", () => {
@@ -398,6 +421,29 @@ describe("htmlToNarrationInput", () => {
       expect(result.paragraphs).toEqual([{ id: 2, text: "- Footnote text" }]);
     });
 
+    it("marks through a figure that announces no image", () => {
+      // The figure speaks nothing of its own, so it owns nothing: the table
+      // inside it carries the item's marker (issue #1441's invariant).
+      const html = "<ul><li><figure><table><tr><td>x</td></tr></table></figure></li></ul>";
+      const result = htmlToNarrationInput(html);
+
+      expect(result.paragraphs).toEqual([{ id: 3, text: "- Table: x End table." }]);
+    });
+
+    it("narrates a list item with thousands of paragraphs in reasonable time", () => {
+      // Answering "which of my blocks carries the marker?" walks the item, and
+      // it is asked once per block — quadratic without memoization, which took
+      // seconds on an item this size.
+      const html = `<ul><li>${"<p>text here</p>".repeat(3000)}</li></ul>`;
+
+      const started = performance.now();
+      const result = htmlToNarrationInput(html);
+
+      expect(performance.now() - started).toBeLessThan(2000);
+      expect(result.paragraphs).toHaveLength(3000);
+      expect(result.paragraphs[0].text).toBe("- text here");
+    });
+
     it("does not repeat a nested list's items in its parent item", () => {
       const html = "<ul><li>Parent<ul><li>Child</li></ul></li></ul>";
       const result = htmlToNarrationInput(html);
@@ -452,7 +498,7 @@ describe("htmlToNarrationInput", () => {
       const result = htmlToNarrationInput(html);
 
       expect(result.paragraphs).toEqual([
-        { id: 0, text: "Table: Image: Sales chart Fig 1, - a - b End table." },
+        { id: 0, text: "Table: Image: Sales chart. Fig 1, - a - b End table." },
       ]);
     });
 
@@ -470,11 +516,15 @@ describe("htmlToNarrationInput", () => {
     });
 
     it("reads a nested table as a cell of the outer one, once", () => {
-      const html = "<table><tr><td><table><tr><td>inner</td></tr></table></td></tr></table>";
+      // More than one inner cell, so cells run together rather than being
+      // separated would fail this too.
+      const html =
+        "<table><tr><td><table><tr><td>A</td><td>B</td></tr><tr><td>C</td></tr></table>" +
+        "</td></tr></table>";
       const result = htmlToNarrationInput(html);
 
       expect(result.paragraphs).toEqual([
-        { id: 0, text: "Table: Table: inner End table. End table." },
+        { id: 0, text: "Table: Table: A, B. C End table. End table." },
       ]);
     });
 


### PR DESCRIPTION
Fixes #1441 and #1445.

## Problem

`htmlToNarrationInput` emitted a paragraph for an `<li>` built from its full `textContent` **and** separate paragraphs for each of its block children, so a loose list item was narrated twice:

```js
htmlToNarrationInput("<ul><li><p>hello</p></li></ul>")
// before: [{ id: 1, text: "- hello" }, { id: 2, text: "hello" }]
// after:  [{ id: 2, text: "- hello" }]
```

Loose lists (`<li><p>…</p></li>`) are what cmark-gfm/GitHub emit for any list with blank lines between items, so this is common in feed HTML rather than exotic.

## Fix

A block element now contributes only **its own** text, leaving out any child that narrates itself. `img` is the exception — a nested image gets no paragraph of its own, so its enclosing block still speaks its alt text.

A loose item then has no text left, so the bullet and the spoken task-list state from #1439 ride along on the item's first block child instead:

```js
htmlToNarrationInput('<ul><li><p><input type="checkbox" checked> done</p></li></ul>')
// [{ id: 2, text: "- Done: done" }]
```

Paragraph ids are unchanged — they are still the document-order index of every block element, so they keep matching the client-side highlighting. The wrapper elements simply contribute no paragraph, exactly like `<ul>`/`<ol>` already did.

Two things fall out:

- A nested list inside an item is no longer repeated in its parent (`<li>Parent<ul><li>Child</li></ul></li>` → `- Parent`, `- Child`).
- Client-side, a `<blockquote>` wrapping a `<p>` no longer double-narrates either; that path has no markers to move, so the same skip fixes it outright.

List items now go through the same inline handling as paragraphs, so a link, inline code, or image inside one is narrated the way it is everywhere else instead of being flattened to raw `textContent`.

## The same bug in quotes and tables (#1445)

`<blockquote><p>…</p></blockquote>` — what every Markdown renderer emits for a `>` quote — was read as "Quote: x End quote." followed by a bare "x", and a `<p>` in a table cell was read twice as well.

Those markers **wrap** the text, so they can't migrate onto a child the way a bullet can: they'd have to split across the first and last child, and an attribution trailing the quote (`<footer>`, `<cite>`) would be read *before* the quote it follows, since a wrapper always precedes its children in document order. So the wrapper keeps speaking and the blocks inside it fall silent — keeping their paragraph index, contributing nothing, exactly like an empty element.

A quote now narrates its content structurally instead of flattening it to `textContent`:

```js
"<blockquote><p>a</p><p>b</p></blockquote>"          // "Quote: a\n\nb End quote."  (was "ab" + "a" + "b")
"<blockquote><ul><li>a</li></ul></blockquote>"       // "Quote: - a End quote."
"<blockquote><p>x</p><footer>— Author</footer></blockquote>" // "Quote: x\n\n— Author End quote."
```

The blank lines are the player's paragraph separator, and `buildAlignedNarration` maps each of them back to the quote — the invariant `paragraph-map.ts` documents. An empty quote no longer speaks a bare pair of markers.

Client-side the same silencing applies to tables (a cell's paragraph was repeated after the table) and to `<pre>` (a block inside one narrated the code the client deliberately skips). A blockquote is *not* in that set there — it speaks only its own text, so the paragraphs inside it are what narrate the quote.

**Figures are deliberately left out.** A figure speaks its alt text, not its subtree, so silencing a caption's paragraph would drop text that *complements* the alt rather than repeating it — and a figure wrapping a table would lose the table entirely.

## Testing

`pnpm typecheck` and `pnpm test:unit` (2663 passed) both pass. New cases cover the loose item, a multi-paragraph item, an item with both its own text and block children, nested lists, loose task lists, and inline images in items — server and client side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
