### PR TITLE
Read entry ownership through visible_entries in the AI routers (#1468)

### DIFF
--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -369,11 +369,13 @@ export async function selectFullEntry(db: typeof dbType, userId: string, entryId
 /**
  * The stored content family of an entry, plus the fields the AI paths key their
  * caches on (`contentHash`/`fullContentHash`) and prompt with (`title`).
+ * Deliberately one shape for both callers even though each reads a subset: the
+ * point of the shared read is that they can't drift, and the row it saves is
+ * noise next to the LLM call that follows.
  */
-const entryContentSelectFields = {
-  id: visibleEntries.id,
+const entryRawContentSelectFields = {
   title: visibleEntries.title,
-  // Raw (untrusted) content — see getOwnedEntryContent.
+  // Raw (untrusted) content — see getOwnedEntryRawContent.
   contentOriginal: visibleEntries.contentOriginal,
   contentCleaned: visibleEntries.contentCleaned,
   contentHash: visibleEntries.contentHash,
@@ -382,8 +384,7 @@ const entryContentSelectFields = {
   fullContentHash: visibleEntries.fullContentHash,
 };
 
-export interface OwnedEntryContent {
-  id: string;
+export interface OwnedEntryRawContent {
   title: string | null;
   contentOriginal: string | null;
   contentCleaned: string | null;
@@ -400,19 +401,20 @@ export interface OwnedEntryContent {
  * door either (a raw `user_entries` join would let e.g. an unsubscribed,
  * unstarred entry through).
  *
- * The content is deliberately **raw**: callers here hash it and hand it to an
- * LLM rather than render it. Anything that reaches a client must be sanitized
- * first (`sanitizeEntryHtml`; the ordinary read path does this in `toFullEntry`).
+ * Unlike every other read out of this service, the content is **raw**: this is
+ * for callers that hash it or feed it to an LLM, not ones that return it.
+ * Anything that reaches a client must be sanitized first (`sanitizeEntryHtml`;
+ * the ordinary read path does it in `toFullEntry`).
  *
  * @throws entryNotFound if the entry doesn't exist or isn't visible to the user
  */
-export async function getOwnedEntryContent(
+export async function getOwnedEntryRawContent(
   db: typeof dbType,
   userId: string,
   entryId: string
-): Promise<OwnedEntryContent> {
+): Promise<OwnedEntryRawContent> {
   const result = await db
-    .select(entryContentSelectFields)
+    .select(entryRawContentSelectFields)
     .from(visibleEntries)
     .where(and(eq(visibleEntries.id, entryId), eq(visibleEntries.userId, userId)))
     .limit(1);

--- a/src/server/services/entries.ts
+++ b/src/server/services/entries.ts
@@ -367,6 +367,64 @@ export async function selectFullEntry(db: typeof dbType, userId: string, entryId
 }
 
 /**
+ * The stored content family of an entry, plus the fields the AI paths key their
+ * caches on (`contentHash`/`fullContentHash`) and prompt with (`title`).
+ */
+const entryContentSelectFields = {
+  id: visibleEntries.id,
+  title: visibleEntries.title,
+  // Raw (untrusted) content — see getOwnedEntryContent.
+  contentOriginal: visibleEntries.contentOriginal,
+  contentCleaned: visibleEntries.contentCleaned,
+  contentHash: visibleEntries.contentHash,
+  fullContentOriginal: visibleEntries.fullContentOriginal,
+  fullContentCleaned: visibleEntries.fullContentCleaned,
+  fullContentHash: visibleEntries.fullContentHash,
+};
+
+export interface OwnedEntryContent {
+  id: string;
+  title: string | null;
+  contentOriginal: string | null;
+  contentCleaned: string | null;
+  contentHash: string;
+  fullContentOriginal: string | null;
+  fullContentCleaned: string | null;
+  fullContentHash: string | null;
+}
+
+/**
+ * Fetch an entry's stored content for a user, enforcing ownership through
+ * `visible_entries` — the same visibility rule `listEntries`/`getEntry` apply,
+ * so an entry the user can't see in a list can't be reached through a side
+ * door either (a raw `user_entries` join would let e.g. an unsubscribed,
+ * unstarred entry through).
+ *
+ * The content is deliberately **raw**: callers here hash it and hand it to an
+ * LLM rather than render it. Anything that reaches a client must be sanitized
+ * first (`sanitizeEntryHtml`; the ordinary read path does this in `toFullEntry`).
+ *
+ * @throws entryNotFound if the entry doesn't exist or isn't visible to the user
+ */
+export async function getOwnedEntryContent(
+  db: typeof dbType,
+  userId: string,
+  entryId: string
+): Promise<OwnedEntryContent> {
+  const result = await db
+    .select(entryContentSelectFields)
+    .from(visibleEntries)
+    .where(and(eq(visibleEntries.id, entryId), eq(visibleEntries.userId, userId)))
+    .limit(1);
+
+  if (result.length === 0) {
+    throw errors.entryNotFound();
+  }
+
+  return result[0];
+}
+
+/**
  * Sanitize both content families of a full entry for display.
  *
  * Entry bodies come from untrusted feeds and are rendered via

--- a/src/server/trpc/routers/narration.ts
+++ b/src/server/trpc/routers/narration.ts
@@ -6,14 +6,14 @@
  */
 
 import { z } from "zod";
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { createHash } from "node:crypto";
 
 import { createTRPCRouter, confirmedProtectedProcedure as protectedProcedure } from "../trpc";
-import { errors } from "../errors";
 import { uuidSchema } from "../validation";
-import { entries, narrationContent, userEntries } from "@/server/db/schema";
+import { narrationContent } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
+import { getOwnedEntryContent } from "@/server/services/entries";
 import {
   generateNarration,
   htmlToNarrationInput,
@@ -129,26 +129,10 @@ export const narrationRouter = createTRPCRouter({
       // Fetch API keys from DB on demand (not cached in session for security)
       const keys = await getUserApiKeys(userId);
 
-      // Fetch the entry with visibility check via user_entries join
-      // Both regular entries and saved articles are in the entries table now
-      const entryResult = await ctx.db
-        .select({
-          id: entries.id,
-          contentCleaned: entries.contentCleaned,
-          contentOriginal: entries.contentOriginal,
-          fullContentCleaned: entries.fullContentCleaned,
-          fullContentOriginal: entries.fullContentOriginal,
-        })
-        .from(entries)
-        .innerJoin(userEntries, eq(userEntries.entryId, entries.id))
-        .where(and(eq(entries.id, input.id), eq(userEntries.userId, userId)))
-        .limit(1);
+      // Fetch the entry with the same visibility rule the entry list applies.
+      // Both regular entries and saved articles are in the entries table now.
+      const entry = await getOwnedEntryContent(ctx.db, userId, input.id);
 
-      if (entryResult.length === 0) {
-        throw errors.entryNotFound();
-      }
-
-      const entry = entryResult[0];
       // Narrate exactly what the user is looking at: the variant the renderer
       // picks (same selector), sanitized the way the read path sanitizes it.
       // Sanitization is read-path-only, so the raw columns hold markup the page

--- a/src/server/trpc/routers/narration.ts
+++ b/src/server/trpc/routers/narration.ts
@@ -13,7 +13,7 @@ import { createTRPCRouter, confirmedProtectedProcedure as protectedProcedure } f
 import { uuidSchema } from "../validation";
 import { narrationContent } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
-import { getOwnedEntryContent } from "@/server/services/entries";
+import { getOwnedEntryRawContent } from "@/server/services/entries";
 import {
   generateNarration,
   htmlToNarrationInput,
@@ -131,7 +131,7 @@ export const narrationRouter = createTRPCRouter({
 
       // Fetch the entry with the same visibility rule the entry list applies.
       // Both regular entries and saved articles are in the entries table now.
-      const entry = await getOwnedEntryContent(ctx.db, userId, input.id);
+      const entry = await getOwnedEntryRawContent(ctx.db, userId, input.id);
 
       // Narrate exactly what the user is looking at: the variant the renderer
       // picks (same selector), sanitized the way the read path sanitizes it.

--- a/src/server/trpc/routers/summarization.ts
+++ b/src/server/trpc/routers/summarization.ts
@@ -15,8 +15,9 @@ import {
 } from "../trpc";
 import { errors } from "../errors";
 import { uuidSchema } from "../validation";
-import { entries, entrySummaries, userEntries } from "@/server/db/schema";
+import { entrySummaries } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
+import { getOwnedEntryContent } from "@/server/services/entries";
 import {
   generateSummary,
   isSummarizationAvailable,
@@ -153,27 +154,8 @@ export const summarizationRouter = createTRPCRouter({
         );
       }
 
-      // Fetch the entry with visibility check via user_entries join
-      const entryResult = await ctx.db
-        .select({
-          id: entries.id,
-          contentCleaned: entries.contentCleaned,
-          contentOriginal: entries.contentOriginal,
-          contentHash: entries.contentHash,
-          fullContentCleaned: entries.fullContentCleaned,
-          fullContentHash: entries.fullContentHash,
-          title: entries.title,
-        })
-        .from(entries)
-        .innerJoin(userEntries, eq(userEntries.entryId, entries.id))
-        .where(and(eq(entries.id, input.entryId), eq(userEntries.userId, userId)))
-        .limit(1);
-
-      if (entryResult.length === 0) {
-        throw errors.entryNotFound();
-      }
-
-      const entry = entryResult[0];
+      // Fetch the entry with the same visibility rule the entry list applies
+      const entry = await getOwnedEntryContent(ctx.db, userId, input.entryId);
 
       // Determine which content version and hash to use based on useFullContent param:
       // - true: use full content (error if not available)

--- a/src/server/trpc/routers/summarization.ts
+++ b/src/server/trpc/routers/summarization.ts
@@ -17,7 +17,7 @@ import { errors } from "../errors";
 import { uuidSchema } from "../validation";
 import { entrySummaries } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
-import { getOwnedEntryContent } from "@/server/services/entries";
+import { getOwnedEntryRawContent } from "@/server/services/entries";
 import {
   generateSummary,
   isSummarizationAvailable,
@@ -155,7 +155,7 @@ export const summarizationRouter = createTRPCRouter({
       }
 
       // Fetch the entry with the same visibility rule the entry list applies
-      const entry = await getOwnedEntryContent(ctx.db, userId, input.entryId);
+      const entry = await getOwnedEntryRawContent(ctx.db, userId, input.entryId);
 
       // Determine which content version and hash to use based on useFullContent param:
       // - true: use full content (error if not available)

--- a/tests/integration/narration.test.ts
+++ b/tests/integration/narration.test.ts
@@ -34,6 +34,7 @@ import type { Context } from "../../src/server/trpc/context";
 import { splitNarrationParagraphs } from "../../src/lib/narration/paragraph-map";
 import { NARRATION_FORMAT_VERSION } from "../../src/lib/narration/constants";
 import { sanitizeEntryHtml } from "../../src/server/html/sanitize";
+import { getOrCreateSavedFeed } from "../../src/server/feed/saved-feed";
 
 /**
  * The narration cache key, mirroring the router: the narration format plus the
@@ -61,11 +62,11 @@ async function createTestUser(): Promise<string> {
 }
 
 /**
- * Creates a feed + entry and makes it visible to the user the way the app does:
- * an active subscription plus the `user_entries` row that grants visibility.
- * The router reads through `visible_entries`, so both are required —
- * `unsubscribed: true` leaves the subscription soft-deleted, which hides an
- * unstarred entry from that view.
+ * Creates an entry and makes it reachable the way the app does. The router
+ * reads through `visible_entries`, so a `user_entries` row alone isn't enough:
+ * an ordinary entry also needs an active subscription (`unsubscribed: true`
+ * soft-deletes it, hiding an unstarred entry), while a `saved: true` article
+ * lives in the per-user saved feed and is visible on its type alone.
  */
 async function createTestEntry(
   userId: string,
@@ -73,25 +74,39 @@ async function createTestEntry(
     contentCleaned?: string;
     contentOriginal?: string;
   },
-  options: { unsubscribed?: boolean } = {}
+  options: { unsubscribed?: boolean; saved?: boolean; starred?: boolean } = {}
 ): Promise<string> {
-  const feedId = generateUuidv7();
   const entryId = generateUuidv7();
   const now = new Date();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url: `https://example.com/${feedId}.xml`,
-    title: "Test Feed",
-    lastFetchedAt: now,
-    lastEntriesUpdatedAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
+  let feedId: string;
+  if (options.saved) {
+    feedId = await getOrCreateSavedFeed(db, userId);
+  } else {
+    feedId = generateUuidv7();
+    await db.insert(feeds).values({
+      id: feedId,
+      type: "web",
+      url: `https://example.com/${feedId}.xml`,
+      title: "Test Feed",
+      lastFetchedAt: now,
+      lastEntriesUpdatedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(subscriptions).values({
+      id: generateUuidv7(),
+      userId,
+      feedId,
+      subscribedAt: now,
+      unsubscribedAt: options.unsubscribed ? now : null,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
   await db.insert(entries).values({
     id: entryId,
     feedId,
-    type: "web",
+    type: options.saved ? "saved" : "web",
     guid: `guid-${entryId}`,
     title: "Test Entry",
     contentCleaned: content.contentCleaned ?? null,
@@ -101,16 +116,9 @@ async function createTestEntry(
     contentHash: `entry-${entryId}`,
     fetchedAt: now,
     publishedAt: now,
-    lastSeenAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
-  await db.insert(subscriptions).values({
-    id: generateUuidv7(),
-    userId,
-    feedId,
-    subscribedAt: now,
-    unsubscribedAt: options.unsubscribed ? now : null,
+    // last_seen_at tracks a feed poll, and the entries_last_seen_only_fetched
+    // constraint requires it exactly for type='web'.
+    lastSeenAt: options.saved ? null : now,
     createdAt: now,
     updatedAt: now,
   });
@@ -119,7 +127,7 @@ async function createTestEntry(
     userId,
     entryId,
     read: false,
-    starred: false,
+    starred: options.starred ?? false,
     readChangedAt: now,
     starredChangedAt: now,
     updatedAt: now,
@@ -354,6 +362,33 @@ describe("narration.generate entry visibility", () => {
     const caller = createCaller(createAuthContext(userId));
 
     await expect(caller.narration.generate({ id: entryId })).rejects.toThrow("Entry not found");
+  });
+
+  // ...and the arms of that rule that don't involve an active subscription still
+  // narrate, which is the risk in reading through the view: a saved article has
+  // no subscription row at all, and a starred entry outlives its subscription.
+  it("narrates a saved article, which has no subscription row", async () => {
+    const contentCleaned = "<p>Saved article body.</p>";
+    createdNarrationHashes.push(narrationHash(contentCleaned));
+    const entryId = await createTestEntry(userId, { contentCleaned }, { saved: true });
+    const caller = createCaller(createAuthContext(userId));
+
+    const result = await caller.narration.generate({ id: entryId });
+    expect(result.narration).toBe("Saved article body.");
+  });
+
+  it("narrates a starred entry left behind by an unsubscribe", async () => {
+    const contentCleaned = "<p>Starred orphan body.</p>";
+    createdNarrationHashes.push(narrationHash(contentCleaned));
+    const entryId = await createTestEntry(
+      userId,
+      { contentCleaned },
+      { unsubscribed: true, starred: true }
+    );
+    const caller = createCaller(createAuthContext(userId));
+
+    const result = await caller.narration.generate({ id: entryId });
+    expect(result.narration).toBe("Starred orphan body.");
   });
 
   it("rejects another user's entry", async () => {

--- a/tests/integration/narration.test.ts
+++ b/tests/integration/narration.test.ts
@@ -20,7 +20,14 @@ import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { eq } from "drizzle-orm";
 import { createHash } from "node:crypto";
 import { db } from "../../src/server/db";
-import { users, feeds, entries, userEntries, narrationContent } from "../../src/server/db/schema";
+import {
+  users,
+  feeds,
+  entries,
+  subscriptions,
+  userEntries,
+  narrationContent,
+} from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
@@ -53,10 +60,21 @@ async function createTestUser(): Promise<string> {
   return userId;
 }
 
-async function createTestFeedAndEntry(content: {
-  contentCleaned?: string;
-  contentOriginal?: string;
-}): Promise<string> {
+/**
+ * Creates a feed + entry and makes it visible to the user the way the app does:
+ * an active subscription plus the `user_entries` row that grants visibility.
+ * The router reads through `visible_entries`, so both are required —
+ * `unsubscribed: true` leaves the subscription soft-deleted, which hides an
+ * unstarred entry from that view.
+ */
+async function createTestEntry(
+  userId: string,
+  content: {
+    contentCleaned?: string;
+    contentOriginal?: string;
+  },
+  options: { unsubscribed?: boolean } = {}
+): Promise<string> {
   const feedId = generateUuidv7();
   const entryId = generateUuidv7();
   const now = new Date();
@@ -87,11 +105,16 @@ async function createTestFeedAndEntry(content: {
     createdAt: now,
     updatedAt: now,
   });
-  return entryId;
-}
-
-async function createUserEntry(userId: string, entryId: string): Promise<void> {
-  const now = new Date();
+  await db.insert(subscriptions).values({
+    id: generateUuidv7(),
+    userId,
+    feedId,
+    subscribedAt: now,
+    unsubscribedAt: options.unsubscribed ? now : null,
+    createdAt: now,
+    updatedAt: now,
+  });
+  // subscription_id is stamped by the user_entries_fill_denormalized trigger.
   await db.insert(userEntries).values({
     userId,
     entryId,
@@ -101,6 +124,7 @@ async function createUserEntry(userId: string, entryId: string): Promise<void> {
     starredChangedAt: now,
     updatedAt: now,
   });
+  return entryId;
 }
 
 function createAuthContext(userId: string): Context {
@@ -182,8 +206,7 @@ describe("narration.generate cached read path", () => {
   it("returns the persisted paragraph map verbatim on a cache hit", async () => {
     const contentCleaned = "<p>First</p><p>Second</p><p>Third</p>";
     const contentHash = narrationHash(contentCleaned);
-    const entryId = await createTestFeedAndEntry({ contentCleaned });
-    await createUserEntry(userId, entryId);
+    const entryId = await createTestEntry(userId, { contentCleaned });
 
     // A stored map that is deliberately NOT what naive reconstruction would
     // produce (element 1 dropped, so two narration paragraphs map to o=0 and
@@ -215,8 +238,7 @@ describe("narration.generate cached read path", () => {
     const contentCleaned = ["<p>Intro.</p>", "<p>Line one.", "<br /><br />", "Line two.</p>"].join(
       "\n"
     );
-    const entryId = await createTestFeedAndEntry({ contentCleaned });
-    await createUserEntry(userId, entryId);
+    const entryId = await createTestEntry(userId, { contentCleaned });
 
     // Keyed by the previous format. Its map numbers elements the way that walk
     // numbered them, so serving it against today's `data-para-id`s would
@@ -265,8 +287,7 @@ describe("narration.generate cached read path", () => {
       "<figcaption>My cat</figcaption></figure>",
       "<p>The end.</p>",
     ].join("");
-    const entryId = await createTestFeedAndEntry({ contentCleaned });
-    await createUserEntry(userId, entryId);
+    const entryId = await createTestEntry(userId, { contentCleaned });
     createdNarrationHashes.push(narrationHash(contentCleaned));
 
     const caller = createCaller(createAuthContext(userId));
@@ -306,8 +327,7 @@ describe("narration.generate narrates the displayed variant", () => {
     // cleaned up too — the check-then-insert doesn't collide on re-run, but we
     // still don't want to leave rows behind (issue #1210).
     createdNarrationHashes.push(narrationHash(contentCleaned), narrationHash(contentOriginal));
-    const entryId = await createTestFeedAndEntry({ contentCleaned, contentOriginal });
-    await createUserEntry(userId, entryId);
+    const entryId = await createTestEntry(userId, { contentCleaned, contentOriginal });
     const caller = createCaller(createAuthContext(userId));
 
     const cleaned = await caller.narration.generate({ id: entryId });
@@ -315,5 +335,35 @@ describe("narration.generate narrates the displayed variant", () => {
 
     const original = await caller.narration.generate({ id: entryId, showOriginal: true });
     expect(original.narration).toBe("Original body paragraph.");
+  });
+});
+
+describe("narration.generate entry visibility", () => {
+  let userId: string;
+
+  beforeEach(async () => {
+    userId = await createTestUser();
+    createdUserIds.push(userId);
+  });
+
+  // The router reads through `visible_entries`, so it applies exactly the rule
+  // the entry list does: a `user_entries` row alone doesn't grant access (#1468).
+  it("rejects an entry hidden by visibility even though a user_entries row exists", async () => {
+    const contentCleaned = "<p>Unsubscribed body paragraph.</p>";
+    const entryId = await createTestEntry(userId, { contentCleaned }, { unsubscribed: true });
+    const caller = createCaller(createAuthContext(userId));
+
+    await expect(caller.narration.generate({ id: entryId })).rejects.toThrow("Entry not found");
+  });
+
+  it("rejects another user's entry", async () => {
+    const otherUserId = await createTestUser();
+    createdUserIds.push(otherUserId);
+    const entryId = await createTestEntry(otherUserId, {
+      contentCleaned: "<p>Someone else's article.</p>",
+    });
+    const caller = createCaller(createAuthContext(userId));
+
+    await expect(caller.narration.generate({ id: entryId })).rejects.toThrow("Entry not found");
   });
 });

--- a/tests/integration/summarization.test.ts
+++ b/tests/integration/summarization.test.ts
@@ -24,6 +24,7 @@ import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
 import { CURRENT_PROMPT_VERSION } from "../../src/server/services/summarization";
+import { getOrCreateSavedFeed } from "../../src/server/feed/saved-feed";
 
 async function createTestUser(): Promise<string> {
   const userId = generateUuidv7();
@@ -42,50 +43,57 @@ async function createTestUser(): Promise<string> {
 }
 
 /**
- * Creates a feed + entry and makes it visible to the user the way the app does:
- * an active subscription plus the `user_entries` row that grants visibility.
- * The router reads through `visible_entries`, so both are required —
- * `unsubscribed: true` leaves the subscription soft-deleted, which hides an
- * unstarred entry from that view.
+ * Creates an entry and makes it reachable the way the app does. The router
+ * reads through `visible_entries`, so a `user_entries` row alone isn't enough:
+ * an ordinary entry also needs an active subscription (`unsubscribed: true`
+ * soft-deletes it, hiding an unstarred entry), while a `saved: true` article
+ * lives in the per-user saved feed and is visible on its type alone.
  */
 async function createTestEntry(
   userId: string,
   contentHash: string,
-  options: { unsubscribed?: boolean } = {}
+  options: { unsubscribed?: boolean; saved?: boolean } = {}
 ): Promise<string> {
-  const feedId = generateUuidv7();
   const entryId = generateUuidv7();
   const now = new Date();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url: `https://example.com/${feedId}.xml`,
-    title: "Test Feed",
-    lastFetchedAt: now,
-    lastEntriesUpdatedAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
+  let feedId: string;
+  if (options.saved) {
+    feedId = await getOrCreateSavedFeed(db, userId);
+  } else {
+    feedId = generateUuidv7();
+    await db.insert(feeds).values({
+      id: feedId,
+      type: "web",
+      url: `https://example.com/${feedId}.xml`,
+      title: "Test Feed",
+      lastFetchedAt: now,
+      lastEntriesUpdatedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(subscriptions).values({
+      id: generateUuidv7(),
+      userId,
+      feedId,
+      subscribedAt: now,
+      unsubscribedAt: options.unsubscribed ? now : null,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
   await db.insert(entries).values({
     id: entryId,
     feedId,
-    type: "web",
+    type: options.saved ? "saved" : "web",
     guid: `guid-${entryId}`,
     title: "Test Entry",
     contentCleaned: "<p>Some article content to summarize.</p>",
     contentHash,
     fetchedAt: now,
     publishedAt: now,
-    lastSeenAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
-  await db.insert(subscriptions).values({
-    id: generateUuidv7(),
-    userId,
-    feedId,
-    subscribedAt: now,
-    unsubscribedAt: options.unsubscribed ? now : null,
+    // last_seen_at tracks a feed poll, and the entries_last_seen_only_fetched
+    // constraint requires it exactly for type='web'.
+    lastSeenAt: options.saved ? null : now,
     createdAt: now,
     updatedAt: now,
   });
@@ -239,5 +247,28 @@ describe("summarization.generate entry visibility", () => {
     const caller = createCaller(createAuthContext(userId));
 
     await expect(caller.summarization.generate({ entryId })).rejects.toThrow("Entry not found");
+  });
+
+  // ...and the arm of that rule with no subscription row at all still resolves,
+  // which is the risk in reading through the view.
+  it("summarizes a saved article, which has no subscription row", async () => {
+    const contentHash = `hash-${generateUuidv7()}`;
+    const entryId = await createTestEntry(userId, contentHash, { saved: true });
+    await db.insert(entrySummaries).values({
+      id: generateUuidv7(),
+      userId,
+      contentHash,
+      summaryText: "<p>Saved article summary</p>",
+      modelId: "claude-test",
+      promptVersion: CURRENT_PROMPT_VERSION,
+      generatedAt: new Date(),
+      createdAt: new Date(),
+    });
+
+    const caller = createCaller(createAuthContext(userId));
+    const result = await caller.summarization.generate({ entryId, useFullContent: false });
+
+    expect(result.cached).toBe(true);
+    expect(result.summary).toContain("Saved article summary");
   });
 });

--- a/tests/integration/summarization.test.ts
+++ b/tests/integration/summarization.test.ts
@@ -12,7 +12,14 @@
 import { describe, it, expect, beforeEach, beforeAll, afterAll } from "vitest";
 import { eq } from "drizzle-orm";
 import { db } from "../../src/server/db";
-import { users, feeds, entries, userEntries, entrySummaries } from "../../src/server/db/schema";
+import {
+  users,
+  feeds,
+  entries,
+  subscriptions,
+  userEntries,
+  entrySummaries,
+} from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
@@ -34,7 +41,18 @@ async function createTestUser(): Promise<string> {
   return userId;
 }
 
-async function createTestFeedAndEntry(contentHash: string): Promise<string> {
+/**
+ * Creates a feed + entry and makes it visible to the user the way the app does:
+ * an active subscription plus the `user_entries` row that grants visibility.
+ * The router reads through `visible_entries`, so both are required —
+ * `unsubscribed: true` leaves the subscription soft-deleted, which hides an
+ * unstarred entry from that view.
+ */
+async function createTestEntry(
+  userId: string,
+  contentHash: string,
+  options: { unsubscribed?: boolean } = {}
+): Promise<string> {
   const feedId = generateUuidv7();
   const entryId = generateUuidv7();
   const now = new Date();
@@ -62,11 +80,16 @@ async function createTestFeedAndEntry(contentHash: string): Promise<string> {
     createdAt: now,
     updatedAt: now,
   });
-  return entryId;
-}
-
-async function createUserEntry(userId: string, entryId: string): Promise<void> {
-  const now = new Date();
+  await db.insert(subscriptions).values({
+    id: generateUuidv7(),
+    userId,
+    feedId,
+    subscribedAt: now,
+    unsubscribedAt: options.unsubscribed ? now : null,
+    createdAt: now,
+    updatedAt: now,
+  });
+  // subscription_id is stamped by the user_entries_fill_denormalized trigger.
   await db.insert(userEntries).values({
     userId,
     entryId,
@@ -76,6 +99,7 @@ async function createUserEntry(userId: string, entryId: string): Promise<void> {
     starredChangedAt: now,
     updatedAt: now,
   });
+  return entryId;
 }
 
 function createAuthContext(userId: string): Context {
@@ -161,8 +185,7 @@ describe("summarization.generate cached read path", () => {
 
   it("re-sanitizes a cached summary containing disallowed HTML on read", async () => {
     const contentHash = `hash-${generateUuidv7()}`;
-    const entryId = await createTestFeedAndEntry(contentHash);
-    await createUserEntry(userId, entryId);
+    const entryId = await createTestEntry(userId, contentHash);
 
     // Simulate a summary stored before a sanitizer hardening: it still carries a
     // <script> tag and an inline event handler that the current sanitizer strips.
@@ -187,5 +210,34 @@ describe("summarization.generate cached read path", () => {
     expect(result.summary).not.toContain("<script>");
     expect(result.summary.toLowerCase()).not.toContain("onclick");
     expect(result.summary.toLowerCase()).not.toContain("onerror");
+  });
+});
+
+describe("summarization.generate entry visibility", () => {
+  let userId: string;
+
+  beforeEach(async () => {
+    userId = await createTestUser();
+    createdUserIds.push(userId);
+  });
+
+  // The router reads through `visible_entries`, so it applies exactly the rule
+  // the entry list does: a `user_entries` row alone doesn't grant access (#1468).
+  it("rejects an entry hidden by visibility even though a user_entries row exists", async () => {
+    const entryId = await createTestEntry(userId, `hash-${generateUuidv7()}`, {
+      unsubscribed: true,
+    });
+    const caller = createCaller(createAuthContext(userId));
+
+    await expect(caller.summarization.generate({ entryId })).rejects.toThrow("Entry not found");
+  });
+
+  it("rejects another user's entry", async () => {
+    const otherUserId = await createTestUser();
+    createdUserIds.push(otherUserId);
+    const entryId = await createTestEntry(otherUserId, `hash-${generateUuidv7()}`);
+    const caller = createCaller(createAuthContext(userId));
+
+    await expect(caller.summarization.generate({ entryId })).rejects.toThrow("Entry not found");
   });
 });


### PR DESCRIPTION
Fixes #1468.

## Problem

`narration.generate` and `summarization.generate` each hand-rolled their entry lookup as `entries` innerJoin `user_entries` scoped to the user. That is a **different visibility rule** from the one every other entry read uses: `visible_entries` additionally requires an active subscription unless the entry is starred or a saved article.

So an entry the user can't see anywhere in the app — e.g. one left behind by an unsubscribe, unstarred — was still narratable and summarizable, and the two rules could drift further apart as the view evolves. Per `src/server/CLAUDE.md`, frontend-facing queries go through the views.

## Change

- New `getOwnedEntryContent(db, userId, entryId)` in `src/server/services/entries.ts`: reads the stored content family (plus `title` and the two content hashes the AI caches key on) through `visible_entries`, throwing `entryNotFound` when the entry isn't visible. The content is deliberately raw — both callers hash it and hand it to an LLM rather than render it.
- Both routers use it, dropping the duplicated join.

## Tests

The existing integration fixtures inserted a `user_entries` row with **no subscription at all**, so they were only visible under the old rule — they now subscribe the user the way the app does. Each suite gains a regression test that an entry hidden by visibility (unsubscribed, unstarred) is rejected, plus a cross-user check.

`pnpm typecheck`, `pnpm lint`, and the full `pnpm test:integration` suite pass locally (746 passed / 15 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)