### PR TITLE
Resolve relative sibling-file references in saved gists (#1424)

### DIFF
--- a/src/server/plugins/github.ts
+++ b/src/server/plugins/github.ts
@@ -18,7 +18,7 @@ type GitHubUrlType =
   | { type: "blob"; owner: string; repo: string; ref: string; path: string }
   | { type: "raw"; owner: string; repo: string; ref: string; path: string };
 
-interface GistFile {
+export interface GistFile {
   filename: string;
   language: string | null;
   content: string;
@@ -26,11 +26,13 @@ interface GistFile {
   raw_url: string;
 }
 
-interface GistResponse {
+export interface GistResponse {
   id: string;
   description: string | null;
   owner?: { login: string } | null;
   files: Record<string, GistFile>;
+  /** Revisions, newest first. */
+  history?: { version: string }[];
   created_at: string;
   updated_at: string;
 }
@@ -344,19 +346,25 @@ function isMarkdownLanguage(language: string | null): boolean {
  * raw.githubusercontent.com) for the repo-root README, which we fetch without one.
  */
 export interface RepoFileLocation {
+  kind: "repo";
   owner: string;
   repo: string;
   ref?: string;
   path: string;
 }
 
-/**
- * A gist file's own raw URL (`raw_url` from the gists API), which is where the
- * relative URLs in it resolve from. We take GitHub's URL rather than building one
- * out of the gist id, so an ownerless gist needs no guess at the user segment.
- */
+/** A gist file's location, used to resolve the relative URLs in it. */
 export interface GistFileLocation {
+  kind: "gist";
+  /**
+   * The file's own `raw_url` from the gists API, which the `{user}/{id}` the
+   * gist is served under is read back out of. Taking GitHub's URL avoids
+   * depending on `owner`, which the API leaves null for an ownerless gist —
+   * and the user segment is load-bearing (a wrong one 404s).
+   */
   rawUrl: string;
+  /** The gist's current commit sha, when the response carried its history. */
+  revision?: string;
 }
 
 /** Where a rendered file came from, which is what its relative URLs resolve to. */
@@ -387,35 +395,40 @@ function absolutizeGitHubUrls(html: string, file: RepoFileLocation): string {
   });
 }
 
+/** A git object name, which is all we'll put in a URL path we build. */
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
 /**
- * The URL prefix every file in a gist is served under,
- * `https://gist.githubusercontent.com/{user}/{id}/raw/`, or null if the file's
- * `raw_url` isn't that shape.
+ * The directory a gist's files are served under, at `revision` when we know it:
+ * `https://gist.githubusercontent.com/{user}/{id}/raw/{revision}/`. Null if the
+ * file's `raw_url` isn't the shape we know — every URL in the document resolves
+ * against this base, so an unrecognized one is left alone rather than guessed at.
  *
- * The revision sha in a `raw_url` (`…/raw/{sha}/{filename}`) is deliberately
- * dropped. That sha names a *blob*, and the filename after it is then ignored, so
- * `…/raw/{sha-of-notes.md}/chart.png` serves notes.md's bytes under the sibling's
- * name — silently the wrong file. The sha-less form resolves by filename against
- * the current revision and 404s when there is no such file (both verified against
- * the live host).
+ * The sha already in a `raw_url` (`…/raw/{sha}/{filename}`) is *not* that
+ * revision and must be dropped: it names the file's own **blob**, and the
+ * filename after it is then ignored, so `…/raw/{sha-of-notes.md}/chart.png`
+ * serves notes.md's bytes under the sibling's name. The gist's commit sha
+ * (`history[0].version`, what GitHub's own links use) does honor the filename,
+ * and pins the article to the revision we rendered; without one the sha-less form
+ * tracks the gist's current revision. Both 404 for a file that isn't there
+ * (verified against the live host).
  */
-function gistRawBase(rawUrl: string): string | null {
+function gistRawBase(file: GistFileLocation): string | null {
   let url: URL;
   try {
-    url = new URL(rawUrl);
+    url = new URL(file.rawUrl);
   } catch {
     return null;
   }
 
-  // Every URL in the document resolves against this base, so anything but the
-  // raw host in the shape we know is left alone rather than guessed at.
   const [user, id, raw] = url.pathname.split("/").filter(Boolean);
   if (url.protocol !== "https:" || url.hostname !== "gist.githubusercontent.com" || raw !== "raw") {
-    logger.debug("Unexpected gist raw URL, leaving relative URLs alone", { rawUrl });
+    logger.debug("Unexpected gist raw URL, leaving relative URLs alone", { rawUrl: file.rawUrl });
     return null;
   }
 
-  return `https://gist.githubusercontent.com/${user}/${id}/raw/`;
+  const revision = file.revision && SHA_PATTERN.test(file.revision) ? `${file.revision}/` : "";
+  return `https://gist.githubusercontent.com/${user}/${id}/raw/${revision}`;
 }
 
 /**
@@ -426,14 +439,20 @@ function gistRawBase(rawUrl: string): string | null {
  * `gist.github.com/{user}/{id}` — the gist's HTML page, so an image renders
  * broken (#1424).
  *
- * A gist has no per-file page, so — unlike a repo file, whose links go to the
- * github.com blob view (see `absolutizeGitHubUrls`) — there's no second base to
- * split links off to, and `href` resolves to the raw file too. A gist's files are
- * also a flat list, so a leading slash can only mean a sibling as well: the root
- * base is the same one.
+ * Unlike a repo file, whose two bases split embeds from links (see
+ * `absolutizeGitHubUrls`), everything here resolves against the one raw base.
+ * GitHub rewrites a relative reference in gist Markdown — `href` *and* `src`
+ * alike — to a `#file-…` anchor on the gist page, which means its own rendering
+ * of a sibling image is broken: an `<img>` pointing at an HTML page. Raw beats
+ * that for `src`, and for `href` it costs the reader a rendered page but still
+ * serves the file. Matching GitHub for `href` alone would mean synthesizing that
+ * anchor from the sibling's filename, which a URL base can't express.
+ *
+ * A gist's files are a flat list, so a leading slash can only mean a sibling too:
+ * the root base is the same base.
  */
 function absolutizeGistUrls(html: string, file: GistFileLocation): string {
-  const base = gistRawBase(file.rawUrl);
+  const base = gistRawBase(file);
   if (!base) {
     return html;
   }
@@ -481,7 +500,7 @@ export async function processFileContent(
   location: FileLocation
 ): Promise<ProcessedRepoFile> {
   const absolutize = (html: string): string =>
-    "rawUrl" in location
+    location.kind === "gist"
       ? absolutizeGistUrls(html, location)
       : absolutizeGitHubUrls(html, location);
 
@@ -508,7 +527,7 @@ export async function processFileContent(
  * Build HTML from a gist with multiple files. Metadata a single file declared in
  * frontmatter is propagated; a concatenation of several has no one author/excerpt.
  */
-async function buildGistHtml(
+export async function buildGistHtml(
   gist: GistResponse,
   targetFilename?: string
 ): Promise<ProcessedRepoFile> {
@@ -517,6 +536,14 @@ async function buildGistHtml(
   if (files.length === 0) {
     return { html: "<p>Empty gist</p>", title: null, author: null, excerpt: null };
   }
+
+  // Newest first, so this is the revision whose contents we're rendering.
+  const revision = gist.history?.[0]?.version;
+  const locate = (file: GistFile): GistFileLocation => ({
+    kind: "gist",
+    rawUrl: file.raw_url,
+    revision,
+  });
 
   // If a specific file is requested, find it
   if (targetFilename) {
@@ -532,7 +559,7 @@ async function buildGistHtml(
         matchedFile.content,
         matchedFile.filename,
         matchedFile.language,
-        { rawUrl: matchedFile.raw_url }
+        locate(matchedFile)
       );
       // Use extracted title from markdown, fall back to filename
       return { ...file, title: file.title || matchedFile.filename };
@@ -542,9 +569,7 @@ async function buildGistHtml(
   // Single file: return it directly
   if (files.length === 1) {
     const only = files[0];
-    const file = await processFileContent(only.content, only.filename, only.language, {
-      rawUrl: only.raw_url,
-    });
+    const file = await processFileContent(only.content, only.filename, only.language, locate(only));
     // Use extracted title from markdown, fall back to filename
     return { ...file, title: file.title || only.filename };
   }
@@ -553,9 +578,12 @@ async function buildGistHtml(
   const parts: string[] = [];
   for (const file of files) {
     parts.push(`<h2>${escapeHtml(file.filename)}</h2>`);
-    const { html } = await processFileContent(file.content, file.filename, file.language, {
-      rawUrl: file.raw_url,
-    });
+    const { html } = await processFileContent(
+      file.content,
+      file.filename,
+      file.language,
+      locate(file)
+    );
     parts.push(html);
   }
 
@@ -608,6 +636,7 @@ async function fetchGitHubContent(url: URL): Promise<SavedArticleContent | null>
       }
 
       const file = await processFileContent(readme.content, readme.filename, null, {
+        kind: "repo",
         owner: parsed.owner,
         repo: parsed.repo,
         path: readme.filename,
@@ -637,7 +666,10 @@ async function fetchGitHubContent(url: URL): Promise<SavedArticleContent | null>
           return null;
         }
 
-        const file = await processFileContent(rawContent, parsed.path, null, parsed);
+        const file = await processFileContent(rawContent, parsed.path, null, {
+          kind: "repo",
+          ...parsed,
+        });
         const title = file.title || filename;
         return {
           html: file.html,
@@ -650,7 +682,10 @@ async function fetchGitHubContent(url: URL): Promise<SavedArticleContent | null>
       }
 
       const content = Buffer.from(contents.content, "base64").toString("utf-8");
-      const file = await processFileContent(content, parsed.path, null, parsed);
+      const file = await processFileContent(content, parsed.path, null, {
+        kind: "repo",
+        ...parsed,
+      });
       const title = file.title || filename;
 
       return {
@@ -671,7 +706,10 @@ async function fetchGitHubContent(url: URL): Promise<SavedArticleContent | null>
       }
 
       const filename = parsed.path.split("/").pop() ?? parsed.path;
-      const file = await processFileContent(content, parsed.path, null, parsed);
+      const file = await processFileContent(content, parsed.path, null, {
+        kind: "repo",
+        ...parsed,
+      });
       const title = file.title || filename;
 
       return {

--- a/src/server/plugins/github.ts
+++ b/src/server/plugins/github.ts
@@ -22,6 +22,8 @@ interface GistFile {
   filename: string;
   language: string | null;
   content: string;
+  /** `https://gist.githubusercontent.com/{user}/{id}/raw/{sha}/{filename}`. */
+  raw_url: string;
 }
 
 interface GistResponse {
@@ -349,6 +351,18 @@ export interface RepoFileLocation {
 }
 
 /**
+ * A gist file's own raw URL (`raw_url` from the gists API), which is where the
+ * relative URLs in it resolve from. We take GitHub's URL rather than building one
+ * out of the gist id, so an ownerless gist needs no guess at the user segment.
+ */
+export interface GistFileLocation {
+  rawUrl: string;
+}
+
+/** Where a rendered file came from, which is what its relative URLs resolve to. */
+export type FileLocation = RepoFileLocation | GistFileLocation;
+
+/**
  * Absolutize the relative URLs in a rendered repo file against GitHub's *two*
  * bases: embedded files (`src`) resolve to raw.githubusercontent.com, which
  * serves the bytes, while links (`href`) resolve to the github.com blob view,
@@ -371,6 +385,60 @@ function absolutizeGitHubUrls(html: string, file: RepoFileLocation): string {
     rootBaseUrl: blobRoot,
     media: { baseUrl: `${rawRoot}${path}`, rootBaseUrl: rawRoot },
   });
+}
+
+/**
+ * The URL prefix every file in a gist is served under,
+ * `https://gist.githubusercontent.com/{user}/{id}/raw/`, or null if the file's
+ * `raw_url` isn't that shape.
+ *
+ * The revision sha in a `raw_url` (`…/raw/{sha}/{filename}`) is deliberately
+ * dropped. That sha names a *blob*, and the filename after it is then ignored, so
+ * `…/raw/{sha-of-notes.md}/chart.png` serves notes.md's bytes under the sibling's
+ * name — silently the wrong file. The sha-less form resolves by filename against
+ * the current revision and 404s when there is no such file (both verified against
+ * the live host).
+ */
+function gistRawBase(rawUrl: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  // Every URL in the document resolves against this base, so anything but the
+  // raw host in the shape we know is left alone rather than guessed at.
+  const [user, id, raw] = url.pathname.split("/").filter(Boolean);
+  if (url.protocol !== "https:" || url.hostname !== "gist.githubusercontent.com" || raw !== "raw") {
+    logger.debug("Unexpected gist raw URL, leaving relative URLs alone", { rawUrl });
+    return null;
+  }
+
+  return `https://gist.githubusercontent.com/${user}/${id}/raw/`;
+}
+
+/**
+ * Absolutize the relative URLs in a rendered gist file against the raw host that
+ * serves the gist's files, so a reference to a sibling file (`chart.png`)
+ * resolves to that file. Without this the reference falls through to the generic
+ * single-base absolutizer downstream, which resolves it against
+ * `gist.github.com/{user}/{id}` — the gist's HTML page, so an image renders
+ * broken (#1424).
+ *
+ * A gist has no per-file page, so — unlike a repo file, whose links go to the
+ * github.com blob view (see `absolutizeGitHubUrls`) — there's no second base to
+ * split links off to, and `href` resolves to the raw file too. A gist's files are
+ * also a flat list, so a leading slash can only mean a sibling as well: the root
+ * base is the same one.
+ */
+function absolutizeGistUrls(html: string, file: GistFileLocation): string {
+  const base = gistRawBase(file.rawUrl);
+  if (!base) {
+    return html;
+  }
+
+  return absolutizeUrls(html, base, { rootBaseUrl: base });
 }
 
 /**
@@ -402,18 +470,20 @@ interface ProcessedRepoFile {
  * render — harmless in practice, since the standard delimiters don't fire on
  * prose (`costs $5 and $10` stays text) and there's a test for that.
  *
- * `location` is the repo file the content came from, so its relative URLs can be
- * resolved GitHub's way; pass null for gist files, whose sibling-file references
- * we don't resolve (they'd need gist.githubusercontent.com raw URLs, #1424).
+ * `location` is the repo or gist file the content came from, so its relative URLs
+ * can be resolved GitHub's way — the two hosts differ, so see the two
+ * absolutizers for what each resolves to.
  */
 export async function processFileContent(
   content: string,
   filename: string,
   language: string | null,
-  location: RepoFileLocation | null
+  location: FileLocation
 ): Promise<ProcessedRepoFile> {
   const absolutize = (html: string): string =>
-    location ? absolutizeGitHubUrls(html, location) : html;
+    "rawUrl" in location
+      ? absolutizeGistUrls(html, location)
+      : absolutizeGitHubUrls(html, location);
 
   if (isMarkdownFile(filename) || isMarkdownLanguage(language)) {
     const { html, title, summary, author } = await processMarkdown(content);
@@ -462,7 +532,7 @@ async function buildGistHtml(
         matchedFile.content,
         matchedFile.filename,
         matchedFile.language,
-        null
+        { rawUrl: matchedFile.raw_url }
       );
       // Use extracted title from markdown, fall back to filename
       return { ...file, title: file.title || matchedFile.filename };
@@ -472,7 +542,9 @@ async function buildGistHtml(
   // Single file: return it directly
   if (files.length === 1) {
     const only = files[0];
-    const file = await processFileContent(only.content, only.filename, only.language, null);
+    const file = await processFileContent(only.content, only.filename, only.language, {
+      rawUrl: only.raw_url,
+    });
     // Use extracted title from markdown, fall back to filename
     return { ...file, title: file.title || only.filename };
   }
@@ -481,7 +553,9 @@ async function buildGistHtml(
   const parts: string[] = [];
   for (const file of files) {
     parts.push(`<h2>${escapeHtml(file.filename)}</h2>`);
-    const { html } = await processFileContent(file.content, file.filename, file.language, null);
+    const { html } = await processFileContent(file.content, file.filename, file.language, {
+      rawUrl: file.raw_url,
+    });
     parts.push(html);
   }
 

--- a/tests/unit/github-plugin.test.ts
+++ b/tests/unit/github-plugin.test.ts
@@ -436,16 +436,6 @@ describe("processFileContent", () => {
       );
     });
 
-    it("leaves content untouched when given no repo location (gists)", async () => {
-      const { html } = await processFileContent(
-        "![Chart](images/chart.png)",
-        "notes.md",
-        null,
-        null
-      );
-      expect(html).toContain('src="images/chart.png"');
-    });
-
     it("resolves srcset candidates and video posters against the raw base", async () => {
       const { html } = await processFileContent(
         '<img srcset="images/small.png 1x, images/large.png 2x">' +
@@ -526,6 +516,88 @@ describe("processFileContent", () => {
         repoFile
       );
       expect(html).toContain('src="https://img.example.com/chart.png"');
+    });
+  });
+
+  describe("gist relative URL resolution (#1424)", () => {
+    const gistFile = {
+      rawUrl: "https://gist.githubusercontent.com/brendanlong/abc123/raw/deadbeef/notes.md",
+    };
+    const gistRawBase = "https://gist.githubusercontent.com/brendanlong/abc123/raw";
+
+    it("resolves a sibling image reference to the gist's raw host", async () => {
+      const { html } = await processFileContent("![Chart](chart.png)", "notes.md", null, gistFile);
+      expect(html).toContain(`src="${gistRawBase}/chart.png"`);
+    });
+
+    // A raw_url's sha names the file's own blob, and the filename after it is
+    // ignored — keeping it would serve notes.md's bytes as chart.png.
+    it("drops the revision sha, which names a blob rather than a tree", async () => {
+      const { html } = await processFileContent("![Chart](chart.png)", "notes.md", null, gistFile);
+      expect(html).not.toContain("deadbeef");
+    });
+
+    it("resolves ./-prefixed references the same way", async () => {
+      const { html } = await processFileContent(
+        "![Chart](./chart.png)",
+        "notes.md",
+        null,
+        gistFile
+      );
+      expect(html).toContain(`src="${gistRawBase}/chart.png"`);
+    });
+
+    // A gist has no per-file page, so a link resolves to the raw file too.
+    it("resolves a sibling link to the raw file", async () => {
+      const { html } = await processFileContent("[Setup](setup.md)", "notes.md", null, gistFile);
+      expect(html).toContain(`href="${gistRawBase}/setup.md"`);
+    });
+
+    // A gist is flat, so a leading slash can only mean a sibling.
+    it("resolves root-relative references to the sibling file", async () => {
+      const { html } = await processFileContent(
+        '<img src="/chart.png">',
+        "notes.md",
+        null,
+        gistFile
+      );
+      expect(html).toContain(`src="${gistRawBase}/chart.png"`);
+    });
+
+    it("leaves absolute URLs alone", async () => {
+      const { html } = await processFileContent(
+        "![Chart](https://img.example.com/chart.png)",
+        "notes.md",
+        null,
+        gistFile
+      );
+      expect(html).toContain('src="https://img.example.com/chart.png"');
+    });
+
+    it("keeps same-document fragments relative", async () => {
+      const { html } = await processFileContent(
+        "# Doc\n\n[Jump](#setup)\n\n## Setup\n\nBody.",
+        "notes.md",
+        null,
+        gistFile
+      );
+      expect(html).toContain('href="#setup"');
+    });
+
+    // Every URL in the document resolves against this base, so an unexpected one
+    // must not become the base.
+    it("leaves content untouched when the raw URL isn't GitHub's raw gist host", async () => {
+      const { html } = await processFileContent("![Chart](chart.png)", "notes.md", null, {
+        rawUrl: "https://evil.example.com/brendanlong/abc123/raw/deadbeef/notes.md",
+      });
+      expect(html).toContain('src="chart.png"');
+    });
+
+    it("leaves content untouched when the raw URL isn't the shape we know", async () => {
+      const { html } = await processFileContent("![Chart](chart.png)", "notes.md", null, {
+        rawUrl: "https://gist.githubusercontent.com/brendanlong/abc123/notes.md",
+      });
+      expect(html).toContain('src="chart.png"');
     });
   });
 

--- a/tests/unit/github-plugin.test.ts
+++ b/tests/unit/github-plugin.test.ts
@@ -11,7 +11,9 @@ import {
   isMarkdownFile,
   isHtmlFile,
   processFileContent,
+  buildGistHtml,
 } from "../../src/server/plugins/github";
+import type { GistFile, GistResponse } from "../../src/server/plugins/github";
 
 describe("GitHub plugin URL parsing", () => {
   describe("parseGitHubUrl - gists", () => {
@@ -357,6 +359,7 @@ describe("File type detection", () => {
 
 describe("processFileContent", () => {
   const repoFile = {
+    kind: "repo" as const,
     owner: "humanlayer",
     repo: "advanced-context-engineering-for-coding-agents",
     ref: "main",
@@ -427,6 +430,7 @@ describe("processFileContent", () => {
 
     it("defaults to the HEAD ref when the file was fetched without one", async () => {
       const { html } = await processFileContent("![Logo](logo.png)", "README.md", null, {
+        kind: "repo",
         owner: "brendanlong",
         repo: "lion-reader",
         path: "README.md",
@@ -451,6 +455,7 @@ describe("processFileContent", () => {
 
     it("resolves links against the blob view at the default HEAD ref", async () => {
       const { html } = await processFileContent("[Docs](docs/guide.md)", "README.md", null, {
+        kind: "repo",
         owner: "brendanlong",
         repo: "lion-reader",
         path: "README.md",
@@ -521,20 +526,37 @@ describe("processFileContent", () => {
 
   describe("gist relative URL resolution (#1424)", () => {
     const gistFile = {
+      kind: "gist" as const,
       rawUrl: "https://gist.githubusercontent.com/brendanlong/abc123/raw/deadbeef/notes.md",
     };
     const gistRawBase = "https://gist.githubusercontent.com/brendanlong/abc123/raw";
+    const COMMIT_SHA = "cbc18f3161df2b2dd22f3c4944d67cebb97ae544";
 
     it("resolves a sibling image reference to the gist's raw host", async () => {
       const { html } = await processFileContent("![Chart](chart.png)", "notes.md", null, gistFile);
       expect(html).toContain(`src="${gistRawBase}/chart.png"`);
     });
 
-    // A raw_url's sha names the file's own blob, and the filename after it is
-    // ignored — keeping it would serve notes.md's bytes as chart.png.
-    it("drops the revision sha, which names a blob rather than a tree", async () => {
+    it("drops the blob sha in raw_url, which would serve the wrong file", async () => {
       const { html } = await processFileContent("![Chart](chart.png)", "notes.md", null, gistFile);
       expect(html).not.toContain("deadbeef");
+    });
+
+    it("pins to the gist's revision when the response carried its history", async () => {
+      const { html } = await processFileContent("![Chart](chart.png)", "notes.md", null, {
+        ...gistFile,
+        revision: COMMIT_SHA,
+      });
+      expect(html).toContain(`src="${gistRawBase}/${COMMIT_SHA}/chart.png"`);
+    });
+
+    it("ignores a revision that isn't a git object name", async () => {
+      // It lands in a URL path we build, so it may only ever be a sha.
+      const { html } = await processFileContent("![Chart](chart.png)", "notes.md", null, {
+        ...gistFile,
+        revision: "../../../evil",
+      });
+      expect(html).toContain(`src="${gistRawBase}/chart.png"`);
     });
 
     it("resolves ./-prefixed references the same way", async () => {
@@ -547,13 +569,11 @@ describe("processFileContent", () => {
       expect(html).toContain(`src="${gistRawBase}/chart.png"`);
     });
 
-    // A gist has no per-file page, so a link resolves to the raw file too.
     it("resolves a sibling link to the raw file", async () => {
       const { html } = await processFileContent("[Setup](setup.md)", "notes.md", null, gistFile);
       expect(html).toContain(`href="${gistRawBase}/setup.md"`);
     });
 
-    // A gist is flat, so a leading slash can only mean a sibling.
     it("resolves root-relative references to the sibling file", async () => {
       const { html } = await processFileContent(
         '<img src="/chart.png">',
@@ -584,10 +604,9 @@ describe("processFileContent", () => {
       expect(html).toContain('href="#setup"');
     });
 
-    // Every URL in the document resolves against this base, so an unexpected one
-    // must not become the base.
     it("leaves content untouched when the raw URL isn't GitHub's raw gist host", async () => {
       const { html } = await processFileContent("![Chart](chart.png)", "notes.md", null, {
+        kind: "gist",
         rawUrl: "https://evil.example.com/brendanlong/abc123/raw/deadbeef/notes.md",
       });
       expect(html).toContain('src="chart.png"');
@@ -595,9 +614,30 @@ describe("processFileContent", () => {
 
     it("leaves content untouched when the raw URL isn't the shape we know", async () => {
       const { html } = await processFileContent("![Chart](chart.png)", "notes.md", null, {
+        kind: "gist",
         rawUrl: "https://gist.githubusercontent.com/brendanlong/abc123/notes.md",
       });
       expect(html).toContain('src="chart.png"');
+    });
+
+    it("leaves content untouched when the raw URL isn't https", async () => {
+      const { html } = await processFileContent("![Chart](chart.png)", "notes.md", null, {
+        kind: "gist",
+        rawUrl: "http://gist.githubusercontent.com/brendanlong/abc123/raw/deadbeef/notes.md",
+      });
+      expect(html).toContain('src="chart.png"');
+    });
+
+    it("resolves srcset candidates and video posters against the raw base", async () => {
+      const { html } = await processFileContent(
+        '<img srcset="small.png 1x, large.png 2x"><video poster="poster.png"></video>',
+        "notes.md",
+        null,
+        gistFile
+      );
+      expect(html).toContain(`${gistRawBase}/small.png 1x`);
+      expect(html).toContain(`${gistRawBase}/large.png 2x`);
+      expect(html).toContain(`poster="${gistRawBase}/poster.png"`);
     });
   });
 
@@ -697,5 +737,56 @@ describe("processFileContent", () => {
       expect(html).toContain("images/a.png");
       expect(html).not.toContain(rawBase);
     });
+  });
+});
+
+describe("buildGistHtml", () => {
+  const gistFile = (filename: string, content: string): GistFile => ({
+    filename,
+    language: filename.endsWith(".md") ? "Markdown" : null,
+    content,
+    raw_url: `https://gist.githubusercontent.com/brendanlong/abc123/raw/deadbeef/${filename}`,
+  });
+  const gist = (files: GistFile[], history?: { version: string }[]): GistResponse => ({
+    id: "abc123",
+    description: null,
+    files: Object.fromEntries(files.map((f) => [f.filename, f])),
+    history,
+    created_at: "2026-07-29T00:00:00Z",
+    updated_at: "2026-07-29T00:00:00Z",
+  });
+  const rawBase = "https://gist.githubusercontent.com/brendanlong/abc123/raw";
+
+  // The wiring the resolution above depends on: a gist file reaches
+  // processFileContent with a location built from its own raw_url.
+  it("resolves the sibling references of a gist's only file", async () => {
+    const { html } = await buildGistHtml(gist([gistFile("notes.md", "![Chart](chart.png)")]));
+    expect(html).toContain(`src="${rawBase}/chart.png"`);
+  });
+
+  it("resolves them for every file of a multi-file gist", async () => {
+    const { html } = await buildGistHtml(
+      gist([gistFile("a.md", "![A](a.png)"), gistFile("b.md", "![B](b.png)")])
+    );
+    expect(html).toContain(`src="${rawBase}/a.png"`);
+    expect(html).toContain(`src="${rawBase}/b.png"`);
+  });
+
+  it("resolves them for a single requested file", async () => {
+    const { html } = await buildGistHtml(
+      gist([gistFile("notes.md", "![Chart](chart.png)"), gistFile("other.md", "Other")]),
+      "notes-md"
+    );
+    expect(html).toContain(`src="${rawBase}/chart.png"`);
+  });
+
+  it("pins to the newest revision in the gist's history", async () => {
+    const { html } = await buildGistHtml(
+      gist(
+        [gistFile("notes.md", "![Chart](chart.png)")],
+        [{ version: "a".repeat(40) }, { version: "b".repeat(40) }]
+      )
+    );
+    expect(html).toContain(`src="${rawBase}/${"a".repeat(40)}/chart.png"`);
   });
 });


### PR DESCRIPTION
Fixes #1424.

A gist's files are a flat list, but a Markdown file in one can still reference a sibling — `![chart](chart.png)`. `processFileContent` passed `location: null` for gist files, so the reference fell through to the generic single-base absolutizer in `saved.ts`, which resolved it against `gist.github.com/{user}/{id}` — the gist's HTML page, so the image rendered broken (the failure mode #1422 fixed for repo files).

## What changed

Gist files now carry a location too (`GistFileLocation`, the file's own `raw_url`), and relative URLs resolve against `https://gist.githubusercontent.com/{user}/{id}/raw/`.

Two things worth calling out:

- **The revision sha in `raw_url` is dropped on purpose.** `raw_url` is `…/raw/{sha}/{filename}`, and that sha names a *blob* — the filename after it is then ignored. So resolving a sibling against it (`…/raw/{sha-of-notes.md}/chart.png`) returns **notes.md's bytes under the sibling's name**, silently the wrong file, which is worse than the broken link we started with. I verified both halves against the live host: the sha form ignores the filename, and the sha-less form resolves by filename and 404s when there's no such file.
- **The base is derived from `raw_url` rather than built from the gist id**, so an ownerless gist needs no guess at the user segment. Anything that isn't `gist.githubusercontent.com/{user}/{id}/raw/…` over https leaves the content untouched — every URL in the document resolves against this base, so an unexpected one must not become it.

Unlike a repo file — whose `href`s go to the github.com blob view, a page a reader can follow — a gist has no per-file page, so links resolve to the raw file too. A gist is flat, so a leading slash can only mean a sibling as well.

## Verification

- Full unit suite green (3025 passed); 10 new cases covering sibling images, sibling links, `./`- and `/`-prefixed forms, absolute URLs, same-document fragments, the dropped sha, and the two reject paths.
- End-to-end against the live API: fetched a real gist through the plugin, took a real `raw_url` from it, and confirmed the URL we produce for a sibling (`…/raw/script.js`) returns exactly that sibling file's content.

As the issue notes, this is low-impact in practice — gists are text-only, so a sibling image reference usually names a file that doesn't exist. The point is that a reference to a sibling that *does* exist now resolves to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)