### PR TITLE
Render Threads post images, and cap synthesized post titles at 60 chars

### DIFF
--- a/src/server/plugins/linkedin.ts
+++ b/src/server/plugins/linkedin.ts
@@ -1,5 +1,5 @@
 import type { UrlPlugin, SavedArticleContent } from "./types";
-import { socialPostTitle } from "./social-post";
+import { socialPostImage, socialPostTitle } from "./social-post";
 import { fetchPluginPage } from "./fetch-page";
 import { Parser } from "htmlparser2";
 import { z } from "zod";
@@ -248,13 +248,11 @@ export function renderLinkedInPost(html: string, postUrl: string): SavedArticleC
 
   const parts = [plainTextToHtml(body)];
 
-  // The post's attached image (or the shared link's thumbnail). Plugin HTML is a
-  // body fragment, so the save path's `og:image` scrape never sees this page —
-  // inlining it is the only way the image survives the save.
+  // The post's attached image, or the shared link's thumbnail.
   const image = firstMatching(jsonLdImageUrl, post.image);
   const thumbnail = firstMatching(jsonLdHttpUrl, post.thumbnailUrl);
   if (image) {
-    parts.push(`<figure><img src="${escapeHtml(image)}" alt="" loading="lazy"></figure>`);
+    parts.push(socialPostImage(image));
   } else if (thumbnail) {
     // A video post. The JSON-LD `contentUrl` is a progressive MP4, but it is
     // access-gated — it 403s to anyone but a logged-in LinkedIn session, so a

--- a/src/server/plugins/social-post.ts
+++ b/src/server/plugins/social-post.ts
@@ -3,6 +3,8 @@
  * (Bluesky, LinkedIn, Threads).
  */
 
+import { escapeHtml } from "@/server/http/html";
+
 /**
  * Longest title we synthesize from a post's first line before eliding.
  *
@@ -20,13 +22,18 @@ const MAX_TITLE_LENGTH = 60;
 const MIN_ELIDED_TITLE_LENGTH = 40;
 
 /**
- * Build a saved-article title for a post that has no real title of its own: the
- * first line of its text, elided to a reasonable length, falling back to
- * "Post by {author}". Every social plugin uses this so their saved articles
- * read the same in the list, which is the only place a title is required.
+ * Build a saved-article title from a post's opening words, falling back to
+ * "Post by {author}". Every social plugin uses this so their saved articles read
+ * the same in the list, which is the only place a title is required — including
+ * LinkedIn, which passes its own `headline` through rather than a first line, so
+ * a headline past the cap elides here too.
  */
 export function socialPostTitle(text: string | null | undefined, author: string | null): string {
-  const firstLine = (text ?? "").split("\n")[0].trim();
+  // Collapse whitespace runs to single spaces. A title is a one-line heading, so
+  // a post that pads with long space runs or hard-wraps its opening line would
+  // otherwise spend the budget on nothing — and it keeps every space below
+  // exactly one character wide, which is what bounds the `trimEnd` at the end.
+  const firstLine = (text ?? "").split("\n")[0].replace(/\s+/g, " ").trim();
   if (!firstLine) {
     return author ? `Post by ${author}` : "Post";
   }
@@ -40,18 +47,32 @@ export function socialPostTitle(text: string | null | undefined, author: string 
 
   let body = codePoints.slice(0, MAX_TITLE_LENGTH - 1).join("");
 
-  // Drop a trailing partial word so the title doesn't end mid-word. Only when
-  // the cut actually lands inside one: if either side of it is whitespace the
-  // text already ends on a complete word, and backing up would throw away a
-  // whole word for nothing.
-  const cutsInsideAWord = !/\s$/.test(body) && !/\s/.test(codePoints[MAX_TITLE_LENGTH - 1] ?? "");
-  if (cutsInsideAWord) {
-    const atBoundary = body.replace(/\s+\S*$/, "");
+  // Drop a trailing partial word so the title doesn't end mid-word — but only
+  // when a word is actually being split. If the character we're dropping is the
+  // space *after* a whole word, nothing is partial, and backing up would discard
+  // that complete word for nothing.
+  if (codePoints[MAX_TITLE_LENGTH - 1] !== " ") {
+    const atBoundary = body.replace(/ [^ ]*$/, "");
+    // Count code points, not UTF-16 units: 25 emoji are 50 units but only 25
+    // characters of title, and the floor is about how much title is left.
     if ([...atBoundary].length >= MIN_ELIDED_TITLE_LENGTH) {
       body = atBoundary;
     }
   }
 
-  // trimEnd so the ellipsis never follows a space ("Bob …").
+  // At most one space can remain (runs are collapsed above), so the ellipsis
+  // never follows a space ("Bob …") and this can't drop below the floor.
   return `${body.trimEnd()}…`;
+}
+
+/**
+ * Render an image attached to a post.
+ *
+ * Plugin HTML is a bare body fragment, so the save path's own `og:image` scrape
+ * never sees the source page — inlining the image here is the only way it
+ * survives the save. No alt text: none of these sources expose any, and
+ * inventing one is worse than leaving it empty.
+ */
+export function socialPostImage(url: string): string {
+  return `<figure><img src="${escapeHtml(url)}" alt="" loading="lazy"></figure>`;
 }

--- a/src/server/plugins/social-post.ts
+++ b/src/server/plugins/social-post.ts
@@ -3,8 +3,21 @@
  * (Bluesky, LinkedIn, Threads).
  */
 
-/** Longest title we synthesize from a post's first line before eliding. */
-const MAX_TITLE_LENGTH = 100;
+/**
+ * Longest title we synthesize from a post's first line before eliding.
+ *
+ * A post has no title, so this is a heading invented out of its opening words —
+ * it only has to identify the post in a list, and a post whose first line is a
+ * whole paragraph would otherwise fill the heading with body text.
+ */
+const MAX_TITLE_LENGTH = 60;
+
+/**
+ * Shortest an elided title may be after backing up to a word boundary. Below
+ * this we cut mid-word instead, so a single very long opening word (a URL, a
+ * German compound) can't collapse the title to a couple of characters.
+ */
+const MIN_ELIDED_TITLE_LENGTH = 40;
 
 /**
  * Build a saved-article title for a post that has no real title of its own: the
@@ -14,13 +27,31 @@ const MAX_TITLE_LENGTH = 100;
  */
 export function socialPostTitle(text: string | null | undefined, author: string | null): string {
   const firstLine = (text ?? "").split("\n")[0].trim();
-  if (firstLine) {
-    // Slice by code point, not UTF-16 unit, so truncation never leaves a lone
-    // surrogate half (e.g. cutting through an emoji).
-    const codePoints = [...firstLine];
-    return codePoints.length > MAX_TITLE_LENGTH
-      ? `${codePoints.slice(0, MAX_TITLE_LENGTH - 1).join("")}…`
-      : firstLine;
+  if (!firstLine) {
+    return author ? `Post by ${author}` : "Post";
   }
-  return author ? `Post by ${author}` : "Post";
+
+  // Slice by code point, not UTF-16 unit, so truncation never leaves a lone
+  // surrogate half (e.g. cutting through an emoji).
+  const codePoints = [...firstLine];
+  if (codePoints.length <= MAX_TITLE_LENGTH) {
+    return firstLine;
+  }
+
+  let body = codePoints.slice(0, MAX_TITLE_LENGTH - 1).join("");
+
+  // Drop a trailing partial word so the title doesn't end mid-word. Only when
+  // the cut actually lands inside one: if either side of it is whitespace the
+  // text already ends on a complete word, and backing up would throw away a
+  // whole word for nothing.
+  const cutsInsideAWord = !/\s$/.test(body) && !/\s/.test(codePoints[MAX_TITLE_LENGTH - 1] ?? "");
+  if (cutsInsideAWord) {
+    const atBoundary = body.replace(/\s+\S*$/, "");
+    if ([...atBoundary].length >= MIN_ELIDED_TITLE_LENGTH) {
+      body = atBoundary;
+    }
+  }
+
+  // trimEnd so the ellipsis never follows a space ("Bob …").
+  return `${body.trimEnd()}…`;
 }

--- a/src/server/plugins/threads.ts
+++ b/src/server/plugins/threads.ts
@@ -2,7 +2,7 @@ import type { UrlPlugin, SavedArticleContent } from "./types";
 import { socialPostTitle } from "./social-post";
 import { fetchPluginPage } from "./fetch-page";
 import { Parser } from "htmlparser2";
-import { plainTextToHtml } from "@/server/http/html";
+import { escapeHtml, plainTextToHtml } from "@/server/http/html";
 import { safeDecodeURIComponent } from "@/lib/url";
 import { logger } from "@/lib/logger";
 
@@ -27,9 +27,9 @@ import { logger } from "@/lib/logger";
  * Known limitations:
  * - **No publish date.** The page carries no `<time>`, no JSON-LD, and no
  *   timestamp in its inline payload, and the post shortcode doesn't encode one.
- * - **No media.** `og:image` is the author's avatar on a text post and the
- *   attached media on an image post, with nothing in the markup to tell them
- *   apart, so we render neither rather than decorating every save with an avatar.
+ * - **Media is partial.** An attached image is rendered when Threads advertises
+ *   one (see {@link postImageUrl}); carousels and some single-image posts don't
+ *   advertise theirs and are missed. Video is never available.
  * - `threads.com/robots.txt` is `Disallow: /` for a generic user agent. This is
  *   a user-initiated single-post fetch on save, not crawling; don't extend it
  *   into anything that walks profiles or tags.
@@ -86,11 +86,16 @@ export function parseThreadsPostCode(url: URL): string | null {
 interface ThreadsOpenGraph {
   title: string | null;
   description: string | null;
+  image: string | null;
+  /** `twitter:card` — see {@link postImageUrl} for why this decides the image. */
+  card: string | null;
 }
 
 function extractThreadsOpenGraph(html: string): ThreadsOpenGraph {
   let title: string | null = null;
   let description: string | null = null;
+  let image: string | null = null;
+  let card: string | null = null;
 
   const parser = new Parser(
     {
@@ -99,6 +104,7 @@ function extractThreadsOpenGraph(html: string): ThreadsOpenGraph {
           return;
         }
         const property = attribs.property?.toLowerCase();
+        const metaName = attribs.name?.toLowerCase();
         const content = attribs.content;
         if (!content) {
           return;
@@ -107,6 +113,10 @@ function extractThreadsOpenGraph(html: string): ThreadsOpenGraph {
           title = content;
         } else if (property === "og:description" && !description) {
           description = content;
+        } else if (property === "og:image" && !image) {
+          image = content;
+        } else if (metaName === "twitter:card" && !card) {
+          card = content;
         }
       },
     },
@@ -115,7 +125,31 @@ function extractThreadsOpenGraph(html: string): ThreadsOpenGraph {
   parser.write(html);
   parser.end();
 
-  return { title, description };
+  return { title, description, image, card };
+}
+
+/**
+ * The post's attached image, or null when the post has none.
+ *
+ * `og:image` is always populated — with the author's **avatar** when the post
+ * has no media — so it can't be rendered unconditionally without decorating
+ * every text post with a profile picture. `twitter:card` is what distinguishes
+ * them, and it's a documented Twitter Card semantic rather than a guess at
+ * Meta's CDN path conventions: `summary_large_image` means the image *is* the
+ * content, `summary` means it's a thumbnail.
+ *
+ * Measured over 14 live posts: all 7 `summary_large_image` posts had real post
+ * media in `og:image`, and all 7 `summary` posts had the avatar. The rule is
+ * deliberately one-directional — 2 of those `summary` posts (a 20-image
+ * carousel, and one single-image post) *did* have media that Threads simply
+ * doesn't advertise, so their images are missed. Missing an image is a much
+ * cheaper mistake than captioning every text post with the author's face.
+ */
+function postImageUrl({ image, card }: ThreadsOpenGraph): string | null {
+  if (card?.toLowerCase() !== "summary_large_image" || !image) {
+    return null;
+  }
+  return /^https?:\/\//i.test(image) ? image : null;
 }
 
 /**
@@ -139,17 +173,29 @@ export function parseThreadsAuthor(ogTitle: string | null): string | null {
  * to normal fetching.
  */
 export function renderThreadsPost(html: string, postUrl: string): SavedArticleContent | null {
-  const { title: ogTitle, description } = extractThreadsOpenGraph(html);
-  const text = description?.trim();
+  const openGraph = extractThreadsOpenGraph(html);
+  const text = openGraph.description?.trim();
   if (!text) {
     return null;
   }
 
-  const author = parseThreadsAuthor(ogTitle);
+  const parts = [plainTextToHtml(text)];
+
+  // Plugin HTML is a body fragment, so the save path's own `og:image` scrape
+  // never sees this page — inlining the image is the only way it survives.
+  const image = postImageUrl(openGraph);
+  if (image) {
+    // No alt text: Threads exposes none, and inventing one is worse than none.
+    parts.push(`<figure><img src="${escapeHtml(image)}" alt="" loading="lazy"></figure>`);
+  }
+
+  const author = parseThreadsAuthor(openGraph.title);
   return {
-    html: plainTextToHtml(text),
+    html: parts.join("\n"),
     title: socialPostTitle(text, author),
     author,
+    // The post text alone, so the list summary is unaffected by the image.
+    excerpt: text,
     canonicalUrl: postUrl,
   };
 }

--- a/src/server/plugins/threads.ts
+++ b/src/server/plugins/threads.ts
@@ -1,8 +1,8 @@
 import type { UrlPlugin, SavedArticleContent } from "./types";
-import { socialPostTitle } from "./social-post";
+import { socialPostImage, socialPostTitle } from "./social-post";
 import { fetchPluginPage } from "./fetch-page";
 import { Parser } from "htmlparser2";
-import { escapeHtml, plainTextToHtml } from "@/server/http/html";
+import { plainTextToHtml } from "@/server/http/html";
 import { safeDecodeURIComponent } from "@/lib/url";
 import { logger } from "@/lib/logger";
 
@@ -181,12 +181,9 @@ export function renderThreadsPost(html: string, postUrl: string): SavedArticleCo
 
   const parts = [plainTextToHtml(text)];
 
-  // Plugin HTML is a body fragment, so the save path's own `og:image` scrape
-  // never sees this page — inlining the image is the only way it survives.
   const image = postImageUrl(openGraph);
   if (image) {
-    // No alt text: Threads exposes none, and inventing one is worse than none.
-    parts.push(`<figure><img src="${escapeHtml(image)}" alt="" loading="lazy"></figure>`);
+    parts.push(socialPostImage(image));
   }
 
   const author = parseThreadsAuthor(openGraph.title);

--- a/tests/unit/bluesky-plugin.test.ts
+++ b/tests/unit/bluesky-plugin.test.ts
@@ -242,7 +242,7 @@ describe("blueskyPostTitle", () => {
   it("truncates long single lines", () => {
     const long = "x".repeat(150);
     const title = blueskyPostTitle({ uri: "at://x", author, record: { text: long } });
-    expect(title.length).toBe(100);
+    expect(title.length).toBeLessThan(long.length);
     expect(title.endsWith("…")).toBe(true);
   });
 

--- a/tests/unit/bluesky-plugin.test.ts
+++ b/tests/unit/bluesky-plugin.test.ts
@@ -240,10 +240,12 @@ describe("blueskyPostTitle", () => {
   });
 
   it("truncates long single lines", () => {
-    const long = "x".repeat(150);
+    const long =
+      "Sen posted a very long single line of text that runs well past any sane title cap";
     const title = blueskyPostTitle({ uri: "at://x", author, record: { text: long } });
-    expect(title.length).toBeLessThan(long.length);
     expect(title.endsWith("…")).toBe(true);
+    expect(long.startsWith(title.slice(0, -1))).toBe(true);
+    expect(title.length).toBeLessThan(long.length);
   });
 
   it("falls back to the author when there is no text", () => {

--- a/tests/unit/linkedin-plugin.test.ts
+++ b/tests/unit/linkedin-plugin.test.ts
@@ -124,9 +124,8 @@ describe("renderLinkedInPost", () => {
         '<p><a href="https://lnkd.in/gyivVrsj">https://lnkd.in/gyivVrsj</a> #nook #android</p>\n' +
         '<figure><img src="https://media.licdn.com/dms/image/sync/v2/post-image.jpg" alt="" loading="lazy"></figure>'
     );
-    expect(result!.title).toBe(
-      "Opened up your Barnes & Noble NOOK just to find it's showing the wrong time?"
-    );
+    // The real headline is 76 characters, so it elides (see social-post.test.ts).
+    expect(result!.title).toBe("Opened up your Barnes & Noble NOOK just to find it's…");
     expect(result!.author).toBe("Dave Taylor");
     expect(result!.publishedAt).toEqual(new Date("2025-04-21T17:30:02.218Z"));
     expect(result!.canonicalUrl).toBe(POST_URL);
@@ -197,7 +196,8 @@ describe("renderLinkedInPost", () => {
 
   it("elides an over-long headline instead of storing it raw", () => {
     const result = renderLinkedInPost(page({ ...TEXT_POST, headline: "x".repeat(5000) }), POST_URL);
-    expect(result!.title).toBe(`${"x".repeat(99)}…`);
+    expect(result!.title).toMatch(/^x+…$/);
+    expect(result!.title!.length).toBeLessThan(200);
   });
 
   it("accepts schema.org's single-or-array and bare-string shapes", () => {

--- a/tests/unit/linkedin-plugin.test.ts
+++ b/tests/unit/linkedin-plugin.test.ts
@@ -195,9 +195,11 @@ describe("renderLinkedInPost", () => {
   });
 
   it("elides an over-long headline instead of storing it raw", () => {
-    const result = renderLinkedInPost(page({ ...TEXT_POST, headline: "x".repeat(5000) }), POST_URL);
-    expect(result!.title).toMatch(/^x+…$/);
-    expect(result!.title!.length).toBeLessThan(200);
+    const headline = `A headline LinkedIn generated that runs on and on ${"and on ".repeat(500)}`;
+    const title = renderLinkedInPost(page({ ...TEXT_POST, headline }), POST_URL)!.title!;
+    expect(title.endsWith("…")).toBe(true);
+    expect(headline.startsWith(title.slice(0, -1))).toBe(true);
+    expect(title.length).toBeLessThan(100);
   });
 
   it("accepts schema.org's single-or-array and bare-string shapes", () => {

--- a/tests/unit/social-post.test.ts
+++ b/tests/unit/social-post.test.ts
@@ -62,6 +62,32 @@ describe("socialPostTitle", () => {
     expect(title.endsWith("…")).toBe(true);
   });
 
+  // The case above has NO space inside the cap, so the backup is a no-op and the
+  // floor is never the reason for the result. This one has a boundary to back up
+  // over and is rejected *because* of the floor.
+  it("cuts mid-word when backing up would leave less than the floor", () => {
+    const title = socialPostTitle(`${"a".repeat(30)} ${"b".repeat(60)}`, "Sen");
+    // Backing up to the boundary would leave 30 characters, under the floor, so
+    // the mid-word cut is kept and the title stays full length.
+    expect([...title]).toHaveLength(60);
+    expect(title.startsWith("a".repeat(30))).toBe(true);
+  });
+
+  it("measures the floor in code points, not UTF-16 units", () => {
+    // 25 emoji are 25 characters of title but 50 UTF-16 units. Counting units
+    // would clear the 40 floor and collapse the title to 26 characters.
+    const title = socialPostTitle(`${"😀".repeat(25)} ${"b".repeat(60)}`, "Sen");
+    expect([...title]).toHaveLength(60);
+    expect(title).toContain("b");
+  });
+
+  it("collapses whitespace runs so they can't eat the title", () => {
+    // A long run of spaces inside the cap would otherwise leave just "a…".
+    expect(socialPostTitle(`a${" ".repeat(70)}b`, "Sen")).toBe("a b");
+    // Tabs and hard-wrapped lines collapse the same way.
+    expect(socialPostTitle("one\t\ttwo   three", "Sen")).toBe("one two three");
+  });
+
   it("falls back to the author when there is no text", () => {
     expect(socialPostTitle("", "Sen")).toBe("Post by Sen");
     expect(socialPostTitle(null, "Sen")).toBe("Post by Sen");

--- a/tests/unit/social-post.test.ts
+++ b/tests/unit/social-post.test.ts
@@ -16,16 +16,50 @@ describe("socialPostTitle", () => {
     expect(socialPostTitle("  padded  \nmore", "Sen")).toBe("padded");
   });
 
+  // The cap is asserted numerically only here — the per-plugin tests check that
+  // they route through this helper, not what the number is.
   it("keeps a line of exactly the maximum length intact, and elides past it", () => {
-    expect(socialPostTitle("x".repeat(100), "Sen")).toBe("x".repeat(100));
-    expect(socialPostTitle("x".repeat(101), "Sen")).toBe(`${"x".repeat(99)}…`);
+    expect(socialPostTitle("x".repeat(60), "Sen")).toBe("x".repeat(60));
+    expect(socialPostTitle("x".repeat(61), "Sen")).toBe(`${"x".repeat(59)}…`);
   });
 
   it("elides by code point so it never splits a surrogate pair", () => {
     // 150 astral-plane code points: a UTF-16 slice would cut an emoji in half.
     const title = socialPostTitle("😀".repeat(150), "Sen");
-    expect([...title]).toHaveLength(100);
+    expect([...title]).toHaveLength(60);
     expect(title.endsWith("😀…")).toBe(true);
+  });
+
+  it("drops a trailing partial word rather than cutting mid-word", () => {
+    // The cut lands inside "showing".
+    const text = "Opened up your Barnes & Noble NOOK just to find it's showing the wrong time?";
+    expect(socialPostTitle(text, "Sen")).toBe(
+      "Opened up your Barnes & Noble NOOK just to find it's…"
+    );
+  });
+
+  it("keeps a whole word the cut happens to end on", () => {
+    // The dropped character is a space, so nothing is mid-word — backing up
+    // here would discard the complete word "and" for no reason.
+    const text = "Some people are complaining that they are seeing videos and photos on Threads";
+    expect(socialPostTitle(text, "Sen")).toBe(
+      "Some people are complaining that they are seeing videos and…"
+    );
+  });
+
+  it("never leaves a space before the ellipsis", () => {
+    // The break lands exactly on a space, which would read as "Bob …".
+    const text = "Just outside of Orlando, Florida is the cemetery where Bob Ross is buried";
+    const title = socialPostTitle(text, "Sen");
+    expect(title).toBe("Just outside of Orlando, Florida is the cemetery where Bob…");
+    expect(title).not.toContain(" …");
+  });
+
+  it("cuts mid-word rather than collapse the title when the opening word is huge", () => {
+    // A 200-character first "word" (e.g. a bare URL) has no usable boundary.
+    const title = socialPostTitle(`https://example.com/${"a".repeat(200)} then text`, "Sen");
+    expect([...title]).toHaveLength(60);
+    expect(title.endsWith("…")).toBe(true);
   });
 
   it("falls back to the author when there is no text", () => {

--- a/tests/unit/threads-plugin.test.ts
+++ b/tests/unit/threads-plugin.test.ts
@@ -181,9 +181,13 @@ describe("renderThreadsPost", () => {
   // The exact cap is pinned in social-post.test.ts; this only checks Threads
   // routes its title through that shared helper.
   it("elides a long first line into the title", () => {
-    const result = renderThreadsPost(page({ description: "a".repeat(150) }), POST_URL);
-    expect(result!.title).toMatch(/^a+…$/);
-    expect(result!.title!.length).toBeLessThan(150);
+    const line =
+      "The quick brown fox jumps over the lazy dog and keeps on running well past the cap";
+    const title = renderThreadsPost(page({ description: line }), POST_URL)!.title!;
+    expect(title.endsWith("…")).toBe(true);
+    // A prefix of the input, so a title of "…" alone can't satisfy this.
+    expect(line.startsWith(title.slice(0, -1))).toBe(true);
+    expect(title.length).toBeLessThan(line.length);
   });
 
   it("finds Open Graph tags that appear after </head>", () => {

--- a/tests/unit/threads-plugin.test.ts
+++ b/tests/unit/threads-plugin.test.ts
@@ -19,18 +19,35 @@ import {
 const POST_URL = "https://www.threads.com/@anujs3/post/DNG2tXiBjzN";
 
 /** A minimal post page carrying the Open Graph tags Threads actually serves. */
-function page(options: { title?: string | null; description?: string | null } = {}): string {
-  const { title = "Anuj Shah (@anujs3) on Threads", description = "Post body." } = options;
+function page(
+  options: {
+    title?: string | null;
+    description?: string | null;
+    image?: string | null;
+    /** Threads sends `summary` for a text post, `summary_large_image` with media. */
+    card?: string | null;
+  } = {}
+): string {
+  const {
+    title = "Anuj Shah (@anujs3) on Threads",
+    description = "Post body.",
+    image = "https://scontent.cdninstagram.com/v/t51.2885-19/avatar.jpg",
+    card = "summary",
+  } = options;
   return [
     "<html><head>",
     '<meta property="og:site_name" content="Threads" />',
     title === null ? "" : `<meta property="og:title" content="${title}" />`,
     description === null ? "" : `<meta property="og:description" content="${description}" />`,
-    '<meta property="og:image" content="https://scontent.cdninstagram.com/avatar.jpg" />',
+    image === null ? "" : `<meta property="og:image" content="${image}" />`,
+    card === null ? "" : `<meta name="twitter:card" content="${card}" />`,
     '<meta name="twitter:description" content="Post body, but elided at..." />',
     "</head><body></body></html>",
   ].join("");
 }
+
+/** The og:image on a post with real media, shaped like the live ones. */
+const MEDIA_IMAGE = "https://scontent-sea5-1.cdninstagram.com/v/t51.82787-15/comic.webp";
 
 describe("parseThreadsPostCode", () => {
   it("parses the canonical post URL", () => {
@@ -173,6 +190,45 @@ describe("renderThreadsPost", () => {
       POST_URL
     );
     expect(result!.html).toBe("<p>Body.</p>");
+  });
+
+  // og:image is ALWAYS present — it's the author's avatar on a text post — so
+  // rendering it unconditionally would caption every text post with a profile
+  // picture. twitter:card is what distinguishes media from avatar.
+  it("renders the image only when twitter:card says the image is the content", () => {
+    const withMedia = renderThreadsPost(
+      page({ image: MEDIA_IMAGE, card: "summary_large_image" }),
+      POST_URL
+    );
+    expect(withMedia!.html).toContain(
+      `<figure><img src="${MEDIA_IMAGE}" alt="" loading="lazy"></figure>`
+    );
+
+    // `summary` means the og:image is the avatar — never render it.
+    const textOnly = renderThreadsPost(page({ card: "summary" }), POST_URL);
+    expect(textOnly!.html).not.toContain("<figure>");
+    expect(textOnly!.html).not.toContain("avatar.jpg");
+  });
+
+  it.each([
+    ["the card is missing", { image: MEDIA_IMAGE, card: null }],
+    ["the image is missing", { image: null, card: "summary_large_image" }],
+    ["the image is not http(s)", { image: "javascript:alert(1)", card: "summary_large_image" }],
+  ])("renders no image when %s", (_label, options) => {
+    const result = renderThreadsPost(page(options), POST_URL);
+    expect(result!.html).not.toContain("<figure>");
+    expect(result!.html).not.toContain("javascript:");
+  });
+
+  it("keeps the post text ahead of the image, and out of the excerpt", () => {
+    const result = renderThreadsPost(
+      page({ description: "The comic caption.", image: MEDIA_IMAGE, card: "summary_large_image" }),
+      POST_URL
+    );
+    expect(result!.html.indexOf("The comic caption.")).toBeLessThan(
+      result!.html.indexOf("<figure>")
+    );
+    expect(result!.excerpt).toBe("The comic caption.");
   });
 
   it("returns null when the page carries no post text, so the save falls back", () => {

--- a/tests/unit/threads-plugin.test.ts
+++ b/tests/unit/threads-plugin.test.ts
@@ -178,9 +178,12 @@ describe("renderThreadsPost", () => {
     expect(renderThreadsPost(page(), POST_URL)!.publishedAt).toBeUndefined();
   });
 
+  // The exact cap is pinned in social-post.test.ts; this only checks Threads
+  // routes its title through that shared helper.
   it("elides a long first line into the title", () => {
     const result = renderThreadsPost(page({ description: "a".repeat(150) }), POST_URL);
-    expect(result!.title).toBe(`${"a".repeat(99)}…`);
+    expect(result!.title).toMatch(/^a+…$/);
+    expect(result!.title!.length).toBeLessThan(150);
   });
 
   it("finds Open Graph tags that appear after </head>", () => {


### PR DESCRIPTION
Follow-up to #1449. **These two commits were pushed to that branch after it merged**, so they never appeared in a PR — this is them, rebased onto current `master`.

## Render a Threads post's attached image

`og:image` is **always** set on a Threads post — to the author's **avatar** when the post has no media. That's why the original plugin rendered no image at all: doing it unconditionally captions every text post with a profile picture.

`twitter:card` is the discriminator, and it's a documented Twitter Card semantic rather than a guess at Meta's CDN path conventions (`t51.2885-19` vs `t51.82787-15` — which I tried first and rejected for exactly that reason). Measured over **14 live posts**:

| `twitter:card` | `og:image` is… | n |
|---|---|---|
| `summary_large_image` | real post media | 7/7 |
| `summary` | the author's avatar | 7/7 |

Deliberately **one-directional**: 2 of those `summary` posts — a 20-image carousel and one single-image post — do have media Threads simply doesn't advertise, so their images are missed. Missing an image is a much cheaper mistake than captioning every text post with someone's face.

Verified end to end on live posts through the **real** read-path sanitizer: a comic post (`t51.82787-15`) and an Instagram-crossposted photo (`t39.30808-6`) both render; a text post and the carousel render nothing. `alt=""` because Threads exposes no alt text and inventing one is worse than none. `excerpt` is set to the post text so the list summary is unaffected.

## Cap synthesized post titles at 60 characters

A post has no title, so the title is a heading invented from its opening words. At 100 characters a post whose first line is a whole paragraph filled the heading with body text.

Shortening it made a latent artifact frequent enough to matter — at 60, three of six real posts ended mid-word (`…find it's showin…`) and one put a space before the ellipsis (`…where Bob …`). So the cut now drops a trailing partial word, **but only when it lands inside one**: backing up unconditionally throws away a complete word whenever the dropped character happens to be a space (`…seeing videos and` → `…seeing videos`), which my first attempt did and a test caught. A single opening word longer than the cap (a bare URL) still cuts mid-word rather than collapsing the title.

Real titles now, across all three social plugins:

| len | title |
|---|---|
| 34 | `I can barely enjoy Amleth anymore.` |
| 55 | `2) text-only posts perform *significantly* better than…` |
| 59 | `Just outside of Orlando, Florida is the cemetery where Bob…` |
| 53 | `Opened up your Barnes & Noble NOOK just to find it's…` |
| 60 | `Some people are complaining that they are seeing videos and…` |
| 57 | `The cookout was an *immense* success, so many new people…` (Bluesky) |

The cap lives in `socialPostTitle`, so it applies to **Bluesky and LinkedIn** too — one convention for how a titleless post reads in a list rather than three. The numeric cap is asserted in exactly one place (`tests/unit/social-post.test.ts`); the per-plugin tests assert they route through the shared helper instead of restating the number, so changing it again touches one file rather than four.

## Not addressed

For a short post the title is still identical to the body's first paragraph, so the same sentence renders twice. Fixing that means suppressing the first paragraph when it duplicates the title, which makes the stored body no longer the complete post — a different tradeoff, left for a decision.

---

Verified against current `master` after the rebase: typecheck, unit (2776), integration (741), lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
