### PR TITLE
Insert the user before claiming the invite (#1447)

### DIFF
--- a/src/server/auth/oauth/callback.ts
+++ b/src/server/auth/oauth/callback.ts
@@ -12,7 +12,7 @@
 
 import { eq, and } from "drizzle-orm";
 
-import { db, type Database } from "@/server/db";
+import { db } from "@/server/db";
 import { users, oauthAccounts } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
 import { createUser, runPostSignupTasks } from "@/server/auth/signup";
@@ -72,11 +72,6 @@ export interface ProcessOAuthCallbackResult {
   /** Whether this is a newly created user */
   isNewUser: boolean;
 }
-
-/**
- * Transaction type for database operations
- */
-type DbOrTx = Database | Parameters<Parameters<Database["transaction"]>[0]>[0];
 
 /**
  * Process an OAuth callback for login/signup.
@@ -210,7 +205,7 @@ export async function processOAuthCallback(
   }
 
   // Create new user and OAuth account in a transaction
-  const newUser = await db.transaction(async (tx: DbOrTx) => {
+  const newUser = await db.transaction(async (tx) => {
     // Create user (handles invite validation and provider restriction atomically)
     const user = await createUser(tx, {
       email,

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -11,7 +11,7 @@
 
 import crypto from "crypto";
 import { eq, and, isNull, ne, gt, sql } from "drizzle-orm";
-import { db, type Database } from "@/server/db";
+import { db, type DbOrTx } from "@/server/db";
 import { sessions, users, type User, type Session } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
 import { getRedisClient } from "@/server/redis";
@@ -174,11 +174,6 @@ export interface CreateSessionResult {
   /** Raw session token to return to client (never stored) */
   token: string;
 }
-
-/**
- * Transaction type - accepts both db and transaction contexts
- */
-type DbOrTx = Database | Parameters<Parameters<Database["transaction"]>[0]>[0];
 
 /**
  * Creates a new session for a user.

--- a/src/server/auth/signup.ts
+++ b/src/server/auth/signup.ts
@@ -18,7 +18,7 @@ import { resolveSignupProviderAccess } from "@/server/auth/signup-providers";
 import { generateUuidv7 } from "@/lib/uuidv7";
 import { errors } from "@/server/trpc/errors";
 import { logger } from "@/lib/logger";
-import type { Database } from "@/server/db";
+import type { Database, Transaction } from "@/server/db";
 
 /**
  * Parameters for creating a new user
@@ -46,20 +46,16 @@ export interface CreateUserResult {
 }
 
 /**
- * Transaction type - accepts both db and transaction contexts
- */
-type DbOrTx = Database | Parameters<Parameters<Database["transaction"]>[0]>[0];
-
-/**
  * Creates a new user account with invite validation.
  *
  * This function implements the "just-do-it" pattern for invite tokens:
  * - Atomically tries to claim the invite (UPDATE WHERE conditions RETURNING)
  * - Only queries for error details if the claim fails
  *
- * Should be called within a transaction to ensure atomicity.
+ * Requires a transaction: the user row is inserted before the invite is
+ * claimed, so only a rollback undoes the user when the claim loses a race.
  *
- * @param tx - Database or transaction context
+ * @param tx - Transaction context
  * @param params - User creation parameters
  * @returns The created user info
  * @throws INVITE_REQUIRED if invite is needed but not provided
@@ -67,12 +63,13 @@ type DbOrTx = Database | Parameters<Parameters<Database["transaction"]>[0]>[0];
  * @throws INVITE_ALREADY_USED if invite was already claimed
  * @throws INVITE_EXPIRED if invite has expired
  */
-export async function createUser(tx: DbOrTx, params: CreateUserParams): Promise<CreateUserResult> {
+export async function createUser(
+  tx: Transaction,
+  params: CreateUserParams
+): Promise<CreateUserResult> {
   const { email, passwordHash, emailVerified, inviteToken, provider } = params;
   const now = new Date();
   const userId = generateUuidv7();
-
-  let claimedInviteId: string | undefined;
 
   // Determine how this provider may sign up: publicly, only with an invite, or
   // not at all. Public providers skip the invite requirement entirely.
@@ -81,12 +78,27 @@ export async function createUser(tx: DbOrTx, params: CreateUserParams): Promise<
     throw errors.signupProviderNotAllowed(provider);
   }
 
-  // Invite-only providers must present and claim a valid invite atomically.
-  if (access === "invite-only") {
-    if (!inviteToken) {
-      throw errors.inviteRequired();
-    }
+  // Invite-only providers must present an invite; claiming it happens after the
+  // user row exists (see below).
+  if (access === "invite-only" && !inviteToken) {
+    throw errors.inviteRequired();
+  }
 
+  // Create user. This must come before the invite claim: the claim writes
+  // invites.used_by_user_id, whose FK to users(id) is non-deferrable and so is
+  // checked at the end of that statement, not the transaction (#1447).
+  await tx.insert(users).values({
+    id: userId,
+    email,
+    passwordHash,
+    emailVerifiedAt: emailVerified ? now : null,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  // Invite-only providers must claim a valid invite atomically. A failed claim
+  // throws, which rolls back the user insert above.
+  if (access === "invite-only" && inviteToken) {
     // Just-do-it: try to mark invite as used in one atomic operation
     const claimed = await tx
       .update(invites)
@@ -123,19 +135,10 @@ export async function createUser(tx: DbOrTx, params: CreateUserParams): Promise<
       throw errors.inviteInvalid();
     }
 
-    claimedInviteId = claimed[0].id;
+    // users.invite_id is the other half of the circular FK, so it can only be
+    // set once the invite row is known-claimed.
+    await tx.update(users).set({ inviteId: claimed[0].id }).where(eq(users.id, userId));
   }
-
-  // Create user
-  await tx.insert(users).values({
-    id: userId,
-    email,
-    passwordHash,
-    emailVerifiedAt: emailVerified ? now : null,
-    inviteId: claimedInviteId,
-    createdAt: now,
-    updatedAt: now,
-  });
 
   return {
     userId,

--- a/tests/integration/signup-invite.test.ts
+++ b/tests/integration/signup-invite.test.ts
@@ -164,6 +164,21 @@ describe("createUser with an invite", () => {
     expect(inviteRow.usedByUserId).toBe(survivors[0].id);
   });
 
+  it("rejects a denied provider without creating a user", async () => {
+    process.env.ALLOWED_SIGNUP_PROVIDERS = "google";
+    const invite = await createInvite();
+    const email = `invite-denied-${generateUuidv7()}@example.com`;
+
+    await expectSignupError(
+      signUp({ email, inviteToken: invite.token }),
+      "SIGNUP_PROVIDER_NOT_ALLOWED"
+    );
+    expect(await emailExists(email)).toBe(false);
+
+    const [inviteRow] = await db.select().from(invites).where(eq(invites.id, invite.id));
+    expect(inviteRow.usedAt).toBeNull();
+  });
+
   it("ignores invites for a publicly allowed provider", async () => {
     process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS = "email";
     const email = `invite-public-${generateUuidv7()}@example.com`;

--- a/tests/integration/signup-invite.test.ts
+++ b/tests/integration/signup-invite.test.ts
@@ -1,66 +1,176 @@
 /**
- * Integration test for invite-claiming signup (`createUser`).
+ * Integration tests for invite-based signup (`createUser`).
  *
- * Currently skipped: invite-based signup is broken (issue #1447). `createUser`
- * writes `invites.used_by_user_id = userId` before inserting the user row, and
- * the FK added in migration 0076 is non-deferrable, so the claim fails the
- * statement-level check with a 23503. This test asserts the intended behavior;
- * un-skip it when #1447 is fixed.
+ * Issue #1447: `invites.used_by_user_id` and `users.invite_id` form a circular,
+ * non-deferrable FK pair, so the order of the writes inside the signup
+ * transaction is load-bearing — claiming the invite before the user row existed
+ * made every invite-only signup fail with a 23503. These tests run against a
+ * real Postgres so the constraints are actually enforced.
  */
 
-import { describe, it, expect, afterAll } from "vitest";
-import { eq } from "drizzle-orm";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+
 import { db } from "../../src/server/db";
 import { users, invites } from "../../src/server/db/schema";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createUser } from "../../src/server/auth/signup";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const createdUserIds: string[] = [];
 const createdInviteIds: string[] = [];
 
-async function createInvite(): Promise<string> {
-  const id = generateUuidv7();
-  const token = `invite-${id}`;
-  await db.insert(invites).values({
-    id,
-    token,
-    expiresAt: new Date(Date.now() + 86_400_000),
-    createdAt: new Date(),
-  });
-  createdInviteIds.push(id);
-  return token;
-}
+let originalAllowed: string | undefined;
+let originalPublic: string | undefined;
 
-afterAll(async () => {
-  for (const id of createdUserIds) {
-    await db.delete(users).where(eq(users.id, id));
+beforeEach(() => {
+  originalAllowed = process.env.ALLOWED_SIGNUP_PROVIDERS;
+  originalPublic = process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS;
+  // email + google are allowed, but only with an invite.
+  process.env.ALLOWED_SIGNUP_PROVIDERS = "email,google";
+  delete process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS;
+});
+
+afterEach(async () => {
+  if (originalAllowed === undefined) delete process.env.ALLOWED_SIGNUP_PROVIDERS;
+  else process.env.ALLOWED_SIGNUP_PROVIDERS = originalAllowed;
+  if (originalPublic === undefined) delete process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS;
+  else process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS = originalPublic;
+
+  if (createdUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, createdUserIds.splice(0)));
   }
-  for (const id of createdInviteIds) {
-    await db.delete(invites).where(eq(invites.id, id));
+  if (createdInviteIds.length > 0) {
+    await db.delete(invites).where(inArray(invites.id, createdInviteIds.splice(0)));
   }
 });
 
-describe.skip("createUser with an invite (issue #1447)", () => {
-  it("creates the user and marks the invite used", async () => {
-    const token = await createInvite();
-    process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS = "";
+async function createInvite(options: { expiresAt?: Date; usedAt?: Date } = {}) {
+  const id = generateUuidv7();
+  const token = `test-invite-${id}`;
+  await db.insert(invites).values({
+    id,
+    token,
+    expiresAt: options.expiresAt ?? new Date(Date.now() + 7 * DAY_MS),
+    usedAt: options.usedAt ?? null,
+  });
+  createdInviteIds.push(id);
+  return { id, token };
+}
 
-    const user = await db.transaction((tx) =>
-      createUser(tx, {
-        email: `invite-signup-${generateUuidv7()}@test.com`,
-        passwordHash: "test-hash",
-        emailVerified: false,
-        inviteToken: token,
-        provider: "email",
-      })
+/** Runs `createUser` in its own transaction, the way the real signup paths do. */
+async function signUp(params: { email: string; inviteToken?: string }) {
+  const user = await db.transaction((tx) =>
+    createUser(tx, {
+      email: params.email,
+      passwordHash: "not-a-real-hash",
+      emailVerified: false,
+      inviteToken: params.inviteToken,
+      provider: "email",
+    })
+  );
+  createdUserIds.push(user.userId);
+  return user;
+}
+
+function appErrorCode(err: unknown): string | undefined {
+  if (!(err instanceof TRPCError)) return undefined;
+  const cause = err.cause as { code?: string } | undefined;
+  return cause?.code;
+}
+
+async function expectSignupError(promise: Promise<unknown>, code: string) {
+  await expect(promise).rejects.toThrow(TRPCError);
+  const err = await promise.catch((e: unknown) => e);
+  expect(appErrorCode(err)).toBe(code);
+}
+
+async function emailExists(email: string) {
+  const rows = await db.select({ id: users.id }).from(users).where(eq(users.email, email));
+  return rows.length > 0;
+}
+
+describe("createUser with an invite", () => {
+  it("creates the user and claims the invite", async () => {
+    const invite = await createInvite();
+    const email = `invite-ok-${generateUuidv7()}@example.com`;
+
+    const user = await signUp({ email, inviteToken: invite.token });
+
+    const [inviteRow] = await db.select().from(invites).where(eq(invites.id, invite.id));
+    expect(inviteRow.usedByUserId).toBe(user.userId);
+    expect(inviteRow.usedAt).toBeInstanceOf(Date);
+
+    const [userRow] = await db.select().from(users).where(eq(users.id, user.userId));
+    expect(userRow.inviteId).toBe(invite.id);
+  });
+
+  it("rejects a missing invite token without creating a user", async () => {
+    const email = `invite-missing-${generateUuidv7()}@example.com`;
+    await expectSignupError(signUp({ email }), "INVITE_REQUIRED");
+    expect(await emailExists(email)).toBe(false);
+  });
+
+  it("rejects an unknown invite token without creating a user", async () => {
+    const email = `invite-unknown-${generateUuidv7()}@example.com`;
+    await expectSignupError(
+      signUp({ email, inviteToken: "definitely-not-a-real-token" }),
+      "INVITE_INVALID"
     );
-    createdUserIds.push(user.userId);
+    expect(await emailExists(email)).toBe(false);
+  });
 
-    const [invite] = await db.select().from(invites).where(eq(invites.token, token));
-    expect(invite.usedAt).toBeInstanceOf(Date);
-    expect(invite.usedByUserId).toBe(user.userId);
+  it("rejects an already-used invite without creating a user", async () => {
+    const invite = await createInvite({ usedAt: new Date() });
+    const email = `invite-used-${generateUuidv7()}@example.com`;
 
-    const [row] = await db.select().from(users).where(eq(users.id, user.userId));
-    expect(row.inviteId).toBe(invite.id);
+    await expectSignupError(signUp({ email, inviteToken: invite.token }), "INVITE_ALREADY_USED");
+    expect(await emailExists(email)).toBe(false);
+  });
+
+  it("rejects an expired invite without creating a user", async () => {
+    const invite = await createInvite({ expiresAt: new Date(Date.now() - DAY_MS) });
+    const email = `invite-expired-${generateUuidv7()}@example.com`;
+
+    await expectSignupError(signUp({ email, inviteToken: invite.token }), "INVITE_EXPIRED");
+    expect(await emailExists(email)).toBe(false);
+  });
+
+  it("lets only one of two concurrent signups claim the same invite", async () => {
+    const invite = await createInvite();
+    const emailA = `invite-race-a-${generateUuidv7()}@example.com`;
+    const emailB = `invite-race-b-${generateUuidv7()}@example.com`;
+
+    const results = await Promise.allSettled([
+      signUp({ email: emailA, inviteToken: invite.token }),
+      signUp({ email: emailB, inviteToken: invite.token }),
+    ]);
+
+    const winners = results.filter((r) => r.status === "fulfilled");
+    const losers = results.filter((r) => r.status === "rejected");
+    expect(winners).toHaveLength(1);
+    expect(losers).toHaveLength(1);
+    expect(appErrorCode((losers[0] as PromiseRejectedResult).reason)).toBe("INVITE_ALREADY_USED");
+
+    // The loser's user insert must have rolled back with its failed claim.
+    const [inviteRow] = await db.select().from(invites).where(eq(invites.id, invite.id));
+    const survivors = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(inArray(users.email, [emailA, emailB]));
+    expect(survivors).toHaveLength(1);
+    expect(inviteRow.usedByUserId).toBe(survivors[0].id);
+  });
+
+  it("ignores invites for a publicly allowed provider", async () => {
+    process.env.ALLOWED_PUBLIC_SIGNUP_PROVIDERS = "email";
+    const email = `invite-public-${generateUuidv7()}@example.com`;
+
+    const user = await signUp({ email });
+
+    const [userRow] = await db.select().from(users).where(eq(users.id, user.userId));
+    expect(userRow.inviteId).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #1447.

## Problem

`invites.used_by_user_id → users(id)` and `users.invite_id → invites(id)` are a circular pair of **non-deferrable** FKs. A non-deferrable FK is checked at the end of the *statement*, not the transaction, so `createUser` claiming the invite before inserting the user row failed every time:

```
error: insert or update on table "invites" violates foreign key constraint "invites_used_by_user_id_fkey"
```

Every invite-only signup (email/password and OAuth) 500'd; the register page showed the raw drizzle query as an alert. Public signup was unaffected — only `access === "invite-only"` touches `invites`.

## Fix

Reorder the writes in `createUser`: insert the user, then claim the invite, then stamp `users.invite_id` from the claim's `RETURNING`. No migration needed. The atomic just-do-it claim is unchanged, so a lost race still throws — and now rolls the user insert back with it.

Since that rollback is what keeps a failed claim from leaving an orphan user, `createUser` now takes a `Transaction` instead of `DbOrTx`, making the requirement its docstring already stated a type error to violate. Both callers already passed a transaction.

## Tests

New `tests/integration/signup-invite.test.ts` (the invite path had no test, which is why this shipped): successful claim + both FK directions stamped, `INVITE_REQUIRED` / `INVITE_INVALID` / `INVITE_ALREADY_USED` / `INVITE_EXPIRED` each leaving no user row, two concurrent signups racing one invite (exactly one wins, loser rolls back), and a public provider ignoring invites.

Reverting the fix fails 2 of the 7 with the exact 23503 from the issue; all 7 pass with it. Full integration suite: 735 passed, 15 skipped.

Also verified against a running dev app: `POST /api/v1/auth/register` with a real invite now succeeds, the invite row records `used_by_user_id`, the user row records `invite_id`, and a second signup on the same token gets a clean "Invite token has already been used" with no user row left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)