### PR TITLE
CI: enforce knip and prettier; share build:native artifact across jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,3 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,63 @@ jobs:
       - name: Run linter
         run: pnpm lint
 
+      # The husky pre-commit hook also formats, but it is bypassable
+      # (`--no-verify`, or edits from tools that skip hooks), so gate it here.
+      - name: Check formatting
+        run: pnpm format:check
+
+      - name: Check for unused files, exports, and dependencies
+        run: pnpm knip
+
       - name: Check for raw color utilities
         run: pnpm check:colors
+
+  # The Rust `.node` binaries depend only on native/, so build them once here
+  # and share them with every job that needs them instead of paying for three
+  # independent cargo builds. The cache makes even that one build a no-op when
+  # native/ is unchanged; the artifact is what downstream jobs consume, so they
+  # never depend on a cache hit.
+  build-native:
+    name: Build Native Modules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Restore native modules
+        id: native-cache
+        uses: actions/cache@v6.1.0
+        with:
+          path: native/*/*.node
+          key: native-modules-${{ runner.os }}-${{ hashFiles('native/**') }}
+
+      - uses: pnpm/action-setup@v6.0.9
+        if: steps.native-cache.outputs.cache-hit != 'true'
+
+      - uses: actions/setup-node@v7.0.0
+        if: steps.native-cache.outputs.cache-hit != 'true'
+        with:
+          node-version: "26"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        if: steps.native-cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build native modules
+        if: steps.native-cache.outputs.cache-hit != 'true'
+        run: pnpm build:native
+
+      - name: Upload native modules
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-modules
+          path: native/*/*.node
+          retention-days: 1
 
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
+    needs: build-native
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -71,8 +122,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build native modules
-        run: pnpm build:native
+      - name: Download native modules
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: native-modules
+          path: native/
 
       - name: Run unit tests
         run: pnpm test:unit
@@ -101,6 +155,7 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
+    needs: build-native
     # Service credentials mirror docker-compose.yml / .env.test so the job can
     # run `pnpm test:integration` exactly as developers do locally (migrations,
     # schema dump, and env all come from .env.test).
@@ -141,8 +196,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build native modules
-        run: pnpm build:native
+      - name: Download native modules
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: native-modules
+          path: native/
 
       - name: Run integration tests
         run: pnpm test:integration
@@ -150,6 +208,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    needs: build-native
     services:
       postgres:
         image: postgres:16
@@ -187,8 +246,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build native modules
-        run: pnpm build:native
+      - name: Download native modules
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: native-modules
+          path: native/
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,15 +52,21 @@ jobs:
       - name: Run linter
         run: pnpm lint
 
+      # These run even when an earlier check fails, so one push surfaces every
+      # problem instead of one per round-trip.
+
       # The husky pre-commit hook also formats, but it is bypassable
       # (`--no-verify`, or edits from tools that skip hooks), so gate it here.
       - name: Check formatting
+        if: ${{ !cancelled() }}
         run: pnpm format:check
 
       - name: Check for unused files, exports, and dependencies
+        if: ${{ !cancelled() }}
         run: pnpm knip
 
       - name: Check for raw color utilities
+        if: ${{ !cancelled() }}
         run: pnpm check:colors
 
   # The Rust `.node` binaries depend only on native/, so build them once here
@@ -68,6 +74,10 @@ jobs:
   # independent cargo builds. The cache makes even that one build a no-op when
   # native/ is unchanged; the artifact is what downstream jobs consume, so they
   # never depend on a cache hit.
+  #
+  # Trade-off: a PR that *does* touch native/ pays one cold cargo build on the
+  # critical path ahead of the test jobs, rather than in parallel inside each.
+  # Total runner minutes still drop; wall clock for those PRs is slightly worse.
   build-native:
     name: Build Native Modules
     runs-on: ubuntu-latest
@@ -98,12 +108,15 @@ jobs:
         if: steps.native-cache.outputs.cache-hit != 'true'
         run: pnpm build:native
 
+      # Retention must outlive a plausible "Re-run failed jobs": that reruns
+      # only the failed job, so an expired artifact here breaks the download in
+      # every downstream job with no way to regenerate it short of a full rerun.
       - name: Upload native modules
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: native-modules
           path: native/*/*.node
-          retention-days: 1
+          retention-days: 7
 
   unit-tests:
     name: Unit Tests

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -1,241 +1,247 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Lion Reader Settings</title>
-  <style>
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
-
-    :root {
-      --bg: #fafafa;
-      --bg-card: #ffffff;
-      --border: #e4e4e7;
-      --text: #18181b;
-      --text-muted: #71717a;
-      --text-dim: #a1a1aa;
-      --success: #16a34a;
-      --primary: #18181b;
-      --primary-hover: #27272a;
-      --input-bg: #ffffff;
-      --input-border: #d4d4d8;
-      --focus-ring: #3b82f6;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --bg: #09090b;
-        --bg-card: #18181b;
-        --border: #27272a;
-        --text: #fafafa;
-        --text-muted: #a1a1aa;
-        --text-dim: #71717a;
-        --success: #22c55e;
-        --primary: #fafafa;
-        --primary-hover: #e4e4e7;
-        --input-bg: #27272a;
-        --input-border: #3f3f46;
-        --focus-ring: #60a5fa;
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lion Reader Settings</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-    }
 
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      font-size: 14px;
-      background: var(--bg);
-      color: var(--text);
-      min-width: 400px;
-      padding: 24px;
-    }
+      :root {
+        --bg: #fafafa;
+        --bg-card: #ffffff;
+        --border: #e4e4e7;
+        --text: #18181b;
+        --text-muted: #71717a;
+        --text-dim: #a1a1aa;
+        --success: #16a34a;
+        --primary: #18181b;
+        --primary-hover: #27272a;
+        --input-bg: #ffffff;
+        --input-border: #d4d4d8;
+        --focus-ring: #3b82f6;
+      }
 
-    .container {
-      max-width: 500px;
-    }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #09090b;
+          --bg-card: #18181b;
+          --border: #27272a;
+          --text: #fafafa;
+          --text-muted: #a1a1aa;
+          --text-dim: #71717a;
+          --success: #22c55e;
+          --primary: #fafafa;
+          --primary-hover: #e4e4e7;
+          --input-bg: #27272a;
+          --input-border: #3f3f46;
+          --focus-ring: #60a5fa;
+        }
+      }
 
-    h1 {
-      font-size: 20px;
-      font-weight: 600;
-      margin-bottom: 8px;
-    }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        font-size: 14px;
+        background: var(--bg);
+        color: var(--text);
+        min-width: 400px;
+        padding: 24px;
+      }
 
-    .description {
-      color: var(--text-muted);
-      margin-bottom: 24px;
-      line-height: 1.5;
-    }
+      .container {
+        max-width: 500px;
+      }
 
-    .field {
-      margin-bottom: 20px;
-    }
+      h1 {
+        font-size: 20px;
+        font-weight: 600;
+        margin-bottom: 8px;
+      }
 
-    label {
-      display: block;
-      font-weight: 500;
-      margin-bottom: 6px;
-    }
+      .description {
+        color: var(--text-muted);
+        margin-bottom: 24px;
+        line-height: 1.5;
+      }
 
-    .hint {
-      font-size: 12px;
-      color: var(--text-dim);
-      margin-top: 4px;
-    }
+      .field {
+        margin-bottom: 20px;
+      }
 
-    input[type="url"] {
-      width: 100%;
-      padding: 10px 12px;
-      border: 1px solid var(--input-border);
-      border-radius: 6px;
-      font-size: 14px;
-      background: var(--input-bg);
-      color: var(--text);
-      transition: border-color 0.15s, box-shadow 0.15s;
-    }
+      label {
+        display: block;
+        font-weight: 500;
+        margin-bottom: 6px;
+      }
 
-    input[type="url"]:focus {
-      outline: none;
-      border-color: var(--focus-ring);
-      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
-    }
+      .hint {
+        font-size: 12px;
+        color: var(--text-dim);
+        margin-top: 4px;
+      }
 
-    .buttons {
-      display: flex;
-      gap: 12px;
-      align-items: center;
-    }
+      input[type="url"] {
+        width: 100%;
+        padding: 10px 12px;
+        border: 1px solid var(--input-border);
+        border-radius: 6px;
+        font-size: 14px;
+        background: var(--input-bg);
+        color: var(--text);
+        transition:
+          border-color 0.15s,
+          box-shadow 0.15s;
+      }
 
-    .btn {
-      padding: 10px 20px;
-      border-radius: 6px;
-      font-size: 14px;
-      font-weight: 500;
-      cursor: pointer;
-      border: none;
-      transition: background-color 0.15s;
-    }
+      input[type="url"]:focus {
+        outline: none;
+        border-color: var(--focus-ring);
+        box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+      }
 
-    .btn-primary {
-      background: var(--primary);
-      color: var(--bg);
-    }
+      .buttons {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+      }
 
-    .btn-primary:hover {
-      background: var(--primary-hover);
-    }
+      .btn {
+        padding: 10px 20px;
+        border-radius: 6px;
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+        border: none;
+        transition: background-color 0.15s;
+      }
 
-    .btn-secondary {
-      background: var(--bg-card);
-      border: 1px solid var(--border);
-      color: var(--text);
-    }
+      .btn-primary {
+        background: var(--primary);
+        color: var(--bg);
+      }
 
-    .btn-secondary:hover {
-      background: var(--bg);
-    }
+      .btn-primary:hover {
+        background: var(--primary-hover);
+      }
 
-    .status {
-      font-size: 13px;
-      color: var(--success);
-      opacity: 0;
-      transition: opacity 0.2s;
-    }
+      .btn-secondary {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        color: var(--text);
+      }
 
-    .status.visible {
-      opacity: 1;
-    }
+      .btn-secondary:hover {
+        background: var(--bg);
+      }
 
-    .section {
-      border-top: 1px solid var(--border);
-      padding-top: 20px;
-      margin-top: 24px;
-    }
+      .status {
+        font-size: 13px;
+        color: var(--success);
+        opacity: 0;
+        transition: opacity 0.2s;
+      }
 
-    .section h2 {
-      font-size: 16px;
-      font-weight: 600;
-      margin-bottom: 12px;
-    }
+      .status.visible {
+        opacity: 1;
+      }
 
-    .shortcut {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 10px 0;
-      border-bottom: 1px solid var(--border);
-    }
+      .section {
+        border-top: 1px solid var(--border);
+        padding-top: 20px;
+        margin-top: 24px;
+      }
 
-    .shortcut:last-child {
-      border-bottom: none;
-    }
+      .section h2 {
+        font-size: 16px;
+        font-weight: 600;
+        margin-bottom: 12px;
+      }
 
-    .shortcut-name {
-      font-weight: 500;
-    }
+      .shortcut {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 10px 0;
+        border-bottom: 1px solid var(--border);
+      }
 
-    .shortcut-key {
-      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-      font-size: 12px;
-      background: var(--bg-card);
-      border: 1px solid var(--border);
-      padding: 4px 8px;
-      border-radius: 4px;
-    }
+      .shortcut:last-child {
+        border-bottom: none;
+      }
 
-    .link {
-      color: var(--focus-ring);
-      text-decoration: none;
-    }
+      .shortcut-name {
+        font-weight: 500;
+      }
 
-    .link:hover {
-      text-decoration: underline;
-    }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Lion Reader Settings</h1>
-    <p class="description">
-      Configure your Lion Reader extension. For self-hosted instances, enter your server URL below.
-    </p>
+      .shortcut-key {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 12px;
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        padding: 4px 8px;
+        border-radius: 4px;
+      }
 
-    <div class="field">
-      <label for="server-url">Server URL</label>
-      <input type="url" id="server-url" placeholder="https://lionreader.com">
-      <p class="hint">Leave empty to use the default (https://lionreader.com)</p>
-    </div>
+      .link {
+        color: var(--focus-ring);
+        text-decoration: none;
+      }
 
-    <div class="buttons">
-      <button id="save-btn" class="btn btn-primary">Save Settings</button>
-      <button id="reset-btn" class="btn btn-secondary">Reset to Default</button>
-      <span id="status" class="status">Saved!</span>
-    </div>
+      .link:hover {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Lion Reader Settings</h1>
+      <p class="description">
+        Configure your Lion Reader extension. For self-hosted instances, enter your server URL
+        below.
+      </p>
 
-    <div class="section">
-      <h2>Keyboard Shortcuts</h2>
-      <div class="shortcut">
-        <span class="shortcut-name">Save current page</span>
-        <span class="shortcut-key" id="shortcut-key">Ctrl+Shift+S</span>
+      <div class="field">
+        <label for="server-url">Server URL</label>
+        <input type="url" id="server-url" placeholder="https://lionreader.com" />
+        <p class="hint">Leave empty to use the default (https://lionreader.com)</p>
       </div>
-      <p class="hint" style="margin-top: 12px;">
-        You can customize shortcuts in your browser's extension settings.
-        <br>
-        <a href="#" id="shortcuts-link" class="link">Open extension shortcuts</a>
-      </p>
+
+      <div class="buttons">
+        <button id="save-btn" class="btn btn-primary">Save Settings</button>
+        <button id="reset-btn" class="btn btn-secondary">Reset to Default</button>
+        <span id="status" class="status">Saved!</span>
+      </div>
+
+      <div class="section">
+        <h2>Keyboard Shortcuts</h2>
+        <div class="shortcut">
+          <span class="shortcut-name">Save current page</span>
+          <span class="shortcut-key" id="shortcut-key">Ctrl+Shift+S</span>
+        </div>
+        <p class="hint" style="margin-top: 12px">
+          You can customize shortcuts in your browser's extension settings.
+          <br />
+          <a href="#" id="shortcuts-link" class="link">Open extension shortcuts</a>
+        </p>
+      </div>
+
+      <div class="section">
+        <h2>About</h2>
+        <p style="color: var(--text-muted); line-height: 1.6">
+          Lion Reader is an open-source RSS reader with read-it-later functionality.
+          <br /><br />
+          <a href="https://github.com/brendanlong/lion-reader" target="_blank" class="link"
+            >View on GitHub</a
+          >
+        </p>
+      </div>
     </div>
 
-    <div class="section">
-      <h2>About</h2>
-      <p style="color: var(--text-muted); line-height: 1.6;">
-        Lion Reader is an open-source RSS reader with read-it-later functionality.
-        <br><br>
-        <a href="https://github.com/brendanlong/lion-reader" target="_blank" class="link">View on GitHub</a>
-      </p>
-    </div>
-  </div>
-
-  <script type="module" src="options.js"></script>
-</body>
+    <script type="module" src="options.js"></script>
+  </body>
 </html>

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -1,271 +1,304 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Save to Lion Reader</title>
-  <style>
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
-
-    :root {
-      --bg: #fafafa;
-      --bg-card: #ffffff;
-      --border: #e4e4e7;
-      --text: #18181b;
-      --text-muted: #71717a;
-      --text-dim: #a1a1aa;
-      --success: #16a34a;
-      --success-light: #15803d;
-      --error: #dc2626;
-      --error-light: #b91c1c;
-      --primary: #18181b;
-      --primary-hover: #27272a;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --bg: #09090b;
-        --bg-card: #18181b;
-        --border: #27272a;
-        --text: #fafafa;
-        --text-muted: #a1a1aa;
-        --text-dim: #71717a;
-        --success: #22c55e;
-        --success-light: #4ade80;
-        --error: #ef4444;
-        --error-light: #f87171;
-        --primary: #fafafa;
-        --primary-hover: #e4e4e7;
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Save to Lion Reader</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
       }
-    }
 
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      font-size: 14px;
-      background: var(--bg);
-      color: var(--text);
-      width: 320px;
-      min-height: 120px;
-    }
+      :root {
+        --bg: #fafafa;
+        --bg-card: #ffffff;
+        --border: #e4e4e7;
+        --text: #18181b;
+        --text-muted: #71717a;
+        --text-dim: #a1a1aa;
+        --success: #16a34a;
+        --success-light: #15803d;
+        --error: #dc2626;
+        --error-light: #b91c1c;
+        --primary: #18181b;
+        --primary-hover: #27272a;
+      }
 
-    .container {
-      padding: 16px;
-    }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #09090b;
+          --bg-card: #18181b;
+          --border: #27272a;
+          --text: #fafafa;
+          --text-muted: #a1a1aa;
+          --text-dim: #71717a;
+          --success: #22c55e;
+          --success-light: #4ade80;
+          --error: #ef4444;
+          --error-light: #f87171;
+          --primary: #fafafa;
+          --primary-hover: #e4e4e7;
+        }
+      }
 
-    .header {
-      text-align: center;
-      margin-bottom: 16px;
-    }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        font-size: 14px;
+        background: var(--bg);
+        color: var(--text);
+        width: 320px;
+        min-height: 120px;
+      }
 
-    .header h1 {
-      font-size: 16px;
-      font-weight: 600;
-    }
+      .container {
+        padding: 16px;
+      }
 
-    .status {
-      text-align: center;
-    }
+      .header {
+        text-align: center;
+        margin-bottom: 16px;
+      }
 
-    .spinner {
-      width: 32px;
-      height: 32px;
-      margin: 0 auto 12px;
-      animation: spin 1s linear infinite;
-    }
+      .header h1 {
+        font-size: 16px;
+        font-weight: 600;
+      }
 
-    @keyframes spin {
-      from { transform: rotate(0deg); }
-      to { transform: rotate(360deg); }
-    }
+      .status {
+        text-align: center;
+      }
 
-    .icon {
-      width: 32px;
-      height: 32px;
-      margin: 0 auto 12px;
-    }
+      .spinner {
+        width: 32px;
+        height: 32px;
+        margin: 0 auto 12px;
+        animation: spin 1s linear infinite;
+      }
 
-    .icon.success { color: var(--success); }
-    .icon.error { color: var(--error); }
+      @keyframes spin {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
 
-    .message {
-      font-size: 14px;
-      color: var(--text-muted);
-      margin-bottom: 8px;
-    }
+      .icon {
+        width: 32px;
+        height: 32px;
+        margin: 0 auto 12px;
+      }
 
-    .message.success {
-      color: var(--success);
-      font-weight: 500;
-    }
+      .icon.success {
+        color: var(--success);
+      }
+      .icon.error {
+        color: var(--error);
+      }
 
-    .message.error {
-      color: var(--error);
-    }
+      .message {
+        font-size: 14px;
+        color: var(--text-muted);
+        margin-bottom: 8px;
+      }
 
-    .title {
-      font-size: 13px;
-      color: var(--text-muted);
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-      margin-bottom: 12px;
-    }
+      .message.success {
+        color: var(--success);
+        font-weight: 500;
+      }
 
-    .url {
-      font-size: 11px;
-      color: var(--text-dim);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      margin-bottom: 12px;
-    }
+      .message.error {
+        color: var(--error);
+      }
 
-    .countdown {
-      font-size: 12px;
-      color: var(--text-dim);
-      margin-bottom: 12px;
-    }
+      .title {
+        font-size: 13px;
+        color: var(--text-muted);
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        margin-bottom: 12px;
+      }
 
-    .buttons {
-      display: flex;
-      gap: 8px;
-    }
+      .url {
+        font-size: 11px;
+        color: var(--text-dim);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin-bottom: 12px;
+      }
 
-    .btn {
-      flex: 1;
-      padding: 8px 12px;
-      border-radius: 6px;
-      font-size: 13px;
-      font-weight: 500;
-      cursor: pointer;
-      border: none;
-      transition: background-color 0.15s;
-    }
+      .countdown {
+        font-size: 12px;
+        color: var(--text-dim);
+        margin-bottom: 12px;
+      }
 
-    .btn-secondary {
-      background: var(--bg-card);
-      border: 1px solid var(--border);
-      color: var(--text);
-    }
+      .buttons {
+        display: flex;
+        gap: 8px;
+      }
 
-    .btn-secondary:hover {
-      background: var(--bg);
-    }
+      .btn {
+        flex: 1;
+        padding: 8px 12px;
+        border-radius: 6px;
+        font-size: 13px;
+        font-weight: 500;
+        cursor: pointer;
+        border: none;
+        transition: background-color 0.15s;
+      }
 
-    .btn-primary {
-      background: var(--primary);
-      color: var(--bg);
-    }
+      .btn-secondary {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        color: var(--text);
+      }
 
-    .btn-primary:hover {
-      background: var(--primary-hover);
-    }
+      .btn-secondary:hover {
+        background: var(--bg);
+      }
 
-    .alert {
-      padding: 10px 12px;
-      border-radius: 6px;
-      font-size: 13px;
-      text-align: left;
-      margin-bottom: 12px;
-    }
+      .btn-primary {
+        background: var(--primary);
+        color: var(--bg);
+      }
 
-    .alert.error {
-      background: rgba(220, 38, 38, 0.1);
-      border: 1px solid rgba(220, 38, 38, 0.2);
-      color: var(--error);
-    }
+      .btn-primary:hover {
+        background: var(--primary-hover);
+      }
 
-    .hidden {
-      display: none;
-    }
+      .alert {
+        padding: 10px 12px;
+        border-radius: 6px;
+        font-size: 13px;
+        text-align: left;
+        margin-bottom: 12px;
+      }
 
-    .settings-link {
-      display: block;
-      text-align: center;
-      margin-top: 12px;
-      font-size: 12px;
-      color: var(--text-dim);
-      text-decoration: none;
-    }
+      .alert.error {
+        background: rgba(220, 38, 38, 0.1);
+        border: 1px solid rgba(220, 38, 38, 0.2);
+        color: var(--error);
+      }
 
-    .settings-link:hover {
-      color: var(--text-muted);
-    }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="header">
-      <h1>Save to Lion Reader</h1>
-    </div>
+      .hidden {
+        display: none;
+      }
 
-    <!-- Loading State -->
-    <div id="loading" class="status">
-      <svg class="spinner" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <circle cx="12" cy="12" r="10" stroke-opacity="0.25"/>
-        <path d="M4 12a8 8 0 018-8" stroke-opacity="0.75" stroke-linecap="round"/>
-      </svg>
-      <p class="message">Saving article...</p>
-      <p id="loading-url" class="url"></p>
-    </div>
+      .settings-link {
+        display: block;
+        text-align: center;
+        margin-top: 12px;
+        font-size: 12px;
+        color: var(--text-dim);
+        text-decoration: none;
+      }
 
-    <!-- Success State -->
-    <div id="success" class="status hidden">
-      <svg class="icon success" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
-      </svg>
-      <p class="message success">Saved successfully!</p>
-      <p id="success-title" class="title"></p>
-      <p id="countdown" class="countdown"></p>
-      <div class="buttons">
-        <button id="close-btn" class="btn btn-secondary">Close Now</button>
+      .settings-link:hover {
+        color: var(--text-muted);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <h1>Save to Lion Reader</h1>
+      </div>
+
+      <!-- Loading State -->
+      <div id="loading" class="status">
+        <svg class="spinner" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="12" cy="12" r="10" stroke-opacity="0.25" />
+          <path d="M4 12a8 8 0 018-8" stroke-opacity="0.75" stroke-linecap="round" />
+        </svg>
+        <p class="message">Saving article...</p>
+        <p id="loading-url" class="url"></p>
+      </div>
+
+      <!-- Success State -->
+      <div id="success" class="status hidden">
+        <svg
+          class="icon success"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+        <p class="message success">Saved successfully!</p>
+        <p id="success-title" class="title"></p>
+        <p id="countdown" class="countdown"></p>
+        <div class="buttons">
+          <button id="close-btn" class="btn btn-secondary">Close Now</button>
+        </div>
+      </div>
+
+      <!-- Error State -->
+      <div id="error" class="status hidden">
+        <svg
+          class="icon error"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+        <div id="error-alert" class="alert error"></div>
+        <p id="error-url" class="url"></p>
+        <div class="buttons">
+          <button id="error-close-btn" class="btn btn-secondary">Close</button>
+          <button id="retry-btn" class="btn btn-primary">Retry</button>
+        </div>
+      </div>
+
+      <!-- Not Configured State -->
+      <div id="not-configured" class="status hidden">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+          />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+        <p class="message">Please configure Lion Reader</p>
+        <p class="message" style="font-size: 12px">
+          Set your server URL and sign in to start saving articles.
+        </p>
+        <div class="buttons" style="margin-top: 12px">
+          <button id="open-options-btn" class="btn btn-primary">Open Settings</button>
+        </div>
+      </div>
+
+      <!-- Not Signed In State -->
+      <div id="not-signed-in" class="status hidden">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+          />
+        </svg>
+        <p class="message">Sign in required</p>
+        <p class="message" style="font-size: 12px">
+          Please sign in to Lion Reader in your browser first.
+        </p>
+        <div class="buttons" style="margin-top: 12px">
+          <button id="open-lionreader-btn" class="btn btn-primary">Open Lion Reader</button>
+        </div>
       </div>
     </div>
 
-    <!-- Error State -->
-    <div id="error" class="status hidden">
-      <svg class="icon error" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-      </svg>
-      <div id="error-alert" class="alert error"></div>
-      <p id="error-url" class="url"></p>
-      <div class="buttons">
-        <button id="error-close-btn" class="btn btn-secondary">Close</button>
-        <button id="retry-btn" class="btn btn-primary">Retry</button>
-      </div>
-    </div>
-
-    <!-- Not Configured State -->
-    <div id="not-configured" class="status hidden">
-      <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
-        <circle cx="12" cy="12" r="3"/>
-      </svg>
-      <p class="message">Please configure Lion Reader</p>
-      <p class="message" style="font-size: 12px;">Set your server URL and sign in to start saving articles.</p>
-      <div class="buttons" style="margin-top: 12px;">
-        <button id="open-options-btn" class="btn btn-primary">Open Settings</button>
-      </div>
-    </div>
-
-    <!-- Not Signed In State -->
-    <div id="not-signed-in" class="status hidden">
-      <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
-      </svg>
-      <p class="message">Sign in required</p>
-      <p class="message" style="font-size: 12px;">Please sign in to Lion Reader in your browser first.</p>
-      <div class="buttons" style="margin-top: 12px;">
-        <button id="open-lionreader-btn" class="btn btn-primary">Open Lion Reader</button>
-      </div>
-    </div>
-  </div>
-
-  <script type="module" src="popup.js"></script>
-</body>
+    <script type="module" src="popup.js"></script>
+  </body>
 </html>

--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "workspaces": {
     ".": {
+      "entry": ["scripts/fixup-standalone.mjs"],
       "ignore": [
         "extension/**",
         "src/lib/stubs/**",

--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
     "discord-bot": "dotenv -- tsx scripts/discord-bot.ts"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx,mjs,cjs}": [
+    "*.{ts,tsx,js,jsx,mjs,cjs,mts,cts}": [
       "eslint --fix --max-warnings 0 --no-warn-ignored",
       "prettier --write"
     ],
-    "*.{json,md,css,scss,yaml,yml}": [
+    "*.{json,md,css,scss,yaml,yml,html}": [
       "prettier --write"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "format:check": "prettier --check .",
     "prepare": "husky",
     "social-preview": "tsx scripts/generate-social-preview.ts",
+    "bench:sanitize": "tsx scripts/bench-sanitize.mts",
     "db:migrate": "dotenv -- tsx scripts/migrate.ts",
     "db:schema": "dotenv -- tsx scripts/dump-schema.ts",
     "db:seed": "dotenv -- tsx scripts/seed.ts",

--- a/scripts/bench-sanitize.mts
+++ b/scripts/bench-sanitize.mts
@@ -1,7 +1,7 @@
 /**
  * Benchmark for the entry-content sanitizer (`sanitizeEntryHtml`).
  *
- * Run with: pnpm tsx scripts/bench-sanitize.mts
+ * Run with: pnpm bench:sanitize
  *
  * Measures the full native pipeline (MathJax CHTML→MathML + inline-SVG +
  * lol_html allow-list pass, one N-API call) across representative document

--- a/src/app/(spa)/auth/oauth/callback/page.tsx
+++ b/src/app/(spa)/auth/oauth/callback/page.tsx
@@ -23,8 +23,7 @@ import { SpinnerIcon } from "@/components/ui/icon-button";
  * Validation result for OAuth callback parameters
  */
 type CallbackValidation =
-  | { valid: true; code: string; state: string }
-  | { valid: false; error: string; errorCode: string };
+  { valid: true; code: string; state: string } | { valid: false; error: string; errorCode: string };
 
 /**
  * Helper to map error messages to error codes for redirect

--- a/src/lib/appearance/config.ts
+++ b/src/lib/appearance/config.ts
@@ -82,7 +82,7 @@ export interface FontConfig {
   lineHeight: number;
 }
 
-export const FONT_CONFIGS: Record<FontFamily, FontConfig> = {
+const FONT_CONFIGS: Record<FontFamily, FontConfig> = {
   system: {
     family: "inherit",
     // Varies by platform (San Francisco, Segoe UI, Roboto, etc.)
@@ -116,7 +116,7 @@ export const FONT_CONFIGS: Record<FontFamily, FontConfig> = {
 };
 
 /** Base font size (rem) for each size option, before per-font sizeAdjust. */
-export const BASE_SIZES: Record<TextSize, number> = {
+const BASE_SIZES: Record<TextSize, number> = {
   small: 0.875,
   medium: 1,
   large: 1.125,

--- a/src/lib/cache/count-cache.ts
+++ b/src/lib/cache/count-cache.ts
@@ -38,7 +38,7 @@ const subscriptionLookupMap = new Map<string, CachedSubscription>();
  * session (it isn't tied to the QueryClient), so without an explicit clear one
  * account's subscription data bleeds into the next login on a shared browser.
  */
-export function clearSubscriptionLookupMap(): void {
+function clearSubscriptionLookupMap(): void {
   subscriptionLookupMap.clear();
 }
 

--- a/src/lib/events/connection-state.ts
+++ b/src/lib/events/connection-state.ts
@@ -50,12 +50,7 @@ export const SSE_RETRY_INTERVAL_MS = 60_000;
 export type ConnectionStatus = "connecting" | "connected" | "disconnected" | "error" | "polling";
 
 export type ConnectionPhase =
-  | "disconnected"
-  | "connecting"
-  | "connected"
-  | "probing"
-  | "backoff"
-  | "polling";
+  "disconnected" | "connecting" | "connected" | "probing" | "backoff" | "polling";
 
 export interface ConnectionState {
   phase: ConnectionPhase;

--- a/src/lib/hooks/viewPreferences.ts
+++ b/src/lib/hooks/viewPreferences.ts
@@ -9,13 +9,7 @@
  * View types for different entry list pages.
  */
 export type ViewType =
-  | "all"
-  | "starred"
-  | "subscription"
-  | "tag"
-  | "saved"
-  | "uncategorized"
-  | "recently-read";
+  "all" | "starred" | "subscription" | "tag" | "saved" | "uncategorized" | "recently-read";
 
 /**
  * View preference settings.

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -6,8 +6,8 @@ import type { Metadata } from "next";
  * Emitting og:image:width/height lets crawlers reserve the card's space up front
  * (no layout shift, and some clients require dimensions to render a large card).
  */
-export const OG_IMAGE_WIDTH = 1200;
-export const OG_IMAGE_HEIGHT = 630;
+const OG_IMAGE_WIDTH = 1200;
+const OG_IMAGE_HEIGHT = 630;
 
 export const defaultOpenGraph: Metadata["openGraph"] = {
   images: [{ url: "/social-preview.png", width: OG_IMAGE_WIDTH, height: OG_IMAGE_HEIGHT }],

--- a/src/server/db/errors.ts
+++ b/src/server/db/errors.ts
@@ -5,7 +5,7 @@
 /**
  * Postgres SQLSTATE for a unique-constraint violation.
  */
-export const PG_UNIQUE_VIOLATION = "23505";
+const PG_UNIQUE_VIOLATION = "23505";
 
 /**
  * Returns true if the error is a Postgres unique-constraint violation.

--- a/src/server/feed/lesswrong.ts
+++ b/src/server/feed/lesswrong.ts
@@ -535,8 +535,7 @@ async function fetchLessWrongComment(commentId: string): Promise<LessWrongCommen
  * Union type for content fetched from LessWrong.
  */
 export type LessWrongContent =
-  | (LessWrongPostContent & { type: "post" })
-  | (LessWrongCommentContent & { type: "comment" });
+  (LessWrongPostContent & { type: "post" }) | (LessWrongCommentContent & { type: "comment" });
 
 /**
  * Fetches LessWrong content from a URL, detecting whether it's a post or comment.

--- a/src/server/google-reader/id.ts
+++ b/src/server/google-reader/id.ts
@@ -177,8 +177,7 @@ export async function feedStreamIdToSubscriptionUuid(
  * see issue #730).
  */
 export type FeedStreamResolution =
-  | { kind: "subscription"; subscriptionId: string }
-  | { kind: "saved"; feedId: string };
+  { kind: "subscription"; subscriptionId: string } | { kind: "saved"; feedId: string };
 
 /**
  * Resolves a `feed/{int64}` stream ID to either a subscription or the user's

--- a/src/server/http/fetch.ts
+++ b/src/server/http/fetch.ts
@@ -245,7 +245,7 @@ export const FEED_FETCH_TIMEOUT_MS = 10000;
  * Bounds slow-loris connection holding on webhook endpoints that must buffer
  * the body before authenticating it (see `readRequestBufferWithSizeLimit`).
  */
-export const REQUEST_BODY_READ_TIMEOUT_MS = 30000;
+const REQUEST_BODY_READ_TIMEOUT_MS = 30000;
 
 /**
  * Timeout for page fetch requests (30 seconds).

--- a/src/server/http/trailing-slash.ts
+++ b/src/server/http/trailing-slash.ts
@@ -24,7 +24,7 @@
 /**
  * True for the (slash-trimmed) paths that must answer slashed URLs in place.
  */
-export function isOauthMcpSurfacePath(pathname: string): boolean {
+function isOauthMcpSurfacePath(pathname: string): boolean {
   return (
     pathname === "/api/mcp" ||
     pathname === "/token" ||

--- a/src/server/plugins/youtube.ts
+++ b/src/server/plugins/youtube.ts
@@ -32,7 +32,7 @@ export const YOUTUBE_MIN_FETCH_INTERVAL_SECONDS = 60 * 60;
  * path (see transformTags.iframe in sanitize.ts); setting them here just keeps
  * the stored raw content self-contained.
  */
-export function buildYouTubeEmbedIframe(videoId: string, title?: string | null): string {
+function buildYouTubeEmbedIframe(videoId: string, title?: string | null): string {
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
   return (
     `<iframe src="https://www.youtube-nocookie.com/embed/${videoId}"` +


### PR DESCRIPTION
Fixes #1469.

Three gaps in `.github/workflows/ci.yml`:

### 1. knip now runs in CI
`knip.json` and `pnpm knip` existed but nothing invoked them. Added to the **Lint** job, and cleaned up so it starts green:

- Dropped `export` from 9 constants/functions only ever used inside their own module (`FONT_CONFIGS`, `BASE_SIZES`, `clearSubscriptionLookupMap`, `OG_IMAGE_WIDTH`/`OG_IMAGE_HEIGHT`, `PG_UNIQUE_VIOLATION`, `REQUEST_BODY_READ_TIMEOUT_MS`, `isOauthMcpSurfacePath`, `buildYouTubeEmbedIframe`).
- The two "unused" files are both live code, so **neither was deleted** — the issue suggested cleaning them up, but knip simply can't see how they're reached:
  - `scripts/fixup-standalone.mjs` is invoked by `Dockerfile:154` → declared a knip `entry`.
  - `scripts/bench-sanitize.mts` is the benchmark harness documented in `src/server/html/CLAUDE.md` → gave it a `pnpm bench:sanitize` script, which makes it both reachable and discoverable (better than an ignore entry, which would just re-hide it).

### 2. prettier `format:check` now runs in CI
Previously only the husky `lint-staged` hook enforced it, which `--no-verify` (or any tool that skips hooks) bypasses.

Commit 1 formats the files that had drifted — mostly the extension's `.html`. But that alone would let the drift recur: **`lint-staged`'s globs never matched `.html` or `.mts`**, which is precisely why those files were unformatted in the first place. With CI now gating `format:check`, that gap would turn an ordinary commit into a red build, so the globs are fixed too (`html` added to the prettier glob; `mts,cts` to the eslint+prettier one — `eslint .` already linted `.mts`, only the hook skipped it). Verified by staging a badly-formatted `.html` + `.mts` and running `pnpm exec lint-staged`: untouched under the old globs, formatted under the new ones.

### 3. `build:native` builds once instead of three times
New `build-native` job builds the four Rust crates and publishes the `.node` binaries as an artifact that unit/integration/e2e download. It also caches them on `hashFiles('native/**')`, so an unchanged `native/` skips cargo entirely. Downstream jobs consume the **artifact**, not the cache, so they never depend on a cache hit.

**Measured** (master baseline → this PR):

| | master | cold cache | warm cache |
|---|---|---|---|
| Build Native Modules | — | 2.4 min | **6 s** |
| Unit / Integration / E2E | 3.6 / 3.8 / 6.4 min | 1.6 / 2.0 / 3.7 min | 1.6 / 2.2 / 3.8 min |
| **runner minutes** | **13.8** | 9.7 | **7.6 (-45%)** |
| **wall clock** | **6.5 min** | 6.3 min | **4.0 min (-38%)** |

Note the cold-cache column: the producer serializes ahead of E2E, so a PR that *does* touch `native/` sees roughly flat wall clock (runner minutes still drop). The latency win is warm-cache-only; that trade-off is written into the job comment.

### Verification
Beyond the green checks, I verified the two silent-failure modes directly rather than assuming them:

- **Artifact layout** — `gh run download`ed the published artifact and confirmed it restores to exactly `native/<pkg>/<pkg>.node`, matching `pnpm build:native` locally. (Artifact paths are relative to the glob's least-common-ancestor, not the repo root.)
- **Cache genuinely hits** — re-ran the producer job: 8 s vs 2.4 min, with the build steps `skipped` and `Upload native modules: success`. That last part is load-bearing: the upload step is deliberately **not** guarded on `cache-hit`, or every hit would publish nothing and break all three consumers.

Locally: `typecheck`, `lint`, `format:check`, `knip`, `test:unit` (3123 tests) all pass.

### Review follow-ups (4th commit)
An independent review caught: `retention-days: 1` would break "Re-run failed jobs" (that reruns only the *failed* job, so an expired artifact leaves consumers with no way to regenerate it) → 7 days; the lint-staged glob gap above; sequential lint steps hiding the new checks behind a `pnpm lint` failure → `if: ${{ !cancelled() }}`; and a floating action pin.

Not done, deliberately: caching `.next/cache` to speed up E2E's `next build`. It'd be a few hundred MB against a 10 GB repo-wide budget already holding CodeQL databases (~108 MB each) and 230 MB pnpm caches — real risk of evicting caches that already pay off. Worth revisiting with eviction data.

— Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)