### PR TITLE
Add a starred Getting Started article for new users (#1397)

### DIFF
--- a/migrations/0107_getting_started_article.sql
+++ b/migrations/0107_getting_started_article.sql
@@ -1,0 +1,21 @@
+-- Getting Started onboarding article (issue #1397).
+--
+-- Records when the Getting Started saved article was inserted for a user. Set
+-- once and never cleared, so unstarring or deleting the article does not bring
+-- it back on the next signup-path/backfill run.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS getting_started_at timestamptz;
+--> statement-breakpoint
+
+-- Drives the backfill job's "who still needs one" scan. Partial, so it shrinks
+-- to nothing as the backfill drains and costs nothing once every user is done.
+CREATE INDEX IF NOT EXISTS idx_users_getting_started_pending
+  ON users (id) WHERE getting_started_at IS NULL;
+--> statement-breakpoint
+
+-- Register the backfill_getting_started singleton job (fills the article in for
+-- users who predate the feature, and retries anyone whose signup-path insert
+-- failed).
+DROP INDEX jobs_singleton_type_unique;
+--> statement-breakpoint
+CREATE UNIQUE INDEX jobs_singleton_type_unique ON jobs (type)
+  WHERE type IN ('renew_websub', 'monitor_feed_health', 'cleanup', 'reconcile_counters', 'backfill_getting_started');

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -743,6 +743,13 @@
       "when": 1782953900000,
       "tag": "0106_discord_api_token_links",
       "breakpoints": true
+    },
+    {
+      "idx": 106,
+      "version": "7",
+      "when": 1782954000000,
+      "tag": "0107_getting_started_article",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -539,7 +539,8 @@ CREATE TABLE public.users (
     starred_unread_count integer DEFAULT 0 NOT NULL,
     greader_user_id bigint DEFAULT nextval('public.greader_id_seq'::regclass) NOT NULL,
     cerebras_api_key text,
-    narration_model text
+    narration_model text,
+    getting_started_at timestamp with time zone
 );
 
 CREATE VIEW public.visible_entries AS
@@ -853,13 +854,15 @@ CREATE INDEX idx_user_entries_unread ON public.user_entries USING btree (user_id
 
 CREATE INDEX idx_user_entries_updated_at ON public.user_entries USING btree (user_id, updated_at);
 
+CREATE INDEX idx_users_getting_started_pending ON public.users USING btree (id) WHERE (getting_started_at IS NULL);
+
 CREATE INDEX idx_users_last_active_at ON public.users USING btree (last_active_at DESC NULLS LAST, id DESC);
 
 CREATE INDEX idx_websub_expiring ON public.websub_subscriptions USING btree (expires_at);
 
 CREATE INDEX idx_websub_feed ON public.websub_subscriptions USING btree (feed_id);
 
-CREATE UNIQUE INDEX jobs_singleton_type_unique ON public.jobs USING btree (type) WHERE (type = ANY (ARRAY['renew_websub'::text, 'monitor_feed_health'::text, 'cleanup'::text, 'reconcile_counters'::text]));
+CREATE UNIQUE INDEX jobs_singleton_type_unique ON public.jobs USING btree (type) WHERE (type = ANY (ARRAY['renew_websub'::text, 'monitor_feed_health'::text, 'cleanup'::text, 'reconcile_counters'::text, 'backfill_getting_started'::text]));
 
 CREATE UNIQUE INDEX uq_feeds_saved_user ON public.feeds USING btree (user_id) WHERE (type = 'saved'::public.feed_type);
 

--- a/src/components/subscribe/SubscribeContent.tsx
+++ b/src/components/subscribe/SubscribeContent.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert } from "@/components/ui/alert";
 import { Card } from "@/components/ui/card";
+import { ClientLink } from "@/components/ui/client-link";
 import { FeedSiteLink } from "@/components/feeds/FeedSiteLink";
 import {
   CheckCircleIcon,
@@ -294,6 +295,18 @@ export function SubscribeContent() {
               Preview Feed
             </Button>
           </form>
+
+          {/* Coming from another reader? Point at the bulk path (issue #1397). */}
+          <p className="ui-text-sm text-muted mt-4">
+            Moving from another reader? Bring everything over at once with{" "}
+            <ClientLink
+              href="/settings/subscriptions"
+              className="text-accent hover:text-accent-hover font-medium"
+            >
+              OPML import
+            </ClientLink>
+            .
+          </p>
         </Card>
       )}
 

--- a/src/server/CLAUDE.md
+++ b/src/server/CLAUDE.md
@@ -14,12 +14,9 @@ Entry content served by `getEntry`/`getEntries`/`toFullEntry` is **sanitized in 
 
 Everything a brand-new account gets is in `runPostSignupTasks` (`src/server/auth/signup.ts`), called fire-and-forget by both signup paths (email/password and OAuth). **Add onboarding steps there, not in the routes** — otherwise the two paths drift. Each task swallows its own errors: none of them may fail a signup.
 
-Today that's the announcement-feed subscription and the **Getting Started article** (`src/server/services/getting-started.ts`, issue #1397) — a starred saved article inserted through the ordinary Markdown upload path, so it's an entirely normal saved article the user can unstar, read, or delete afterwards. Two rules hold it together:
+Today that's the announcement-feed subscription and the **Getting Started article** (`src/server/services/getting-started.ts`, issue #1397), inserted through the ordinary Markdown upload path so it ends up an entirely normal saved article the user can unstar, read, or delete. The load-bearing idea: **`users.getting_started_at` records that we inserted it, not that it still exists** — which is what keeps a deleted article from coming back (issue #1383). The claim/release ordering that makes it safe against races and partial failure is documented at the function.
 
-- **`users.getting_started_at` records that we inserted it, not that it still exists.** It's claimed atomically _before_ the insert (`UPDATE ... WHERE getting_started_at IS NULL RETURNING`) and released only if the insert then fails, so a signup racing the backfill can't double-insert, and deleting the article never brings it back (issue #1383).
-- **The content (`getting-started-content.ts`) is nearly all links into the app**, and they must be relative so they resolve on a self-hosted instance. `tests/unit/getting-started-content.test.ts` checks each in-app link against the routes that actually exist in `src/app`, so a renamed route fails CI instead of shipping dead links to every future user.
-
-Users who predate the feature are covered by the `backfill_getting_started` singleton job, which walks the same pending-users scan a batch at a time. It never parks: once the backlog drains it drops to a daily cadence, and the same scan then also retries anyone whose signup-path insert failed.
+Users who predate the feature are covered by the `backfill_getting_started` singleton job, a batch per run. It never parks: once the backlog drains it drops to a daily cadence, and that same scan then doubles as the retry for anyone whose signup-path insert failed.
 
 ## Site Status (announcement banner + maintenance mode)
 

--- a/src/server/CLAUDE.md
+++ b/src/server/CLAUDE.md
@@ -10,6 +10,17 @@ Business logic lives in pure service functions in `src/server/services/` — fun
 
 Entry content served by `getEntry`/`getEntries`/`toFullEntry` is **sanitized in the services layer on every read** (raw HTML is stored; see `src/server/html/CLAUDE.md`), so every consumer gets the same guarantee.
 
+## New-Account Onboarding
+
+Everything a brand-new account gets is in `runPostSignupTasks` (`src/server/auth/signup.ts`), called fire-and-forget by both signup paths (email/password and OAuth). **Add onboarding steps there, not in the routes** — otherwise the two paths drift. Each task swallows its own errors: none of them may fail a signup.
+
+Today that's the announcement-feed subscription and the **Getting Started article** (`src/server/services/getting-started.ts`, issue #1397) — a starred saved article inserted through the ordinary Markdown upload path, so it's an entirely normal saved article the user can unstar, read, or delete afterwards. Two rules hold it together:
+
+- **`users.getting_started_at` records that we inserted it, not that it still exists.** It's claimed atomically _before_ the insert (`UPDATE ... WHERE getting_started_at IS NULL RETURNING`) and released only if the insert then fails, so a signup racing the backfill can't double-insert, and deleting the article never brings it back (issue #1383).
+- **The content (`getting-started-content.ts`) is nearly all links into the app**, and they must be relative so they resolve on a self-hosted instance. `tests/unit/getting-started-content.test.ts` checks each in-app link against the routes that actually exist in `src/app`, so a renamed route fails CI instead of shipping dead links to every future user.
+
+Users who predate the feature are covered by the `backfill_getting_started` singleton job, which walks the same pending-users scan a batch at a time. It never parks: once the backlog drains it drops to a daily cadence, and the same scan then also retries anyone whose signup-path insert failed.
+
 ## Site Status (announcement banner + maintenance mode)
 
 Two admin-controlled global flags live in **Redis, not Postgres** (`src/server/services/site-status.ts`): a site-wide **announcement banner** and a **maintenance mode** kill switch. Redis is deliberate — maintenance mode is meant to be turned on _while Postgres is being migrated/locked_, so the code that reads it must not depend on the DB. Both reads are fail-safe (Redis down ⇒ no banner, maintenance = the `MAINTENANCE_MODE` env override only) and cached in-process for a few seconds so the hot paths issue no per-request Redis round-trip.

--- a/src/server/auth/oauth/callback.ts
+++ b/src/server/auth/oauth/callback.ts
@@ -15,7 +15,7 @@ import { eq, and } from "drizzle-orm";
 import { db, type Database } from "@/server/db";
 import { users, oauthAccounts } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
-import { createUser, subscribeToAnnouncementFeed } from "@/server/auth/signup";
+import { createUser, runPostSignupTasks } from "@/server/auth/signup";
 
 /**
  * OAuth provider type
@@ -236,8 +236,8 @@ export async function processOAuthCallback(
     return user;
   });
 
-  // Auto-subscribe new OAuth users to announcement feed (fire-and-forget)
-  void subscribeToAnnouncementFeed(db, newUser.userId);
+  // Announcement-feed subscription + Getting Started article (fire-and-forget)
+  void runPostSignupTasks(db, newUser.userId);
 
   return {
     userId: newUser.userId,

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -62,10 +62,12 @@ const SESSION_CACHE_PREFIX = "session:v2:";
  */
 export interface SessionData {
   session: Session;
-  // greaderUserId is a bigint (uncacheable in the Redis session JSON, and with no
-  // nullable placeholder) that only the Google Reader user-info route needs — and
-  // it reads that straight from the DB — so it's omitted from the session user.
-  user: Omit<User, "greaderUserId">;
+  // Two columns are deliberately absent. greaderUserId is a bigint (uncacheable
+  // in the Redis session JSON, and with no nullable placeholder) that only the
+  // Google Reader user-info route needs — and it reads that straight from the
+  // DB. gettingStartedAt is an onboarding bookkeeping marker with no request-path
+  // reader at all, so caching it would only mean stale data to invalidate.
+  user: Omit<User, "greaderUserId" | "gettingStartedAt">;
   /** Whether user has a Groq API key configured (actual key not cached for security) */
   hasGroqApiKey: boolean;
   /** Whether user has an Anthropic API key configured (actual key not cached for security) */

--- a/src/server/auth/signup.ts
+++ b/src/server/auth/signup.ts
@@ -145,10 +145,28 @@ export async function createUser(tx: DbOrTx, params: CreateUserParams): Promise<
 }
 
 /**
+ * Everything we do for a brand-new account after the signup transaction has
+ * committed. Every caller invokes this fire-and-forget (`void`), and each task
+ * swallows its own errors — none of them may interfere with signup.
+ *
+ * Adding an onboarding step? Put it here, not in the signup routes, so the
+ * email/password and OAuth paths can't drift apart.
+ */
+export async function runPostSignupTasks(db: Database, userId: string): Promise<void> {
+  // Dynamic import to keep the services graph out of the auth modules (see
+  // subscribeToAnnouncementFeed).
+  const { tryCreateGettingStartedArticle } = await import("@/server/services/getting-started");
+  await Promise.all([
+    subscribeToAnnouncementFeed(db, userId),
+    tryCreateGettingStartedArticle(db, userId),
+  ]);
+}
+
+/**
  * Subscribe a newly created user to the announcement feed.
  * Runs async and catches all errors — must never interfere with signup.
  */
-export async function subscribeToAnnouncementFeed(db: Database, userId: string): Promise<void> {
+async function subscribeToAnnouncementFeed(db: Database, userId: string): Promise<void> {
   const feedUrl = announcementFeedConfig.url;
   if (!feedUrl) return;
 

--- a/src/server/auth/signup.ts
+++ b/src/server/auth/signup.ts
@@ -146,20 +146,28 @@ export async function createUser(tx: DbOrTx, params: CreateUserParams): Promise<
 
 /**
  * Everything we do for a brand-new account after the signup transaction has
- * committed. Every caller invokes this fire-and-forget (`void`), and each task
- * swallows its own errors — none of them may interfere with signup.
+ * committed. Every caller invokes this fire-and-forget (`void`), so this
+ * function must be **total** — a rejection here has no `.catch()` anywhere and
+ * would take the process down as an unhandled rejection. The individual tasks
+ * already swallow their own errors; the outer catch covers everything around
+ * them (notably the dynamic import).
  *
  * Adding an onboarding step? Put it here, not in the signup routes, so the
  * email/password and OAuth paths can't drift apart.
  */
 export async function runPostSignupTasks(db: Database, userId: string): Promise<void> {
-  // Dynamic import to keep the services graph out of the auth modules (see
-  // subscribeToAnnouncementFeed).
-  const { tryCreateGettingStartedArticle } = await import("@/server/services/getting-started");
-  await Promise.all([
-    subscribeToAnnouncementFeed(db, userId),
-    tryCreateGettingStartedArticle(db, userId),
-  ]);
+  try {
+    // Dynamic import to keep the services graph out of the auth modules (see
+    // subscribeToAnnouncementFeed).
+    const { tryCreateGettingStartedArticle } = await import("@/server/services/getting-started");
+    await Promise.all([
+      subscribeToAnnouncementFeed(db, userId),
+      tryCreateGettingStartedArticle(db, userId),
+    ]);
+  } catch (err) {
+    logger.error("Post-signup tasks failed", { userId, err });
+    Sentry.captureException(err, { tags: { source: "post-signup-tasks" }, extra: { userId } });
+  }
 }
 
 /**

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -127,12 +127,22 @@ export const users = pgTable(
       .notNull()
       .default(sql`nextval('greader_id_seq'::regclass)`),
 
+    // When the Getting Started saved article was inserted for this user (issue
+    // #1397). Set once and never cleared, so unstarring or deleting the article
+    // doesn't bring it back.
+    gettingStartedAt: timestamp("getting_started_at", { withTimezone: true }),
+
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
     // Supports the admin user list "most recent activity" sort + keyset cursor.
     index("idx_users_last_active_at").on(table.lastActiveAt.desc().nullsLast(), table.id.desc()),
+    // Drives the backfill_getting_started job's "who still needs one" scan.
+    // Partial, so it drains to empty once every user has been covered.
+    index("idx_users_getting_started_pending")
+      .on(table.id)
+      .where(sql`getting_started_at IS NULL`),
   ]
 );
 
@@ -940,7 +950,9 @@ export const jobs = pgTable(
     // INSERT...catch actually races correctly (see SINGLETON_JOB_TYPES).
     uniqueIndex("jobs_singleton_type_unique")
       .on(table.type)
-      .where(sql`type IN ('renew_websub', 'monitor_feed_health', 'cleanup')`),
+      .where(
+        sql`type IN ('renew_websub', 'monitor_feed_health', 'cleanup', 'reconcile_counters', 'backfill_getting_started')`
+      ),
   ]
 );
 

--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -1495,9 +1495,10 @@ export async function handleBackfillGettingStarted(
 ): Promise<JobHandlerResult> {
   const result = await backfillGettingStartedArticles(db, GETTING_STARTED_BATCH_SIZE);
 
-  // Come back promptly only while we're both filling batches and making
-  // progress. Requiring progress means a persistently failing batch backs off
-  // to the idle cadence instead of spinning every 15 seconds forever.
+  // Come back promptly while we're filling batches and getting somewhere. A
+  // batch where *nothing* succeeded drops to the idle cadence rather than
+  // spinning every 15 seconds; a batch with a few stuck users still counts as
+  // progress, so one poison row can't throttle the whole backfill to daily.
   const moreLikely = result.attempted === GETTING_STARTED_BATCH_SIZE && result.created > 0;
 
   return {

--- a/src/server/jobs/handlers.ts
+++ b/src/server/jobs/handlers.ts
@@ -62,6 +62,7 @@ import { getFeedPlugin } from "@/server/plugins";
 import { createSubscription } from "../services/subscriptions";
 import { runRetentionCleanup } from "../services/retention";
 import { reconcileCounters } from "../services/reconcile-counters";
+import { backfillGettingStartedArticles } from "../services/getting-started";
 import {
   findPermanentRedirectUrl,
   isHttpToHttpsUpgrade,
@@ -1467,6 +1468,44 @@ export async function handleReconcileCounters(
   return {
     success: true,
     nextRunAt: new Date(now.getTime() + RECONCILE_COUNTERS_INTERVAL_MS),
+    metadata: { ...result },
+  };
+}
+
+/** Users given a Getting Started article per backfill run. */
+const GETTING_STARTED_BATCH_SIZE = 100;
+
+/** Gap between backfill runs while users are still waiting. */
+const GETTING_STARTED_BACKLOG_INTERVAL_MS = 15 * 1000;
+
+/**
+ * Gap once the backlog is drained. The job stays alive rather than parking:
+ * the same scan also catches anyone whose signup-path insert failed, and once
+ * the partial index is empty the query costs nothing.
+ */
+const GETTING_STARTED_IDLE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Handler for backfill_getting_started jobs (singleton, stateless).
+ * See src/server/services/getting-started.ts.
+ */
+export async function handleBackfillGettingStarted(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _payload: JobPayloads["backfill_getting_started"]
+): Promise<JobHandlerResult> {
+  const result = await backfillGettingStartedArticles(db, GETTING_STARTED_BATCH_SIZE);
+
+  // Come back promptly only while we're both filling batches and making
+  // progress. Requiring progress means a persistently failing batch backs off
+  // to the idle cadence instead of spinning every 15 seconds forever.
+  const moreLikely = result.attempted === GETTING_STARTED_BATCH_SIZE && result.created > 0;
+
+  return {
+    success: true,
+    nextRunAt: new Date(
+      Date.now() +
+        (moreLikely ? GETTING_STARTED_BACKLOG_INTERVAL_MS : GETTING_STARTED_IDLE_INTERVAL_MS)
+    ),
     metadata: { ...result },
   };
 }

--- a/src/server/jobs/queue.ts
+++ b/src/server/jobs/queue.ts
@@ -83,6 +83,10 @@ export interface JobPayloads {
   // Daily self-healing sweep of the denormalized unread counters (issue
   // #1117). See src/server/services/reconcile-counters.ts.
   reconcile_counters: Record<string, never>;
+  // Fills the Getting Started article in for users who predate it, a batch per
+  // run (issue #1397). Stateless — `users.getting_started_at` is the progress
+  // marker. See src/server/services/getting-started.ts.
+  backfill_getting_started: Record<string, never>;
 }
 
 export type JobType = keyof JobPayloads;
@@ -579,6 +583,9 @@ export const SINGLETON_JOB_TYPES: JobType[] = [
   "monitor_feed_health",
   "cleanup",
   "reconcile_counters",
+  // Last on purpose: while a backlog remains it reschedules itself in seconds,
+  // so anything after it would starve (see the ordering invariant above).
+  "backfill_getting_started",
 ];
 
 /**

--- a/src/server/jobs/worker.ts
+++ b/src/server/jobs/worker.ts
@@ -31,6 +31,7 @@ import {
   handleMonitorFeedHealth,
   handleCleanup,
   handleReconcileCounters,
+  handleBackfillGettingStarted,
   type JobHandlerResult,
 } from "./handlers";
 import type { Job } from "../db/schema";
@@ -487,6 +488,11 @@ function createWorker(config: WorkerConfig = {}): Worker {
         case "reconcile_counters": {
           const payload = getJobPayload<"reconcile_counters">(job);
           result = await handleReconcileCounters(payload);
+          break;
+        }
+        case "backfill_getting_started": {
+          const payload = getJobPayload<"backfill_getting_started">(job);
+          result = await handleBackfillGettingStarted(payload);
           break;
         }
         case "process_opml_import": {

--- a/src/server/services/getting-started-content.ts
+++ b/src/server/services/getting-started-content.ts
@@ -1,0 +1,77 @@
+/**
+ * The Getting Started onboarding article (issue #1397).
+ *
+ * Plain Markdown so it goes in through the ordinary upload path
+ * (`uploadArticle`) — same dialect, same sanitization, same excerpt handling as
+ * anything a user saves. See `getting-started.ts` for the insert.
+ *
+ * Two things to keep in mind when editing the body:
+ *
+ * - **Don't hard-wrap inside a paragraph.** Our Markdown dialect renders a
+ *   single newline as a `<br>`, so a wrapped source line becomes a ragged line
+ *   break in the article. One line per paragraph / list item.
+ * - **Links into the app must be relative**, so they resolve on any instance
+ *   including self-hosted ones (the sanitizer leaves relative hrefs alone and
+ *   only gives external ones `target="_blank"`). Only link to routes that
+ *   exist — `tests/unit/getting-started-content.test.ts` checks the in-app ones
+ *   against the app's actual route list.
+ */
+
+/** Title of the Getting Started article. */
+export const GETTING_STARTED_TITLE = "Getting Started with Lion Reader";
+
+/** Excerpt shown in the entry list, instead of the first lines of the body. */
+export const GETTING_STARTED_EXCERPT =
+  "A short tour of Lion Reader: getting content in, reading it your way, " +
+  "optional AI summaries and narration, connecting AI agents over MCP, and apps for your phone.";
+
+/**
+ * The article body, in the GFM dialect `@/server/markdown` renders.
+ *
+ * No H1: `processMarkdown` would strip a leading H1 into the title, and the
+ * title is passed explicitly anyway.
+ */
+export const GETTING_STARTED_MARKDOWN = `
+Welcome! This article is starred, so you can always find it again under [Starred](/starred). When you're done with it, unstar it or delete it — it won't come back.
+
+## 1. Get some content in
+
+- **Subscribe to a feed.** Go to [Subscribe](/subscribe) and paste a site's address — you don't need to hunt for the feed URL, we'll find it for you.
+- **Coming from another reader?** Export an OPML file from it and import the whole thing at once under [Settings → Subscriptions](/settings/subscriptions).
+- **Newsletters.** Create a private ingest address under [Settings → Email](/settings/email) and subscribe to newsletters with it. They arrive as entries instead of cluttering your inbox, and you can block a sender later from the same page.
+- **Save pages to read later.** Install the browser extension or bookmarklet from [Settings → Integrations](/settings/integrations), or use the **Upload** button in the header for a Markdown, HTML, or Word file. Saved articles land in [Saved](/saved). arXiv, GitHub, Google Docs, LessWrong, YouTube, and Bluesky links get special handling, so you get the real content rather than a landing page.
+
+## 2. Read it your way
+
+Everything lands in [All](/all), and each feed and [tag](/settings/subscriptions) has its own view in the sidebar.
+
+- **Keyboard first.** \`j\` / \`k\` move between entries, \`o\` opens one, \`s\` stars, \`m\` toggles read, \`u\` shows or hides read entries, \`/\` searches, and \`?\` lists every shortcut. You can turn shortcuts off in [Settings](/settings).
+- **On a phone or tablet**, swipe left and right inside an article to move to the next or previous one.
+- **Feed only giving you a teaser?** Turn on full-content fetching for that subscription and we'll pull the whole article in for you.
+
+## 3. Make it yours
+
+[Settings → Appearance](/settings/appearance) has light, dark, and e-paper themes, four reading fonts, text size and alignment, and a compact list density if you'd rather see more entries at once.
+
+## 4. Optional: AI summaries and narration
+
+Both are opt-in, and neither runs behind your back.
+
+- Add an **Anthropic** or **Cerebras** API key under [Settings → AI & Narration](/settings/ai) to get article summaries on demand. Nothing is ever summarized until you ask for it.
+- **Narration** reads articles aloud with synchronized highlighting. It works without any API key; a **Cerebras** or **Groq** key just lets it tidy the text up first so it reads more naturally. If you don't want it at all, turn narration off on the same page.
+
+## 5. Optional: connect an AI agent over MCP
+
+Lion Reader is an [MCP](https://modelcontextprotocol.io/) server, so an agent like Claude Code can search your feeds, mark things read, save a URL, or upload an article it wrote for you.
+
+[Settings → Integrations](/settings/integrations) has your personal MCP URL and copy-paste setup for Claude Code and Claude Desktop. The claude.ai **web** connector doesn't work yet — that's a bug on their side, tracked in [issue #986](https://github.com/brendanlong/lion-reader/issues/986).
+
+## 6. Optional: apps for your phone and desktop
+
+- **Install Lion Reader itself.** It's a PWA: use your browser's "Install" or "Add to Home Screen" option. You get an app icon, and Lion Reader shows up in your phone's share menu for saving links.
+- **Prefer a native client?** Enable the Google Reader API under [Settings → Integrations](/settings/integrations) to sync with Reeder, NetNewsWire, Read You, NewsFlash, and friends. The Wallabag API on the same page connects the Wallabag mobile apps to your saved articles.
+
+---
+
+Curious about the rest? The [feature tour](/demo/all?entry=welcome) goes deeper on all of this, and Lion Reader is [open source](https://github.com/brendanlong/lion-reader) if you'd like to file an issue or host your own.
+`.trim();

--- a/src/server/services/getting-started-content.ts
+++ b/src/server/services/getting-started-content.ts
@@ -32,7 +32,7 @@ export const GETTING_STARTED_EXCERPT =
  * title is passed explicitly anyway.
  */
 export const GETTING_STARTED_MARKDOWN = `
-Welcome! This article is starred, so you can always find it again under [Starred](/starred). When you're done with it, unstar it or delete it — it won't come back.
+Welcome! This article is starred, so you can always find it again under [Starred](/starred). When you're done with it, just unstar or delete it.
 
 ## 1. Get some content in
 

--- a/src/server/services/getting-started.ts
+++ b/src/server/services/getting-started.ts
@@ -31,8 +31,13 @@ import {
  *
  * The flag is claimed *before* the insert (`UPDATE ... WHERE
  * getting_started_at IS NULL RETURNING`), so a signup racing the backfill job
- * can't produce two copies. If anything after the claim fails, the flag is
- * released again so the next backfill run retries.
+ * can't produce two copies.
+ *
+ * The claim is released only when the **insert itself** fails — i.e. only while
+ * there is definitely no article — so a retry can never add a second copy. Once
+ * the article exists the claim stands, which makes starring best-effort: an
+ * unstarred article is a much better failure than a duplicate one, and the user
+ * can star it themselves.
  *
  * @returns the new entry's id, or null if this user already had one.
  */
@@ -50,22 +55,15 @@ export async function createGettingStartedArticle(
     return null;
   }
 
+  let article;
   try {
-    const article = await uploadArticle(db, userId, {
+    article = await uploadArticle(db, userId, {
       content: GETTING_STARTED_MARKDOWN,
       title: GETTING_STARTED_TITLE,
       excerpt: GETTING_STARTED_EXCERPT,
     });
-
-    // Starred so it stays easy to find after it scrolls out of the timeline.
-    // A separate call (rather than an insert-time flag) so it goes through the
-    // same counter/SSE path as a user starring it by hand.
-    await updateEntryStarred(db, userId, article.id, true);
-
-    logger.info("Created Getting Started article", { userId, entryId: article.id });
-    return article.id;
   } catch (err) {
-    // Release the claim so the backfill job can try again.
+    // Nothing was inserted, so hand the user back to the backfill.
     await db
       .update(users)
       .set({ gettingStartedAt: null })
@@ -75,6 +73,22 @@ export async function createGettingStartedArticle(
       });
     throw err;
   }
+
+  // Starred so it stays easy to find after it scrolls out of the timeline. A
+  // separate call rather than an insert-time flag, so it emits the same
+  // `entry_state_changed` event a hand-star does and open tabs update live.
+  try {
+    await updateEntryStarred(db, userId, article.id, true);
+  } catch (err) {
+    logger.error("Created Getting Started article but failed to star it", {
+      userId,
+      entryId: article.id,
+      err,
+    });
+  }
+
+  logger.info("Created Getting Started article", { userId, entryId: article.id });
+  return article.id;
 }
 
 /**

--- a/src/server/services/getting-started.ts
+++ b/src/server/services/getting-started.ts
@@ -1,0 +1,138 @@
+/**
+ * Getting Started Article Service
+ *
+ * Inserts the onboarding article (issue #1397) as a starred saved article, once
+ * per user. Called fire-and-forget from the signup paths and, for users who
+ * predate the feature, from the `backfill_getting_started` job.
+ *
+ * The article goes in through the ordinary Markdown upload path, so it is a
+ * completely normal saved article afterwards: the user can unstar it, mark it
+ * read, or delete it. `users.getting_started_at` is what stops us re-adding it
+ * (issue #1383) — it records that we inserted the article, not that the article
+ * still exists.
+ */
+
+import { and, eq, isNull } from "drizzle-orm";
+import * as Sentry from "@sentry/nextjs";
+
+import type { Database } from "@/server/db";
+import { users } from "@/server/db/schema";
+import { logger } from "@/lib/logger";
+import { uploadArticle } from "@/server/services/saved";
+import { updateEntryStarred } from "@/server/services/entries";
+import {
+  GETTING_STARTED_EXCERPT,
+  GETTING_STARTED_MARKDOWN,
+  GETTING_STARTED_TITLE,
+} from "@/server/services/getting-started-content";
+
+/**
+ * Inserts the Getting Started article for a user, unless they already got one.
+ *
+ * The flag is claimed *before* the insert (`UPDATE ... WHERE
+ * getting_started_at IS NULL RETURNING`), so a signup racing the backfill job
+ * can't produce two copies. If anything after the claim fails, the flag is
+ * released again so the next backfill run retries.
+ *
+ * @returns the new entry's id, or null if this user already had one.
+ */
+export async function createGettingStartedArticle(
+  db: Database,
+  userId: string
+): Promise<string | null> {
+  const claimed = await db
+    .update(users)
+    .set({ gettingStartedAt: new Date() })
+    .where(and(eq(users.id, userId), isNull(users.gettingStartedAt)))
+    .returning({ id: users.id });
+
+  if (claimed.length === 0) {
+    return null;
+  }
+
+  try {
+    const article = await uploadArticle(db, userId, {
+      content: GETTING_STARTED_MARKDOWN,
+      title: GETTING_STARTED_TITLE,
+      excerpt: GETTING_STARTED_EXCERPT,
+    });
+
+    // Starred so it stays easy to find after it scrolls out of the timeline.
+    // A separate call (rather than an insert-time flag) so it goes through the
+    // same counter/SSE path as a user starring it by hand.
+    await updateEntryStarred(db, userId, article.id, true);
+
+    logger.info("Created Getting Started article", { userId, entryId: article.id });
+    return article.id;
+  } catch (err) {
+    // Release the claim so the backfill job can try again.
+    await db
+      .update(users)
+      .set({ gettingStartedAt: null })
+      .where(eq(users.id, userId))
+      .catch(() => {
+        // Nothing left to do — the user just won't get the article.
+      });
+    throw err;
+  }
+}
+
+/**
+ * Same, but never throws — for the fire-and-forget signup callers, where
+ * failing to add an onboarding article must not fail the signup.
+ */
+export async function tryCreateGettingStartedArticle(db: Database, userId: string): Promise<void> {
+  try {
+    await createGettingStartedArticle(db, userId);
+  } catch (err) {
+    logger.error("Failed to create Getting Started article", { userId, err });
+    Sentry.captureException(err, {
+      tags: { source: "getting-started-article" },
+      extra: { userId },
+    });
+  }
+}
+
+/** Result of one {@link backfillGettingStartedArticles} pass. */
+export interface GettingStartedBackfillResult {
+  /** Users we attempted in this pass (the batch size, until the tail). */
+  attempted: number;
+  /** Users who got an article. */
+  created: number;
+  /** Users whose insert failed; their claim was released, so they're retried. */
+  failed: number;
+}
+
+/**
+ * Inserts the article for up to `limit` users who don't have one yet.
+ *
+ * One user at a time: this runs on the worker with no deadline, and rendering
+ * plus two inserts per user is cheap, so there's no reason to add concurrency
+ * (and every reason not to compete with feed fetching for the pool).
+ */
+export async function backfillGettingStartedArticles(
+  db: Database,
+  limit: number
+): Promise<GettingStartedBackfillResult> {
+  const pending = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(isNull(users.gettingStartedAt))
+    .limit(limit);
+
+  let created = 0;
+  let failed = 0;
+
+  for (const user of pending) {
+    try {
+      if (await createGettingStartedArticle(db, user.id)) {
+        created++;
+      }
+    } catch (err) {
+      failed++;
+      logger.error("Getting Started backfill failed for user", { userId: user.id, err });
+    }
+  }
+
+  return { attempted: pending.length, created, failed };
+}

--- a/src/server/services/getting-started.ts
+++ b/src/server/services/getting-started.ts
@@ -39,6 +39,11 @@ import {
  * unstarred article is a much better failure than a duplicate one, and the user
  * can star it themselves.
  *
+ * Deliberately biased that way at the other end too: the claim commits on its
+ * own, so a process that dies between the claim and the insert leaves that one
+ * user with no article and nothing to retry it. Losing an onboarding article
+ * beats showing someone two of them.
+ *
  * @returns the new entry's id, or null if this user already had one.
  */
 export async function createGettingStartedArticle(

--- a/src/server/trpc/routers/auth.ts
+++ b/src/server/trpc/routers/auth.ts
@@ -45,7 +45,7 @@ import {
   validateDiscordCallback,
   isDiscordOAuthEnabled,
 } from "@/server/auth/oauth/discord";
-import { createUser, subscribeToAnnouncementFeed } from "@/server/auth/signup";
+import { createUser, runPostSignupTasks } from "@/server/auth/signup";
 import { processOAuthCallback } from "@/server/auth/oauth/callback";
 import { GOOGLE_DRIVE_SCOPE } from "@/server/google/docs";
 import {
@@ -234,8 +234,9 @@ export const authRouter = createTRPCRouter({
         return { user, token };
       });
 
-      // Auto-subscribe to announcement feed (fire-and-forget, errors are caught internally)
-      void subscribeToAnnouncementFeed(ctx.db, result.user.userId);
+      // Announcement-feed subscription + Getting Started article (fire-and-forget,
+      // errors are caught internally)
+      void runPostSignupTasks(ctx.db, result.user.userId);
 
       // Set the httpOnly session cookie for the browser (the returned sessionToken
       // stays in the body for REST/OpenAPI clients that read it directly).

--- a/tests/integration/getting-started.test.ts
+++ b/tests/integration/getting-started.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Integration tests for the Getting Started onboarding article (issue #1397).
+ *
+ * The behavior worth pinning down is the once-ever guarantee: the article shows
+ * up starred and unread for a new user, and once a user has had it, nothing —
+ * a second signup-path call, the backfill job, or deleting the article — brings
+ * it back (issue #1383).
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { and, eq } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users, entries, userEntries } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import {
+  backfillGettingStartedArticles,
+  createGettingStartedArticle,
+} from "../../src/server/services/getting-started";
+import { GETTING_STARTED_TITLE } from "../../src/server/services/getting-started-content";
+import { deleteSavedArticle } from "../../src/server/services/saved";
+import { getSavedFeedId } from "../../src/server/feed/saved-feed";
+
+const createdUserIds: string[] = [];
+
+async function createTestUser(): Promise<string> {
+  const userId = generateUuidv7();
+  await db.insert(users).values({
+    id: userId,
+    email: `getting-started-${userId}@test.com`,
+    passwordHash: "test-hash",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  createdUserIds.push(userId);
+  return userId;
+}
+
+/** Every saved entry the user can see, newest first. */
+async function savedEntriesFor(userId: string) {
+  const savedFeedId = await getSavedFeedId(db, userId);
+  if (!savedFeedId) return [];
+  return db
+    .select({
+      id: entries.id,
+      title: entries.title,
+      summary: entries.summary,
+      contentOriginal: entries.contentOriginal,
+      read: userEntries.read,
+      starred: userEntries.starred,
+    })
+    .from(entries)
+    .innerJoin(
+      userEntries,
+      and(eq(userEntries.entryId, entries.id), eq(userEntries.userId, userId))
+    )
+    .where(eq(entries.feedId, savedFeedId));
+}
+
+async function gettingStartedAt(userId: string): Promise<Date | null> {
+  const [row] = await db
+    .select({ at: users.gettingStartedAt })
+    .from(users)
+    .where(eq(users.id, userId));
+  return row.at;
+}
+
+const DRAIN_BATCH = 200;
+const DRAIN_MAX_ROUNDS = 25;
+
+/**
+ * Runs the backfill until no pending users are left.
+ *
+ * The backfill is global by design, and this database is shared with the other
+ * integration test files, so a single batch isn't guaranteed to reach our user.
+ * Draining is also what makes the "no pending users left" assertion meaningful.
+ */
+async function drainBackfill(): Promise<{ rounds: number; created: number }> {
+  let created = 0;
+  for (let rounds = 1; rounds <= DRAIN_MAX_ROUNDS; rounds++) {
+    const result = await backfillGettingStartedArticles(db, DRAIN_BATCH);
+    created += result.created;
+    if (result.attempted === 0) return { rounds, created };
+  }
+  return { rounds: DRAIN_MAX_ROUNDS, created };
+}
+
+afterAll(async () => {
+  for (const id of createdUserIds) {
+    await db.delete(users).where(eq(users.id, id));
+  }
+});
+
+describe("createGettingStartedArticle", () => {
+  it("adds a starred, unread saved article and stamps the user", async () => {
+    const userId = await createTestUser();
+
+    const entryId = await createGettingStartedArticle(db, userId);
+    expect(entryId).not.toBeNull();
+
+    const saved = await savedEntriesFor(userId);
+    expect(saved).toHaveLength(1);
+    expect(saved[0].title).toBe(GETTING_STARTED_TITLE);
+    expect(saved[0].starred).toBe(true);
+    expect(saved[0].read).toBe(false);
+    // Rendered through the Markdown pipeline, with its in-app links intact.
+    expect(saved[0].contentOriginal).toContain('href="/subscribe"');
+    expect(saved[0].summary).toBeTruthy();
+
+    expect(await gettingStartedAt(userId)).toBeInstanceOf(Date);
+
+    // The starred counter the badge reads must see it.
+    const [counts] = await db
+      .select({ starred: users.starredUnreadCount, saved: users.savedUnreadCount })
+      .from(users)
+      .where(eq(users.id, userId));
+    expect(counts.starred).toBe(1);
+    expect(counts.saved).toBe(1);
+  });
+
+  it("is a no-op the second time", async () => {
+    const userId = await createTestUser();
+
+    expect(await createGettingStartedArticle(db, userId)).not.toBeNull();
+    expect(await createGettingStartedArticle(db, userId)).toBeNull();
+
+    expect(await savedEntriesFor(userId)).toHaveLength(1);
+  });
+
+  it("does not re-add the article after the user deletes it", async () => {
+    const userId = await createTestUser();
+
+    const entryId = await createGettingStartedArticle(db, userId);
+    expect(entryId).not.toBeNull();
+    expect(await deleteSavedArticle(db, userId, entryId!)).toBe(true);
+
+    // Both the signup path and the backfill must leave it deleted.
+    expect(await createGettingStartedArticle(db, userId)).toBeNull();
+    await drainBackfill();
+
+    expect(await savedEntriesFor(userId)).toHaveLength(0);
+  });
+
+  it("leaves an unstarred copy unstarred", async () => {
+    const userId = await createTestUser();
+    const entryId = await createGettingStartedArticle(db, userId);
+
+    await db
+      .update(userEntries)
+      .set({ starred: false })
+      .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, entryId!)));
+
+    expect(await createGettingStartedArticle(db, userId)).toBeNull();
+
+    const saved = await savedEntriesFor(userId);
+    expect(saved).toHaveLength(1);
+    expect(saved[0].starred).toBe(false);
+  });
+});
+
+describe("backfillGettingStartedArticles", () => {
+  it("covers a user who predates the feature", async () => {
+    const userId = await createTestUser();
+    expect(await gettingStartedAt(userId)).toBeNull();
+
+    const { rounds, created } = await drainBackfill();
+
+    expect(created).toBeGreaterThan(0);
+    // Every round but the last filled a full batch, so this converged.
+    expect(rounds).toBeLessThan(DRAIN_MAX_ROUNDS);
+    expect(await gettingStartedAt(userId)).toBeInstanceOf(Date);
+    expect(await savedEntriesFor(userId)).toHaveLength(1);
+
+    // Nothing is left over: a second pass finds no pending users.
+    expect(await backfillGettingStartedArticles(db, DRAIN_BATCH)).toEqual({
+      attempted: 0,
+      created: 0,
+      failed: 0,
+    });
+  });
+});

--- a/tests/integration/getting-started.test.ts
+++ b/tests/integration/getting-started.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, afterAll } from "vitest";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull, ne } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import { users, entries, userEntries } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
@@ -64,24 +64,23 @@ async function gettingStartedAt(userId: string): Promise<Date | null> {
   return row.at;
 }
 
-const DRAIN_BATCH = 200;
-const DRAIN_MAX_ROUNDS = 25;
+const BATCH = 100;
 
 /**
- * Runs the backfill until no pending users are left.
+ * Marks every *other* user in this database as already covered.
  *
- * The backfill is global by design, and this database is shared with the other
- * integration test files, so a single batch isn't guaranteed to reach our user.
- * Draining is also what makes the "no pending users left" assertion meaningful.
+ * The backfill is global by design, and this database is shared with 50-odd
+ * other integration files whose leftover user rows are all pending. Without
+ * this the backfill would create articles for them (slow, and it mutates rows
+ * this file doesn't own) and the batch counts would depend on how dirty the
+ * database happened to be. Stamping the flag — and only the flag — leaves our
+ * user as the single pending row, so the counts below are exact.
  */
-async function drainBackfill(): Promise<{ rounds: number; created: number }> {
-  let created = 0;
-  for (let rounds = 1; rounds <= DRAIN_MAX_ROUNDS; rounds++) {
-    const result = await backfillGettingStartedArticles(db, DRAIN_BATCH);
-    created += result.created;
-    if (result.attempted === 0) return { rounds, created };
-  }
-  return { rounds: DRAIN_MAX_ROUNDS, created };
+async function claimEveryoneElse(ourUserId: string): Promise<void> {
+  await db
+    .update(users)
+    .set({ gettingStartedAt: new Date() })
+    .where(and(isNull(users.gettingStartedAt), ne(users.id, ourUserId)));
 }
 
 afterAll(async () => {
@@ -135,7 +134,12 @@ describe("createGettingStartedArticle", () => {
 
     // Both the signup path and the backfill must leave it deleted.
     expect(await createGettingStartedArticle(db, userId)).toBeNull();
-    await drainBackfill();
+    await claimEveryoneElse(userId);
+    expect(await backfillGettingStartedArticles(db, BATCH)).toEqual({
+      attempted: 0,
+      created: 0,
+      failed: 0,
+    });
 
     expect(await savedEntriesFor(userId)).toHaveLength(0);
   });
@@ -161,17 +165,19 @@ describe("backfillGettingStartedArticles", () => {
   it("covers a user who predates the feature", async () => {
     const userId = await createTestUser();
     expect(await gettingStartedAt(userId)).toBeNull();
+    await claimEveryoneElse(userId);
 
-    const { rounds, created } = await drainBackfill();
+    expect(await backfillGettingStartedArticles(db, BATCH)).toEqual({
+      attempted: 1,
+      created: 1,
+      failed: 0,
+    });
 
-    expect(created).toBeGreaterThan(0);
-    // Every round but the last filled a full batch, so this converged.
-    expect(rounds).toBeLessThan(DRAIN_MAX_ROUNDS);
     expect(await gettingStartedAt(userId)).toBeInstanceOf(Date);
     expect(await savedEntriesFor(userId)).toHaveLength(1);
 
     // Nothing is left over: a second pass finds no pending users.
-    expect(await backfillGettingStartedArticles(db, DRAIN_BATCH)).toEqual({
+    expect(await backfillGettingStartedArticles(db, BATCH)).toEqual({
       attempted: 0,
       created: 0,
       failed: 0,

--- a/tests/integration/signup-invite.test.ts
+++ b/tests/integration/signup-invite.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Integration test for invite-claiming signup (`createUser`).
+ *
+ * Currently skipped: invite-based signup is broken (issue #1447). `createUser`
+ * writes `invites.used_by_user_id = userId` before inserting the user row, and
+ * the FK added in migration 0076 is non-deferrable, so the claim fails the
+ * statement-level check with a 23503. This test asserts the intended behavior;
+ * un-skip it when #1447 is fixed.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users, invites } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createUser } from "../../src/server/auth/signup";
+
+const createdUserIds: string[] = [];
+const createdInviteIds: string[] = [];
+
+async function createInvite(): Promise<string> {
+  const id = generateUuidv7();
+  const token = `invite-${id}`;
+  await db.insert(invites).values({
+    id,
+    token,
+    expiresAt: new Date(Date.now() + 86_400_000),
+    createdAt: new Date(),
+  });
+  createdInviteIds.push(id);
+  return token;
+}
+
+afterAll(async () => {
+  for (const id of createdUserIds) {
+    await db.delete(users).where(eq(users.id, id));
+  }
+  for (const id of createdInviteIds) {
+    await db.delete(invites).where(eq(invites.id, id));
+  }
+});
+
+describe.skip("createUser with an invite (issue #1447)", () => {
+  it("creates the user and marks the invite used", async () => {
+    const token = await createInvite();
+    process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS = "";
+
+    const user = await db.transaction((tx) =>
+      createUser(tx, {
+        email: `invite-signup-${generateUuidv7()}@test.com`,
+        passwordHash: "test-hash",
+        emailVerified: false,
+        inviteToken: token,
+        provider: "email",
+      })
+    );
+    createdUserIds.push(user.userId);
+
+    const [invite] = await db.select().from(invites).where(eq(invites.token, token));
+    expect(invite.usedAt).toBeInstanceOf(Date);
+    expect(invite.usedByUserId).toBe(user.userId);
+
+    const [row] = await db.select().from(users).where(eq(users.id, user.userId));
+    expect(row.inviteId).toBe(invite.id);
+  });
+});

--- a/tests/unit/getting-started-content.test.ts
+++ b/tests/unit/getting-started-content.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Guards on the Getting Started article's content (issue #1397).
+ *
+ * The article is the first thing a new user reads, and it is almost entirely
+ * links into the app. A route that gets renamed would leave dead links in every
+ * future user's inbox with nothing to catch it, so the in-app links are checked
+ * against the routes that actually exist in src/app.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { describe, it, expect } from "vitest";
+
+import {
+  GETTING_STARTED_EXCERPT,
+  GETTING_STARTED_MARKDOWN,
+  GETTING_STARTED_TITLE,
+} from "../../src/server/services/getting-started-content";
+import { processMarkdown } from "../../src/server/markdown";
+import { sanitizeEntryHtmlAsync } from "../../src/server/html/sanitize";
+
+const APP_DIR = path.join(__dirname, "..", "..", "src", "app");
+
+/**
+ * Every routable pathname in src/app, derived from its page.tsx files: strip
+ * the route-group segments `(spa)`, `(app)`, `(public)`, … and turn the rest
+ * into a URL path. Dynamic segments (`[id]`) are left as-is; the article
+ * doesn't link to any.
+ */
+function appRoutes(): Set<string> {
+  const routes = new Set<string>();
+
+  const walk = (dir: string, segments: string[]): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        const isRouteGroup = entry.name.startsWith("(") && entry.name.endsWith(")");
+        walk(path.join(dir, entry.name), isRouteGroup ? segments : [...segments, entry.name]);
+      } else if (entry.name === "page.tsx") {
+        routes.add(`/${segments.join("/")}`);
+      }
+    }
+  };
+
+  walk(APP_DIR, []);
+  return routes;
+}
+
+/** `[label](target)` targets, in order. */
+function markdownLinkTargets(markdown: string): string[] {
+  return [...markdown.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)].map((m) => m[1]);
+}
+
+describe("Getting Started content", () => {
+  it("only links to app routes that exist", () => {
+    const routes = appRoutes();
+    const internal = markdownLinkTargets(GETTING_STARTED_MARKDOWN).filter((t) => t.startsWith("/"));
+
+    // Strip the query string — /demo/all?entry=welcome routes to /demo/all.
+    const missing = internal.filter((target) => !routes.has(target.split("?")[0]));
+
+    expect(missing).toEqual([]);
+    // Guard against the regex silently matching nothing.
+    expect(internal.length).toBeGreaterThan(5);
+  });
+
+  it("uses relative links for anything in-app", () => {
+    // An absolute lionreader.com link would be wrong on a self-hosted instance.
+    const absolute = markdownLinkTargets(GETTING_STARTED_MARKDOWN).filter((t) =>
+      /^https?:\/\/(www\.)?lionreader\.com/i.test(t)
+    );
+    expect(absolute).toEqual([]);
+  });
+
+  it("has a title and an excerpt", () => {
+    expect(GETTING_STARTED_TITLE.length).toBeGreaterThan(0);
+    expect(GETTING_STARTED_EXCERPT.length).toBeGreaterThan(0);
+    // The body's own first lines are a poor excerpt, so one is supplied; if it
+    // ever grows past the saved-article clip it just gets truncated.
+    expect(GETTING_STARTED_EXCERPT.length).toBeLessThanOrEqual(300);
+  });
+
+  it("starts with prose, not a heading that would become the title", () => {
+    // processMarkdown promotes a leading H1 into the title, which would then
+    // fight the explicit title we pass to uploadArticle.
+    expect(GETTING_STARTED_MARKDOWN.startsWith("#")).toBe(false);
+  });
+});
+
+describe("Getting Started rendering", () => {
+  it("renders through the real pipeline with working links and no stray breaks", async () => {
+    const rendered = await processMarkdown(GETTING_STARTED_MARKDOWN);
+    const html = await sanitizeEntryHtmlAsync(rendered.html);
+
+    // Our dialect turns a single newline into a <br>, so hard-wrapping the
+    // source would show up as ragged line breaks mid-paragraph.
+    expect(html).not.toContain("<br");
+
+    // In-app links stay same-tab; external ones are given a safe new tab.
+    expect(html).toContain('<a href="/subscribe">');
+    expect(html).toContain('<a href="/settings/ai">');
+    expect(html).toContain(
+      '<a href="https://modelcontextprotocol.io/" target="_blank" rel="noopener noreferrer">'
+    );
+
+    // No leading H1 to compete with the explicit title.
+    expect(rendered.title).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1397.

## What new users get

A **Getting Started** article, starred and unread, waiting in their reader on first login. It's a short tour that links straight to the settings page that configures each thing:

1. **Get some content in** — subscribe, OPML import, newsletter ingest addresses, the extension/bookmarklet/upload paths, plugin-aware saving
2. **Read it your way** — keyboard shortcuts, swipe, full-content fetching
3. **Make it yours** — themes, fonts, density
4. **Optional: AI summaries and narration** — Anthropic/Cerebras keys, and that narration works without a key and can be turned off entirely
5. **Optional: connect an AI agent over MCP** — Claude Code / Claude Desktop, with the claude.ai web caveat (#986)
6. **Optional: apps for your phone and desktop** — PWA install, Google Reader API clients, Wallabag apps

![Getting Started article](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/getting-started-1397/gs-article-1.png)

## How it's inserted

Through the **ordinary Markdown upload path** (`uploadArticle`), so it's a completely normal saved article afterwards — the user can unstar it, mark it read, or delete it — and it shares one Markdown dialect, one sanitizer, and one excerpt pipeline with everything else.

`users.getting_started_at` records **that we inserted it, not that it still exists**. It's claimed atomically *before* the insert (`UPDATE ... WHERE getting_started_at IS NULL RETURNING`) and released only if the insert then fails, so:

- a signup racing the backfill can't double-insert, and
- deleting the article never brings it back (#1383).

Both signup paths now go through one `runPostSignupTasks`, so the email/password and OAuth flows can't drift apart as onboarding grows.

**Existing users** are covered by a `backfill_getting_started` singleton job: a batch of 100 per run, rescheduling in 15s while it's both filling batches and making progress, then dropping to a daily cadence. It never parks — that daily scan doubles as a retry for anyone whose signup-path insert failed, and once the partial index drains it costs nothing.

## Discoverability

The subscribe page now points at OPML import, which is where someone moving from another reader lands first.

![Subscribe page with OPML link](https://raw.githubusercontent.com/brendanlong/lion-reader/assets/getting-started-1397/gs-subscribe.png)

## Tests

- `tests/unit/getting-started-content.test.ts` checks **every in-app link against the routes that actually exist in `src/app`**, so a renamed route fails CI instead of shipping dead links to every future user. It also renders the body through the real Markdown + sanitizer pipeline to catch hard-wrapped source turning into ragged `<br>` breaks, and asserts relative links stay same-tab while external ones get `target="_blank"`.
- `tests/integration/getting-started.test.ts` covers the once-ever guarantee: starred + unread + counters on first insert, no-op on the second call, still gone after the user deletes it, unstarring sticks, and the backfill converges.

## Verified end-to-end

Ran the real `runPostSignupTasks` against a local instance, logged in, and confirmed the article appears starred and unread under **Starred**, renders as shown above, and that its in-article links navigate (the screenshots are from that session).

## Also

Found and filed **#1447** while verifying: invite-based signup always fails a non-deferrable FK check, because `createUser` claims the invite before inserting the user row. Unrelated to this change, so this PR only adds a skipped test documenting the intended behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)