### PR TITLE
Fix Threads saves: match /share/ URLs, guard redirects, log declines

### DIFF
--- a/src/server/plugins/linkedin.ts
+++ b/src/server/plugins/linkedin.ts
@@ -330,7 +330,11 @@ export const linkedInPlugin: UrlPlugin = {
 
         const content = renderLinkedInPost(page.html, page.finalUrl);
         if (!content) {
-          logger.debug("LinkedIn post page carried no usable body", { url: url.href });
+          // Info, not debug: this is the plugin silently declining a page it
+          // matched, which is exactly the failure a scraper degrades into when
+          // the markup changes or the post goes private. Prod runs at info, so
+          // at debug the degradation is invisible.
+          logger.info("LinkedIn post page carried no usable body", { url: url.href });
         }
         return content;
       },

--- a/src/server/plugins/threads.ts
+++ b/src/server/plugins/threads.ts
@@ -42,9 +42,17 @@ import { logger } from "@/lib/logger";
 const THREADS_HOSTS = new Set(["threads.com", "www.threads.com", "threads.net", "www.threads.net"]);
 
 /**
- * Parse a Threads post URL into its shortcode. Handles the canonical
- * `/@handle/post/{code}` form (with or without the SEO slug Threads appends),
- * and the `/t/{code}` short permalink its embeds use.
+ * Parse a URL that identifies a single Threads post, returning its id. Threads
+ * hands out three forms and a saved URL can be any of them:
+ *
+ * - `/@handle/post/{code}` — canonical, with or without the SEO slug appended
+ * - `/t/{code}` — short permalink, used by embeds
+ * - `/share/{code}` — what the app's share sheet produces, so it's the form
+ *   most likely to be pasted in; note its id is a share id in its own space,
+ *   not the post's shortcode
+ *
+ * The last two redirect to the canonical form, so `fetchContent` re-checks the
+ * URL it actually landed on rather than trusting the id here to be a post's.
  */
 export function parseThreadsPostCode(url: URL): string | null {
   if (!THREADS_HOSTS.has(url.hostname.toLowerCase())) {
@@ -63,8 +71,8 @@ export function parseThreadsPostCode(url: URL): string | null {
     return parts[2];
   }
 
-  // /t/{code} — the short permalink form used in embeds and share sheets.
-  if (parts.length === 2 && parts[0] === "t" && parts[1]) {
+  // /t/{code} and /share/{code} — both redirect to the canonical form.
+  if (parts.length === 2 && (parts[0] === "t" || parts[0] === "share") && parts[1]) {
     return parts[1];
   }
 
@@ -167,8 +175,8 @@ export const threadsPlugin: UrlPlugin = {
       siteName: "Threads",
 
       async fetchContent(url: URL): Promise<SavedArticleContent | null> {
-        // Fetch what the user gave us; `/t/{code}` redirects to the canonical
-        // `/@handle/post/{code}`, and both serve the same Open Graph tags.
+        // Fetch what the user gave us; the short forms redirect to the
+        // canonical `/@handle/post/{code}`, which serves the Open Graph tags.
         const page = await fetchPluginPage(url, "threads");
         if (!page) {
           return null;
@@ -181,7 +189,7 @@ export const threadsPlugin: UrlPlugin = {
         // so unlike LinkedIn there is no type to gate on; confirming the page we
         // landed on is still a post is this plugin's equivalent of that gate.
         if (!parseThreadsPostCode(new URL(page.finalUrl))) {
-          logger.debug("Threads post URL redirected away from the post", {
+          logger.info("Threads post URL redirected away from the post", {
             url: url.href,
             finalUrl: page.finalUrl,
           });
@@ -190,7 +198,8 @@ export const threadsPlugin: UrlPlugin = {
 
         const content = renderThreadsPost(page.html, page.finalUrl);
         if (!content) {
-          logger.debug("Threads post page carried no post text", { url: url.href });
+          // See the LinkedIn plugin for why these decline paths log at info.
+          logger.info("Threads post page carried no post text", { url: url.href });
         }
         return content;
       },

--- a/src/server/plugins/threads.ts
+++ b/src/server/plugins/threads.ts
@@ -174,6 +174,20 @@ export const threadsPlugin: UrlPlugin = {
           return null;
         }
 
+        // A deleted or invalid post redirects to the Threads home page
+        // (`/?error=invalid_post`), which carries its own `og:description` —
+        // "Join Threads to share ideas, ask questions…" — that would otherwise
+        // be saved as the post body. Every Threads page has an `og:description`,
+        // so unlike LinkedIn there is no type to gate on; confirming the page we
+        // landed on is still a post is this plugin's equivalent of that gate.
+        if (!parseThreadsPostCode(new URL(page.finalUrl))) {
+          logger.debug("Threads post URL redirected away from the post", {
+            url: url.href,
+            finalUrl: page.finalUrl,
+          });
+          return null;
+        }
+
         const content = renderThreadsPost(page.html, page.finalUrl);
         if (!content) {
           logger.debug("Threads post page carried no post text", { url: url.href });

--- a/tests/unit/threads-plugin.test.ts
+++ b/tests/unit/threads-plugin.test.ts
@@ -49,6 +49,30 @@ describe("parseThreadsPostCode", () => {
     );
   });
 
+  // What the Threads app's share sheet produces, so it's the form most likely
+  // to be pasted into the app. Its id lives in its own space, not the post's
+  // shortcode space, and it 302s to the canonical URL.
+  it("parses the /share/ form the app's share sheet produces", () => {
+    for (const href of [
+      "https://www.threads.com/share/BAd-r4UCHz/",
+      "https://www.threads.com/share/BAd-r4UCHz",
+      "https://threads.com/share/BAd-r4UCHz",
+      "https://www.threads.net/share/BAd-r4UCHz/",
+    ]) {
+      expect(parseThreadsPostCode(new URL(href))).toBe("BAd-r4UCHz");
+    }
+  });
+
+  it("drives matchUrl for every form Threads hands out", () => {
+    for (const href of [
+      "https://www.threads.com/@smbccomics/post/DbYcIlkj-Pv",
+      "https://www.threads.com/t/DbYcIlkj-Pv",
+      "https://www.threads.com/share/BAd-r4UCHz/",
+    ]) {
+      expect(threadsPlugin.matchUrl(new URL(href))).toBe(true);
+    }
+  });
+
   it("handles both the threads.com and threads.net domains, with or without www", () => {
     for (const host of ["threads.com", "www.threads.com", "threads.net", "www.threads.net"]) {
       expect(parseThreadsPostCode(new URL(`https://${host}/@anujs3/post/DNG2tXiBjzN`))).toBe(

--- a/tests/unit/threads-plugin.test.ts
+++ b/tests/unit/threads-plugin.test.ts
@@ -63,6 +63,13 @@ describe("parseThreadsPostCode", () => {
     }
   });
 
+  // fetchContent guards against redirects with this: a deleted or invalid post
+  // redirects here, and the home page carries its own og:description that would
+  // otherwise be saved as the post body.
+  it("returns null for the home page a dead post redirects to", () => {
+    expect(parseThreadsPostCode(new URL("https://www.threads.com/?error=invalid_post"))).toBeNull();
+  });
+
   it("returns null for non-Threads hosts", () => {
     expect(parseThreadsPostCode(new URL("https://example.com/@a/post/b"))).toBeNull();
   });


### PR DESCRIPTION
Fixes the reported bug where a saved Threads post had the post text as its excerpt but *"Log in or sign up for Threads…"* as its body, plus two related problems found along the way.

## The actual bug: `/share/` URLs were never matched

`https://www.threads.com/share/BAd-r4UCHz/` is what the **Threads app's share sheet produces** — so it's the form most likely to be pasted into the app — and `matchUrl` didn't recognize it. The plugin never ran, the save fell through to Readability, and Readability extracted the login wall.

The excerpt looked *right* the whole time because Readability takes excerpts from `og:description`, which on Threads is the post text. Only the body was wrong. That split is what made it look like a plugin failure rather than a plugin that never fired.

`/share/{code}` 302s to the canonical `/@handle/post/{code}`, and its id lives in its own space rather than the post shortcode's — the redirect guard below re-checks the URL we land on, so nothing has to trust that id.

I probed for the other forms rather than guessing again: `/p/{code}` is a 404 and `m.threads.com` doesn't resolve, so those aren't gaps. `/share/` works across all four host spellings.

Verified end-to-end with the exact reported URL:

```
matchUrl: true
plugin:   OK
  title:  I can barely enjoy Amleth anymore.
  author: SMBC Comics (@smbccomics)
full save -> siteName=Threads
```

## Redirect guard

A deleted or invalid post redirects to `https://www.threads.com/?error=invalid_post`, whose home page carries its own `og:description` — so we saved *"Join Threads to share ideas, ask questions, post random thoughts, find your people and more"* as the post body. Reproduced with `@zuck/post/C7lLcpjRhBz`.

Every Threads page has an `og:description`, so unlike LinkedIn there's no declared type to gate on. Confirming the page we actually landed on is still a post URL is this plugin's equivalent of LinkedIn's `@type` gate — the same "only claim a page you positively recognize" rule from `docs/DESIGN.md`, applied across redirects instead of within a page. It also covers the `/share/` id being opaque.

## Decline paths now log at info

Both plugins are built to degrade — private post, changed markup, blocked IP — but their decline paths logged at `debug` while prod runs at `info`. **This bug produced no production log line at all**, which is why I couldn't diagnose it from logs and guessed wrong about the cause. Raised to `info` so a silent fallback is visible.

---

Unit 2716, integration 728, typecheck, lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
