### PR TITLE
Add a shared factory module for integration tests

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -27,11 +27,7 @@ Key design points:
 
 ## Integration test fixtures
 
-Build rows with the shared factories in `tests/integration/helpers.ts` (`createTestUser`, `createTestFeed`, `createTestSubscription`, `createTestEntry`) rather than hand-rolling a `db.insert` per file — they're the one place that knows how to satisfy the schema's check constraints (e.g. `last_seen_at` is web-only). Each takes Drizzle insert overrides, so a test needing an unusual column passes it instead of the factory growing a per-caller option.
-
-`createAuthContext(userId)` there builds a session-authenticated tRPC context by **reading the real user row**, so adding a `users` column never means updating a fabricated literal.
-
-Cleanup stays per-file: delete the users and feeds you created in `afterAll` (a user cascades to its subscriptions and `user_entries`).
+Seed rows with the shared factories in `tests/integration/helpers.ts` rather than hand-rolling a `db.insert` per file; its header documents them. Extend a factory (or pass an override) instead of reintroducing a local one — the duplication it replaced meant every schema change touched dozens of files.
 
 ## Asserting on Redis pub/sub events
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -25,6 +25,14 @@ Key design points:
 - **Minimal-request assertions**: `recordTrpcProcedures(page)` records every tRPC procedure the page calls. Tests assert that SSE events update the UI with _zero_ `entries.*` refetches — this encodes the delta-update invariant documented in `src/FRONTEND_STATE.md` as a regression test instead of a code-review concern.
 - **Isolation**: each test creates its own user and feeds (unique IDs), so tests don't interfere with each other or with leftover data; the suite runs serially against one shared server.
 
+## Integration test fixtures
+
+Build rows with the shared factories in `tests/integration/helpers.ts` (`createTestUser`, `createTestFeed`, `createTestSubscription`, `createTestEntry`) rather than hand-rolling a `db.insert` per file — they're the one place that knows how to satisfy the schema's check constraints (e.g. `last_seen_at` is web-only). Each takes Drizzle insert overrides, so a test needing an unusual column passes it instead of the factory growing a per-caller option.
+
+`createAuthContext(userId)` there builds a session-authenticated tRPC context by **reading the real user row**, so adding a `users` column never means updating a fabricated literal.
+
+Cleanup stays per-file: delete the users and feeds you created in `afterAll` (a user cascades to its subscriptions and `user_entries`).
+
 ## Asserting on Redis pub/sub events
 
 Integration tests that assert on published events use the shared helpers in `tests/utils/pubsub.ts` — don't hand-roll listeners per file. A test whose **setup** mutates through a service or tRPC caller must establish that state with `subscribeAndDrain`, never by subscribing afterwards (publishing is fire-and-forget, so the setup's own event can land inside the window under test — see the file header and issue #1427).

--- a/tests/integration/admin.test.ts
+++ b/tests/integration/admin.test.ts
@@ -24,6 +24,7 @@ import {
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
+import { createTestFeed, createTestUser } from "./helpers";
 
 // ============================================================================
 // Test Helpers
@@ -76,42 +77,6 @@ function createWrongTokenContext(): Context {
       authorization: "Bearer wrong-secret",
     }),
   };
-}
-
-/**
- * Creates a test user and returns their ID.
- */
-async function createTestUser(emailPrefix: string = "admin-test"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${emailPrefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
-/**
- * Creates a test web feed and returns its ID.
- */
-async function createTestFeed(
-  url: string,
-  options: { consecutiveFailures?: number; lastError?: string | null; title?: string } = {}
-): Promise<string> {
-  const feedId = generateUuidv7();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url,
-    title: options.title ?? `Test Feed ${feedId}`,
-    consecutiveFailures: options.consecutiveFailures ?? 0,
-    lastError: options.lastError ?? null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return feedId;
 }
 
 /**
@@ -243,7 +208,7 @@ describe("Admin API", () => {
       const caller = createCaller(ctx);
 
       // Create a user and an invite used by that user
-      const userId = await createTestUser("searchable");
+      const userId = await createTestUser({ emailPrefix: "searchable" });
       const usedInvite = await createTestInvite({
         usedAt: new Date(),
         usedByUserId: userId,
@@ -288,8 +253,8 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      const feedId1 = await createTestFeed("https://example.com/feed1.xml");
-      const feedId2 = await createTestFeed("https://example.com/feed2.xml");
+      const feedId1 = await createTestFeed({ url: "https://example.com/feed1.xml" });
+      const feedId2 = await createTestFeed({ url: "https://example.com/feed2.xml" });
 
       const result = await caller.admin.listFeeds();
 
@@ -304,8 +269,8 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      await createTestFeed("https://example.com/unique-feed-abc.xml");
-      await createTestFeed("https://other.com/different.xml");
+      await createTestFeed({ url: "https://example.com/unique-feed-abc.xml" });
+      await createTestFeed({ url: "https://other.com/different.xml" });
 
       const result = await caller.admin.listFeeds({ urlFilter: "unique-feed-abc" });
 
@@ -317,8 +282,12 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      await createTestFeed("https://example.com/healthy.xml", { consecutiveFailures: 0 });
-      const brokenId = await createTestFeed("https://example.com/broken.xml", {
+      await createTestFeed({
+        url: "https://example.com/healthy.xml",
+        consecutiveFailures: 0,
+      });
+      const brokenId = await createTestFeed({
+        url: "https://example.com/broken.xml",
         consecutiveFailures: 5,
         lastError: "Connection timeout",
       });
@@ -340,7 +309,8 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      const feedId = await createTestFeed("https://example.com/retry-test.xml", {
+      const feedId = await createTestFeed({
+        url: "https://example.com/retry-test.xml",
         consecutiveFailures: 10,
         lastError: "Server error",
       });
@@ -367,8 +337,8 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      const userId1 = await createTestUser("user-a");
-      const userId2 = await createTestUser("user-b");
+      const userId1 = await createTestUser({ emailPrefix: "user-a" });
+      const userId2 = await createTestUser({ emailPrefix: "user-b" });
 
       const result = await caller.admin.listUsers();
 
@@ -392,8 +362,8 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      await createTestUser("findme-unique");
-      await createTestUser("other-user");
+      await createTestUser({ emailPrefix: "findme-unique" });
+      await createTestUser({ emailPrefix: "other-user" });
 
       const result = await caller.admin.listUsers({ search: "findme-unique" });
 
@@ -405,7 +375,7 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      const userId = await createTestUser("active-user");
+      const userId = await createTestUser({ emailPrefix: "active-user" });
 
       const activeTime = new Date("2026-03-15T12:00:00Z");
       await db.update(users).set({ lastActiveAt: activeTime }).where(eq(users.id, userId));
@@ -424,7 +394,7 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      const userId = await createTestUser("retained-user");
+      const userId = await createTestUser({ emailPrefix: "retained-user" });
       const activeTime = new Date("2026-02-01T09:00:00Z");
       await db.update(users).set({ lastActiveAt: activeTime }).where(eq(users.id, userId));
 
@@ -450,7 +420,7 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      const userId = await createTestUser("token-user");
+      const userId = await createTestUser({ emailPrefix: "token-user" });
 
       // Session activity and token use are independent signals.
       const sessionTime = new Date("2026-04-01T00:00:00Z");
@@ -481,7 +451,7 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      const userId = await createTestUser("greader-user");
+      const userId = await createTestUser({ emailPrefix: "greader-user" });
 
       // No full-access session activity: users.last_active_at stays NULL.
       const scopedActiveTime = new Date("2026-05-25T00:00:00Z");
@@ -508,7 +478,7 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      const userId = await createTestUser("browser-only-user");
+      const userId = await createTestUser({ emailPrefix: "browser-only-user" });
       await db.insert(sessions).values({
         id: generateUuidv7(),
         userId,
@@ -528,7 +498,7 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      await createTestUser("no-token-user");
+      await createTestUser({ emailPrefix: "no-token-user" });
 
       const result = await caller.admin.listUsers({ search: "no-token-user" });
 
@@ -540,9 +510,9 @@ describe("Admin API", () => {
       const ctx = createAdminContext();
       const caller = createCaller(ctx);
 
-      const idNever = await createTestUser("sort-never");
-      const idOld = await createTestUser("sort-old");
-      const idRecent = await createTestUser("sort-recent");
+      const idNever = await createTestUser({ emailPrefix: "sort-never" });
+      const idOld = await createTestUser({ emailPrefix: "sort-old" });
+      const idRecent = await createTestUser({ emailPrefix: "sort-recent" });
 
       await db
         .update(users)
@@ -566,8 +536,8 @@ describe("Admin API", () => {
 
       // Emails are prefixed with the UUIDv7 id, so create then rewrite them to
       // control alphabetical order independently of creation order.
-      const id1 = await createTestUser("email-sort");
-      const id2 = await createTestUser("email-sort");
+      const id1 = await createTestUser({ emailPrefix: "email-sort" });
+      const id2 = await createTestUser({ emailPrefix: "email-sort" });
       await db.update(users).set({ email: "zzz-emailsort@test.com" }).where(eq(users.id, id1));
       await db.update(users).set({ email: "aaa-emailsort@test.com" }).where(eq(users.id, id2));
 
@@ -582,7 +552,7 @@ describe("Admin API", () => {
 
       const ids: string[] = [];
       for (let i = 0; i < 3; i++) {
-        const id = await createTestUser("activity-page");
+        const id = await createTestUser({ emailPrefix: "activity-page" });
         ids.push(id);
         await db
           .update(users)
@@ -615,9 +585,9 @@ describe("Admin API", () => {
       const caller = createCaller(ctx);
 
       // Create enough users to paginate
-      await createTestUser("page-a");
-      await createTestUser("page-b");
-      await createTestUser("page-c");
+      await createTestUser({ emailPrefix: "page-a" });
+      await createTestUser({ emailPrefix: "page-b" });
+      await createTestUser({ emailPrefix: "page-c" });
 
       const page1 = await caller.admin.listUsers({ limit: 2 });
 

--- a/tests/integration/apple-oauth.test.ts
+++ b/tests/integration/apple-oauth.test.ts
@@ -19,6 +19,7 @@ import { users, sessions, oauthAccounts } from "../../src/server/db/schema";
 import { redis } from "../../src/server/redis";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import * as argon2 from "argon2";
+import { createTestUser } from "./helpers";
 
 // Default mock Apple user info (embedded in JWT)
 const mockAppleUserSub = "apple-user-123.abc.def";
@@ -282,19 +283,11 @@ OF/2NxApJCzGCEDdfSp6VQO30hyhRANCAAQRWz+jn65BtOMvdyHKcvjBeBSDZH2r
 
   describe("OAuth callback integration", () => {
     // Helper to create a test user
-    async function createTestUser(email: string, withPassword = true) {
-      const userId = generateUuidv7();
-      const passwordHash = withPassword ? await argon2.hash("password123") : null;
-
-      await db.insert(users).values({
-        id: userId,
+    async function createUser(email: string, withPassword = true) {
+      return createTestUser({
         email,
-        passwordHash,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        passwordHash: withPassword ? await argon2.hash("password123") : null,
       });
-
-      return userId;
     }
 
     // Helper to create OAuth account
@@ -315,7 +308,7 @@ OF/2NxApJCzGCEDdfSp6VQO30hyhRANCAAQRWz+jn65BtOMvdyHKcvjBeBSDZH2r
 
     it("finds existing Apple OAuth account", async () => {
       // Create existing user and OAuth account
-      const userId = await createTestUser("existing@example.com");
+      const userId = await createUser("existing@example.com");
       await createAppleOAuthAccount(userId, mockAppleUserSub);
 
       // Verify OAuth account exists
@@ -336,7 +329,7 @@ OF/2NxApJCzGCEDdfSp6VQO30hyhRANCAAQRWz+jn65BtOMvdyHKcvjBeBSDZH2r
 
     it("can link Apple OAuth to existing user with matching email", async () => {
       // Create existing user with email that matches Apple user
-      const userId = await createTestUser(mockAppleEmail, true);
+      const userId = await createUser(mockAppleEmail, true);
 
       // Verify user exists
       const user = await db.select().from(users).where(eq(users.id, userId)).limit(1);

--- a/tests/integration/counts.test.ts
+++ b/tests/integration/counts.test.ts
@@ -21,78 +21,11 @@ import {
 } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { getEntryRelatedCounts, getBulkEntryRelatedCounts } from "../../src/server/services/counts";
+import { createTestEntry, createTestFeed, createTestSubscription, createTestUser } from "./helpers";
 
 // ============================================================================
 // Test Helpers
 // ============================================================================
-
-async function createTestUser(emailPrefix: string = "user"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${emailPrefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
-async function createTestFeed(url: string): Promise<string> {
-  const feedId = generateUuidv7();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url,
-    title: `Test Feed ${feedId}`,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return feedId;
-}
-
-async function createTestSubscription(userId: string, feedId: string): Promise<string> {
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return subscriptionId;
-}
-
-async function createTestEntry(feedId: string, userIds: string[]): Promise<string> {
-  const entryId = generateUuidv7();
-  const now = new Date();
-  await db.insert(entries).values({
-    id: entryId,
-    feedId,
-    type: "web",
-    guid: `guid-${entryId}`,
-    title: `Entry ${entryId}`,
-    contentHash: `hash-${entryId}`,
-    fetchedAt: now,
-    lastSeenAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
-
-  if (userIds.length > 0) {
-    await db.insert(userEntries).values(
-      userIds.map((userId) => ({
-        userId,
-        entryId,
-        read: false,
-        starred: false,
-      }))
-    );
-  }
-
-  return entryId;
-}
 
 /**
  * Creates the two-subscription fixture: sub1 covers feedA, sub2 covers feedB,
@@ -101,13 +34,13 @@ async function createTestEntry(feedId: string, userIds: string[]): Promise<strin
  * reachable through overlapping subscription_feeds rows and double-count).
  */
 async function createOverlappingSubscriptions(userId: string) {
-  const feedIdA = await createTestFeed("https://feed-a.com/rss");
-  const feedIdB = await createTestFeed("https://feed-b.com/rss");
+  const feedIdA = await createTestFeed({ url: "https://feed-a.com/rss" });
+  const feedIdB = await createTestFeed({ url: "https://feed-b.com/rss" });
   const subId1 = await createTestSubscription(userId, feedIdA);
   const subId2 = await createTestSubscription(userId, feedIdB);
 
-  const entryIdA = await createTestEntry(feedIdA, [userId]);
-  const entryIdB = await createTestEntry(feedIdB, [userId]);
+  const entryIdA = await createTestEntry(feedIdA, { userIds: [userId] });
+  const entryIdB = await createTestEntry(feedIdB, { userIds: [userId] });
 
   return { feedIdA, feedIdB, subId1, subId2, entryIdA, entryIdB };
 }
@@ -185,10 +118,10 @@ describe("Entry counts service", () => {
       // subscription has no tags", returning the uncategorized count instead.
       // The client sets counts absolutely, so the tag badge went stale.
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://events.com/rss");
+      const feedId = await createTestFeed({ url: "https://events.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
       const tagId = await linkTag(userId, "Events", [subId]);
-      const entryId = await createTestEntry(feedId, [userId]);
+      const entryId = await createTestEntry(feedId, { userIds: [userId] });
       await markEntryRead(userId, entryId);
 
       const counts = await getEntryRelatedCounts(db, userId, entryId);
@@ -202,9 +135,9 @@ describe("Entry counts service", () => {
       // A caller patching these into the cache must not zero the user's
       // badges just because the target entry wasn't visible (issue #956).
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://mine.com/rss");
+      const feedId = await createTestFeed({ url: "https://mine.com/rss" });
       await createTestSubscription(userId, feedId);
-      await createTestEntry(feedId, [userId]); // one real unread entry
+      await createTestEntry(feedId, { userIds: [userId] }); // one real unread entry
 
       const counts = await getEntryRelatedCounts(db, userId, generateUuidv7());
 
@@ -230,13 +163,13 @@ describe("Entry counts service", () => {
       // entries are not visible unless starred/saved. The global count must
       // exclude them.
       const userId = await createTestUser();
-      const activeFeedId = await createTestFeed("https://active.com/rss");
+      const activeFeedId = await createTestFeed({ url: "https://active.com/rss" });
       await createTestSubscription(userId, activeFeedId);
-      const activeEntryId = await createTestEntry(activeFeedId, [userId]);
+      const activeEntryId = await createTestEntry(activeFeedId, { userIds: [userId] });
 
       // A feed the user has unsubscribed from, with an unread (non-starred,
       // non-saved) entry whose user_entries row still exists.
-      const goneFeedId = await createTestFeed("https://gone.com/rss");
+      const goneFeedId = await createTestFeed({ url: "https://gone.com/rss" });
       const goneSubId = generateUuidv7();
       await db.insert(subscriptions).values({
         id: goneSubId,
@@ -247,7 +180,7 @@ describe("Entry counts service", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       });
-      await createTestEntry(goneFeedId, [userId]);
+      await createTestEntry(goneFeedId, { userIds: [userId] });
 
       const counts = await getEntryRelatedCounts(db, userId, activeEntryId);
 
@@ -259,7 +192,7 @@ describe("Entry counts service", () => {
       // unsubscribed from, so they must still count toward All Articles and
       // Starred.
       const userId = await createTestUser();
-      const goneFeedId = await createTestFeed("https://gone-starred.com/rss");
+      const goneFeedId = await createTestFeed({ url: "https://gone-starred.com/rss" });
       const goneSubId = generateUuidv7();
       await db.insert(subscriptions).values({
         id: goneSubId,
@@ -270,7 +203,7 @@ describe("Entry counts service", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       });
-      const starredEntryId = await createTestEntry(goneFeedId, []);
+      const starredEntryId = await createTestEntry(goneFeedId);
       await db.insert(userEntries).values({
         userId,
         entryId: starredEntryId,
@@ -285,16 +218,16 @@ describe("Entry counts service", () => {
     });
 
     it("does not count other users' unread entries in tag counts", async () => {
-      const userId = await createTestUser("user-a");
-      const otherUserId = await createTestUser("user-b");
+      const userId = await createTestUser({ emailPrefix: "user-a" });
+      const otherUserId = await createTestUser({ emailPrefix: "user-b" });
 
-      const feedId = await createTestFeed("https://shared.com/rss");
+      const feedId = await createTestFeed({ url: "https://shared.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
       await createTestSubscription(otherUserId, feedId);
       const tagId = await linkTag(userId, "Mine", [subId]);
 
-      const entryId = await createTestEntry(feedId, [userId, otherUserId]);
-      await createTestEntry(feedId, [otherUserId]);
+      const entryId = await createTestEntry(feedId, { userIds: [userId, otherUserId] });
+      await createTestEntry(feedId, { userIds: [otherUserId] });
 
       const counts = await getEntryRelatedCounts(db, userId, entryId);
 
@@ -334,10 +267,10 @@ describe("Entry counts service", () => {
       // result. The client applies these counts absolutely, so the sidebar
       // badge stayed at its previous value until a refresh.
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://events.com/rss");
+      const feedId = await createTestFeed({ url: "https://events.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
       const tagId = await linkTag(userId, "Events", [subId]);
-      const entryId = await createTestEntry(feedId, [userId]);
+      const entryId = await createTestEntry(feedId, { userIds: [userId] });
       await markEntryRead(userId, entryId);
 
       const counts = await getBulkEntryRelatedCounts(db, userId, [
@@ -353,13 +286,13 @@ describe("Entry counts service", () => {
       // Two tagged subscriptions; only one is drained. The drained one must be
       // zero-filled while the shared tag keeps counting the other's entries.
       const userId = await createTestUser();
-      const feedIdA = await createTestFeed("https://drained.com/rss");
-      const feedIdB = await createTestFeed("https://active.com/rss");
+      const feedIdA = await createTestFeed({ url: "https://drained.com/rss" });
+      const feedIdB = await createTestFeed({ url: "https://active.com/rss" });
       const subIdA = await createTestSubscription(userId, feedIdA);
       const subIdB = await createTestSubscription(userId, feedIdB);
       const tagId = await linkTag(userId, "Mixed", [subIdA, subIdB]);
-      const entryIdA = await createTestEntry(feedIdA, [userId]);
-      await createTestEntry(feedIdB, [userId]);
+      const entryIdA = await createTestEntry(feedIdA, { userIds: [userId] });
+      await createTestEntry(feedIdB, { userIds: [userId] });
       await markEntryRead(userId, entryIdA);
 
       const counts = await getBulkEntryRelatedCounts(db, userId, [
@@ -373,9 +306,9 @@ describe("Entry counts service", () => {
 
     it("returns unread 0 for an uncategorized subscription drained of unread entries", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://uncategorized.com/rss");
+      const feedId = await createTestFeed({ url: "https://uncategorized.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
-      const entryId = await createTestEntry(feedId, [userId]);
+      const entryId = await createTestEntry(feedId, { userIds: [userId] });
       await markEntryRead(userId, entryId);
 
       const counts = await getBulkEntryRelatedCounts(db, userId, [

--- a/tests/integration/discord-links.test.ts
+++ b/tests/integration/discord-links.test.ts
@@ -17,18 +17,7 @@ import {
   resolveDiscordApiTokenUserId,
   unlinkDiscordApiToken,
 } from "../../src/server/services/discord-links";
-
-async function createTestUser(emailPrefix = "discord-link"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${emailPrefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
+import { createTestUser } from "./helpers";
 
 // Discord snowflakes are numeric strings; make them unique per test.
 function makeDiscordId(): string {
@@ -38,7 +27,7 @@ function makeDiscordId(): string {
 const createdUserIds: string[] = [];
 
 async function createUser(): Promise<string> {
-  const userId = await createTestUser();
+  const userId = await createTestUser({ emailPrefix: "discord-link" });
   createdUserIds.push(userId);
   return userId;
 }

--- a/tests/integration/email-resubscription.test.ts
+++ b/tests/integration/email-resubscription.test.ts
@@ -19,22 +19,11 @@ import {
 } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { processInboundEmail, type InboundEmail } from "../../src/server/email/process-inbound";
+import { createTestFeed, createTestSubscription, createTestUser } from "./helpers";
 
 // ============================================================================
 // Test Helpers
 // ============================================================================
-
-async function createTestUser(emailPrefix: string = "user"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${emailPrefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
 
 async function createTestIngestAddress(userId: string): Promise<{ id: string; token: string }> {
   const id = generateUuidv7();
@@ -48,41 +37,19 @@ async function createTestIngestAddress(userId: string): Promise<{ id: string; to
   return { id, token };
 }
 
+/** An email feed owned by `userId`; email feeds are per-user and have no URL. */
 async function createTestEmailFeed(
   userId: string,
   senderEmail: string,
   title: string = "Test Sender"
 ): Promise<string> {
-  const feedId = generateUuidv7();
-  const now = new Date();
-  await db.insert(feeds).values({
-    id: feedId,
+  return createTestFeed({
     type: "email",
     userId,
+    url: null,
     emailSenderPattern: senderEmail.toLowerCase(),
     title,
-    createdAt: now,
-    updatedAt: now,
   });
-  return feedId;
-}
-
-async function createTestSubscription(
-  userId: string,
-  feedId: string,
-  unsubscribedAt: Date | null = null
-): Promise<string> {
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: new Date(),
-    unsubscribedAt,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return subscriptionId;
 }
 
 async function blockSender(userId: string, senderEmail: string): Promise<void> {
@@ -162,11 +129,9 @@ describe("Email Feed Resubscription", () => {
       const { token } = await createTestIngestAddress(userId);
       const senderEmail = "newsletter@example.com";
       const feedId = await createTestEmailFeed(userId, senderEmail);
-      const subscriptionId = await createTestSubscription(
-        userId,
-        feedId,
-        new Date() // unsubscribed
-      );
+      const subscriptionId = await createTestSubscription(userId, feedId, {
+        unsubscribedAt: new Date(),
+      });
 
       // Verify subscription is initially unsubscribed
       let subscription = await getSubscription(subscriptionId);
@@ -189,7 +154,7 @@ describe("Email Feed Resubscription", () => {
       const { token } = await createTestIngestAddress(userId);
       const senderEmail = "blocked@example.com";
       const feedId = await createTestEmailFeed(userId, senderEmail);
-      await createTestSubscription(userId, feedId, new Date());
+      await createTestSubscription(userId, feedId, { unsubscribedAt: new Date() });
 
       // Block the sender
       await blockSender(userId, senderEmail);
@@ -232,7 +197,7 @@ describe("Email Feed Resubscription", () => {
       const { token } = await createTestIngestAddress(userId);
       const senderEmail = "active@example.com";
       const feedId = await createTestEmailFeed(userId, senderEmail);
-      const subscriptionId = await createTestSubscription(userId, feedId, null); // active
+      const subscriptionId = await createTestSubscription(userId, feedId); // active
 
       // Get original subscription state
       const originalSub = await getSubscription(subscriptionId);

--- a/tests/integration/entries-perf.test.ts
+++ b/tests/integration/entries-perf.test.ts
@@ -20,7 +20,7 @@ import {
 } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
-import type { Context } from "../../src/server/trpc/context";
+import { createAuthContext } from "./helpers";
 
 /** Format a JS string array as a PostgreSQL array literal for parameterized queries */
 function pgUuidArray(ids: string[]) {
@@ -56,58 +56,6 @@ const UNCATEGORIZED_FEEDS_PER_USER = 50;
 // ============================================================================
 // Helpers
 // ============================================================================
-
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        tosAgreedAt: now,
-        privacyPolicyAgreedAt: now,
-        notEuAgreedAt: now,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
 
 interface Timing {
   label: string;
@@ -178,6 +126,11 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
         id,
         email: `perf-test-${id}@test.com`,
         passwordHash: "test-hash",
+        // Confirmed signup: the tRPC profiling below goes through procedures
+        // gated on confirmation, and createAuthContext reads the real row.
+        tosAgreedAt: new Date(),
+        privacyPolicyAgreedAt: new Date(),
+        notEuAgreedAt: new Date(),
         createdAt: new Date(),
         updatedAt: new Date(),
       }))
@@ -662,7 +615,7 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
 
   describe("tRPC endpoint profiling", () => {
     it("profiles entries.setStarred end-to-end", async () => {
-      const ctx = createAuthContext(testUserId);
+      const ctx = await createAuthContext(testUserId);
       const caller = createCaller(ctx);
 
       // Pick an unstarred entry
@@ -703,7 +656,7 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
     }, 600000);
 
     it("profiles entries.markRead with 1 entry", async () => {
-      const ctx = createAuthContext(testUserId);
+      const ctx = await createAuthContext(testUserId);
       const caller = createCaller(ctx);
       const timings: Timing[] = [];
 
@@ -728,7 +681,7 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
     }, 600000);
 
     it("profiles entries.markRead with 10 entries", async () => {
-      const ctx = createAuthContext(testUserId);
+      const ctx = await createAuthContext(testUserId);
       const caller = createCaller(ctx);
       const timings: Timing[] = [];
 
@@ -748,7 +701,7 @@ describe.skipIf(!process.env.RUN_PERF_TESTS)("Entries Performance Profiling", ()
     }, 600000);
 
     it("profiles entries.markRead with 50 entries", async () => {
-      const ctx = createAuthContext(testUserId);
+      const ctx = await createAuthContext(testUserId);
       const caller = createCaller(ctx);
 
       const entryIds = testEntryIds.slice(500, 550);

--- a/tests/integration/entries.test.ts
+++ b/tests/integration/entries.test.ts
@@ -18,124 +18,37 @@ import {
 } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
-import type { Context } from "../../src/server/trpc/context";
 import {
   markAllEntriesRead,
   markEntriesRead,
   listEntries,
 } from "../../src/server/services/entries";
+import {
+  createAuthContext,
+  createTestSubscription,
+  createTestUser,
+  createTestEntry as createSharedTestEntry,
+  createTestFeed as createSharedTestFeed,
+} from "./helpers";
 
 // ============================================================================
 // Test Helpers
 // ============================================================================
 
 /**
- * Creates a test user and returns their ID.
- */
-async function createTestUser(emailPrefix: string = "user"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${emailPrefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
-/**
- * Creates an authenticated context for a test user.
- */
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: new Date(),
-        privacyPolicyAgreedAt: new Date(),
-        notEuAgreedAt: new Date(),
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
-
-/**
- * Creates a test feed.
+ * Wraps the shared feed factory: every feed here stands in for one the fetcher
+ * has already pulled, so it carries the fetch timestamps the shared factory
+ * (which builds a never-fetched feed) leaves null.
  */
 async function createTestFeed(url: string, title: string = "Test Feed"): Promise<string> {
-  const feedId = generateUuidv7();
   const now = new Date();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url,
-    title,
-    lastFetchedAt: now,
-    lastEntriesUpdatedAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
-  return feedId;
+  return createSharedTestFeed({ url, title, lastFetchedAt: now, lastEntriesUpdatedAt: now });
 }
 
 /**
- * Creates a test subscription.
- */
-async function createTestSubscription(userId: string, feedId: string): Promise<string> {
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return subscriptionId;
-}
-
-/**
- * Creates a test entry.
+ * Wraps the shared entry factory: the search tests need every entry to have
+ * content (so search_vector is populated), and the spam tests need `isSpam` to
+ * pick the entry type for them.
  */
 async function createTestEntry(
   feedId: string,
@@ -151,17 +64,13 @@ async function createTestEntry(
 ): Promise<string> {
   const entryId = generateUuidv7();
   const now = new Date();
-  const guid = options.guid ?? `guid-${entryId}`;
-  // is_spam is only permitted on email entries (entries_spam_only_email);
-  // last_seen_at is only permitted on fetched/web entries
-  // (entries_last_seen_only_fetched).
+  // is_spam is only permitted on email entries (entries_spam_only_email).
   const type = options.type ?? (options.isSpam ? "email" : "web");
 
-  await db.insert(entries).values({
+  return createSharedTestEntry(feedId, {
     id: entryId,
-    feedId,
     type,
-    guid,
+    guid: options.guid ?? `guid-${entryId}`,
     title: options.title ?? `Entry ${entryId}`,
     // `=== undefined` (not `??`) so an explicit `null` stays null, letting a test
     // exercise the search_vector fallback to content_original (#1249).
@@ -170,16 +79,13 @@ async function createTestEntry(
         ? `Content for ${options.title ?? entryId}`
         : options.contentCleaned,
     contentOriginal: options.contentOriginal,
-    contentHash: `hash-${entryId}`,
     fetchedAt: options.publishedAt ?? now,
     publishedAt: options.publishedAt ?? now,
-    lastSeenAt: type === "web" ? now : null,
+    lastSeenAt: now,
     isSpam: options.isSpam ?? false,
     createdAt: now,
     updatedAt: now,
   });
-
-  return entryId;
 }
 
 /**
@@ -240,7 +146,7 @@ describe("Entries", () => {
       await createUserEntry(userId, entry1Id);
       await createUserEntry(userId, entry2Id);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.list({});
@@ -262,7 +168,7 @@ describe("Entries", () => {
       await createUserEntry(userId, orphanedId);
       await createUserEntry(userId, orphanedStarredId, { starred: true });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.list({});
@@ -281,7 +187,7 @@ describe("Entries", () => {
       await createUserEntry(userId, unreadId, { read: false });
       await createUserEntry(userId, readId, { read: true });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.list({ unreadOnly: true });
@@ -302,7 +208,7 @@ describe("Entries", () => {
       await createUserEntry(userId, starredId, { starred: true });
       await createUserEntry(userId, unstarredId, { starred: false });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.list({ starredOnly: true });
@@ -542,7 +448,7 @@ describe("Entries", () => {
       });
       await createUserEntry(userId, entryId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.get({ id: entryId });
@@ -554,7 +460,7 @@ describe("Entries", () => {
 
     it("throws error for entry that doesn't exist", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const nonExistentId = generateUuidv7();
@@ -562,8 +468,8 @@ describe("Entries", () => {
     });
 
     it("throws error for entry user doesn't have access to", async () => {
-      const user1Id = await createTestUser("user1");
-      const user2Id = await createTestUser("user2");
+      const user1Id = await createTestUser({ emailPrefix: "user1" });
+      const user2Id = await createTestUser({ emailPrefix: "user2" });
       const feedId = await createTestFeed("https://example.com/feed.xml");
       await createTestSubscription(user1Id, feedId);
 
@@ -571,7 +477,7 @@ describe("Entries", () => {
       await createUserEntry(user1Id, entryId);
 
       // User 2 tries to access User 1's entry
-      const ctx2 = createAuthContext(user2Id);
+      const ctx2 = await createAuthContext(user2Id);
       const caller2 = createCaller(ctx2);
 
       await expect(caller2.entries.get({ id: entryId })).rejects.toThrow();
@@ -602,7 +508,7 @@ describe("Entries", () => {
       await createUserEntry(userId, entry2Id);
       await createUserEntry(userId, entry3Id);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.list({ query: "PostgreSQL" });
@@ -629,7 +535,7 @@ describe("Entries", () => {
       await createUserEntry(userId, entry1Id);
       await createUserEntry(userId, entry2Id);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.list({
@@ -662,7 +568,7 @@ describe("Entries", () => {
       await createUserEntry(userId, matchId);
       await createUserEntry(userId, otherId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.list({ query: "photosynthesis" });
@@ -693,7 +599,7 @@ describe("Entries", () => {
       await createUserEntry(userId, entry2Id);
       await createUserEntry(userId, entry3Id);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Should match both entry1 (title) and entry2 (content)
@@ -721,7 +627,7 @@ describe("Entries", () => {
       await createUserEntry(userId, unreadMatch, { read: false });
       await createUserEntry(userId, readMatch, { read: true });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.list({ query: "React", unreadOnly: true });
@@ -739,7 +645,7 @@ describe("Entries", () => {
       await createTestEntry(feedId, { title: "JavaScript Basics" });
       await createUserEntry(userId, await createTestEntry(feedId, { title: "Python Tutorial" }));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.list({ query: "nonexistentquery12345" });
@@ -760,7 +666,7 @@ describe("Entries", () => {
       await createUserEntry(userId, entry1Id, { read: false });
       await createUserEntry(userId, entry2Id, { read: false });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.markRead({
@@ -785,7 +691,7 @@ describe("Entries", () => {
       const entryId = await createTestEntry(feedId, { title: "Read Entry" });
       await createUserEntry(userId, entryId, { read: true });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.markRead({ entries: [{ id: entryId }], read: false });
@@ -816,7 +722,7 @@ describe("Entries", () => {
       await createUserEntry(userId, entry2Id, { read: false });
       await createUserEntry(userId, entry3Id, { read: false });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Mark 2 as read
@@ -848,7 +754,7 @@ describe("Entries", () => {
       const entryId = await createTestEntry(feedId, { title: "Entry to star" });
       await createUserEntry(userId, entryId, { starred: false });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.setStarred({ id: entryId, starred: true });
@@ -874,7 +780,7 @@ describe("Entries", () => {
       const entryId = await createTestEntry(feedId, { title: "Starred entry" });
       await createUserEntry(userId, entryId, { starred: true });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.setStarred({ id: entryId, starred: false });
@@ -893,8 +799,8 @@ describe("Entries", () => {
     });
 
     it("throws error when starring entry user doesn't have access to", async () => {
-      const user1Id = await createTestUser("user1");
-      const user2Id = await createTestUser("user2");
+      const user1Id = await createTestUser({ emailPrefix: "user1" });
+      const user2Id = await createTestUser({ emailPrefix: "user2" });
       const feedId = await createTestFeed("https://example.com/feed.xml");
       await createTestSubscription(user1Id, feedId);
 
@@ -902,7 +808,7 @@ describe("Entries", () => {
       await createUserEntry(user1Id, entryId);
 
       // User 2 tries to star User 1's entry
-      const ctx2 = createAuthContext(user2Id);
+      const ctx2 = await createAuthContext(user2Id);
       const caller2 = createCaller(ctx2);
 
       await expect(caller2.entries.setStarred({ id: entryId, starred: true })).rejects.toThrow();
@@ -923,7 +829,7 @@ describe("Entries", () => {
       await createUserEntry(userId, entry2Id, { read: false });
       await createUserEntry(userId, entry3Id, { read: true });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.count({});
@@ -944,7 +850,7 @@ describe("Entries", () => {
       await createUserEntry(userId, unread2Id, { read: false });
       await createUserEntry(userId, readId, { read: true });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.count({ unreadOnly: true });
@@ -968,7 +874,7 @@ describe("Entries", () => {
       await createUserEntry(userId, entryA, { read: false });
       await createUserEntry(userId, entryB, { read: false });
 
-      const caller = createCaller(createAuthContext(userId));
+      const caller = createCaller(await createAuthContext(userId));
       const result = await caller.entries.count({});
 
       // Two distinct unread entries, not three.
@@ -980,8 +886,8 @@ describe("Entries", () => {
     it("scopes the tag filter to the caller's own tags", async () => {
       // The service is the documented reuse layer, so tag ownership must be
       // enforced here, not just by router pre-validation (issue #956).
-      const victimId = await createTestUser("victim");
-      const attackerId = await createTestUser("attacker");
+      const victimId = await createTestUser({ emailPrefix: "victim" });
+      const attackerId = await createTestUser({ emailPrefix: "attacker" });
 
       const feedId = await createTestFeed("https://victim-feed.com/rss");
       const subscriptionId = await createTestSubscription(victimId, feedId);
@@ -1054,7 +960,7 @@ describe("Entries", () => {
       const entryId = await createTestEntry(feedId, { title: "Entry" });
       await createUserEntry(userId, entryId, { read: false, readChangedAt: oldTimestamp });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Update with newer timestamp should succeed
@@ -1087,7 +993,7 @@ describe("Entries", () => {
       const entryId = await createTestEntry(feedId, { title: "Entry" });
       await createUserEntry(userId, entryId, { read: true, readChangedAt: newerTimestamp });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Update with older timestamp should be rejected (no-op)
@@ -1117,7 +1023,7 @@ describe("Entries", () => {
       const entryId = await createTestEntry(feedId, { title: "Entry" });
       await createUserEntry(userId, entryId, { read: true, readChangedAt: timestamp });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Same timestamp, different value - should succeed with >= comparison
@@ -1152,7 +1058,7 @@ describe("Entries", () => {
         starredChangedAt: initialTimestamp,
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Update read state
@@ -1191,7 +1097,7 @@ describe("Entries", () => {
       // Entry 2 has newer timestamp - should NOT be updated
       await createUserEntry(userId, entry2Id, { read: true, readChangedAt: newerTimestamp });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.markRead({
@@ -1230,7 +1136,7 @@ describe("Entries", () => {
       const entryId = await createTestEntry(feedId, { title: "Entry" });
       await createUserEntry(userId, entryId, { starred: false, starredChangedAt: oldTimestamp });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Star with newer timestamp should succeed
@@ -1272,7 +1178,7 @@ describe("Entries", () => {
       const entryId = await createTestEntry(feedId, { title: "Entry" });
       await createUserEntry(userId, entryId, { read: false, readChangedAt: time0 });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Step 1: Mark read at time 1
@@ -1328,7 +1234,7 @@ describe("Entries", () => {
       const entryId = await createTestEntry(feedId, { title: "Entry" });
       await createUserEntry(userId, entryId, { starred: false, starredChangedAt: time0 });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Step 1: Star at time 1
@@ -1384,7 +1290,7 @@ describe("Entries", () => {
       const entryId = await createTestEntry(feedId, { title: "Entry" });
       await createUserEntry(userId, entryId, { starred: true, starredChangedAt: newerTimestamp });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Unstar with older timestamp should be rejected

--- a/tests/integration/entry-processor.test.ts
+++ b/tests/integration/entry-processor.test.ts
@@ -23,19 +23,18 @@ import {
   processEntries,
 } from "../../src/server/feed/entry-processor";
 import type { ParsedEntry, ParsedFeed } from "../../src/server/feed/types";
+import {
+  createTestEntry,
+  createTestSubscription,
+  createTestUser,
+  createTestFeed as insertTestFeed,
+} from "./helpers";
 
-// Helper to create a test feed in the database
+// Wraps the shared factory because these call sites want the feed row
+// (feed.url, feed.type), not just its id.
 async function createTestFeed(overrides: Partial<typeof feeds.$inferInsert> = {}) {
-  const [feed] = await db
-    .insert(feeds)
-    .values({
-      id: generateUuidv7(),
-      type: "web",
-      url: `https://example.com/feed-${generateUuidv7()}.xml`,
-      title: "Test Feed",
-      ...overrides,
-    })
-    .returning();
+  const feedId = await insertTestFeed({ title: "Test Feed", ...overrides });
+  const [feed] = await db.select().from(feeds).where(eq(feeds.id, feedId));
   return feed;
 }
 
@@ -258,16 +257,7 @@ describe("Entry Processor", () => {
       const guid = "entry-123";
 
       // Create entry directly
-      const now = new Date();
-      await db.insert(entries).values({
-        id: generateUuidv7(),
-        feedId: feed.id,
-        type: "web",
-        guid,
-        fetchedAt: now,
-        lastSeenAt: now,
-        contentHash: "abc123",
-      });
+      await createTestEntry(feed.id, { guid, contentHash: "abc123" });
 
       const found = await findEntryByGuid(feed.id, guid);
       expect(found).not.toBeNull();
@@ -288,16 +278,7 @@ describe("Entry Processor", () => {
       const guid = "shared-guid";
 
       // Create entry in feed1
-      const now = new Date();
-      await db.insert(entries).values({
-        id: generateUuidv7(),
-        feedId: feed1.id,
-        type: "web",
-        guid,
-        fetchedAt: now,
-        lastSeenAt: now,
-        contentHash: "abc123",
-      });
+      await createTestEntry(feed1.id, { guid, contentHash: "abc123" });
 
       // Should find in feed1
       const found1 = await findEntryByGuid(feed1.id, guid);
@@ -610,22 +591,8 @@ describe("Entry Processor", () => {
       );
 
       // A subscriber that joins AFTER the first fetch has no user_entries yet.
-      const userId = generateUuidv7();
-      await db.insert(users).values({
-        id: userId,
-        email: `aiv-${userId}@test.com`,
-        passwordHash: "test-hash",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
-      await db.insert(subscriptions).values({
-        id: generateUuidv7(),
-        userId,
-        feedId: feed.id,
-        subscribedAt: new Date(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      const userId = await createTestUser({ emailPrefix: "aiv" });
+      await createTestSubscription(userId, feed.id);
 
       // Re-fetch the identical feed (nothing changed) with alwaysUpdateVisibility.
       const secondFetchedAt = new Date("2024-06-15T11:00:00Z");
@@ -729,22 +696,8 @@ describe("Entry Processor", () => {
         { fetchedAt: firstFetchedAt }
       );
 
-      const userId = generateUuidv7();
-      await db.insert(users).values({
-        id: userId,
-        email: `noaiv-${userId}@test.com`,
-        passwordHash: "test-hash",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
-      await db.insert(subscriptions).values({
-        id: generateUuidv7(),
-        userId,
-        feedId: feed.id,
-        subscribedAt: new Date(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      const userId = await createTestUser({ emailPrefix: "noaiv" });
+      await createTestSubscription(userId, feed.id);
 
       const secondFetchedAt = new Date("2024-06-15T11:00:00Z");
       await processEntries(
@@ -919,22 +872,8 @@ describe("Entry Processor", () => {
       // already exists.
       const feed = await createTestFeed();
 
-      const userId = generateUuidv7();
-      await db.insert(users).values({
-        id: userId,
-        email: `fanout-${userId}@test.com`,
-        passwordHash: "test-hash",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
-      await db.insert(subscriptions).values({
-        id: generateUuidv7(),
-        userId,
-        feedId: feed.id,
-        subscribedAt: new Date(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      const userId = await createTestUser({ emailPrefix: "fanout" });
+      await createTestSubscription(userId, feed.id);
 
       // On each delivered new_entry, immediately check (at arrival time)
       // whether the subscriber's user_entries row exists.
@@ -984,22 +923,8 @@ describe("Entry Processor", () => {
       // so any later fetch with activity heals it.
       const feed = await createTestFeed();
 
-      const userId = generateUuidv7();
-      await db.insert(users).values({
-        id: userId,
-        email: `heal-${userId}@test.com`,
-        passwordHash: "test-hash",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
-      await db.insert(subscriptions).values({
-        id: generateUuidv7(),
-        userId,
-        feedId: feed.id,
-        subscribedAt: new Date(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      const userId = await createTestUser({ emailPrefix: "heal" });
+      await createTestSubscription(userId, feed.id);
 
       // Simulate the crash: insert the entry directly (as a fetch would) but
       // never fan out user_entries.

--- a/tests/integration/entry-state-events.test.ts
+++ b/tests/integration/entry-state-events.test.ts
@@ -34,6 +34,7 @@ import {
   waitForMessage,
   waitForMessages,
 } from "../utils/pubsub";
+import { createTestEntry, createTestFeed, createTestSubscription, createTestUser } from "./helpers";
 
 let subscriber: Redis;
 
@@ -63,15 +64,7 @@ beforeEach(async () => {
 });
 
 async function seedUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `entry-state-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
+  return createTestUser({ emailPrefix: "entry-state" });
 }
 
 async function seedEntry(
@@ -81,43 +74,19 @@ async function seedEntry(
   // Spam is only valid on email entries (entries_spam_only_email constraint).
   const type = options.type ?? (options.isSpam ? "email" : "web");
   const now = new Date();
-  const feedId = generateUuidv7();
-  await db.insert(feeds).values({
-    id: feedId,
+  const feedId = await createTestFeed({
     type,
     // Email feeds are per-user (feed_type_user_id constraint)
     userId: type === "email" ? userId : null,
-    url: `https://example.com/${feedId}`,
     title: "Test Feed",
     lastFetchedAt: now,
     lastEntriesUpdatedAt: now,
-    createdAt: now,
-    updatedAt: now,
   });
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
+  await createTestSubscription(userId, feedId);
 
-  const entryId = generateUuidv7();
-  await db.insert(entries).values({
-    id: entryId,
-    feedId,
+  const entryId = await createTestEntry(feedId, {
     type,
-    guid: `guid-${entryId}`,
     title: "Entry",
-    contentHash: `hash-${entryId}`,
-    fetchedAt: now,
-    publishedAt: now,
-    // last_seen_at is web-only (entries_last_seen_only_fetched constraint)
-    lastSeenAt: type === "web" ? now : null,
-    createdAt: now,
-    updatedAt: now,
     isSpam: options.isSpam ?? false,
   });
   // starred_changed_at is NOT NULL (defaults to now()); seed an explicitly-old

--- a/tests/integration/feed-health.test.ts
+++ b/tests/integration/feed-health.test.ts
@@ -23,10 +23,6 @@ async function cleanup() {
   await db.delete(users);
 }
 
-async function createUser(): Promise<string> {
-  return createTestUser({ emailPrefix: "feed-health" });
-}
-
 async function createSubscribedFeed(
   userId: string,
   options: {
@@ -64,7 +60,7 @@ describe("getFeedFetchHealthSnapshot", () => {
   });
 
   it("reports the newest successful fetch among error-free feeds", async () => {
-    const userId = await createUser();
+    const userId = await createTestUser({ emailPrefix: "feed-health" });
     await createSubscribedFeed(userId, { lastFetchedAt: minutesAgo(90) });
     await createSubscribedFeed(userId, { lastFetchedAt: minutesAgo(10) });
     // Failing feed fetched most recently: must NOT count as a success
@@ -82,7 +78,7 @@ describe("getFeedFetchHealthSnapshot", () => {
   });
 
   it("ignores feeds without active subscribers", async () => {
-    const userId = await createUser();
+    const userId = await createTestUser({ emailPrefix: "feed-health" });
     await createSubscribedFeed(userId, {
       lastFetchedAt: minutesAgo(5),
       unsubscribed: true,
@@ -102,7 +98,7 @@ describe("handleMonitorFeedHealth", () => {
   afterAll(cleanup);
 
   it("reports healthy and schedules the next run ~15 minutes out", async () => {
-    const userId = await createUser();
+    const userId = await createTestUser({ emailPrefix: "feed-health" });
     await createSubscribedFeed(userId, { lastFetchedAt: minutesAgo(5) });
 
     const result = await handleMonitorFeedHealth({});
@@ -113,7 +109,7 @@ describe("handleMonitorFeedHealth", () => {
   });
 
   it("reports unhealthy when the newest success is older than the threshold", async () => {
-    const userId = await createUser();
+    const userId = await createTestUser({ emailPrefix: "feed-health" });
     // All feeds failing, newest success well beyond the 120-minute default
     await createSubscribedFeed(userId, {
       lastFetchedAt: minutesAgo(10),

--- a/tests/integration/feed-health.test.ts
+++ b/tests/integration/feed-health.test.ts
@@ -14,7 +14,7 @@ import { db } from "../../src/server/db";
 import { jobs, feeds, subscriptions, users } from "../../src/server/db/schema";
 import { getFeedFetchHealthSnapshot } from "../../src/server/feed/health";
 import { handleMonitorFeedHealth } from "../../src/server/jobs/handlers";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createTestFeed, createTestSubscription, createTestUser } from "./helpers";
 
 async function cleanup() {
   await db.delete(jobs);
@@ -24,15 +24,7 @@ async function cleanup() {
 }
 
 async function createUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `feed-health-${userId}@example.com`,
-    passwordHash: "hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
+  return createTestUser({ emailPrefix: "feed-health" });
 }
 
 async function createSubscribedFeed(
@@ -44,25 +36,13 @@ async function createSubscribedFeed(
     unsubscribed?: boolean;
   } = {}
 ): Promise<string> {
-  const feedId = generateUuidv7();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url: `https://example.com/${feedId}.xml`,
+  const feedId = await createTestFeed({
     lastFetchedAt: options.lastFetchedAt ?? null,
     lastError: options.lastError ?? null,
     consecutiveFailures: options.consecutiveFailures ?? 0,
-    createdAt: new Date(),
-    updatedAt: new Date(),
   });
-  await db.insert(subscriptions).values({
-    id: generateUuidv7(),
-    userId,
-    feedId,
-    subscribedAt: new Date(),
+  await createTestSubscription(userId, feedId, {
     unsubscribedAt: options.unsubscribed ? new Date() : null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
   });
   return feedId;
 }

--- a/tests/integration/feed-redirect.test.ts
+++ b/tests/integration/feed-redirect.test.ts
@@ -21,9 +21,14 @@ import {
   jobs,
   type Feed,
 } from "../../src/server/db/schema";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
-import type { Context } from "../../src/server/trpc/context";
+import {
+  createAuthContext,
+  createTestEntry,
+  createTestFeed,
+  createTestSubscription,
+  createTestUser,
+} from "./helpers";
 import { ensureFeedJob } from "../../src/server/jobs/queue";
 import { migrateSubscriptionsToExistingFeed } from "../../src/server/jobs/handlers";
 import { createUserEntriesForFeed } from "../../src/server/feed/entry-processor";
@@ -31,148 +36,6 @@ import { createUserEntriesForFeed } from "../../src/server/feed/entry-processor"
 // ============================================================================
 // Test Helpers
 // ============================================================================
-
-/**
- * Creates a test user and returns their ID.
- */
-async function createTestUser(emailPrefix: string = "user"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${emailPrefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
-/**
- * Creates an authenticated context for a test user.
- */
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: new Date(),
-        privacyPolicyAgreedAt: new Date(),
-        notEuAgreedAt: new Date(),
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
-
-/**
- * Creates a test feed with specified parameters.
- */
-async function createTestFeed(options: {
-  url: string;
-  title?: string;
-  lastFetchedAt?: Date | null;
-  lastEntriesUpdatedAt?: Date | null;
-}): Promise<string> {
-  const feedId = generateUuidv7();
-  const now = new Date();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url: options.url,
-    title: options.title ?? `Test Feed ${feedId}`,
-    lastFetchedAt: options.lastFetchedAt ?? null,
-    lastEntriesUpdatedAt: options.lastEntriesUpdatedAt ?? null,
-    createdAt: now,
-    updatedAt: now,
-  });
-  return feedId;
-}
-
-/**
- * Creates a test subscription for a user and feed.
- */
-async function createTestSubscription(userId: string, feedId: string): Promise<string> {
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return subscriptionId;
-}
-
-/**
- * Creates a test entry with specified parameters.
- */
-async function createTestEntry(
-  feedId: string,
-  options: {
-    guid?: string;
-    title?: string;
-    fetchedAt?: Date;
-    lastSeenAt?: Date | null;
-  } = {}
-): Promise<string> {
-  const entryId = generateUuidv7();
-  const now = options.fetchedAt ?? new Date();
-  const guid = options.guid ?? `guid-${entryId}`;
-
-  await db.insert(entries).values({
-    id: entryId,
-    feedId,
-    type: "web",
-    guid,
-    title: options.title ?? `Entry ${entryId}`,
-    contentHash: `hash-${entryId}`,
-    fetchedAt: now,
-    lastSeenAt: options.lastSeenAt ?? now,
-    createdAt: now,
-    updatedAt: now,
-  });
-
-  return entryId;
-}
 
 /**
  * Creates user_entries for a user and entries.
@@ -494,8 +357,8 @@ describe("Feed Redirect Handling", () => {
 
   describe("Multiple users subscribed to old feed", () => {
     it("migrates all users' subscriptions when feed redirects", async () => {
-      const userA = await createTestUser("userA");
-      const userB = await createTestUser("userB");
+      const userA = await createTestUser({ emailPrefix: "userA" });
+      const userB = await createTestUser({ emailPrefix: "userB" });
       const fetchTime = new Date("2024-01-01T10:00:00Z");
 
       // Create old feed and new feed
@@ -638,7 +501,7 @@ describe("Feed Redirect Handling", () => {
       await createUserEntriesForFeed(newFeedId, [sharedEntryNew, newOnlyEntry]);
 
       // Query entries via the API
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.entries.list({});
       const entryIds = result.items.map((item) => item.id);
@@ -653,8 +516,8 @@ describe("Feed Redirect Handling", () => {
     });
 
     it("user subscribed only to new feed sees only new feed entries", async () => {
-      const userA = await createTestUser("userA"); // Migrated from old feed
-      const userB = await createTestUser("userB"); // Only subscribed to new feed
+      const userA = await createTestUser({ emailPrefix: "userA" }); // Migrated from old feed
+      const userB = await createTestUser({ emailPrefix: "userB" }); // Only subscribed to new feed
       const fetchTime = new Date("2024-01-01T10:00:00Z");
 
       // Create old feed and new feed
@@ -706,7 +569,7 @@ describe("Feed Redirect Handling", () => {
       await createUserEntriesForFeed(newFeedId, [newEntry]);
 
       // Query entries for User A
-      const ctxA = createAuthContext(userA);
+      const ctxA = await createAuthContext(userA);
       const callerA = createCaller(ctxA);
       const resultA = await callerA.entries.list({});
       const entryIdsA = resultA.items.map((item) => item.id);
@@ -716,7 +579,7 @@ describe("Feed Redirect Handling", () => {
       expect(entryIdsA).toContain(newEntry);
 
       // Query entries for User B
-      const ctxB = createAuthContext(userB);
+      const ctxB = await createAuthContext(userB);
       const callerB = createCaller(ctxB);
       const resultB = await callerB.entries.list({});
       const entryIdsB = resultB.items.map((item) => item.id);
@@ -781,7 +644,7 @@ describe("Feed Redirect Handling", () => {
       expect(unreadEntryState?.read).toBe(false);
 
       // Verify entries are still visible via API
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.entries.list({});
 
@@ -843,7 +706,7 @@ describe("Feed Redirect Handling", () => {
       expect(unstarredEntryState?.starred).toBe(false);
 
       // Verify starred entries are visible even when filtering
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.entries.list({ starredOnly: true });
 

--- a/tests/integration/feed-stats.test.ts
+++ b/tests/integration/feed-stats.test.ts
@@ -10,119 +10,14 @@
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { db } from "../../src/server/db";
 import { users, feeds, entries, subscriptions, userEntries } from "../../src/server/db/schema";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
-import type { Context } from "../../src/server/trpc/context";
-
-// ============================================================================
-// Test Helpers
-// ============================================================================
-
-async function createTestUser(emailPrefix = "feedstats"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${emailPrefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: new Date(),
-        privacyPolicyAgreedAt: new Date(),
-        notEuAgreedAt: new Date(),
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
-
-async function createTestFeed(title: string): Promise<string> {
-  const feedId = generateUuidv7();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url: `https://example.com/${feedId}.xml`,
-    title,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return feedId;
-}
-
-async function createTestSubscription(userId: string, feedId: string): Promise<string> {
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return subscriptionId;
-}
-
-async function createTestEntry(feedId: string, fetchedAt: Date): Promise<void> {
-  const entryId = generateUuidv7();
-  await db.insert(entries).values({
-    id: entryId,
-    feedId,
-    type: "web",
-    guid: `guid-${entryId}`,
-    title: `Entry ${entryId}`,
-    contentHash: `hash-${entryId}`,
-    fetchedAt,
-    lastSeenAt: fetchedAt,
-    createdAt: fetchedAt,
-    updatedAt: fetchedAt,
-  });
-}
+import {
+  createAuthContext,
+  createTestEntry,
+  createTestFeed,
+  createTestSubscription,
+  createTestUser,
+} from "./helpers";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -148,18 +43,18 @@ describe("Feed Stats API", () => {
   });
 
   it("reports totalEntryCount and entriesPerWeek for a feed with history", async () => {
-    const userId = await createTestUser();
-    const feedId = await createTestFeed("Feed With History");
+    const userId = await createTestUser({ emailPrefix: "feedstats" });
+    const feedId = await createTestFeed({ title: "Feed With History" });
     const subscriptionId = await createTestSubscription(userId, feedId);
 
     // Oldest entry 14 days ago, 4 entries total => ~2 entries/week.
     const now = Date.now();
-    await createTestEntry(feedId, new Date(now - 14 * DAY_MS));
-    await createTestEntry(feedId, new Date(now - 10 * DAY_MS));
-    await createTestEntry(feedId, new Date(now - 5 * DAY_MS));
-    await createTestEntry(feedId, new Date(now - 1 * DAY_MS));
+    await createTestEntry(feedId, { fetchedAt: new Date(now - 14 * DAY_MS) });
+    await createTestEntry(feedId, { fetchedAt: new Date(now - 10 * DAY_MS) });
+    await createTestEntry(feedId, { fetchedAt: new Date(now - 5 * DAY_MS) });
+    await createTestEntry(feedId, { fetchedAt: new Date(now - 1 * DAY_MS) });
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const result = await caller.feedStats.list();
 
     expect(result.items).toHaveLength(1);
@@ -173,15 +68,15 @@ describe("Feed Stats API", () => {
   });
 
   it("returns null entriesPerWeek when the oldest entry is under a week old", async () => {
-    const userId = await createTestUser();
-    const feedId = await createTestFeed("Fresh Feed");
+    const userId = await createTestUser({ emailPrefix: "feedstats" });
+    const feedId = await createTestFeed({ title: "Fresh Feed" });
     await createTestSubscription(userId, feedId);
 
     const now = Date.now();
-    await createTestEntry(feedId, new Date(now - 2 * DAY_MS));
-    await createTestEntry(feedId, new Date(now - 1 * DAY_MS));
+    await createTestEntry(feedId, { fetchedAt: new Date(now - 2 * DAY_MS) });
+    await createTestEntry(feedId, { fetchedAt: new Date(now - 1 * DAY_MS) });
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const result = await caller.feedStats.list();
 
     expect(result.items).toHaveLength(1);
@@ -190,11 +85,11 @@ describe("Feed Stats API", () => {
   });
 
   it("reports zero total and null entriesPerWeek for a feed with no entries", async () => {
-    const userId = await createTestUser();
-    const feedId = await createTestFeed("Empty Feed");
+    const userId = await createTestUser({ emailPrefix: "feedstats" });
+    const feedId = await createTestFeed({ title: "Empty Feed" });
     await createTestSubscription(userId, feedId);
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const result = await caller.feedStats.list();
 
     expect(result.items).toHaveLength(1);
@@ -203,21 +98,21 @@ describe("Feed Stats API", () => {
   });
 
   it("computes stats independently per feed across multiple subscriptions", async () => {
-    const userId = await createTestUser();
-    const feedA = await createTestFeed("AAA Feed");
-    const feedB = await createTestFeed("BBB Feed");
+    const userId = await createTestUser({ emailPrefix: "feedstats" });
+    const feedA = await createTestFeed({ title: "AAA Feed" });
+    const feedB = await createTestFeed({ title: "BBB Feed" });
     await createTestSubscription(userId, feedA);
     await createTestSubscription(userId, feedB);
 
     const now = Date.now();
     // Feed A: 3 entries
-    await createTestEntry(feedA, new Date(now - 20 * DAY_MS));
-    await createTestEntry(feedA, new Date(now - 10 * DAY_MS));
-    await createTestEntry(feedA, new Date(now - 2 * DAY_MS));
+    await createTestEntry(feedA, { fetchedAt: new Date(now - 20 * DAY_MS) });
+    await createTestEntry(feedA, { fetchedAt: new Date(now - 10 * DAY_MS) });
+    await createTestEntry(feedA, { fetchedAt: new Date(now - 2 * DAY_MS) });
     // Feed B: 1 entry
-    await createTestEntry(feedB, new Date(now - 3 * DAY_MS));
+    await createTestEntry(feedB, { fetchedAt: new Date(now - 3 * DAY_MS) });
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const result = await caller.feedStats.list();
 
     // Ordered by title ASC: "AAA Feed" then "BBB Feed".

--- a/tests/integration/getting-started.test.ts
+++ b/tests/integration/getting-started.test.ts
@@ -11,7 +11,6 @@ import { describe, it, expect, afterAll } from "vitest";
 import { and, eq, isNull, ne } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import { users, entries, userEntries } from "../../src/server/db/schema";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
 import {
   backfillGettingStartedArticles,
   createGettingStartedArticle,
@@ -19,18 +18,13 @@ import {
 import { GETTING_STARTED_TITLE } from "../../src/server/services/getting-started-content";
 import { deleteSavedArticle } from "../../src/server/services/saved";
 import { getSavedFeedId } from "../../src/server/feed/saved-feed";
+import { createTestUser } from "./helpers";
 
 const createdUserIds: string[] = [];
 
-async function createTestUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `getting-started-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
+/** Creates a user and registers it for `afterAll` cleanup. */
+async function createUser(): Promise<string> {
+  const userId = await createTestUser({ emailPrefix: "getting-started" });
   createdUserIds.push(userId);
   return userId;
 }
@@ -91,7 +85,7 @@ afterAll(async () => {
 
 describe("createGettingStartedArticle", () => {
   it("adds a starred, unread saved article and stamps the user", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
 
     const entryId = await createGettingStartedArticle(db, userId);
     expect(entryId).not.toBeNull();
@@ -117,7 +111,7 @@ describe("createGettingStartedArticle", () => {
   });
 
   it("is a no-op the second time", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
 
     expect(await createGettingStartedArticle(db, userId)).not.toBeNull();
     expect(await createGettingStartedArticle(db, userId)).toBeNull();
@@ -126,7 +120,7 @@ describe("createGettingStartedArticle", () => {
   });
 
   it("does not re-add the article after the user deletes it", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
 
     const entryId = await createGettingStartedArticle(db, userId);
     expect(entryId).not.toBeNull();
@@ -145,7 +139,7 @@ describe("createGettingStartedArticle", () => {
   });
 
   it("leaves an unstarred copy unstarred", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const entryId = await createGettingStartedArticle(db, userId);
 
     await db
@@ -163,7 +157,7 @@ describe("createGettingStartedArticle", () => {
 
 describe("backfillGettingStartedArticles", () => {
   it("covers a user who predates the feature", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     expect(await gettingStartedAt(userId)).toBeNull();
     await claimEveryoneElse(userId);
 

--- a/tests/integration/google-oauth.test.ts
+++ b/tests/integration/google-oauth.test.ts
@@ -13,6 +13,7 @@ import { users, sessions, oauthAccounts } from "../../src/server/db/schema";
 import { redis } from "../../src/server/redis";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import * as argon2 from "argon2";
+import { createTestUser } from "./helpers";
 
 // Mock the arctic library to avoid needing real Google credentials
 vi.mock("arctic", () => {
@@ -153,19 +154,11 @@ describe("Google OAuth", () => {
 
   describe("OAuth callback integration", () => {
     // Helper to create a test user
-    async function createTestUser(email: string, withPassword = true) {
-      const userId = generateUuidv7();
-      const passwordHash = withPassword ? await argon2.hash("password123") : null;
-
-      await db.insert(users).values({
-        id: userId,
+    async function createUser(email: string, withPassword = true) {
+      return createTestUser({
         email,
-        passwordHash,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        passwordHash: withPassword ? await argon2.hash("password123") : null,
       });
-
-      return userId;
     }
 
     // Helper to create OAuth account
@@ -208,7 +201,7 @@ describe("Google OAuth", () => {
 
     it("finds existing OAuth account", async () => {
       // Create existing user and OAuth account
-      const userId = await createTestUser("existing@example.com");
+      const userId = await createUser("existing@example.com");
       await createOAuthAccount(userId, "google-user-123");
 
       // Verify OAuth account exists
@@ -229,7 +222,7 @@ describe("Google OAuth", () => {
 
     it("can link OAuth to existing user with matching email", async () => {
       // Create existing user with email that matches Google user
-      const userId = await createTestUser("test@example.com", true);
+      const userId = await createUser("test@example.com", true);
 
       // Verify user exists
       const user = await db.select().from(users).where(eq(users.id, userId)).limit(1);

--- a/tests/integration/google-reader-auth.test.ts
+++ b/tests/integration/google-reader-auth.test.ts
@@ -20,22 +20,19 @@ import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createSession, validateSession } from "../../src/server/auth/session";
 import { clientLogin, requireAuth } from "../../src/server/google-reader/auth";
 import { OAUTH_SCOPES } from "../../src/server/oauth/utils";
+import { createTestUser } from "./helpers";
 
 const createdUserIds: string[] = [];
 const PASSWORD = "correct-horse-battery-staple";
 
-async function createTestUser(): Promise<{ id: string; email: string }> {
+/** A confirmed user with a real password hash, so ClientLogin can sign it in. */
+async function createUser(): Promise<{ id: string; email: string }> {
   const id = generateUuidv7();
   const email = `greader-${id}@test.com`;
-  await db.insert(users).values({
+  await createTestUser({
     id,
     email,
     passwordHash: await argon2.hash(PASSWORD),
-    tosAgreedAt: new Date(),
-    privacyPolicyAgreedAt: new Date(),
-    notEuAgreedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
   });
   createdUserIds.push(id);
   return { id, email };
@@ -55,7 +52,7 @@ afterAll(async () => {
 
 describe("Google Reader ClientLogin mints a reader-scoped session", () => {
   it("issues a token that requireAuth accepts", async () => {
-    const user = await createTestUser();
+    const user = await createUser();
     const login = await clientLogin(user.email, PASSWORD);
     expect(login).not.toBeNull();
     if (!login) throw new Error("unreachable");
@@ -68,7 +65,7 @@ describe("Google Reader ClientLogin mints a reader-scoped session", () => {
   });
 
   it("mints a session that is NOT usable as a full-access session", async () => {
-    const user = await createTestUser();
+    const user = await createUser();
     const login = await clientLogin(user.email, PASSWORD);
     if (!login) throw new Error("unreachable");
 
@@ -82,14 +79,14 @@ describe("Google Reader ClientLogin mints a reader-scoped session", () => {
   });
 
   it("returns null for a wrong password", async () => {
-    const user = await createTestUser();
+    const user = await createUser();
     expect(await clientLogin(user.email, "wrong-password")).toBeNull();
   });
 });
 
 describe("Google Reader requireAuth session acceptance", () => {
   it("accepts a full-access (unscoped) browser session", async () => {
-    const user = await createTestUser();
+    const user = await createUser();
     const { token } = await createSession(db, { userId: user.id });
 
     const result = await requireAuth(greaderRequest(token));
@@ -99,7 +96,7 @@ describe("Google Reader requireAuth session acceptance", () => {
   });
 
   it("rejects a session scoped to something other than reader:full-access with 403", async () => {
-    const user = await createTestUser();
+    const user = await createUser();
     const { token } = await createSession(db, {
       userId: user.id,
       scopes: [OAUTH_SCOPES.SAVED_WRITE],
@@ -146,14 +143,14 @@ describe("Google Reader requireAuth session acceptance", () => {
 
 describe("createSession scope validation", () => {
   it("rejects an unknown scope rather than minting a credential that matches nothing", async () => {
-    const user = await createTestUser();
+    const user = await createUser();
     await expect(
       createSession(db, { userId: user.id, scopes: ["not-a-real-scope"] })
     ).rejects.toThrow(/unknown scope/i);
   });
 
   it("accepts a known scope", async () => {
-    const user = await createTestUser();
+    const user = await createUser();
     const { token } = await createSession(db, {
       userId: user.id,
       scopes: [OAUTH_SCOPES.READER_FULL_ACCESS],
@@ -189,7 +186,7 @@ describe("last_active_at accounting for scoped vs full-access sessions", () => {
   }
 
   it("a scoped (Google Reader) session bumps its session row but never users.last_active_at", async () => {
-    const user = await createTestUser();
+    const user = await createUser();
     const login = await clientLogin(user.email, PASSWORD);
     if (!login) throw new Error("unreachable");
 
@@ -219,7 +216,7 @@ describe("last_active_at accounting for scoped vs full-access sessions", () => {
   });
 
   it("a full-access (browser) session bumps users.last_active_at", async () => {
-    const user = await createTestUser();
+    const user = await createUser();
     const { token } = await createSession(db, { userId: user.id });
 
     await db.update(users).set({ lastActiveAt: null }).where(eq(users.id, user.id));

--- a/tests/integration/google-reader-feed-stream.test.ts
+++ b/tests/integration/google-reader-feed-stream.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, afterAll } from "vitest";
 import { eq, inArray } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import { users, feeds, subscriptions } from "../../src/server/db/schema";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createTestFeed, createTestSubscription, createTestUser } from "./helpers";
 import {
   feedStreamIdToSubscriptionUuid,
   resolveFeedStream,
@@ -30,35 +30,30 @@ afterAll(async () => {
 });
 
 async function createUser(): Promise<string> {
-  const id = generateUuidv7();
-  await db.insert(users).values({
-    id,
-    email: `feed-stream-${id}@test.com`,
-    passwordHash: "test-hash",
-  });
+  const id = await createTestUser({ emailPrefix: "feed-stream" });
   createdUserIds.push(id);
   return id;
 }
 
 async function createSubscription(userId: string): Promise<{ subId: string; streamId: bigint }> {
-  const feedId = generateUuidv7();
-  const subId = generateUuidv7();
-  await db.insert(feeds).values({ id: feedId, type: "web", url: `https://f/${feedId}` });
+  const feedId = await createTestFeed();
   createdFeedIds.push(feedId);
+  const subId = await createTestSubscription(userId, feedId);
   const [sub] = await db
-    .insert(subscriptions)
-    .values({ id: subId, userId, feedId })
-    .returning({ greaderStreamId: subscriptions.greaderStreamId });
+    .select({ greaderStreamId: subscriptions.greaderStreamId })
+    .from(subscriptions)
+    .where(eq(subscriptions.id, subId));
   return { subId, streamId: sub.greaderStreamId };
 }
 
 async function createSavedFeed(userId: string): Promise<{ feedId: string; streamId: bigint }> {
-  const feedId = generateUuidv7();
-  const [feed] = await db
-    .insert(feeds)
-    .values({ id: feedId, type: "saved", userId })
-    .returning({ greaderStreamId: feeds.greaderStreamId });
+  // Saved feeds carry no URL (see getOrCreateSavedFeed).
+  const feedId = await createTestFeed({ type: "saved", userId, url: null });
   createdFeedIds.push(feedId);
+  const [feed] = await db
+    .select({ greaderStreamId: feeds.greaderStreamId })
+    .from(feeds)
+    .where(eq(feeds.id, feedId));
   return { feedId, streamId: feed.greaderStreamId };
 }
 

--- a/tests/integration/google-reader-id.test.ts
+++ b/tests/integration/google-reader-id.test.ts
@@ -13,10 +13,11 @@
  */
 
 import { describe, it, expect, afterAll } from "vitest";
-import { inArray, eq, and } from "drizzle-orm";
+import { inArray, eq } from "drizzle-orm";
 import { db } from "../../src/server/db";
-import { feeds, entries, users, userEntries, subscriptions } from "../../src/server/db/schema";
+import { feeds, entries, users, subscriptions } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createTestEntry, createTestFeed, createTestUser } from "./helpers";
 import { greaderItemIdsToUuids } from "../../src/server/google-reader/id";
 
 const createdUserIds: string[] = [];
@@ -24,26 +25,13 @@ const createdFeedIds: string[] = [];
 const createdEntryIds: string[] = [];
 
 async function createUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `greader-id-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
+  const userId = await createTestUser({ emailPrefix: "greader-id" });
   createdUserIds.push(userId);
   return userId;
 }
 
 async function createFeed(): Promise<string> {
-  const feedId = generateUuidv7();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url: `https://example.com/greader-id/${feedId}/feed.xml`,
-    title: "GReader ID Test Feed",
-  });
+  const feedId = await createTestFeed({ title: "GReader ID Test Feed" });
   createdFeedIds.push(feedId);
   return feedId;
 }
@@ -57,33 +45,17 @@ async function insertEntry(
   feedId: string,
   userId: string
 ): Promise<{ id: string; greaderItemId: bigint }> {
-  const id = generateUuidv7();
-  const when = new Date();
-  await db.insert(entries).values({
-    id,
-    feedId,
-    type: "web",
-    guid: `greader-id-${id}`,
-    title: `Entry ${id}`,
-    contentHash: `hash-${id}`,
-    fetchedAt: when,
-    publishedAt: when,
-    lastSeenAt: when,
-  });
-  createdEntryIds.push(id);
-
+  // Subscribe first: the `user_entries` BEFORE INSERT trigger stamps
+  // `subscription_id` from the user's subscription to the feed, and
+  // `visible_entries` hides rows without one. Every entry on a feed shares the
+  // one subscription, so this is an upsert rather than createTestSubscription.
   await db
     .insert(subscriptions)
     .values({ id: generateUuidv7(), userId, feedId })
     .onConflictDoNothing();
-  const [sub] = await db
-    .select({ id: subscriptions.id })
-    .from(subscriptions)
-    .where(and(eq(subscriptions.userId, userId), eq(subscriptions.feedId, feedId)));
-  await db
-    .insert(userEntries)
-    .values({ userId, entryId: id, subscriptionId: sub.id })
-    .onConflictDoNothing();
+
+  const id = await createTestEntry(feedId, { userIds: [userId] });
+  createdEntryIds.push(id);
 
   const [row] = await db
     .select({ greaderItemId: entries.greaderItemId })

--- a/tests/integration/google-reader-subscription-import.test.ts
+++ b/tests/integration/google-reader-subscription-import.test.ts
@@ -12,7 +12,7 @@ import * as argon2 from "argon2";
 import { eq, inArray } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import { users, opmlImports, jobs } from "../../src/server/db/schema";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createTestUser } from "./helpers";
 import { createSession } from "../../src/server/auth/session";
 import { OAUTH_SCOPES } from "../../src/server/oauth/utils";
 import { MAX_OPML_BYTES } from "../../src/server/services/imports";
@@ -22,16 +22,9 @@ const createdUserIds: string[] = [];
 const PASSWORD = "correct-horse-battery-staple";
 
 async function createConfirmedUser(): Promise<string> {
-  const id = generateUuidv7();
-  await db.insert(users).values({
-    id,
-    email: `greader-import-${id}@test.com`,
+  const id = await createTestUser({
+    emailPrefix: "greader-import",
     passwordHash: await argon2.hash(PASSWORD),
-    tosAgreedAt: new Date(),
-    privacyPolicyAgreedAt: new Date(),
-    notEuAgreedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
   });
   createdUserIds.push(id);
   return id;

--- a/tests/integration/google-reader-unread-count.test.ts
+++ b/tests/integration/google-reader-unread-count.test.ts
@@ -13,10 +13,10 @@
  */
 
 import { describe, it, expect, afterAll } from "vitest";
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { db } from "../../src/server/db";
-import { users, feeds, entries, userEntries, subscriptions } from "../../src/server/db/schema";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { users, feeds, userEntries, subscriptions } from "../../src/server/db/schema";
+import { createTestEntry, createTestFeed, createTestSubscription, createTestUser } from "./helpers";
 import { getGreaderUnreadCounts } from "../../src/server/google-reader/subscriptions";
 
 /**
@@ -44,14 +44,7 @@ afterAll(async () => {
 });
 
 async function createUser(): Promise<string> {
-  const id = generateUuidv7();
-  await db.insert(users).values({
-    id,
-    email: `newest-${id}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
+  const id = await createTestUser({ emailPrefix: "newest" });
   createdUserIds.push(id);
   return id;
 }
@@ -59,31 +52,23 @@ async function createUser(): Promise<string> {
 async function createSubscribedFeed(
   userId: string
 ): Promise<{ feedId: string; subId: string; streamId: string }> {
-  const feedId = generateUuidv7();
-  const subId = generateUuidv7();
-  const now = new Date();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url: `https://f/${feedId}`,
-    createdAt: now,
-    updatedAt: now,
-  });
+  const feedId = await createTestFeed();
+  const subId = await createTestSubscription(userId, feedId);
   const [sub] = await db
-    .insert(subscriptions)
-    .values({ id: subId, userId, feedId, subscribedAt: now, createdAt: now, updatedAt: now })
-    .returning({ greaderStreamId: subscriptions.greaderStreamId });
+    .select({ greaderStreamId: subscriptions.greaderStreamId })
+    .from(subscriptions)
+    .where(eq(subscriptions.id, subId));
   createdFeedIds.push(feedId);
   return { feedId, subId, streamId: sub.greaderStreamId.toString() };
 }
 
 async function createSavedFeed(userId: string): Promise<{ feedId: string; streamId: string }> {
-  const feedId = generateUuidv7();
-  const now = new Date();
+  // Saved feeds carry no URL (see getOrCreateSavedFeed).
+  const feedId = await createTestFeed({ type: "saved", userId, url: null });
   const [feed] = await db
-    .insert(feeds)
-    .values({ id: feedId, type: "saved", userId, createdAt: now, updatedAt: now })
-    .returning({ greaderStreamId: feeds.greaderStreamId });
+    .select({ greaderStreamId: feeds.greaderStreamId })
+    .from(feeds)
+    .where(eq(feeds.id, feedId));
   createdFeedIds.push(feedId);
   return { feedId, streamId: feed.greaderStreamId.toString() };
 }
@@ -98,18 +83,10 @@ async function addEntry(opts: {
   read: boolean;
   withUserEntry: boolean;
 }): Promise<void> {
-  const entryId = generateUuidv7();
-  await db.insert(entries).values({
-    id: entryId,
-    feedId: opts.feedId,
+  const entryId = await createTestEntry(opts.feedId, {
     type: opts.type,
-    guid: `guid-${entryId}`,
-    contentHash: `hash-${entryId}`,
     publishedAt: opts.publishedAt,
     fetchedAt: opts.fetchedAt,
-    lastSeenAt: opts.type === "web" ? opts.fetchedAt : null,
-    createdAt: opts.fetchedAt,
-    updatedAt: opts.fetchedAt,
   });
   if (opts.withUserEntry) {
     // publishedOrFetchedAt is filled by the user_entries_fill_denormalized

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -122,10 +122,15 @@ export interface CreateTestEntryOptions extends Partial<typeof entries.$inferIns
 /**
  * Inserts an entry on `feedId`, defaulting to a web entry fetched now.
  *
- * `lastSeenAt` is forced to null for non-web entries
- * (`entries_last_seen_only_fetched`), and defaults to `fetchedAt` for web
- * entries — which is what makes the entry "current" for the subscribe-time
- * visibility check (see "Entry Visibility" in `src/server/CLAUDE.md`).
+ * `lastSeenAt` defaults to `fetchedAt` on web entries and is forced to null
+ * otherwise, because `entries_last_seen_only_fetched` makes both mismatch
+ * directions illegal.
+ *
+ * Note this alone does NOT make the entry visible to a new subscriber: the
+ * subscribe-time populate also needs the feed's `lastEntriesUpdatedAt` set and
+ * not-null, which `createTestFeed` deliberately leaves unset (see "Entry
+ * Visibility" in `src/server/CLAUDE.md`). A test exercising that path has to
+ * stamp the feed's fetch timestamps itself.
  */
 export async function createTestEntry(
   feedId: string,
@@ -196,12 +201,14 @@ export async function createAuthContext(userId: string): Promise<Context> {
         revokedAt: null,
         lastActiveAt: now,
       },
-      // SessionData's user omits two columns the full row carries; the extra
-      // properties are structurally harmless.
-      user,
-      hasGroqApiKey: user.groqApiKey !== null,
-      hasAnthropicApiKey: user.anthropicApiKey !== null,
-      hasCerebrasApiKey: user.cerebrasApiKey !== null,
+      // validateSession never puts the key material in the session (both the
+      // Redis and DB paths null it out and expose only the booleans), so
+      // neither do we — otherwise a test could read a key off `ctx.session.user`
+      // that is always null in production.
+      user: { ...user, groqApiKey: null, anthropicApiKey: null, cerebrasApiKey: null },
+      hasGroqApiKey: !!user.groqApiKey,
+      hasAnthropicApiKey: !!user.anthropicApiKey,
+      hasCerebrasApiKey: !!user.cerebrasApiKey,
     },
     apiToken: null,
     authType: "session",

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -35,7 +35,13 @@ export interface CreateTestUserOptions extends Partial<typeof users.$inferInsert
   emailPrefix?: string;
 }
 
-/** Inserts a user with a password hash and a unique email. Returns its id. */
+/**
+ * Inserts a user with a password hash and a unique email. Returns its id.
+ *
+ * The signup agreements are accepted by default, because most procedures sit
+ * behind `confirmedMiddleware` and would otherwise throw FORBIDDEN. Pass them
+ * as null to test an unconfirmed account.
+ */
 export async function createTestUser(options: CreateTestUserOptions = {}): Promise<string> {
   const { emailPrefix = "user", ...overrides } = options;
   const userId = overrides.id ?? generateUuidv7();
@@ -44,6 +50,9 @@ export async function createTestUser(options: CreateTestUserOptions = {}): Promi
     id: userId,
     email: `${emailPrefix}-${userId}@test.com`,
     passwordHash: "test-hash",
+    tosAgreedAt: now,
+    privacyPolicyAgreedAt: now,
+    notEuAgreedAt: now,
     createdAt: now,
     updatedAt: now,
     ...overrides,

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -1,0 +1,203 @@
+/**
+ * Shared row factories for the integration suite.
+ *
+ * Every integration test needs a user, and most need a feed/subscription/entry
+ * behind it. These factories are the one place that knows how to build a valid
+ * row, so a change to the schema or to a check constraint (e.g. `last_seen_at`
+ * is web-only) is a single edit instead of dozens.
+ *
+ * Conventions:
+ * - Factories return the new row's **id**; tests that need more re-read the row.
+ * - Every factory takes Drizzle insert overrides, so a test can set any column
+ *   without the factory growing a bespoke option per caller.
+ * - Generated values (email, url, guid) embed the UUIDv7, so rows are unique
+ *   across tests without a per-file counter.
+ *
+ * Cleanup stays per-file: tests delete the users/feeds they created in
+ * `afterAll` (deleting a user cascades to its subscriptions and user_entries).
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users, feeds, entries, subscriptions, userEntries } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import type { Context } from "../../src/server/trpc/context";
+
+// ============================================================================
+// Users
+// ============================================================================
+
+export interface CreateTestUserOptions extends Partial<typeof users.$inferInsert> {
+  /**
+   * Prefix for the generated unique email, so a failing test's rows are
+   * identifiable in the DB. Ignored when `email` is given.
+   */
+  emailPrefix?: string;
+}
+
+/** Inserts a user with a password hash and a unique email. Returns its id. */
+export async function createTestUser(options: CreateTestUserOptions = {}): Promise<string> {
+  const { emailPrefix = "user", ...overrides } = options;
+  const userId = overrides.id ?? generateUuidv7();
+  const now = new Date();
+  await db.insert(users).values({
+    id: userId,
+    email: `${emailPrefix}-${userId}@test.com`,
+    passwordHash: "test-hash",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  });
+  return userId;
+}
+
+// ============================================================================
+// Feeds
+// ============================================================================
+
+/** Inserts a web feed with a unique URL. Returns its id. */
+export async function createTestFeed(
+  overrides: Partial<typeof feeds.$inferInsert> = {}
+): Promise<string> {
+  const feedId = overrides.id ?? generateUuidv7();
+  const now = new Date();
+  await db.insert(feeds).values({
+    id: feedId,
+    type: "web",
+    url: `https://example.com/feed-${feedId}.xml`,
+    title: `Test Feed ${feedId}`,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  });
+  return feedId;
+}
+
+// ============================================================================
+// Subscriptions
+// ============================================================================
+
+/** Subscribes `userId` to `feedId`. Returns the subscription id. */
+export async function createTestSubscription(
+  userId: string,
+  feedId: string,
+  overrides: Partial<typeof subscriptions.$inferInsert> = {}
+): Promise<string> {
+  const subscriptionId = overrides.id ?? generateUuidv7();
+  const now = new Date();
+  await db.insert(subscriptions).values({
+    id: subscriptionId,
+    userId,
+    feedId,
+    subscribedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  });
+  return subscriptionId;
+}
+
+// ============================================================================
+// Entries
+// ============================================================================
+
+export interface CreateTestEntryOptions extends Partial<typeof entries.$inferInsert> {
+  /**
+   * Users to make the entry visible to, by inserting unread `user_entries`
+   * rows. The BEFORE INSERT trigger stamps `subscription_id` from each user's
+   * subscription to this entry's feed.
+   */
+  userIds?: string[];
+}
+
+/**
+ * Inserts an entry on `feedId`, defaulting to a web entry fetched now.
+ *
+ * `lastSeenAt` is forced to null for non-web entries
+ * (`entries_last_seen_only_fetched`), and defaults to `fetchedAt` for web
+ * entries — which is what makes the entry "current" for the subscribe-time
+ * visibility check (see "Entry Visibility" in `src/server/CLAUDE.md`).
+ */
+export async function createTestEntry(
+  feedId: string,
+  options: CreateTestEntryOptions = {}
+): Promise<string> {
+  const { userIds, ...overrides } = options;
+  const entryId = overrides.id ?? generateUuidv7();
+  const now = new Date();
+  const type = overrides.type ?? "web";
+  const fetchedAt = overrides.fetchedAt ?? now;
+
+  await db.insert(entries).values({
+    id: entryId,
+    feedId,
+    type,
+    guid: `guid-${entryId}`,
+    title: `Entry ${entryId}`,
+    contentHash: `hash-${entryId}`,
+    fetchedAt,
+    publishedAt: fetchedAt,
+    createdAt: fetchedAt,
+    updatedAt: fetchedAt,
+    ...overrides,
+    // `lastSeenAt` is only permitted on web entries, so it can't come straight
+    // from the overrides: a caller passing `type: "saved"` alongside the
+    // default would violate the check constraint.
+    lastSeenAt: type === "web" ? (overrides.lastSeenAt ?? fetchedAt) : null,
+  });
+
+  if (userIds?.length) {
+    await db
+      .insert(userEntries)
+      .values(userIds.map((userId) => ({ userId, entryId, read: false, starred: false })));
+  }
+
+  return entryId;
+}
+
+// ============================================================================
+// tRPC context
+// ============================================================================
+
+/**
+ * Builds a session-authenticated tRPC context for `userId`, reading the real
+ * user row so the context can't drift from the schema the way a hand-written
+ * literal does. The session itself is synthetic — no `sessions` row is needed,
+ * because nothing downstream of the context re-validates it.
+ */
+export async function createAuthContext(userId: string): Promise<Context> {
+  const [user] = await db.select().from(users).where(eq(users.id, userId)).limit(1);
+  if (!user) {
+    throw new Error(`createAuthContext: no user with id ${userId}`);
+  }
+  const now = new Date();
+
+  return {
+    db,
+    session: {
+      session: {
+        id: generateUuidv7(),
+        userId,
+        tokenHash: "test-hash",
+        scopes: null,
+        userAgent: null,
+        ipAddress: null,
+        createdAt: now,
+        expiresAt: new Date(now.getTime() + 3600000),
+        revokedAt: null,
+        lastActiveAt: now,
+      },
+      // SessionData's user omits two columns the full row carries; the extra
+      // properties are structurally harmless.
+      user,
+      hasGroqApiKey: user.groqApiKey !== null,
+      hasAnthropicApiKey: user.anthropicApiKey !== null,
+      hasCerebrasApiKey: user.cerebrasApiKey !== null,
+    },
+    apiToken: null,
+    authType: "session",
+    scopes: [],
+    sessionToken: "test-token",
+    headers: new Headers(),
+  };
+}

--- a/tests/integration/job-queue.test.ts
+++ b/tests/integration/job-queue.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../../src/server/jobs/queue";
 import { startJobLeaseHeartbeat } from "../../src/server/jobs/worker";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createTestFeed, createTestSubscription, createTestUser } from "./helpers";
 
 // A valid UUID that doesn't exist in the database
 const NON_EXISTENT_JOB_ID = "00000000-0000-7000-8000-000000000000";
@@ -782,14 +783,7 @@ describe("Job Queue", () => {
   describe("claimFeedJob (data-driven)", () => {
     it("does not claim feed job when no active subscribers", async () => {
       // Create a feed
-      const feedId = generateUuidv7();
-      await db.insert(feeds).values({
-        id: feedId,
-        type: "web",
-        url: "https://example.com/feed.xml",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      const feedId = await createTestFeed();
 
       // Create a job due to run
       await createJob({
@@ -805,34 +799,13 @@ describe("Job Queue", () => {
 
     it("claims feed job when there are active subscribers", async () => {
       // Create a test user
-      const userId = generateUuidv7();
-      await db.insert(users).values({
-        id: userId,
-        email: "test@example.com",
-        passwordHash: "hash",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      const userId = await createTestUser();
 
       // Create a feed
-      const feedId = generateUuidv7();
-      await db.insert(feeds).values({
-        id: feedId,
-        type: "web",
-        url: "https://example.com/feed.xml",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      const feedId = await createTestFeed();
 
       // Create an active subscription
-      await db.insert(subscriptions).values({
-        id: generateUuidv7(),
-        userId,
-        feedId,
-        subscribedAt: new Date(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      await createTestSubscription(userId, feedId);
 
       // Create a job due to run
       await createJob({
@@ -849,35 +822,13 @@ describe("Job Queue", () => {
 
     it("does not claim feed job when subscriber has unsubscribed", async () => {
       // Create a test user
-      const userId = generateUuidv7();
-      await db.insert(users).values({
-        id: userId,
-        email: "test@example.com",
-        passwordHash: "hash",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      const userId = await createTestUser();
 
       // Create a feed
-      const feedId = generateUuidv7();
-      await db.insert(feeds).values({
-        id: feedId,
-        type: "web",
-        url: "https://example.com/feed.xml",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      const feedId = await createTestFeed();
 
       // Create an unsubscribed subscription
-      await db.insert(subscriptions).values({
-        id: generateUuidv7(),
-        userId,
-        feedId,
-        subscribedAt: new Date(),
-        unsubscribedAt: new Date(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      await createTestSubscription(userId, feedId, { unsubscribedAt: new Date() });
 
       // Create a job due to run
       await createJob({
@@ -893,34 +844,13 @@ describe("Job Queue", () => {
 
     it("does not claim feed job scheduled for the future", async () => {
       // Create a test user
-      const userId = generateUuidv7();
-      await db.insert(users).values({
-        id: userId,
-        email: "test@example.com",
-        passwordHash: "hash",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      const userId = await createTestUser();
 
       // Create a feed
-      const feedId = generateUuidv7();
-      await db.insert(feeds).values({
-        id: feedId,
-        type: "web",
-        url: "https://example.com/feed.xml",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      const feedId = await createTestFeed();
 
       // Create an active subscription
-      await db.insert(subscriptions).values({
-        id: generateUuidv7(),
-        userId,
-        feedId,
-        subscribedAt: new Date(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
+      await createTestSubscription(userId, feedId);
 
       // Create a job scheduled for the future
       await createJob({

--- a/tests/integration/mailgun-webhook.test.ts
+++ b/tests/integration/mailgun-webhook.test.ts
@@ -21,8 +21,9 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { createHmac, randomBytes } from "crypto";
 import { eq } from "drizzle-orm";
 import { db } from "../../src/server/db";
-import { users, ingestAddresses, entries } from "../../src/server/db/schema";
+import { ingestAddresses, entries } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createTestUser } from "./helpers";
 
 const SIGNING_KEY = "test-mailgun-signing-key";
 process.env.MAILGUN_WEBHOOK_SIGNING_KEY = SIGNING_KEY;
@@ -76,21 +77,13 @@ function buildWebhookRequest(fields: WebhookFields): Request {
 
 /** Creates a user with an ingest address; returns the recipient address. */
 async function createIngestRecipient(): Promise<string> {
-  const userId = generateUuidv7();
-  const now = new Date();
-  await db.insert(users).values({
-    id: userId,
-    email: `mailgun-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: now,
-    updatedAt: now,
-  });
+  const userId = await createTestUser({ emailPrefix: "mailgun" });
   const token = `mg${randomBytes(8).toString("hex")}`;
   await db.insert(ingestAddresses).values({
     id: generateUuidv7(),
     userId,
     token,
-    createdAt: now,
+    createdAt: new Date(),
   });
   return `${token}@ingest.lionreader.com`;
 }

--- a/tests/integration/mark-all-read-events.test.ts
+++ b/tests/integration/mark-all-read-events.test.ts
@@ -15,11 +15,16 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import Redis from "ioredis";
 import { db } from "../../src/server/db";
 import { users, feeds, entries, subscriptions, userEntries } from "../../src/server/db/schema";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import { getUserEventsChannel } from "../../src/server/redis/pubsub";
-import type { Context } from "../../src/server/trpc/context";
 import { expectNoMessage, waitForMessage } from "../utils/pubsub";
+import {
+  createAuthContext,
+  createTestEntry,
+  createTestFeed,
+  createTestSubscription,
+  createTestUser,
+} from "./helpers";
 
 let subscriber: Redis;
 
@@ -48,126 +53,30 @@ beforeEach(async () => {
   await db.delete(users);
 });
 
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: new Date(),
-        privacyPolicyAgreedAt: new Date(),
-        notEuAgreedAt: new Date(),
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
-
 async function seedUnreadEntries(userId: string, count: number): Promise<string[]> {
   const now = new Date();
-  const feedId = generateUuidv7();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url: `https://example.com/${feedId}`,
-    title: "Test Feed",
-    lastFetchedAt: now,
-    lastEntriesUpdatedAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
+  const feedId = await createTestFeed({ lastFetchedAt: now, lastEntriesUpdatedAt: now });
+  await createTestSubscription(userId, feedId);
 
   const entryIds: string[] = [];
   for (let i = 0; i < count; i++) {
-    const entryId = generateUuidv7();
-    entryIds.push(entryId);
-    await db.insert(entries).values({
-      id: entryId,
-      feedId,
-      type: "web",
-      guid: `guid-${entryId}`,
-      title: `Entry ${i}`,
-      contentHash: `hash-${entryId}`,
-      fetchedAt: now,
-      publishedAt: now,
-      lastSeenAt: now,
-      createdAt: now,
-      updatedAt: now,
-    });
-    await db.insert(userEntries).values({
-      userId,
-      entryId,
-      read: false,
-      starred: false,
-      updatedAt: now,
-    });
+    entryIds.push(
+      await createTestEntry(feedId, { title: `Entry ${i}`, fetchedAt: now, userIds: [userId] })
+    );
   }
   return entryIds;
 }
 
 describe("entries.markAllRead SSE publishing", () => {
   it("publishes a mark_all_read signal carrying a cursor timestamp and the max marked id", async () => {
-    const userId = generateUuidv7();
-    await db.insert(users).values({
-      id: userId,
-      email: `mark-all-${userId}@test.com`,
-      passwordHash: "test-hash",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
+    const userId = await createTestUser({ emailPrefix: "mark-all" });
     const entryIds = await seedUnreadEntries(userId, 3);
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
     const messagePromise = waitForMessage(subscriber, channel);
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const result = await caller.entries.markAllRead({});
     expect(result.count).toBe(3);
 
@@ -183,20 +92,13 @@ describe("entries.markAllRead SSE publishing", () => {
   });
 
   it("publishes no event when nothing was unread", async () => {
-    const userId = generateUuidv7();
-    await db.insert(users).values({
-      id: userId,
-      email: `mark-all-none-${userId}@test.com`,
-      passwordHash: "test-hash",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
+    const userId = await createTestUser({ emailPrefix: "mark-all-none" });
 
     const channel = getUserEventsChannel(userId);
     await subscriber.subscribe(channel);
 
     await expectNoMessage(subscriber, channel, async () => {
-      const caller = createCaller(createAuthContext(userId));
+      const caller = createCaller(await createAuthContext(userId));
       const result = await caller.entries.markAllRead({});
       expect(result.count).toBe(0);
     });

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { db } from "../../src/server/db";
 import { users, feeds, entries, subscriptions, userEntries } from "../../src/server/db/schema";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createTestEntry, createTestFeed, createTestSubscription, createTestUser } from "./helpers";
 import { registerTools } from "../../src/server/mcp/tools";
 
 let userId: string;
@@ -25,54 +25,17 @@ function tool(name: string) {
 }
 
 beforeAll(async () => {
-  userId = generateUuidv7();
-  otherUserId = generateUuidv7();
-  const feedId = generateUuidv7();
-  const subscriptionId = generateUuidv7();
-  entryId = generateUuidv7();
   const now = new Date();
 
-  for (const id of [userId, otherUserId]) {
-    await db.insert(users).values({
-      id,
-      email: `mcp-tools-${id}@test.com`,
-      passwordHash: "test-hash",
-      createdAt: now,
-      updatedAt: now,
-    });
-  }
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url: `https://example.com/${feedId}.xml`,
+  userId = await createTestUser({ emailPrefix: "mcp-tools" });
+  otherUserId = await createTestUser({ emailPrefix: "mcp-tools" });
+  const feedId = await createTestFeed({
     title: "MCP Tools Test Feed",
     lastFetchedAt: now,
     lastEntriesUpdatedAt: now,
-    createdAt: now,
-    updatedAt: now,
   });
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
-  await db.insert(entries).values({
-    id: entryId,
-    feedId,
-    type: "web",
-    guid: `guid-${entryId}`,
-    title: "MCP visible entry",
-    contentHash: `hash-${entryId}`,
-    fetchedAt: now,
-    publishedAt: now,
-    lastSeenAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
-  await db.insert(userEntries).values({ userId, entryId, read: false, starred: false });
+  await createTestSubscription(userId, feedId);
+  entryId = await createTestEntry(feedId, { title: "MCP visible entry", userIds: [userId] });
 });
 
 afterAll(async () => {

--- a/tests/integration/narration.test.ts
+++ b/tests/integration/narration.test.ts
@@ -20,21 +20,20 @@ import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { eq } from "drizzle-orm";
 import { createHash } from "node:crypto";
 import { db } from "../../src/server/db";
-import {
-  users,
-  feeds,
-  entries,
-  subscriptions,
-  userEntries,
-  narrationContent,
-} from "../../src/server/db/schema";
+import { users, userEntries, narrationContent } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
-import type { Context } from "../../src/server/trpc/context";
 import { splitNarrationParagraphs } from "../../src/lib/narration/paragraph-map";
 import { NARRATION_FORMAT_VERSION } from "../../src/lib/narration/constants";
 import { sanitizeEntryHtml } from "../../src/server/html/sanitize";
 import { getOrCreateSavedFeed } from "../../src/server/feed/saved-feed";
+import {
+  createAuthContext,
+  createTestEntry,
+  createTestFeed,
+  createTestSubscription,
+  createTestUser,
+} from "./helpers";
 
 /**
  * The narration cache key, mirroring the router: the narration format plus the
@@ -48,19 +47,6 @@ function narrationHash(content: string, format = NARRATION_FORMAT_VERSION): stri
     .digest("hex");
 }
 
-async function createTestUser(): Promise<string> {
-  const userId = generateUuidv7();
-  const now = new Date();
-  await db.insert(users).values({
-    id: userId,
-    email: `narr-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: now,
-    updatedAt: now,
-  });
-  return userId;
-}
-
 /**
  * Creates an entry and makes it reachable the way the app does. The router
  * reads through `visible_entries`, so a `user_entries` row alone isn't enough:
@@ -68,7 +54,7 @@ async function createTestUser(): Promise<string> {
  * soft-deletes it, hiding an unstarred entry), while a `saved: true` article
  * lives in the per-user saved feed and is visible on its type alone.
  */
-async function createTestEntry(
+async function createVisibleEntry(
   userId: string,
   content: {
     contentCleaned?: string;
@@ -82,32 +68,20 @@ async function createTestEntry(
   if (options.saved) {
     feedId = await getOrCreateSavedFeed(db, userId);
   } else {
-    feedId = generateUuidv7();
-    await db.insert(feeds).values({
-      id: feedId,
-      type: "web",
-      url: `https://example.com/${feedId}.xml`,
+    // The fetch timestamps are what make the entry current for this
+    // subscription; createTestFeed builds a never-polled feed.
+    feedId = await createTestFeed({
       title: "Test Feed",
       lastFetchedAt: now,
       lastEntriesUpdatedAt: now,
-      createdAt: now,
-      updatedAt: now,
     });
-    await db.insert(subscriptions).values({
-      id: generateUuidv7(),
-      userId,
-      feedId,
-      subscribedAt: now,
+    await createTestSubscription(userId, feedId, {
       unsubscribedAt: options.unsubscribed ? now : null,
-      createdAt: now,
-      updatedAt: now,
     });
   }
-  await db.insert(entries).values({
+  await createTestEntry(feedId, {
     id: entryId,
-    feedId,
     type: options.saved ? "saved" : "web",
-    guid: `guid-${entryId}`,
     title: "Test Entry",
     contentCleaned: content.contentCleaned ?? null,
     contentOriginal: content.contentOriginal ?? null,
@@ -115,14 +89,10 @@ async function createTestEntry(
     // hashes the exact narrated content); any stable value works here.
     contentHash: `entry-${entryId}`,
     fetchedAt: now,
-    publishedAt: now,
-    // last_seen_at tracks a feed poll, and the entries_last_seen_only_fetched
-    // constraint requires it exactly for type='web'.
-    lastSeenAt: options.saved ? null : now,
-    createdAt: now,
-    updatedAt: now,
   });
-  // subscription_id is stamped by the user_entries_fill_denormalized trigger.
+  // Not createTestEntry's `userIds`, which can't express `starred` or the
+  // explicit change stamps. subscription_id is filled by the
+  // user_entries_fill_denormalized trigger.
   await db.insert(userEntries).values({
     userId,
     entryId,
@@ -133,58 +103,6 @@ async function createTestEntry(
     updatedAt: now,
   });
   return entryId;
-}
-
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: new Date(),
-        privacyPolicyAgreedAt: new Date(),
-        notEuAgreedAt: new Date(),
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
 }
 
 const createdUserIds: string[] = [];
@@ -207,14 +125,14 @@ describe("narration.generate cached read path", () => {
   let userId: string;
 
   beforeEach(async () => {
-    userId = await createTestUser();
+    userId = await createTestUser({ emailPrefix: "narr" });
     createdUserIds.push(userId);
   });
 
   it("returns the persisted paragraph map verbatim on a cache hit", async () => {
     const contentCleaned = "<p>First</p><p>Second</p><p>Third</p>";
     const contentHash = narrationHash(contentCleaned);
-    const entryId = await createTestEntry(userId, { contentCleaned });
+    const entryId = await createVisibleEntry(userId, { contentCleaned });
 
     // A stored map that is deliberately NOT what naive reconstruction would
     // produce (element 1 dropped, so two narration paragraphs map to o=0 and
@@ -233,7 +151,7 @@ describe("narration.generate cached read path", () => {
       createdAt: new Date(),
     });
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const result = await caller.narration.generate({ id: entryId, useLlmNormalization: true });
 
     expect(result.cached).toBe(true);
@@ -246,7 +164,7 @@ describe("narration.generate cached read path", () => {
     const contentCleaned = ["<p>Intro.</p>", "<p>Line one.", "<br /><br />", "Line two.</p>"].join(
       "\n"
     );
-    const entryId = await createTestEntry(userId, { contentCleaned });
+    const entryId = await createVisibleEntry(userId, { contentCleaned });
 
     // Keyed by the previous format. Its map numbers elements the way that walk
     // numbered them, so serving it against today's `data-para-id`s would
@@ -265,7 +183,7 @@ describe("narration.generate cached read path", () => {
       createdAt: new Date(),
     });
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const result = await caller.narration.generate({ id: entryId, useLlmNormalization: true });
 
     expect(result.cached).toBe(false);
@@ -295,10 +213,10 @@ describe("narration.generate cached read path", () => {
       "<figcaption>My cat</figcaption></figure>",
       "<p>The end.</p>",
     ].join("");
-    const entryId = await createTestEntry(userId, { contentCleaned });
+    const entryId = await createVisibleEntry(userId, { contentCleaned });
     createdNarrationHashes.push(narrationHash(contentCleaned));
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const result = await caller.narration.generate({ id: entryId, useLlmNormalization: false });
 
     expect(splitNarrationParagraphs(result.narration)).toEqual([
@@ -320,7 +238,7 @@ describe("narration.generate narrates the displayed variant", () => {
   let userId: string;
 
   beforeEach(async () => {
-    userId = await createTestUser();
+    userId = await createTestUser({ emailPrefix: "narr" });
     createdUserIds.push(userId);
   });
 
@@ -335,8 +253,8 @@ describe("narration.generate narrates the displayed variant", () => {
     // cleaned up too — the check-then-insert doesn't collide on re-run, but we
     // still don't want to leave rows behind (issue #1210).
     createdNarrationHashes.push(narrationHash(contentCleaned), narrationHash(contentOriginal));
-    const entryId = await createTestEntry(userId, { contentCleaned, contentOriginal });
-    const caller = createCaller(createAuthContext(userId));
+    const entryId = await createVisibleEntry(userId, { contentCleaned, contentOriginal });
+    const caller = createCaller(await createAuthContext(userId));
 
     const cleaned = await caller.narration.generate({ id: entryId });
     expect(cleaned.narration).toBe("Cleaned body paragraph.");
@@ -350,7 +268,7 @@ describe("narration.generate entry visibility", () => {
   let userId: string;
 
   beforeEach(async () => {
-    userId = await createTestUser();
+    userId = await createTestUser({ emailPrefix: "narr" });
     createdUserIds.push(userId);
   });
 
@@ -358,8 +276,8 @@ describe("narration.generate entry visibility", () => {
   // the entry list does: a `user_entries` row alone doesn't grant access (#1468).
   it("rejects an entry hidden by visibility even though a user_entries row exists", async () => {
     const contentCleaned = "<p>Unsubscribed body paragraph.</p>";
-    const entryId = await createTestEntry(userId, { contentCleaned }, { unsubscribed: true });
-    const caller = createCaller(createAuthContext(userId));
+    const entryId = await createVisibleEntry(userId, { contentCleaned }, { unsubscribed: true });
+    const caller = createCaller(await createAuthContext(userId));
 
     await expect(caller.narration.generate({ id: entryId })).rejects.toThrow("Entry not found");
   });
@@ -370,8 +288,8 @@ describe("narration.generate entry visibility", () => {
   it("narrates a saved article, which has no subscription row", async () => {
     const contentCleaned = "<p>Saved article body.</p>";
     createdNarrationHashes.push(narrationHash(contentCleaned));
-    const entryId = await createTestEntry(userId, { contentCleaned }, { saved: true });
-    const caller = createCaller(createAuthContext(userId));
+    const entryId = await createVisibleEntry(userId, { contentCleaned }, { saved: true });
+    const caller = createCaller(await createAuthContext(userId));
 
     const result = await caller.narration.generate({ id: entryId });
     expect(result.narration).toBe("Saved article body.");
@@ -380,24 +298,24 @@ describe("narration.generate entry visibility", () => {
   it("narrates a starred entry left behind by an unsubscribe", async () => {
     const contentCleaned = "<p>Starred orphan body.</p>";
     createdNarrationHashes.push(narrationHash(contentCleaned));
-    const entryId = await createTestEntry(
+    const entryId = await createVisibleEntry(
       userId,
       { contentCleaned },
       { unsubscribed: true, starred: true }
     );
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
 
     const result = await caller.narration.generate({ id: entryId });
     expect(result.narration).toBe("Starred orphan body.");
   });
 
   it("rejects another user's entry", async () => {
-    const otherUserId = await createTestUser();
+    const otherUserId = await createTestUser({ emailPrefix: "narr" });
     createdUserIds.push(otherUserId);
-    const entryId = await createTestEntry(otherUserId, {
+    const entryId = await createVisibleEntry(otherUserId, {
       contentCleaned: "<p>Someone else's article.</p>",
     });
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
 
     await expect(caller.narration.generate({ id: entryId })).rejects.toThrow("Entry not found");
   });

--- a/tests/integration/oauth-callback.test.ts
+++ b/tests/integration/oauth-callback.test.ts
@@ -12,20 +12,9 @@ import { db } from "../../src/server/db";
 import { users, sessions, oauthAccounts } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { processOAuthCallback } from "../../src/server/auth/oauth/callback";
+import { createTestUser } from "./helpers";
 
 const VICTIM_EMAIL = "victim@example.com";
-
-async function seedUser(email: string): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email,
-    passwordHash: "not-a-real-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
 
 async function countOAuthAccounts(userId: string): Promise<number> {
   const rows = await db.select().from(oauthAccounts).where(eq(oauthAccounts.userId, userId));
@@ -46,7 +35,7 @@ describe("processOAuthCallback email verification", () => {
   });
 
   it("refuses to link an unverified provider email to an existing account", async () => {
-    const victimId = await seedUser(VICTIM_EMAIL);
+    const victimId = await createTestUser({ email: VICTIM_EMAIL });
 
     await expect(
       processOAuthCallback({
@@ -63,7 +52,7 @@ describe("processOAuthCallback email verification", () => {
   });
 
   it("links a verified provider email to the existing account", async () => {
-    const victimId = await seedUser(VICTIM_EMAIL);
+    const victimId = await createTestUser({ email: VICTIM_EMAIL });
 
     const result = await processOAuthCallback({
       provider: "google",
@@ -100,7 +89,7 @@ describe("processOAuthCallback email verification", () => {
   it("logs in a returning user by provider account id regardless of emailVerified", async () => {
     // Apple stops sending email/verification on subsequent sign-ins; a returning
     // user matched by providerAccountId must still work with emailVerified=false.
-    const userId = await seedUser("returning@example.com");
+    const userId = await createTestUser({ email: "returning@example.com" });
     await db.insert(oauthAccounts).values({
       id: generateUuidv7(),
       userId,

--- a/tests/integration/oauth-service.test.ts
+++ b/tests/integration/oauth-service.test.ts
@@ -19,6 +19,7 @@ import { eq, inArray } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import { users, oauthClients, oauthRefreshTokens } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createTestUser } from "./helpers";
 import {
   createAuthorizationCode,
   validateAndConsumeAuthCode,
@@ -52,17 +53,9 @@ const CODE_CHALLENGE = crypto
   .update(CODE_VERIFIER, "ascii")
   .digest("base64url");
 
-async function createTestUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `oauth-service-${userId}@test.com`,
-    passwordHash: "test-hash",
-    tosAgreedAt: new Date(),
-    privacyPolicyAgreedAt: new Date(),
-    notEuAgreedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
+async function createUser(): Promise<string> {
+  const userId = await createTestUser({
+    emailPrefix: "oauth-service",
   });
   createdUserIds.push(userId);
   return userId;
@@ -104,7 +97,7 @@ afterAll(async () => {
 
 describe("validateAndConsumeAuthCode", () => {
   it("redeems a valid code exactly once", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const clientId = await createTestClient();
     const code = await createTestAuthCode(userId, clientId);
 
@@ -118,7 +111,7 @@ describe("validateAndConsumeAuthCode", () => {
   });
 
   it("allows at most one of many concurrent redemptions to succeed", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const clientId = await createTestClient();
     const code = await createTestAuthCode(userId, clientId);
 
@@ -133,7 +126,7 @@ describe("validateAndConsumeAuthCode", () => {
   });
 
   it("burns the code when PKCE verification fails", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const clientId = await createTestClient();
     const code = await createTestAuthCode(userId, clientId);
 
@@ -149,7 +142,7 @@ describe("validateAndConsumeAuthCode", () => {
 
 describe("rotateRefreshToken", () => {
   it("rotates a valid refresh token and invalidates the old one", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const clientId = await createTestClient();
     const tokens = await createTokens({ clientId, userId, scopes: ["mcp"] });
 
@@ -162,7 +155,7 @@ describe("rotateRefreshToken", () => {
   });
 
   it("allows at most one of many concurrent rotations to succeed", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const clientId = await createTestClient();
     const tokens = await createTokens({ clientId, userId, scopes: ["mcp"] });
 
@@ -182,7 +175,7 @@ describe("rotateRefreshToken", () => {
   });
 
   it("treats an immediate replay as benign concurrency and does not revoke the chain", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const clientId = await createTestClient();
     const tokens = await createTokens({ clientId, userId, scopes: ["mcp"] });
 
@@ -199,7 +192,7 @@ describe("rotateRefreshToken", () => {
   });
 
   it("revokes the whole grant when a rotated refresh token is replayed after the grace window", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const clientId = await createTestClient();
     const tokens = await createTokens({ clientId, userId, scopes: ["mcp"] });
 
@@ -223,7 +216,7 @@ describe("rotateRefreshToken", () => {
     // Two independent grants for the same user+client — e.g. two Wallabag
     // devices, which all share client_id "wallabag". A reuse event on one must
     // not sign the other out.
-    const userId = await createTestUser();
+    const userId = await createUser();
     const clientId = await createTestClient();
     const grantA = await createTokens({ clientId, userId, scopes: ["mcp"] });
     const grantB = await createTokens({ clientId, userId, scopes: ["mcp"] });
@@ -246,7 +239,7 @@ describe("rotateRefreshToken", () => {
   });
 
   it("does not revoke the grant for an unknown refresh token", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const clientId = await createTestClient();
     const tokens = await createTokens({ clientId, userId, scopes: ["mcp"] });
 
@@ -264,7 +257,7 @@ describe("rotateRefreshToken", () => {
   // mislabel a Wallabag credential (minted with a null resource) as MCP-audienced.
   describe("resource/audience preservation", () => {
     it("keeps a null resource null (does not stamp the MCP audience)", async () => {
-      const userId = await createTestUser();
+      const userId = await createUser();
       const clientId = await createTestClient();
       // Wallabag mints with no resource.
       const tokens = await createTokens({ clientId, userId, scopes: ["reader:full-access"] });
@@ -277,7 +270,7 @@ describe("rotateRefreshToken", () => {
     });
 
     it("migrates the legacy bare-origin audience to the canonical identifier", async () => {
-      const userId = await createTestUser();
+      const userId = await createUser();
       const clientId = await createTestClient();
       const tokens = await createTokens({
         clientId,
@@ -294,7 +287,7 @@ describe("rotateRefreshToken", () => {
     });
 
     it("preserves the canonical MCP audience across rotation", async () => {
-      const userId = await createTestUser();
+      const userId = await createUser();
       const clientId = await createTestClient();
       const tokens = await createTokens({
         clientId,
@@ -314,7 +307,7 @@ describe("rotateRefreshToken", () => {
 
 describe("revokeClientToken (RFC 7009)", () => {
   it("revokes an access token", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const clientId = await createTestClient();
     const tokens = await createTokens({ clientId, userId, scopes: ["mcp"] });
 
@@ -327,7 +320,7 @@ describe("revokeClientToken (RFC 7009)", () => {
   });
 
   it("revokes a refresh token and its linked access token", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const clientId = await createTestClient();
     const tokens = await createTokens({ clientId, userId, scopes: ["mcp"] });
 
@@ -345,7 +338,7 @@ describe("revokeClientToken (RFC 7009)", () => {
   });
 
   it("does not revoke a token owned by a different client", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const clientId = await createTestClient();
     const otherClientId = await createTestClient();
     const tokens = await createTokens({ clientId, userId, scopes: ["mcp"] });

--- a/tests/integration/oauth-unlink.test.ts
+++ b/tests/integration/oauth-unlink.test.ts
@@ -16,22 +16,14 @@ import { db } from "../../src/server/db";
 import { users, oauthAccounts } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
-import type { Context } from "../../src/server/trpc/context";
+import { createAuthContext, createTestUser } from "./helpers";
 
 const createdUserIds: string[] = [];
 
-async function createTestUser(hasPassword: boolean): Promise<string> {
-  const userId = generateUuidv7();
-  const now = new Date();
-  await db.insert(users).values({
-    id: userId,
-    email: `unlink-${userId}@test.com`,
+async function createUser(hasPassword: boolean): Promise<string> {
+  const userId = await createTestUser({
+    emailPrefix: "unlink",
     passwordHash: hasPassword ? "test-hash" : null,
-    tosAgreedAt: now,
-    privacyPolicyAgreedAt: now,
-    notEuAgreedAt: now,
-    createdAt: now,
-    updatedAt: now,
   });
   createdUserIds.push(userId);
   return userId;
@@ -46,58 +38,6 @@ async function linkProvider(userId: string, provider: string): Promise<void> {
   });
 }
 
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: now,
-        privacyPolicyAgreedAt: now,
-        notEuAgreedAt: now,
-        passwordHash: null,
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
-
 afterAll(async () => {
   if (createdUserIds.length > 0) {
     await db.delete(users).where(inArray(users.id, createdUserIds));
@@ -106,10 +46,10 @@ afterAll(async () => {
 
 describe("auth.unlinkProvider", () => {
   it("unlinks one provider when the user has others", async () => {
-    const userId = await createTestUser(false);
+    const userId = await createUser(false);
     await linkProvider(userId, "google");
     await linkProvider(userId, "apple");
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
 
     await caller.auth.unlinkProvider({ provider: "google" });
 
@@ -121,9 +61,9 @@ describe("auth.unlinkProvider", () => {
   });
 
   it("refuses to unlink the only auth method (no password, one provider)", async () => {
-    const userId = await createTestUser(false);
+    const userId = await createUser(false);
     await linkProvider(userId, "google");
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
 
     await expect(caller.auth.unlinkProvider({ provider: "google" })).rejects.toThrow();
 
@@ -132,9 +72,9 @@ describe("auth.unlinkProvider", () => {
   });
 
   it("allows unlinking the last provider when the user has a password", async () => {
-    const userId = await createTestUser(true);
+    const userId = await createUser(true);
     await linkProvider(userId, "google");
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
 
     await caller.auth.unlinkProvider({ provider: "google" });
 
@@ -143,9 +83,9 @@ describe("auth.unlinkProvider", () => {
   });
 
   it("is idempotent when the provider is already unlinked", async () => {
-    const userId = await createTestUser(true);
+    const userId = await createUser(true);
     await linkProvider(userId, "google");
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
 
     const result = await caller.auth.unlinkProvider({ provider: "apple" });
     expect(result).toEqual({ success: true });
@@ -155,7 +95,7 @@ describe("auth.unlinkProvider", () => {
   });
 
   it("keeps at least one auth method when two providers are unlinked concurrently (#825)", async () => {
-    const userId = await createTestUser(false);
+    const userId = await createUser(false);
     await linkProvider(userId, "google");
     await linkProvider(userId, "apple");
 
@@ -163,7 +103,7 @@ describe("auth.unlinkProvider", () => {
     // The FOR UPDATE lock serializes them: the first to acquire the lock
     // succeeds; the second re-reads the (now single) remaining account and
     // is blocked by the "only auth method" guard.
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const results = await Promise.allSettled([
       caller.auth.unlinkProvider({ provider: "google" }),
       caller.auth.unlinkProvider({ provider: "apple" }),

--- a/tests/integration/opml-import.test.ts
+++ b/tests/integration/opml-import.test.ts
@@ -17,81 +17,11 @@ import {
 } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
-import type { Context } from "../../src/server/trpc/context";
+import { createAuthContext, createTestUser } from "./helpers";
 
 // ============================================================================
 // Test Helpers
 // ============================================================================
-
-/**
- * Creates a test user and returns their ID.
- */
-async function createTestUser(emailPrefix: string = "user"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${emailPrefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
-/**
- * Creates an authenticated context for a test user.
- */
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: new Date(),
-        privacyPolicyAgreedAt: new Date(),
-        notEuAgreedAt: new Date(),
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
 
 /**
  * Generates a simple OPML string with the specified number of feeds.
@@ -136,7 +66,7 @@ describe("OPML Import", () => {
   describe("subscriptions.import", () => {
     it("imports a simple OPML with few feeds", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const opml = generateOpml(3);
@@ -160,7 +90,7 @@ describe("OPML Import", () => {
 
     it("imports OPML with many feeds (stress test)", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Generate OPML with 500+ feeds to simulate real-world usage
@@ -186,7 +116,7 @@ describe("OPML Import", () => {
 
     it("handles empty OPML", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const opml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -203,7 +133,7 @@ describe("OPML Import", () => {
 
     it("rejects invalid OPML", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const invalidOpml = "not valid xml at all";
@@ -215,7 +145,7 @@ describe("OPML Import", () => {
 
     it("handles OPML with special characters in feed titles", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const opml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -237,7 +167,7 @@ describe("OPML Import", () => {
   describe("imports.preview", () => {
     it("parses OPML server-side and returns the feed list without importing", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.imports.preview({ opml: generateOpml(3) });
@@ -258,7 +188,7 @@ describe("OPML Import", () => {
 
     it("rejects invalid OPML with a validation error", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       await expect(
@@ -270,7 +200,7 @@ describe("OPML Import", () => {
   describe("imports.get", () => {
     it("retrieves import status", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // First create an import
@@ -290,16 +220,16 @@ describe("OPML Import", () => {
 
     it("rejects access to another user's import", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
       // User 1 creates an import
-      const ctx1 = createAuthContext(userId1);
+      const ctx1 = await createAuthContext(userId1);
       const caller1 = createCaller(ctx1);
       const opml = generateOpml(3);
       const importResult = await caller1.subscriptions.import({ opml });
 
       // User 2 tries to access it
-      const ctx2 = createAuthContext(userId2);
+      const ctx2 = await createAuthContext(userId2);
       const caller2 = createCaller(ctx2);
 
       await expect(caller2.imports.get({ id: importResult.importId })).rejects.toThrow(
@@ -311,7 +241,7 @@ describe("OPML Import", () => {
   describe("imports.list", () => {
     it("lists user imports", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Create multiple imports
@@ -328,7 +258,7 @@ describe("OPML Import", () => {
 
     it("returns empty list for user with no imports", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.imports.list();

--- a/tests/integration/redirect-tracking.test.ts
+++ b/tests/integration/redirect-tracking.test.ts
@@ -19,6 +19,7 @@ import {
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { REDIRECT_WAIT_PERIOD_MS } from "../../src/server/feed/redirect-utils";
 import { ensureFeedJob, getJobPayload, claimFeedJob } from "../../src/server/jobs/queue";
+import { createTestEntry, createTestFeed, createTestSubscription, createTestUser } from "./helpers";
 
 describe("Redirect Tracking", () => {
   // Clean up before each test
@@ -42,86 +43,11 @@ describe("Redirect Tracking", () => {
   });
 
   /**
-   * Helper to create a test user
-   */
-  async function createTestUser(): Promise<string> {
-    const userId = generateUuidv7();
-    await db.insert(users).values({
-      id: userId,
-      email: `test-${userId}@example.com`,
-      passwordHash: "hash",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
-    return userId;
-  }
-
-  /**
-   * Helper to create a test feed
-   */
-  async function createTestFeed(
-    overrides: Partial<typeof feeds.$inferInsert> = {}
-  ): Promise<string> {
-    const feedId = generateUuidv7();
-    const now = new Date();
-    await db.insert(feeds).values({
-      id: feedId,
-      type: "web",
-      url: `https://example.com/feed-${feedId}.xml`,
-      createdAt: now,
-      updatedAt: now,
-      ...overrides,
-    });
-    return feedId;
-  }
-
-  /**
    * Helper to get a feed by ID
    */
   async function getFeed(feedId: string) {
     const [feed] = await db.select().from(feeds).where(eq(feeds.id, feedId)).limit(1);
     return feed;
-  }
-
-  /**
-   * Helper to create an active subscription
-   */
-  async function createSubscription(userId: string, feedId: string): Promise<string> {
-    const subscriptionId = generateUuidv7();
-    const now = new Date();
-    await db.insert(subscriptions).values({
-      id: subscriptionId,
-      userId,
-      feedId,
-      subscribedAt: now,
-      createdAt: now,
-      updatedAt: now,
-    });
-    return subscriptionId;
-  }
-
-  /**
-   * Helper to create an entry with a user_entries row. The BEFORE INSERT
-   * trigger stamps user_entries.subscription_id from the user's subscription
-   * to the entry's feed.
-   */
-  async function createEntryWithUserEntry(feedId: string, userId: string): Promise<string> {
-    const entryId = generateUuidv7();
-    const now = new Date();
-    await db.insert(entries).values({
-      id: entryId,
-      feedId,
-      type: "web",
-      guid: `guid-${entryId}`,
-      title: `Entry ${entryId}`,
-      contentHash: `hash-${entryId}`,
-      fetchedAt: now,
-      lastSeenAt: now,
-      createdAt: now,
-      updatedAt: now,
-    });
-    await db.insert(userEntries).values({ userId, entryId });
-    return entryId;
   }
 
   /**
@@ -279,10 +205,10 @@ describe("Redirect Tracking", () => {
       // Create old feed (being redirected)
       const oldFeedUrl = "https://oldsite.com/feed.xml";
       const oldFeedId = await createTestFeed({ url: oldFeedUrl });
-      const oldSubId = await createSubscription(userId, oldFeedId);
+      const oldSubId = await createTestSubscription(userId, oldFeedId);
       await ensureFeedJob(oldFeedId);
       // An old-feed entry the user can see, attributed to the old subscription.
-      const oldEntryId = await createEntryWithUserEntry(oldFeedId, userId);
+      const oldEntryId = await createTestEntry(oldFeedId, { userIds: [userId] });
       expect(await getStampedSubscriptionId(userId, oldEntryId)).toBe(oldSubId);
 
       // Create new feed (redirect destination)
@@ -366,11 +292,11 @@ describe("Redirect Tracking", () => {
       const newFeedId = await createTestFeed({ url: "https://newsite.com/feed.xml" });
 
       // User already subscribed to new feed
-      const existingSubId = await createSubscription(userId, newFeedId);
+      const existingSubId = await createTestSubscription(userId, newFeedId);
 
       // User also subscribed to old feed, with a visible old-feed entry
-      const oldSubId = await createSubscription(userId, oldFeedId);
-      const oldEntryId = await createEntryWithUserEntry(oldFeedId, userId);
+      const oldSubId = await createTestSubscription(userId, oldFeedId);
+      const oldEntryId = await createTestEntry(oldFeedId, { userIds: [userId] });
       expect(await getStampedSubscriptionId(userId, oldEntryId)).toBe(oldSubId);
 
       const now = new Date();
@@ -424,8 +350,8 @@ describe("Redirect Tracking", () => {
         updatedAt: unsubscribedAt,
       });
       // User subscribed to old feed, with a visible old-feed entry
-      const oldSubId = await createSubscription(userId, oldFeedId);
-      const oldEntryId = await createEntryWithUserEntry(oldFeedId, userId);
+      const oldSubId = await createTestSubscription(userId, oldFeedId);
+      const oldEntryId = await createTestEntry(oldFeedId, { userIds: [userId] });
       expect(await getStampedSubscriptionId(userId, oldEntryId)).toBe(oldSubId);
 
       // Simulate migration: reactivate new sub, unsubscribe old, re-stamp

--- a/tests/integration/retention.test.ts
+++ b/tests/integration/retention.test.ts
@@ -24,21 +24,10 @@ import {
 } from "../../src/server/db/schema";
 import { runRetentionCleanup } from "../../src/server/services/retention";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createTestFeed, createTestSubscription, createTestUser } from "./helpers";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const TEST_CLIENT_ID = "retention-test-client";
-
-async function createTestUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `retention-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
 
 async function createSession(userId: string, expiresAt: Date, revokedAt?: Date): Promise<string> {
   const id = generateUuidv7();
@@ -146,31 +135,6 @@ async function createAuthCode(userId: string, expiresAt: Date): Promise<string> 
   return id;
 }
 
-async function createFeed(): Promise<string> {
-  const id = generateUuidv7();
-  await db.insert(feeds).values({
-    id,
-    type: "web",
-    url: `https://retention-${id}.example.com/feed.xml`,
-  });
-  return id;
-}
-
-async function createSubscription(
-  userId: string,
-  feedId: string,
-  options: { unsubscribedAt?: Date } = {}
-): Promise<string> {
-  const id = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id,
-    userId,
-    feedId,
-    unsubscribedAt: options.unsubscribedAt ?? null,
-  });
-  return id;
-}
-
 async function createFeedJob(
   feedId: string,
   options: { createdAt?: Date; runningSince?: Date } = {}
@@ -241,7 +205,7 @@ describe("runRetentionCleanup", () => {
   afterAll(cleanupTables);
 
   it("deletes expired sessions and keeps live ones", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "retention" });
     const expired = await createSession(userId, new Date(Date.now() - 2 * DAY_MS));
     const live = await createSession(userId, new Date(Date.now() + DAY_MS));
     // Expired less than the 1-day grace period ago: kept.
@@ -263,7 +227,7 @@ describe("runRetentionCleanup", () => {
   });
 
   it("deletes expired/long-revoked API tokens and keeps live/non-expiring ones", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "retention" });
     const expired = await createApiToken(userId, { expiresAt: new Date(Date.now() - 2 * DAY_MS) });
     const live = await createApiToken(userId, { expiresAt: new Date(Date.now() + 30 * DAY_MS) });
     // Non-expiring token (expiresAt NULL): never swept until revoked.
@@ -288,7 +252,7 @@ describe("runRetentionCleanup", () => {
   });
 
   it("deletes old terminal OPML imports and keeps recent/in-progress ones", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "retention" });
     const oldCompleted = await createOpmlImport(userId, {
       status: "completed",
       createdAt: new Date(Date.now() - 31 * DAY_MS),
@@ -318,7 +282,7 @@ describe("runRetentionCleanup", () => {
   });
 
   it("deletes expired OAuth authorization codes, access tokens, and refresh tokens", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "retention" });
 
     const expiredCode = await createAuthCode(userId, new Date(Date.now() - 2 * DAY_MS));
     const liveCode = await createAuthCode(userId, new Date(Date.now() + 10 * 60 * 1000));
@@ -355,7 +319,7 @@ describe("runRetentionCleanup", () => {
   });
 
   it("handles refresh-token rotation chains (replaced_by_id) without FK failures", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "retention" });
 
     // Rotation: old token revoked long ago points at its expired replacement.
     // Both are deletable; the replaced_by_id FK is ON DELETE SET NULL so the
@@ -429,37 +393,37 @@ describe("runRetentionCleanup", () => {
   });
 
   it("deletes subscriber-less fetch_feed jobs but keeps subscribed, running, or fresh ones", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "retention" });
 
     // Active subscriber: kept.
-    const subscribedFeed = await createFeed();
-    await createSubscription(userId, subscribedFeed);
+    const subscribedFeed = await createTestFeed();
+    await createTestSubscription(userId, subscribedFeed);
     const subscribedJobId = await createFeedJob(subscribedFeed);
 
     // Only an unsubscribed (soft-deleted) subscription: dead, deleted.
-    const unsubscribedFeed = await createFeed();
-    await createSubscription(userId, unsubscribedFeed, { unsubscribedAt: new Date() });
+    const unsubscribedFeed = await createTestFeed();
+    await createTestSubscription(userId, unsubscribedFeed, { unsubscribedAt: new Date() });
     const unsubscribedJobId = await createFeedJob(unsubscribedFeed);
 
     // No subscription at all (e.g. deleteUser orphan cleanup): dead, deleted.
-    const orphanFeed = await createFeed();
+    const orphanFeed = await createTestFeed();
     const orphanJobId = await createFeedJob(orphanFeed);
 
     // No subscribers but currently running: kept (never touch an in-flight job).
-    const runningFeed = await createFeed();
+    const runningFeed = await createTestFeed();
     const runningJobId = await createFeedJob(runningFeed, { runningSince: new Date() });
 
     // No subscribers, running_since set but stale (crashed mid-fetch): still
     // kept — the guard is intentionally stricter than claimFeedJob's staleness
     // check, deferring to a later sweep after the stale job is reclaimed.
-    const staleRunningFeed = await createFeed();
+    const staleRunningFeed = await createTestFeed();
     const staleRunningJobId = await createFeedJob(staleRunningFeed, {
       runningSince: new Date(Date.now() - 7 * DAY_MS),
     });
 
     // No subscribers but freshly created — races the first-ever subscribe, whose
     // job commits just before its subscription: kept by the created_at grace.
-    const freshFeed = await createFeed();
+    const freshFeed = await createTestFeed();
     const freshJobId = await createFeedJob(freshFeed, { createdAt: new Date() });
 
     const result = await runRetentionCleanup(db);
@@ -474,7 +438,7 @@ describe("runRetentionCleanup", () => {
   });
 
   it("deletes orphaned old DCR clients but keeps recent or actively-used ones", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "retention" });
     const old = new Date(Date.now() - 40 * DAY_MS);
     const recentDate = new Date(Date.now() - 2 * DAY_MS);
 

--- a/tests/integration/sanitized-entry-content.test.ts
+++ b/tests/integration/sanitized-entry-content.test.ts
@@ -13,91 +13,23 @@ import { db } from "../../src/server/db";
 import { users, feeds, entries, subscriptions, userEntries } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
-import type { Context } from "../../src/server/trpc/context";
 import * as entriesService from "../../src/server/services/entries";
-
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: now,
-        privacyPolicyAgreedAt: now,
-        notEuAgreedAt: now,
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
+import {
+  createAuthContext,
+  createTestFeed,
+  createTestSubscription,
+  createTestUser,
+} from "./helpers";
 
 async function seedSubscribedUser(): Promise<{ userId: string; feedId: string }> {
-  const userId = generateUuidv7();
-  const feedId = generateUuidv7();
   const now = new Date();
-  await db.insert(users).values({
-    id: userId,
-    email: `user-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: now,
-    updatedAt: now,
-  });
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url: `https://example.com/${feedId}.xml`,
+  const userId = await createTestUser();
+  const feedId = await createTestFeed({
     title: "Test Feed",
     lastFetchedAt: now,
     lastEntriesUpdatedAt: now,
-    createdAt: now,
-    updatedAt: now,
   });
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
+  await createTestSubscription(userId, feedId);
   return { userId, feedId };
 }
 
@@ -145,7 +77,7 @@ describe("entries.get sanitized content", () => {
     });
     await makeEntryVisible(userId, entryId);
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const { entry } = await caller.entries.get({ id: entryId });
 
     expect(entry.contentCleaned).toContain("hello");
@@ -175,7 +107,7 @@ describe("entries.get sanitized content", () => {
     });
     await makeEntryVisible(userId, entryId);
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const { entry } = await caller.entries.get({ id: entryId });
     expect(entry.contentCleaned).toContain("hello");
     expect(entry.fullContentOriginal).toBeNull();
@@ -209,7 +141,7 @@ describe("entries.get sanitized content", () => {
     });
     await makeEntryVisible(userId, entryId);
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const { entry } = await caller.entries.get({ id: entryId });
 
     expect(entry.fullContentCleaned).toContain("full cleaned");
@@ -242,7 +174,7 @@ describe("entries.get sanitized content", () => {
     });
     await makeEntryVisible(userId, entryId);
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const { entry } = await caller.entries.get({ id: entryId });
 
     expect(entry.fullContentOriginal).toContain("raw page");

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -25,81 +25,11 @@ import {
   savedArticleExistsByUrl,
 } from "../../src/server/services/saved";
 import { markEntriesRead } from "../../src/server/services/entries";
+import { createAuthContext, createTestUser } from "./helpers";
 
 // ============================================================================
 // Test Helpers
 // ============================================================================
-
-/**
- * Creates a test user and returns their ID.
- * Uses a unique email based on the userId to avoid conflicts in parallel tests.
- */
-async function createTestUser(emailPrefix: string = "user"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${emailPrefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
-/**
- * Creates an authenticated context for a test user.
- */
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: new Date(),
-        privacyPolicyAgreedAt: new Date(),
-        notEuAgreedAt: new Date(),
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
 
 function createUnauthContext(): Context {
   return {
@@ -214,7 +144,7 @@ describe("Saved Articles API", () => {
   describe("entries.list with type='saved'", () => {
     it("returns empty list for user with no saved articles", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.list({ type: "saved" });
@@ -225,14 +155,14 @@ describe("Saved Articles API", () => {
 
     it("returns saved articles for the authenticated user only", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
       // Create articles for both users
       await createTestSavedArticle(userId1, { title: "User 1 Article 1" });
       await createTestSavedArticle(userId1, { title: "User 1 Article 2" });
       await createTestSavedArticle(userId2, { title: "User 2 Article" });
 
-      const ctx1 = createAuthContext(userId1);
+      const ctx1 = await createAuthContext(userId1);
       const caller1 = createCaller(ctx1);
       const result1 = await caller1.entries.list({ type: "saved" });
 
@@ -242,7 +172,7 @@ describe("Saved Articles API", () => {
         "User 1 Article 2",
       ]);
 
-      const ctx2 = createAuthContext(userId2);
+      const ctx2 = await createAuthContext(userId2);
       const caller2 = createCaller(ctx2);
       const result2 = await caller2.entries.list({ type: "saved" });
 
@@ -260,7 +190,7 @@ describe("Saved Articles API", () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
       const id3 = await createTestSavedArticle(userId, { title: "Third" });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.entries.list({ type: "saved" });
 
@@ -276,7 +206,7 @@ describe("Saved Articles API", () => {
       await createTestSavedArticle(userId, { title: "Read Article", read: true });
       await createTestSavedArticle(userId, { title: "Unread Article", read: false });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.entries.list({ type: "saved", unreadOnly: true });
 
@@ -290,7 +220,7 @@ describe("Saved Articles API", () => {
       await createTestSavedArticle(userId, { title: "Starred Article", starred: true });
       await createTestSavedArticle(userId, { title: "Unstarred Article", starred: false });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.entries.list({ type: "saved", starredOnly: true });
 
@@ -317,7 +247,7 @@ describe("Saved Articles API", () => {
         starred: false,
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.entries.list({
         type: "saved",
@@ -338,7 +268,7 @@ describe("Saved Articles API", () => {
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Get first page (2 items)
@@ -376,7 +306,7 @@ describe("Saved Articles API", () => {
         await createTestSavedArticle(userId, { title: `Article ${i}` });
       }
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.entries.list({ type: "saved", limit: 3 });
 
@@ -390,7 +320,7 @@ describe("Saved Articles API", () => {
       const userId = await createTestUser();
       const articleId = await createTestSavedArticle(userId, { title: "Test Article" });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.entries.get({ id: articleId });
 
@@ -406,7 +336,7 @@ describe("Saved Articles API", () => {
 
     it("throws error for non-existent article", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       await expect(caller.entries.get({ id: generateUuidv7() })).rejects.toThrow("Entry not found");
@@ -414,11 +344,11 @@ describe("Saved Articles API", () => {
 
     it("throws error when accessing another user's article", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
       const articleId = await createTestSavedArticle(userId1, { title: "User 1's Article" });
 
-      const ctx = createAuthContext(userId2);
+      const ctx = await createAuthContext(userId2);
       const caller = createCaller(ctx);
 
       await expect(caller.entries.get({ id: articleId })).rejects.toThrow("Entry not found");
@@ -430,7 +360,7 @@ describe("Saved Articles API", () => {
       const userId = await createTestUser();
       const articleId = await createTestSavedArticle(userId, { title: "To Delete" });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.saved.delete({ id: articleId });
@@ -443,7 +373,7 @@ describe("Saved Articles API", () => {
 
     it("throws error for non-existent article", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       await expect(caller.saved.delete({ id: generateUuidv7() })).rejects.toThrow(
@@ -453,11 +383,11 @@ describe("Saved Articles API", () => {
 
     it("throws error when deleting another user's article", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
       const articleId = await createTestSavedArticle(userId1, { title: "User 1's Article" });
 
-      const ctx = createAuthContext(userId2);
+      const ctx = await createAuthContext(userId2);
       const caller = createCaller(ctx);
 
       await expect(caller.saved.delete({ id: articleId })).rejects.toThrow(
@@ -476,7 +406,7 @@ describe("Saved Articles API", () => {
       const id1 = await createTestSavedArticle(userId, { read: false });
       const id2 = await createTestSavedArticle(userId, { read: false });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.markRead({
@@ -499,7 +429,7 @@ describe("Saved Articles API", () => {
       const id1 = await createTestSavedArticle(userId, { read: true });
       const id2 = await createTestSavedArticle(userId, { read: true });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.markRead({
@@ -521,7 +451,7 @@ describe("Saved Articles API", () => {
       const userId = await createTestUser();
       const validId = await createTestSavedArticle(userId, { read: false });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Should not throw, just ignore invalid ID
@@ -544,12 +474,12 @@ describe("Saved Articles API", () => {
 
     it("ignores articles belonging to other users", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
       const myArticle = await createTestSavedArticle(userId1, { read: false });
       const otherArticle = await createTestSavedArticle(userId2, { read: false });
 
-      const ctx = createAuthContext(userId1);
+      const ctx = await createAuthContext(userId1);
       const caller = createCaller(ctx);
 
       await caller.entries.markRead({
@@ -576,7 +506,7 @@ describe("Saved Articles API", () => {
 
     it("returns empty articles array when no valid IDs provided", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.markRead({
@@ -593,7 +523,7 @@ describe("Saved Articles API", () => {
       const userId = await createTestUser();
       const articleId = await createTestSavedArticle(userId, { starred: false });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.setStarred({ id: articleId, starred: true });
@@ -612,7 +542,7 @@ describe("Saved Articles API", () => {
 
     it("throws error for non-existent article", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       await expect(
@@ -622,11 +552,11 @@ describe("Saved Articles API", () => {
 
     it("throws error when starring another user's article", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
       const articleId = await createTestSavedArticle(userId1, { starred: false });
 
-      const ctx = createAuthContext(userId2);
+      const ctx = await createAuthContext(userId2);
       const caller = createCaller(ctx);
 
       await expect(caller.entries.setStarred({ id: articleId, starred: true })).rejects.toThrow(
@@ -648,7 +578,7 @@ describe("Saved Articles API", () => {
       const userId = await createTestUser();
       const articleId = await createTestSavedArticle(userId, { starred: true });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.setStarred({ id: articleId, starred: false });
@@ -667,7 +597,7 @@ describe("Saved Articles API", () => {
 
     it("throws error for non-existent article", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       await expect(
@@ -677,11 +607,11 @@ describe("Saved Articles API", () => {
 
     it("throws error when unstarring another user's article", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
       const articleId = await createTestSavedArticle(userId1, { starred: true });
 
-      const ctx = createAuthContext(userId2);
+      const ctx = await createAuthContext(userId2);
       const caller = createCaller(ctx);
 
       await expect(caller.entries.setStarred({ id: articleId, starred: false })).rejects.toThrow(
@@ -761,7 +691,7 @@ describe("Saved Articles API", () => {
         title: "Already Saved Article",
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // With refetch=false, returns existing without attempting to fetch
@@ -774,7 +704,7 @@ describe("Saved Articles API", () => {
 
     it("allows different users to save the same URL", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
       const sharedUrl = "https://example.com/shared";
 
       // User 1 saves the URL
@@ -801,7 +731,7 @@ describe("Saved Articles API", () => {
         title: "Original Title",
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Refetch with new HTML
@@ -846,7 +776,7 @@ describe("Saved Articles API", () => {
         starred: true,
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const newHtml = `
@@ -893,7 +823,7 @@ describe("Saved Articles API", () => {
         .from(userEntries)
         .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, articleId)));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const newHtml = `
@@ -959,7 +889,7 @@ describe("Saved Articles API", () => {
         })
         .where(eq(entries.id, articleId));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Try to refetch with very short content (simulating error page)
@@ -999,7 +929,7 @@ describe("Saved Articles API", () => {
         })
         .where(eq(entries.id, articleId));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Force refetch with short content
@@ -1040,7 +970,7 @@ describe("Saved Articles API", () => {
         })
         .where(eq(entries.id, articleId));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Refetch with content that's 60% of original but >500 chars
@@ -1070,7 +1000,7 @@ describe("Saved Articles API", () => {
   describe("saved.save with provided HTML", () => {
     it("rejects provided HTML larger than the saved article size limit", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const { usageLimitsConfig } = await import("../../src/server/config/env");
@@ -1090,7 +1020,7 @@ describe("Saved Articles API", () => {
 
     it("uses provided HTML instead of fetching the URL", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const testHtml = `
@@ -1131,7 +1061,7 @@ describe("Saved Articles API", () => {
 
     it("uses provided title parameter over extracted metadata", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const testHtml = `
@@ -1159,7 +1089,7 @@ describe("Saved Articles API", () => {
 
     it("uses provided author and excerpt parameters over extracted metadata", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const testHtml = `
@@ -1193,7 +1123,7 @@ describe("Saved Articles API", () => {
 
     it("falls back to og:title when title parameter is not provided", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const testHtml = `
@@ -1217,7 +1147,7 @@ describe("Saved Articles API", () => {
 
     it("handles HTML without metadata gracefully", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const testHtml = `
@@ -1247,7 +1177,7 @@ describe("Saved Articles API", () => {
 
     it("omits article body from the response; body is sanitized on read (#927)", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Body carries XSS vectors. The mutation response must not echo content
@@ -1317,7 +1247,7 @@ describe("Saved Articles API", () => {
   describe("saved.uploadFile size limit (#1082)", () => {
     it("rejects a decoded upload larger than the saved article size limit before processing", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const { usageLimitsConfig } = await import("../../src/server/config/env");
@@ -1362,7 +1292,7 @@ describe("Saved Articles API", () => {
 
     it("is scoped per user", async () => {
       const userId = await createTestUser();
-      const otherId = await createTestUser("other");
+      const otherId = await createTestUser({ emailPrefix: "other" });
       const url = "https://example.com/mine";
       await createTestSavedArticle(userId, { url });
 
@@ -1445,7 +1375,7 @@ describe("Saved Articles API", () => {
       expect(await isPlaceholderFlag(healed.id)).toBe(false);
 
       // The served body is now the real content, not the placeholder text.
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const fetched = await caller.entries.get({ id: healed.id });
       expect(fetched.entry.contentCleaned).toContain("real article content");

--- a/tests/integration/saved-feed-detection.test.ts
+++ b/tests/integration/saved-feed-detection.test.ts
@@ -16,10 +16,9 @@ import { createServer, type Server } from "node:http";
 import { type AddressInfo } from "node:net";
 import { TRPCError } from "@trpc/server";
 import { db } from "../../src/server/db";
-import { users } from "../../src/server/db/schema";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { saveArticle } from "../../src/server/services/saved";
 import { getAppErrorCode } from "../../src/server/trpc/errors";
+import { createTestUser } from "./helpers";
 
 const RSS_BODY = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0"><channel><title>Example Feed</title>
@@ -84,21 +83,9 @@ afterAll(async () => {
   await new Promise<void>((resolve) => server.close(() => resolve()));
 });
 
-async function createTestUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `feed-detect-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
 describe("saveArticle feed detection", () => {
   it("throws URL_IS_FEED for a URL served as a feed content type", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "feed-detect" });
     const promise = saveArticle(db, userId, { url: `${baseUrl}/feed.xml` });
     await expect(promise).rejects.toBeInstanceOf(TRPCError);
     await promise.catch((error) => {
@@ -108,14 +95,14 @@ describe("saveArticle feed detection", () => {
   });
 
   it("throws URL_IS_FEED for an ambiguous content type whose body is a feed", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "feed-detect" });
     await expect(saveArticle(db, userId, { url: `${baseUrl}/ambiguous-feed` })).rejects.toThrow(
       "URL_IS_FEED"
     );
   });
 
   it("does not treat a non-feed XML document (sitemap) as a feed", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "feed-detect" });
     const promise = saveArticle(db, userId, { url: `${baseUrl}/sitemap.xml` });
     // Not a feed → the original fetch failure surfaces, not URL_IS_FEED.
     await expect(promise).rejects.toThrow();
@@ -126,14 +113,14 @@ describe("saveArticle feed detection", () => {
   });
 
   it("throws URL_IS_FEED for a valid JSON Feed served as application/json", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "feed-detect" });
     await expect(saveArticle(db, userId, { url: `${baseUrl}/json-feed` })).rejects.toThrow(
       "URL_IS_FEED"
     );
   });
 
   it("does not treat a plain JSON API response as a feed", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "feed-detect" });
     const promise = saveArticle(db, userId, { url: `${baseUrl}/json-api` });
     await expect(promise).rejects.toThrow();
     await promise.catch((error) => {
@@ -143,7 +130,7 @@ describe("saveArticle feed detection", () => {
   });
 
   it("saves a normal HTML article without triggering feed detection", async () => {
-    const userId = await createTestUser();
+    const userId = await createTestUser({ emailPrefix: "feed-detect" });
     const result = await saveArticle(db, userId, { url: `${baseUrl}/article` });
     expect(result.outcome).toBe("created");
     expect(result.title).toBe("An Article");

--- a/tests/integration/saved-google-docs-auth.test.ts
+++ b/tests/integration/saved-google-docs-auth.test.ts
@@ -23,6 +23,7 @@ import { db } from "../../src/server/db";
 import { users, oauthAccounts } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { saveArticle } from "../../src/server/services/saved";
+import { createTestUser } from "./helpers";
 
 // A syntactically-valid but non-public Google Docs URL. The plugin's public
 // fetch no-ops (no service account), so this always reaches the private path.
@@ -30,15 +31,9 @@ const PRIVATE_DOC_URL = "https://docs.google.com/document/d/1PrIvAtEdOcIdAbCdEfG
 
 const createdUserIds: string[] = [];
 
-async function createTestUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `gdocs-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
+/** Creates a user and registers it for `afterAll` cleanup. */
+async function createUser(): Promise<string> {
+  const userId = await createTestUser({ emailPrefix: "gdocs" });
   createdUserIds.push(userId);
   return userId;
 }
@@ -65,7 +60,7 @@ afterAll(async () => {
 
 describe("Saving private Google Docs via compat surfaces (issue #1165)", () => {
   it("returns a 401 with a web-app-pointing message when Google is not linked", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
 
     let thrown: unknown;
     try {
@@ -90,7 +85,7 @@ describe("Saving private Google Docs via compat surfaces (issue #1165)", () => {
   });
 
   it("returns a 403 with a web-app-pointing message when Docs scopes are missing", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     // Linked, but only the base sign-in scopes — no Docs/Drive access.
     await linkGoogleAccount(userId, ["openid", "email", "profile"]);
 
@@ -113,7 +108,7 @@ describe("Saving private Google Docs via compat surfaces (issue #1165)", () => {
   });
 
   it("still throws the machine-readable NEEDS_* codes in interactive mode (web UI contract)", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
 
     // No Google account linked → interactive mode surfaces the code verbatim.
     await expect(

--- a/tests/integration/saved-uploads.test.ts
+++ b/tests/integration/saved-uploads.test.ts
@@ -12,22 +12,16 @@ import { describe, it, expect, afterAll } from "vitest";
 import { eq } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import { users, entries } from "../../src/server/db/schema";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createSavedFromUpload, uploadArticle } from "../../src/server/services/saved";
 import { convertUploadedFile } from "../../src/server/file/process-upload";
 import { buildMinimalDocx } from "../utils/docx";
+import { createTestUser } from "./helpers";
 
 const createdUserIds: string[] = [];
 
-async function createTestUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `upload-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
+/** Creates a user and registers it for `afterAll` cleanup. */
+async function createUser(): Promise<string> {
+  const userId = await createTestUser({ emailPrefix: "upload" });
   createdUserIds.push(userId);
   return userId;
 }
@@ -70,7 +64,7 @@ afterAll(async () => {
 
 describe("createSavedFromUpload (HTML)", () => {
   it("stores a null URL and an uploaded: guid", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const converted = await convertUploadedFile(
       `<html><head><title>Doc Title</title></head><body>${ARTICLE_BODY}</body></html>`,
       "notes.html"
@@ -84,7 +78,7 @@ describe("createSavedFromUpload (HTML)", () => {
   });
 
   it("prefers a provided title over the document title", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const converted = await convertUploadedFile(
       `<html><head><title>Document Title</title></head><body>${ARTICLE_BODY}</body></html>`,
       "notes.html"
@@ -94,7 +88,7 @@ describe("createSavedFromUpload (HTML)", () => {
   });
 
   it("falls back to the filename-derived title when content has none", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     // No <title> and no heading Readability would pick up as a title.
     const converted = await convertUploadedFile(
       `<html><body>${ARTICLE_BODY}</body></html>`,
@@ -105,7 +99,7 @@ describe("createSavedFromUpload (HTML)", () => {
   });
 
   it("rewrites relative URLs against the dummy upload base (not Lion Reader)", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const converted = await convertUploadedFile(
       `<html><body>${ARTICLE_BODY}</body></html>`,
       "notes.html"
@@ -122,7 +116,7 @@ describe("createSavedFromUpload (HTML)", () => {
   });
 
   it("keeps the raw original when Readability fails (contentCleaned null, still readable)", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     // Too short for Readability to extract → cleaned is null. Matches how a URL
     // save behaves on a page Readability can't parse: store the original, serve
     // `cleaned ?? original` on read.
@@ -140,7 +134,7 @@ describe("createSavedFromUpload (HTML)", () => {
   });
 
   it("extracts Open Graph metadata (author, image) from uploaded HTML", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const html =
       "<html><head>" +
       '<meta property="og:image" content="https://cdn.example.com/cover.jpg">' +
@@ -168,7 +162,7 @@ describe("createSavedFromUpload (.docx)", () => {
   ];
 
   it("uses docProps/core.xml for title, author, and summary", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const docx = buildMinimalDocx({
       paragraphs: DOCX_PARAGRAPHS,
       core: {
@@ -188,7 +182,7 @@ describe("createSavedFromUpload (.docx)", () => {
   });
 
   it("skips Readability: stores the mammoth body verbatim as cleaned content", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const docx = buildMinimalDocx({
       paragraphs: DOCX_PARAGRAPHS,
       core: { title: "Skip Readability Doc" },
@@ -204,7 +198,7 @@ describe("createSavedFromUpload (.docx)", () => {
   });
 
   it("falls back to the filename-derived title when core.xml has no title", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     // core.xml present but with only an author — no dc:title.
     const docx = buildMinimalDocx({
       paragraphs: DOCX_PARAGRAPHS,
@@ -218,7 +212,7 @@ describe("createSavedFromUpload (.docx)", () => {
   });
 
   it("prefers a caller-provided title over the core.xml title", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const docx = buildMinimalDocx({
       paragraphs: DOCX_PARAGRAPHS,
       core: { title: "Core.xml Title" },
@@ -235,7 +229,7 @@ describe("createSavedFromUpload (.docx)", () => {
 
 describe("uploadArticle (Markdown)", () => {
   it("uses frontmatter title/summary/author", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const md = [
       "---",
       "title: Frontmatter Title",
@@ -256,14 +250,14 @@ describe("uploadArticle (Markdown)", () => {
   });
 
   it("prefers the provided title over frontmatter", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const md = ["---", "title: Frontmatter Title", "---", "", "Body text here."].join("\n");
     const article = await uploadArticle(db, userId, { content: md, title: "Explicit Title" });
     expect(article.title).toBe("Explicit Title");
   });
 
   it("prefers the provided author/excerpt over frontmatter", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const md = [
       "---",
       "title: Frontmatter Title",

--- a/tests/integration/subscription-update-events.test.ts
+++ b/tests/integration/subscription-update-events.test.ts
@@ -28,9 +28,14 @@ import {
 } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
-import type { Context } from "../../src/server/trpc/context";
 import { getUserEventsChannel } from "../../src/server/redis/pubsub";
 import { expectNoMessage, subscribeAndDrain, waitForMessage } from "../utils/pubsub";
+import {
+  createAuthContext,
+  createTestFeed,
+  createTestSubscription,
+  createTestUser,
+} from "./helpers";
 
 let subscriber: Redis;
 
@@ -65,99 +70,19 @@ beforeEach(async () => {
 // Test Helpers
 // ============================================================================
 
-async function createTestUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `sub-update-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: new Date(),
-        privacyPolicyAgreedAt: new Date(),
-        notEuAgreedAt: new Date(),
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
-
 /**
- * Seeds a feed + active subscription; returns the subscription ID.
+ * Seeds a feed + active subscription; returns the subscription ID. Every test
+ * here needs both, and none cares about the feed itself.
  */
-async function createTestSubscription(
+async function createSubscribedFeed(
   userId: string,
   options: { customTitle?: string | null; fetchFullContent?: boolean } = {}
 ): Promise<string> {
-  const now = new Date();
-  const feedId = generateUuidv7();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url: `https://example.com/${feedId}`,
-    title: "Test Feed",
-    createdAt: now,
-    updatedAt: now,
-  });
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
+  const feedId = await createTestFeed();
+  return createTestSubscription(userId, feedId, {
     customTitle: options.customTitle ?? null,
     fetchFullContent: options.fetchFullContent ?? false,
-    subscribedAt: now,
-    createdAt: now,
-    updatedAt: now,
   });
-  return subscriptionId;
 }
 
 async function createTestTag(userId: string, name: string): Promise<string> {
@@ -187,8 +112,8 @@ async function getSubscriptionUpdatedAt(subscriptionId: string): Promise<Date> {
 describe("subscriptions.update meaningful-change gating (issue #1160)", () => {
   it("publishes subscription_updated and advances updated_at on a real title change", async () => {
     const userId = await createTestUser();
-    const subscriptionId = await createTestSubscription(userId, { customTitle: "Old Title" });
-    const caller = createCaller(createAuthContext(userId));
+    const subscriptionId = await createSubscribedFeed(userId, { customTitle: "Old Title" });
+    const caller = createCaller(await createAuthContext(userId));
     const before = await getSubscriptionUpdatedAt(subscriptionId);
 
     const channel = getUserEventsChannel(userId);
@@ -211,11 +136,11 @@ describe("subscriptions.update meaningful-change gating (issue #1160)", () => {
 
   it("does not publish or advance updated_at when re-saving identical settings", async () => {
     const userId = await createTestUser();
-    const subscriptionId = await createTestSubscription(userId, {
+    const subscriptionId = await createSubscribedFeed(userId, {
       customTitle: "Same Title",
       fetchFullContent: true,
     });
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const before = await getSubscriptionUpdatedAt(subscriptionId);
 
     const channel = getUserEventsChannel(userId);
@@ -239,8 +164,8 @@ describe("subscriptions.update meaningful-change gating (issue #1160)", () => {
 
   it("treats a NULL custom title re-save as a no-op (IS DISTINCT FROM semantics)", async () => {
     const userId = await createTestUser();
-    const subscriptionId = await createTestSubscription(userId, { customTitle: null });
-    const caller = createCaller(createAuthContext(userId));
+    const subscriptionId = await createSubscribedFeed(userId, { customTitle: null });
+    const caller = createCaller(await createAuthContext(userId));
     const before = await getSubscriptionUpdatedAt(subscriptionId);
 
     const channel = getUserEventsChannel(userId);
@@ -256,8 +181,8 @@ describe("subscriptions.update meaningful-change gating (issue #1160)", () => {
 
   it("does not publish or advance updated_at when no fields are provided", async () => {
     const userId = await createTestUser();
-    const subscriptionId = await createTestSubscription(userId);
-    const caller = createCaller(createAuthContext(userId));
+    const subscriptionId = await createSubscribedFeed(userId);
+    const caller = createCaller(await createAuthContext(userId));
     const before = await getSubscriptionUpdatedAt(subscriptionId);
 
     const channel = getUserEventsChannel(userId);
@@ -273,11 +198,11 @@ describe("subscriptions.update meaningful-change gating (issue #1160)", () => {
 
   it("publishes when only fetchFullContent flips alongside an identical title", async () => {
     const userId = await createTestUser();
-    const subscriptionId = await createTestSubscription(userId, {
+    const subscriptionId = await createSubscribedFeed(userId, {
       customTitle: "Same Title",
       fetchFullContent: false,
     });
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const before = await getSubscriptionUpdatedAt(subscriptionId);
 
     const channel = getUserEventsChannel(userId);
@@ -302,9 +227,9 @@ describe("subscriptions.update meaningful-change gating (issue #1160)", () => {
 describe("subscriptions.setTags meaningful-change gating (issue #1160)", () => {
   it("publishes and advances updated_at when the tag set actually changes", async () => {
     const userId = await createTestUser();
-    const subscriptionId = await createTestSubscription(userId);
+    const subscriptionId = await createSubscribedFeed(userId);
     const tagId = await createTestTag(userId, "Tech");
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const before = await getSubscriptionUpdatedAt(subscriptionId);
 
     const channel = getUserEventsChannel(userId);
@@ -323,10 +248,10 @@ describe("subscriptions.setTags meaningful-change gating (issue #1160)", () => {
 
   it("does not publish or advance updated_at when re-applying the identical tag set", async () => {
     const userId = await createTestUser();
-    const subscriptionId = await createTestSubscription(userId);
+    const subscriptionId = await createSubscribedFeed(userId);
     const tagA = await createTestTag(userId, "Tech");
     const tagB = await createTestTag(userId, "News");
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
 
     // Setup mutates through the API, which publishes fire-and-forget — so
     // subscribe first and drain that event rather than racing it (issue #1427).
@@ -354,10 +279,10 @@ describe("subscriptions.setTags meaningful-change gating (issue #1160)", () => {
 
   it("publishes when the tag set partially overlaps the previous one", async () => {
     const userId = await createTestUser();
-    const subscriptionId = await createTestSubscription(userId);
+    const subscriptionId = await createSubscribedFeed(userId);
     const tagA = await createTestTag(userId, "Tech");
     const tagB = await createTestTag(userId, "News");
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
 
     const channel = getUserEventsChannel(userId);
     await subscribeAndDrain(subscriber, channel, () =>
@@ -377,9 +302,9 @@ describe("subscriptions.setTags meaningful-change gating (issue #1160)", () => {
 
   it("publishes with empty tags when clearing a tagged subscription", async () => {
     const userId = await createTestUser();
-    const subscriptionId = await createTestSubscription(userId);
+    const subscriptionId = await createSubscribedFeed(userId);
     const tagId = await createTestTag(userId, "Tech");
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
 
     const channel = getUserEventsChannel(userId);
     await subscribeAndDrain(subscriber, channel, () =>
@@ -400,8 +325,8 @@ describe("subscriptions.setTags meaningful-change gating (issue #1160)", () => {
 
   it("does not publish or advance updated_at when clearing an already-untagged subscription", async () => {
     const userId = await createTestUser();
-    const subscriptionId = await createTestSubscription(userId);
-    const caller = createCaller(createAuthContext(userId));
+    const subscriptionId = await createSubscribedFeed(userId);
+    const caller = createCaller(await createAuthContext(userId));
     const before = await getSubscriptionUpdatedAt(subscriptionId);
 
     const channel = getUserEventsChannel(userId);

--- a/tests/integration/subscriptions.test.ts
+++ b/tests/integration/subscriptions.test.ts
@@ -19,160 +19,31 @@ import {
 } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
-import type { Context } from "../../src/server/trpc/context";
 import * as subscriptionsService from "../../src/server/services/subscriptions";
+import {
+  createAuthContext,
+  createTestEntry,
+  createTestSubscription,
+  createTestUser,
+  createTestFeed as createSharedTestFeed,
+} from "./helpers";
 
 // ============================================================================
 // Test Helpers
 // ============================================================================
 
 /**
- * Creates a test user and returns their ID.
+ * Wraps the shared feed factory with a feed that is not due for a poll, so the
+ * subscribe flow doesn't attempt a real network refresh
+ * (shouldRefetchOnSubscribe → false). Tests that exercise the forced-refresh
+ * path override nextFetchAt/websubActive.
  */
-async function createTestUser(emailPrefix: string = "user"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${emailPrefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
+async function createTestFeed(overrides: Partial<typeof feeds.$inferInsert>): Promise<string> {
+  return createSharedTestFeed({
+    nextFetchAt: new Date(Date.now() + 60 * 60 * 1000),
+    websubActive: false,
+    ...overrides,
   });
-  return userId;
-}
-
-/**
- * Creates an authenticated context for a test user.
- */
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: new Date(),
-        privacyPolicyAgreedAt: new Date(),
-        notEuAgreedAt: new Date(),
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
-
-/**
- * Creates a test feed with specified timestamps.
- */
-async function createTestFeed(options: {
-  url: string;
-  title?: string;
-  lastFetchedAt?: Date | null;
-  lastEntriesUpdatedAt?: Date | null;
-  nextFetchAt?: Date | null;
-  websubActive?: boolean;
-}): Promise<string> {
-  const feedId = generateUuidv7();
-  const now = new Date();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url: options.url,
-    title: options.title ?? `Test Feed ${feedId}`,
-    lastFetchedAt: options.lastFetchedAt ?? null,
-    lastEntriesUpdatedAt: options.lastEntriesUpdatedAt ?? null,
-    // Default to "not due for a poll" so the subscribe flow doesn't attempt a
-    // real network refresh (shouldRefetchOnSubscribe → false). Tests that
-    // exercise the forced-refresh path override nextFetchAt/websubActive.
-    nextFetchAt: options.nextFetchAt ?? new Date(now.getTime() + 60 * 60 * 1000),
-    websubActive: options.websubActive ?? false,
-    createdAt: now,
-    updatedAt: now,
-  });
-  return feedId;
-}
-
-/**
- * Creates a test subscription for a user and feed.
- */
-async function createTestSubscription(userId: string, feedId: string): Promise<string> {
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return subscriptionId;
-}
-
-/**
- * Creates a test entry with specified timestamps.
- */
-async function createTestEntry(
-  feedId: string,
-  options: {
-    guid?: string;
-    title?: string;
-    fetchedAt?: Date;
-    lastSeenAt?: Date | null;
-  } = {}
-): Promise<string> {
-  const entryId = generateUuidv7();
-  const now = options.fetchedAt ?? new Date();
-  const guid = options.guid ?? `guid-${entryId}`;
-
-  await db.insert(entries).values({
-    id: entryId,
-    feedId,
-    type: "web",
-    guid,
-    title: options.title ?? `Entry ${entryId}`,
-    contentHash: `hash-${entryId}`,
-    fetchedAt: now,
-    lastSeenAt: options.lastSeenAt ?? now,
-    createdAt: now,
-    updatedAt: now,
-  });
-
-  return entryId;
 }
 
 /**
@@ -220,7 +91,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
   describe("Entry visibility based on lastSeenAt", () => {
     it("shows only current entries when subscribing to existing feed", async () => {
       // User A subscribes to a feed
-      const userAId = await createTestUser("userA");
+      const userAId = await createTestUser({ emailPrefix: "userA" });
 
       // Create a feed that has been fetched
       const feedUrl = "https://example.com/feed.xml";
@@ -270,8 +141,8 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       await createTestSubscription(userAId, feedId);
 
       // User B subscribes to the same feed
-      const userBId = await createTestUser("userB");
-      const ctxB = createAuthContext(userBId);
+      const userBId = await createTestUser({ emailPrefix: "userB" });
+      const ctxB = await createAuthContext(userBId);
       const callerB = createCaller(ctxB);
 
       const result = await callerB.subscriptions.create({ url: feedUrl });
@@ -324,7 +195,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         lastSeenAt: fetchTime,
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.subscriptions.create({ url: feedUrl });
@@ -414,7 +285,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       });
 
       // User subscribes after all 3 fetches
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.subscriptions.create({ url: feedUrl });
@@ -469,7 +340,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         lastSeenAt: pushTime,
       });
 
-      const caller = createCaller(createAuthContext(userId));
+      const caller = createCaller(await createAuthContext(userId));
       const result = await caller.subscriptions.create({ url: feedUrl });
 
       expect(result.unreadCount).toBe(3);
@@ -498,7 +369,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         title: "Entry 1",
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.subscriptions.create({ url: feedUrl });
@@ -522,7 +393,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
 
       // No entries created
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.subscriptions.create({ url: feedUrl });
@@ -560,7 +431,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         lastSeenAt: fetchTime,
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // First subscription
@@ -619,7 +490,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         lastEntriesUpdatedAt: null,
       });
 
-      const caller = createCaller(createAuthContext(userId));
+      const caller = createCaller(await createAuthContext(userId));
       await expect(caller.subscriptions.create({ url: feedUrl })).rejects.toThrow();
     });
 
@@ -647,7 +518,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         lastSeenAt: fetchTime,
       });
 
-      const caller = createCaller(createAuthContext(userId));
+      const caller = createCaller(await createAuthContext(userId));
       const result = await caller.subscriptions.create({ url: feedUrl });
 
       // No synchronous populate — entries arrive via the background refresh.
@@ -698,7 +569,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       // Second fetch had no entries (all disappeared)
       // lastEntriesUpdatedAt is fetch2Time but no entries have that lastSeenAt
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.subscriptions.create({ url: feedUrl });
@@ -736,7 +607,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         lastSeenAt: fetchTime,
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // First subscribe
@@ -775,7 +646,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         lastSeenAt: fetchTime,
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Subscribe
@@ -814,7 +685,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         lastEntriesUpdatedAt: fetchTime,
       });
 
-      const caller = createCaller(createAuthContext(userId));
+      const caller = createCaller(await createAuthContext(userId));
       const result = await caller.subscriptions.create({ url: feedUrl });
 
       expect(result.fetchFullContent).toBe(true);
@@ -831,7 +702,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         lastEntriesUpdatedAt: fetchTime,
       });
 
-      const caller = createCaller(createAuthContext(userId));
+      const caller = createCaller(await createAuthContext(userId));
       const result = await caller.subscriptions.create({ url: feedUrl });
 
       expect(result.fetchFullContent).toBe(false);
@@ -848,7 +719,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         lastEntriesUpdatedAt: fetchTime,
       });
 
-      const caller = createCaller(createAuthContext(userId));
+      const caller = createCaller(await createAuthContext(userId));
       const first = await caller.subscriptions.create({ url: feedUrl });
       expect(first.fetchFullContent).toBe(true);
 
@@ -886,7 +757,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
     it("create returns absolute counts for the new untagged subscription", async () => {
       const userId = await createTestUser();
       await seedFeedWithUnread("https://example.com/counts-a.xml", 3);
-      const caller = createCaller(createAuthContext(userId));
+      const caller = createCaller(await createAuthContext(userId));
 
       const result = await caller.subscriptions.create({ url: "https://example.com/counts-a.xml" });
 
@@ -899,7 +770,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
     it("delete returns absolute counts reflecting the removal (uncategorized)", async () => {
       const userId = await createTestUser();
       await seedFeedWithUnread("https://example.com/counts-b.xml", 3);
-      const caller = createCaller(createAuthContext(userId));
+      const caller = createCaller(await createAuthContext(userId));
       const sub = await caller.subscriptions.create({ url: "https://example.com/counts-b.xml" });
 
       const result = await caller.subscriptions.delete({ id: sub.id });
@@ -913,7 +784,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       const userId = await createTestUser();
       await seedFeedWithUnread("https://example.com/counts-c.xml", 2);
       await seedFeedWithUnread("https://example.com/counts-d.xml", 3);
-      const caller = createCaller(createAuthContext(userId));
+      const caller = createCaller(await createAuthContext(userId));
       const subC = await caller.subscriptions.create({ url: "https://example.com/counts-c.xml" });
       const subD = await caller.subscriptions.create({ url: "https://example.com/counts-d.xml" });
 
@@ -933,9 +804,9 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
 
   describe("Multiple users subscribing", () => {
     it("each user gets their own user_entries for current entries", async () => {
-      const userAId = await createTestUser("userA");
-      const userBId = await createTestUser("userB");
-      const userCId = await createTestUser("userC");
+      const userAId = await createTestUser({ emailPrefix: "userA" });
+      const userBId = await createTestUser({ emailPrefix: "userB" });
+      const userCId = await createTestUser({ emailPrefix: "userC" });
 
       const feedUrl = "https://example.com/multi-user.xml";
       const fetchTime = new Date("2024-01-01T10:00:00Z");
@@ -961,15 +832,15 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       });
 
       // All three users subscribe
-      const ctxA = createAuthContext(userAId);
+      const ctxA = await createAuthContext(userAId);
       const callerA = createCaller(ctxA);
       await callerA.subscriptions.create({ url: feedUrl });
 
-      const ctxB = createAuthContext(userBId);
+      const ctxB = await createAuthContext(userBId);
       const callerB = createCaller(ctxB);
       await callerB.subscriptions.create({ url: feedUrl });
 
-      const ctxC = createAuthContext(userCId);
+      const ctxC = await createAuthContext(userCId);
       const callerC = createCaller(ctxC);
       await callerC.subscriptions.create({ url: feedUrl });
 
@@ -1012,7 +883,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       await createTestSubscription(userId, feed2Id);
       await createTestSubscription(userId, feed3Id);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Search for "Tech"
@@ -1037,7 +908,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
         .set({ customTitle: "My Custom Feed Name" })
         .where(eq(subscriptions.id, subscriptionId));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Query should match custom title
@@ -1067,7 +938,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       await createTestSubscription(userId, feed2Id);
       await createTestSubscription(userId, feed3Id);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.subscriptions.list({ query: "JavaScript" });
@@ -1086,7 +957,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       });
       await createTestSubscription(userId, feedId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.subscriptions.list({ query: "nonexistentquery12345" });
@@ -1095,8 +966,8 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
     });
 
     it("only filters user's own subscriptions", async () => {
-      const user1Id = await createTestUser("user1");
-      const user2Id = await createTestUser("user2");
+      const user1Id = await createTestUser({ emailPrefix: "user1" });
+      const user2Id = await createTestUser({ emailPrefix: "user2" });
 
       const feed1Id = await createTestFeed({
         url: "https://example.com/feed1.xml",
@@ -1113,7 +984,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       await createTestSubscription(user2Id, feed2Id);
 
       // User 1 searches for "Topic"
-      const ctx1 = createAuthContext(user1Id);
+      const ctx1 = await createAuthContext(user1Id);
       const caller1 = createCaller(ctx1);
       const result1 = await caller1.subscriptions.list({ query: "Topic" });
 
@@ -1131,7 +1002,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       });
       await createTestSubscription(userId, feedId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Search with lowercase - should match
@@ -1150,7 +1021,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       });
       await createTestSubscription(userId, feedId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Search with uppercase - should match
@@ -1169,7 +1040,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       });
       await createTestSubscription(userId, feedId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Search with different casing
@@ -1202,7 +1073,7 @@ describe("Subscriptions - Subscribe to Existing Feed", () => {
       await createTestSubscription(userId, feed1Id);
       await createTestSubscription(userId, feed2Id);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Search for partial substring with different casing

--- a/tests/integration/summarization.test.ts
+++ b/tests/integration/summarization.test.ts
@@ -12,35 +12,18 @@
 import { describe, it, expect, beforeEach, beforeAll, afterAll } from "vitest";
 import { eq } from "drizzle-orm";
 import { db } from "../../src/server/db";
-import {
-  users,
-  feeds,
-  entries,
-  subscriptions,
-  userEntries,
-  entrySummaries,
-} from "../../src/server/db/schema";
+import { users, userEntries, entrySummaries } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
-import type { Context } from "../../src/server/trpc/context";
 import { CURRENT_PROMPT_VERSION } from "../../src/server/services/summarization";
 import { getOrCreateSavedFeed } from "../../src/server/feed/saved-feed";
-
-async function createTestUser(): Promise<string> {
-  const userId = generateUuidv7();
-  const now = new Date();
-  await db.insert(users).values({
-    id: userId,
-    email: `summ-${userId}@test.com`,
-    passwordHash: "test-hash",
-    // No user API key (it would be encrypted-at-rest); availability comes from the
-    // server ANTHROPIC_API_KEY env set in beforeAll. The cached read path returns
-    // before any LLM call anyway.
-    createdAt: now,
-    updatedAt: now,
-  });
-  return userId;
-}
+import {
+  createAuthContext,
+  createTestEntry,
+  createTestFeed,
+  createTestSubscription,
+  createTestUser,
+} from "./helpers";
 
 /**
  * Creates an entry and makes it reachable the way the app does. The router
@@ -49,55 +32,38 @@ async function createTestUser(): Promise<string> {
  * soft-deletes it, hiding an unstarred entry), while a `saved: true` article
  * lives in the per-user saved feed and is visible on its type alone.
  */
-async function createTestEntry(
+async function createVisibleEntry(
   userId: string,
   contentHash: string,
   options: { unsubscribed?: boolean; saved?: boolean } = {}
 ): Promise<string> {
-  const entryId = generateUuidv7();
   const now = new Date();
   let feedId: string;
   if (options.saved) {
     feedId = await getOrCreateSavedFeed(db, userId);
   } else {
-    feedId = generateUuidv7();
-    await db.insert(feeds).values({
-      id: feedId,
-      type: "web",
-      url: `https://example.com/${feedId}.xml`,
+    // The fetch timestamps are what make the entry current for this
+    // subscription; createTestFeed builds a never-polled feed.
+    feedId = await createTestFeed({
       title: "Test Feed",
       lastFetchedAt: now,
       lastEntriesUpdatedAt: now,
-      createdAt: now,
-      updatedAt: now,
     });
-    await db.insert(subscriptions).values({
-      id: generateUuidv7(),
-      userId,
-      feedId,
-      subscribedAt: now,
+    await createTestSubscription(userId, feedId, {
       unsubscribedAt: options.unsubscribed ? now : null,
-      createdAt: now,
-      updatedAt: now,
     });
   }
-  await db.insert(entries).values({
-    id: entryId,
-    feedId,
+  const entryId = await createTestEntry(feedId, {
     type: options.saved ? "saved" : "web",
-    guid: `guid-${entryId}`,
     title: "Test Entry",
     contentCleaned: "<p>Some article content to summarize.</p>",
+    // The summary cache is keyed off this, so it's the caller's value verbatim.
     contentHash,
     fetchedAt: now,
-    publishedAt: now,
-    // last_seen_at tracks a feed poll, and the entries_last_seen_only_fetched
-    // constraint requires it exactly for type='web'.
-    lastSeenAt: options.saved ? null : now,
-    createdAt: now,
-    updatedAt: now,
   });
-  // subscription_id is stamped by the user_entries_fill_denormalized trigger.
+  // Not createTestEntry's `userIds`, which can't express the explicit change
+  // stamps. subscription_id is filled by the user_entries_fill_denormalized
+  // trigger.
   await db.insert(userEntries).values({
     userId,
     entryId,
@@ -108,58 +74,6 @@ async function createTestEntry(
     updatedAt: now,
   });
   return entryId;
-}
-
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: new Date(),
-        privacyPolicyAgreedAt: new Date(),
-        notEuAgreedAt: new Date(),
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
 }
 
 const createdUserIds: string[] = [];
@@ -187,13 +101,13 @@ describe("summarization.generate cached read path", () => {
   let userId: string;
 
   beforeEach(async () => {
-    userId = await createTestUser();
+    userId = await createTestUser({ emailPrefix: "summ" });
     createdUserIds.push(userId);
   });
 
   it("re-sanitizes a cached summary containing disallowed HTML on read", async () => {
     const contentHash = `hash-${generateUuidv7()}`;
-    const entryId = await createTestEntry(userId, contentHash);
+    const entryId = await createVisibleEntry(userId, contentHash);
 
     // Simulate a summary stored before a sanitizer hardening: it still carries a
     // <script> tag and an inline event handler that the current sanitizer strips.
@@ -209,7 +123,7 @@ describe("summarization.generate cached read path", () => {
       createdAt: new Date(),
     });
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const result = await caller.summarization.generate({ entryId, useFullContent: false });
 
     expect(result.cached).toBe(true);
@@ -225,26 +139,26 @@ describe("summarization.generate entry visibility", () => {
   let userId: string;
 
   beforeEach(async () => {
-    userId = await createTestUser();
+    userId = await createTestUser({ emailPrefix: "summ" });
     createdUserIds.push(userId);
   });
 
   // The router reads through `visible_entries`, so it applies exactly the rule
   // the entry list does: a `user_entries` row alone doesn't grant access (#1468).
   it("rejects an entry hidden by visibility even though a user_entries row exists", async () => {
-    const entryId = await createTestEntry(userId, `hash-${generateUuidv7()}`, {
+    const entryId = await createVisibleEntry(userId, `hash-${generateUuidv7()}`, {
       unsubscribed: true,
     });
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
 
     await expect(caller.summarization.generate({ entryId })).rejects.toThrow("Entry not found");
   });
 
   it("rejects another user's entry", async () => {
-    const otherUserId = await createTestUser();
+    const otherUserId = await createTestUser({ emailPrefix: "summ" });
     createdUserIds.push(otherUserId);
-    const entryId = await createTestEntry(otherUserId, `hash-${generateUuidv7()}`);
-    const caller = createCaller(createAuthContext(userId));
+    const entryId = await createVisibleEntry(otherUserId, `hash-${generateUuidv7()}`);
+    const caller = createCaller(await createAuthContext(userId));
 
     await expect(caller.summarization.generate({ entryId })).rejects.toThrow("Entry not found");
   });
@@ -253,7 +167,7 @@ describe("summarization.generate entry visibility", () => {
   // which is the risk in reading through the view.
   it("summarizes a saved article, which has no subscription row", async () => {
     const contentHash = `hash-${generateUuidv7()}`;
-    const entryId = await createTestEntry(userId, contentHash, { saved: true });
+    const entryId = await createVisibleEntry(userId, contentHash, { saved: true });
     await db.insert(entrySummaries).values({
       id: generateUuidv7(),
       userId,
@@ -265,7 +179,7 @@ describe("summarization.generate entry visibility", () => {
       createdAt: new Date(),
     });
 
-    const caller = createCaller(createAuthContext(userId));
+    const caller = createCaller(await createAuthContext(userId));
     const result = await caller.summarization.generate({ entryId, useFullContent: false });
 
     expect(result.cached).toBe(true);

--- a/tests/integration/sync-events.test.ts
+++ b/tests/integration/sync-events.test.ts
@@ -22,136 +22,27 @@ import { createCaller } from "../../src/server/trpc/root";
 import { parseTimestamptz } from "../../src/server/db/temporal";
 import { advanceCursors, type SyncCursors } from "../../src/lib/events/cursors";
 import type { SyncEvent } from "../../src/lib/events/schemas";
-import type { Context } from "../../src/server/trpc/context";
+import {
+  createAuthContext,
+  createTestEntry,
+  createTestFeed,
+  createTestSubscription,
+  createTestUser,
+} from "./helpers";
 
 // ============================================================================
 // Test Helpers
 // ============================================================================
 
-async function createTestUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `sync-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: new Date(),
-        privacyPolicyAgreedAt: new Date(),
-        notEuAgreedAt: new Date(),
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
-
-async function createTestFeed(url: string, title: string = "Test Feed"): Promise<string> {
-  const feedId = generateUuidv7();
-  const now = new Date();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url,
-    title,
-    lastFetchedAt: now,
-    lastEntriesUpdatedAt: now,
-    createdAt: now,
-    updatedAt: now,
-  });
-  return feedId;
-}
-
-async function createTestSubscription(
-  userId: string,
-  feedId: string,
-  options: { subscribedAt?: Date; updatedAt?: Date; customTitle?: string | null } = {}
+/**
+ * A feed that has been polled: the delta arms key off the poll timestamps, so
+ * every web feed in this file needs them (the shared factory leaves them NULL).
+ */
+async function createFetchedFeed(
+  overrides: Partial<typeof feeds.$inferInsert> = {}
 ): Promise<string> {
-  const subscriptionId = generateUuidv7();
-  const now = options.subscribedAt ?? new Date();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: now,
-    customTitle: options.customTitle ?? null,
-    createdAt: now,
-    updatedAt: options.updatedAt ?? now,
-  });
-  return subscriptionId;
-}
-
-async function createTestEntry(
-  feedId: string,
-  options: {
-    title?: string;
-    publishedAt?: Date;
-    createdAt?: Date;
-    updatedAt?: Date;
-  } = {}
-): Promise<string> {
-  const entryId = generateUuidv7();
   const now = new Date();
-  await db.insert(entries).values({
-    id: entryId,
-    feedId,
-    type: "web",
-    guid: `guid-${entryId}`,
-    title: options.title ?? `Entry ${entryId}`,
-    contentHash: `hash-${entryId}`,
-    fetchedAt: now,
-    publishedAt: options.publishedAt ?? now,
-    lastSeenAt: now,
-    createdAt: options.createdAt ?? now,
-    updatedAt: options.updatedAt ?? now,
-  });
-  return entryId;
+  return createTestFeed({ lastFetchedAt: now, lastEntriesUpdatedAt: now, ...overrides });
 }
 
 async function createSavedFeed(userId: string): Promise<string> {
@@ -249,7 +140,7 @@ async function drainEntrySync(userId: string, start: SyncCursors): Promise<SyncE
   let cursors = start;
   const collected: SyncEvent[] = [];
   for (let guard = 0; guard < 50; guard++) {
-    const result = await createCaller(createAuthContext(userId)).sync.events({
+    const result = await createCaller(await createAuthContext(userId)).sync.events({
       cursors: {
         entries: cursors.entries ?? undefined,
         entriesAfterId: cursors.entriesAfterId ?? undefined,
@@ -297,7 +188,7 @@ describe("sync.events", () => {
 
   it("returns empty events when no cursors provided", async () => {
     const userId = await createTestUser();
-    const ctx = createAuthContext(userId);
+    const ctx = await createAuthContext(userId);
     const caller = createCaller(ctx);
 
     const result = await caller.sync.events({ cursors: {} });
@@ -313,18 +204,18 @@ describe("sync.events", () => {
   describe("entry events", () => {
     it("returns new_entry for entry created after cursor", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/sync-feed.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/sync-feed.xml" });
       const subId = await createTestSubscription(userId, feedId);
 
       // Get cursor before creating entry
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
       const baseCursor = cursorResult.entries ?? new Date("2020-01-01").toISOString();
 
       // Create entry after cursor
       const entryId = await createTestEntry(feedId, { title: "New Post" });
       await createUserEntry(userId, entryId);
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: baseCursor },
       });
 
@@ -349,18 +240,18 @@ describe("sync.events", () => {
 
     it("includes the subscription's tag in new_entry absolute counts", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/tagged-sync-feed.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/tagged-sync-feed.xml" });
       const subId = await createTestSubscription(userId, feedId);
       const tagId = await createTestTag(userId, "News");
       await linkTagToSubscription(tagId, subId);
 
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
       const baseCursor = cursorResult.entries ?? new Date("2020-01-01").toISOString();
 
       const entryId = await createTestEntry(feedId, { title: "Tagged Post" });
       await createUserEntry(userId, entryId);
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: baseCursor },
       });
 
@@ -379,7 +270,7 @@ describe("sync.events", () => {
 
     it("returns entry_updated for metadata changes after cursor", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/update-feed.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/update-feed.xml" });
       await createTestSubscription(userId, feedId);
 
       // Create entry and user_entry
@@ -392,7 +283,7 @@ describe("sync.events", () => {
       await createUserEntry(userId, entryId, { updatedAt: entryCreatedAt });
 
       // Get cursor
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       // Update entry metadata
       const newUpdatedAt = new Date();
@@ -401,7 +292,7 @@ describe("sync.events", () => {
         .set({ title: "Updated Title", updatedAt: newUpdatedAt })
         .where(eq(entries.id, entryId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: cursorResult.entries! },
       });
 
@@ -416,7 +307,7 @@ describe("sync.events", () => {
 
     it("returns entry_state_changed for read/starred changes after cursor", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/state-feed.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/state-feed.xml" });
       await createTestSubscription(userId, feedId);
 
       const entryCreatedAt = new Date("2024-01-01");
@@ -426,7 +317,7 @@ describe("sync.events", () => {
       });
       await createUserEntry(userId, entryId, { updatedAt: entryCreatedAt });
 
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       // Update state
       const newUpdatedAt = new Date();
@@ -435,7 +326,7 @@ describe("sync.events", () => {
         .set({ read: true, starred: true, updatedAt: newUpdatedAt })
         .where(eq(userEntries.entryId, entryId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: cursorResult.entries! },
       });
 
@@ -453,7 +344,9 @@ describe("sync.events", () => {
 
     it("attaches the entry list payload to entry_state_changed for unread entries (#1237)", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/unread-payload-feed.xml");
+      const feedId = await createFetchedFeed({
+        url: "https://example.com/unread-payload-feed.xml",
+      });
       const subscriptionId = await createTestSubscription(userId, feedId);
 
       const entryCreatedAt = new Date("2024-01-01");
@@ -464,7 +357,7 @@ describe("sync.events", () => {
       });
       await createUserEntry(userId, entryId, { read: true, updatedAt: entryCreatedAt });
 
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       // Marked unread on another device while this client was offline.
       await db
@@ -472,7 +365,7 @@ describe("sync.events", () => {
         .set({ read: false, updatedAt: new Date() })
         .where(eq(userEntries.entryId, entryId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: cursorResult.entries! },
       });
 
@@ -493,7 +386,7 @@ describe("sync.events", () => {
 
     it("returns both metadata and state events when both change", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/both-feed.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/both-feed.xml" });
       await createTestSubscription(userId, feedId);
 
       const entryCreatedAt = new Date("2024-01-01");
@@ -504,7 +397,7 @@ describe("sync.events", () => {
       });
       await createUserEntry(userId, entryId, { updatedAt: entryCreatedAt });
 
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       // Update both metadata and state
       const newUpdatedAt = new Date();
@@ -517,7 +410,7 @@ describe("sync.events", () => {
         .set({ starred: true, updatedAt: newUpdatedAt })
         .where(eq(userEntries.entryId, entryId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: cursorResult.entries! },
       });
 
@@ -528,16 +421,16 @@ describe("sync.events", () => {
 
     it("returns no entry events for entries before cursor", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/before-feed.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/before-feed.xml" });
       await createTestSubscription(userId, feedId);
 
       const entryId = await createTestEntry(feedId);
       await createUserEntry(userId, entryId);
 
       // Get cursor AFTER the entry was created
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: cursorResult.entries! },
       });
 
@@ -559,13 +452,16 @@ describe("sync.events", () => {
       const userId = await createTestUser();
 
       // Get cursor before creating subscription
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
       const baseCursor = cursorResult.subscriptions ?? new Date("2020-01-01").toISOString();
 
-      const feedId = await createTestFeed("https://example.com/sub-create.xml", "Sub Create Feed");
+      const feedId = await createFetchedFeed({
+        url: "https://example.com/sub-create.xml",
+        title: "Sub Create Feed",
+      });
       const subId = await createTestSubscription(userId, feedId);
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { subscriptions: baseCursor },
       });
 
@@ -583,13 +479,13 @@ describe("sync.events", () => {
       const userId = await createTestUser();
 
       const baseCursor = new Date("2020-01-01").toISOString();
-      const feedId = await createTestFeed("https://example.com/sub-tags.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/sub-tags.xml" });
       const subId = await createTestSubscription(userId, feedId);
 
       const tagId = await createTestTag(userId, "My Tag", { color: "#aabbcc" });
       await linkTagToSubscription(tagId, subId);
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { subscriptions: baseCursor },
       });
 
@@ -605,15 +501,16 @@ describe("sync.events", () => {
 
     it("returns subscription_updated for property changes", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/sub-update.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/sub-update.xml" });
 
       const earlyDate = new Date("2024-01-01");
       const subId = await createTestSubscription(userId, feedId, {
         subscribedAt: earlyDate,
+        createdAt: earlyDate,
         updatedAt: earlyDate,
       });
 
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       // Update subscription
       await db
@@ -621,7 +518,7 @@ describe("sync.events", () => {
         .set({ customTitle: "My Title", updatedAt: new Date() })
         .where(eq(subscriptions.id, subId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { subscriptions: cursorResult.subscriptions! },
       });
 
@@ -636,15 +533,16 @@ describe("sync.events", () => {
 
     it("returns subscription_deleted for unsubscribed feeds", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/sub-delete.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/sub-delete.xml" });
 
       const earlyDate = new Date("2024-01-01");
       const subId = await createTestSubscription(userId, feedId, {
         subscribedAt: earlyDate,
+        createdAt: earlyDate,
         updatedAt: earlyDate,
       });
 
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       // Soft-delete subscription
       await db
@@ -652,7 +550,7 @@ describe("sync.events", () => {
         .set({ unsubscribedAt: new Date(), updatedAt: new Date() })
         .where(eq(subscriptions.id, subId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { subscriptions: cursorResult.subscriptions! },
       });
 
@@ -676,7 +574,7 @@ describe("sync.events", () => {
 
       const tagId = await createTestTag(userId, "New Tag", { color: "#123456" });
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { tags: baseCursor },
       });
 
@@ -697,14 +595,14 @@ describe("sync.events", () => {
         updatedAt: earlyDate,
       });
 
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       await db
         .update(tags)
         .set({ name: "New Name", color: "#ffffff", updatedAt: new Date() })
         .where(eq(tags.id, tagId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { tags: cursorResult.tags! },
       });
 
@@ -724,14 +622,14 @@ describe("sync.events", () => {
         updatedAt: earlyDate,
       });
 
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       await db
         .update(tags)
         .set({ deletedAt: new Date(), updatedAt: new Date() })
         .where(eq(tags.id, tagId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { tags: cursorResult.tags! },
       });
 
@@ -767,7 +665,7 @@ describe("sync.events", () => {
         updatedAt: new Date("2024-06-03"),
       });
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { tags: baseCursor },
       });
 
@@ -784,7 +682,7 @@ describe("sync.events", () => {
 
     it("preserves microsecond precision in cursors", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/precision.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/precision.xml" });
       await createTestSubscription(userId, feedId);
 
       // Use explicit timestamps to avoid setTimeout and ensure deterministic ordering
@@ -797,7 +695,7 @@ describe("sync.events", () => {
       await createUserEntry(userId, entry1Id, { updatedAt: entry1Time });
 
       // Get cursor after first entry - this captures entry1's timestamp
-      const midCursor = await createCaller(createAuthContext(userId)).sync.cursors();
+      const midCursor = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       // Create second entry with a later explicit timestamp
       const entry2Time = new Date("2024-06-01T00:00:01.000Z");
@@ -809,7 +707,7 @@ describe("sync.events", () => {
       await createUserEntry(userId, entry2Id, { updatedAt: entry2Time });
 
       // Using the mid cursor should only return the second entry
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: midCursor.entries! },
       });
 
@@ -834,7 +732,7 @@ describe("sync.events", () => {
     it("returns a null entries cursor when the user has no entries", async () => {
       const userId = await createTestUser();
 
-      const cursor = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursor = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       expect(cursor.entries).toBeNull();
       expect(cursor.entriesAfterId).toBeNull();
@@ -842,7 +740,7 @@ describe("sync.events", () => {
 
     it("uses user_entries.updated_at when a state change is newest", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/argmax-state.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/argmax-state.xml" });
       await createTestSubscription(userId, feedId);
 
       const contentTime = new Date("2024-06-01T00:00:00.000Z");
@@ -853,7 +751,7 @@ describe("sync.events", () => {
       });
       await createUserEntry(userId, entryId, { updatedAt: stateTime });
 
-      const cursor = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursor = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       expect(cursor.entriesAfterId).toBe(entryId);
       expect(
@@ -863,7 +761,7 @@ describe("sync.events", () => {
 
     it("uses entries.updated_at when a content refetch is newer than any state change", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/argmax-content.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/argmax-content.xml" });
       await createTestSubscription(userId, feedId);
 
       const stateTime = new Date("2024-06-01T00:00:00.000Z");
@@ -874,7 +772,7 @@ describe("sync.events", () => {
       });
       await createUserEntry(userId, entryId, { updatedAt: stateTime });
 
-      const cursor = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursor = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       // The naive query would still find this (it materialized GREATEST for every
       // row); the point is the index-driven arm_sub does too, without the scan.
@@ -886,7 +784,7 @@ describe("sync.events", () => {
 
     it("breaks a tie at the max timestamp by the larger entry id", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/argmax-tie.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/argmax-tie.xml" });
       await createTestSubscription(userId, feedId);
 
       // Two entries share the exact max timestamp: one via a state change, one via
@@ -901,7 +799,7 @@ describe("sync.events", () => {
       const contentEntryId = await createTestEntry(feedId, { createdAt: old, updatedAt: tie }); // content at tie
       await createUserEntry(userId, contentEntryId, { updatedAt: old });
 
-      const cursor = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursor = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       const expectedId = stateEntryId > contentEntryId ? stateEntryId : contentEntryId;
       expect(cursor.entriesAfterId).toBe(expectedId);
@@ -922,7 +820,7 @@ describe("sync.events", () => {
       });
       await createUserEntry(userId, savedEntryId, { updatedAt: stateTime });
 
-      const cursor = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursor = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       expect(cursor.entriesAfterId).toBe(savedEntryId);
       expect(
@@ -932,7 +830,7 @@ describe("sync.events", () => {
 
     it("includes content updates to starred orphans on unsubscribed feeds", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/argmax-orphan.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/argmax-orphan.xml" });
       const subId = await createTestSubscription(userId, feedId);
 
       const stateTime = new Date("2024-06-01T00:00:00.000Z");
@@ -949,7 +847,7 @@ describe("sync.events", () => {
         .where(eq(subscriptions.id, subId));
       await db.update(entries).set({ updatedAt: contentTime }).where(eq(entries.id, entryId));
 
-      const cursor = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursor = await createCaller(await createAuthContext(userId)).sync.cursors();
 
       expect(cursor.entriesAfterId).toBe(entryId);
       expect(
@@ -965,7 +863,7 @@ describe("sync.events", () => {
   describe("pagination", () => {
     it("sets hasMore when entries exceed limit", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/pagination.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/pagination.xml" });
       await createTestSubscription(userId, feedId);
       const baseCursor = new Date("2020-01-01").toISOString();
 
@@ -1004,7 +902,7 @@ describe("sync.events", () => {
         await db.insert(userEntries).values(userEntryValues.slice(i, i + batchSize));
       }
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: baseCursor },
       });
 
@@ -1028,7 +926,7 @@ describe("sync.events", () => {
   describe("keyset pagination (#1080)", () => {
     it("pages within a tied-timestamp group using entriesAfterId without losing rows", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/tied.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/tied.xml" });
       await createTestSubscription(userId, feedId);
 
       // Three entries sharing one exact timestamp (like markAllEntriesRead
@@ -1048,7 +946,7 @@ describe("sync.events", () => {
       // comparison would exclude every remaining tied row (data loss); the
       // keyset must instead return the two rows past `first`.
       const cursorTs = tiedTime.toISOString();
-      const afterFirst = await createCaller(createAuthContext(userId)).sync.events({
+      const afterFirst = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: cursorTs, entriesAfterId: first },
       });
       const afterFirstNewIds = afterFirst.events
@@ -1057,7 +955,7 @@ describe("sync.events", () => {
       expect(afterFirstNewIds.sort()).toEqual([second, third]);
 
       // Cursor past the last tied row → nothing left in the group.
-      const afterLast = await createCaller(createAuthContext(userId)).sync.events({
+      const afterLast = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: cursorTs, entriesAfterId: third },
       });
       expect(afterLast.events.filter((e) => ENTRY_EVENT_TYPES.has(e.type))).toHaveLength(0);
@@ -1065,7 +963,7 @@ describe("sync.events", () => {
 
     it("delivers every row of an oversized tied group across a full drain", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/tied-large.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/tied-large.xml" });
       await createTestSubscription(userId, feedId);
 
       // More than MAX_ENTRIES (500) rows sharing ONE timestamp — the exact
@@ -1127,7 +1025,7 @@ describe("sync.events", () => {
     // while none of the marked rows re-deliver.
     it("delivers an unrelated entry written in the same instant as a mark-all-read (#1102)", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/mark-all-tied.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/mark-all-tied.xml" });
       await createTestSubscription(userId, feedId);
 
       // Three unread entries; mark-all-read stamps them all with one
@@ -1142,7 +1040,7 @@ describe("sync.events", () => {
       const maxMarkedId = markedIds[markedIds.length - 1];
       const seededAtMs = Date.now();
 
-      const caller = createCaller(createAuthContext(userId));
+      const caller = createCaller(await createAuthContext(userId));
       const result = await caller.entries.markAllRead({});
       expect(result.count).toBe(3);
 
@@ -1215,7 +1113,7 @@ describe("sync.events", () => {
   describe("visibility (#1080)", () => {
     it("hides an orphaned user_entries row (no active subscription, not starred)", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/orphan.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/orphan.xml" });
       // No subscription row → orphaned. Old fail-open
       // predicate leaked this via `NULL IS NULL`; fail-closed must hide it.
       const entryId = await createTestEntry(feedId, {
@@ -1224,7 +1122,7 @@ describe("sync.events", () => {
       });
       await createUserEntry(userId, entryId, { updatedAt: new Date("2025-03-02T00:00:00.000Z") });
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: new Date("2025-03-01T00:00:00.000Z").toISOString() },
       });
 
@@ -1233,7 +1131,7 @@ describe("sync.events", () => {
 
     it("shows an orphaned entry when it is starred (starred exception)", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/orphan-starred.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/orphan-starred.xml" });
       const entryId = await createTestEntry(feedId, {
         createdAt: new Date("2025-03-02T00:00:00.000Z"),
         updatedAt: new Date("2025-03-02T00:00:00.000Z"),
@@ -1243,7 +1141,7 @@ describe("sync.events", () => {
         updatedAt: new Date("2025-03-02T00:00:00.000Z"),
       });
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: new Date("2025-03-01T00:00:00.000Z").toISOString() },
       });
 
@@ -1253,7 +1151,7 @@ describe("sync.events", () => {
 
     it("hides entries from an unsubscribed subscription (not starred)", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/unsubscribed.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/unsubscribed.xml" });
       // Subscription exists but is soft-deleted (unsubscribed).
       await createTestSubscription(userId, feedId);
       await db
@@ -1267,7 +1165,7 @@ describe("sync.events", () => {
       });
       await createUserEntry(userId, entryId, { updatedAt: new Date("2025-03-02T00:00:00.000Z") });
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: new Date("2025-03-01T00:00:00.000Z").toISOString() },
       });
 
@@ -1296,7 +1194,7 @@ describe("sync.events", () => {
 
     it("delivers a content refetch (entries.updated_at bumped, user_entries stale) via the subscribed-feed arm", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/refetch.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/refetch.xml" });
       await createTestSubscription(userId, feedId);
 
       const entryId = await createTestEntry(feedId, {
@@ -1315,7 +1213,7 @@ describe("sync.events", () => {
         .where(eq(entries.id, entryId));
       await db.update(feeds).set({ lastEntriesUpdatedAt: NEW }).where(eq(feeds.id, feedId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: CURSOR.toISOString() },
       });
 
@@ -1339,7 +1237,7 @@ describe("sync.events", () => {
       // window that must still be delivered. A `last_entries_updated_at >= cursor`
       // pre-filter (the original bug) would prune the feed and drop this entry.
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/refetch-lag.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/refetch-lag.xml" });
       await createTestSubscription(userId, feedId);
       const entryId = await createTestEntry(feedId, { createdAt: OLD, updatedAt: OLD });
       await createUserEntry(userId, entryId, { updatedAt: OLD });
@@ -1349,7 +1247,7 @@ describe("sync.events", () => {
       await db.update(entries).set({ updatedAt: NEW }).where(eq(entries.id, entryId));
       await db.update(feeds).set({ lastEntriesUpdatedAt: OLD }).where(eq(feeds.id, feedId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: CURSOR.toISOString() },
       });
       expect(result.events.filter((e) => e.type === "entry_updated")).toHaveLength(1);
@@ -1375,7 +1273,7 @@ describe("sync.events", () => {
         .set({ title: "Saved Updated", updatedAt: NEW })
         .where(eq(entries.id, entryId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: CURSOR.toISOString() },
       });
 
@@ -1386,7 +1284,9 @@ describe("sync.events", () => {
 
     it("delivers a content refetch for a STARRED entry on an unsubscribed feed (visible via starred)", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/starred-orphan-refetch.xml");
+      const feedId = await createFetchedFeed({
+        url: "https://example.com/starred-orphan-refetch.xml",
+      });
       await createTestSubscription(userId, feedId);
       // Soft-delete the subscription: the row still exists, so Arm B1 (which
       // drives from subscriptions without the unsubscribed filter) still reaches
@@ -1402,7 +1302,7 @@ describe("sync.events", () => {
       await db.update(entries).set({ updatedAt: NEW }).where(eq(entries.id, entryId));
       await db.update(feeds).set({ lastEntriesUpdatedAt: NEW }).where(eq(feeds.id, feedId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: CURSOR.toISOString() },
       });
       expect(result.events.filter((e) => e.type === "entry_updated")).toHaveLength(1);
@@ -1410,7 +1310,7 @@ describe("sync.events", () => {
 
     it("does NOT deliver a content refetch for a non-starred entry on an unsubscribed feed", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/unsub-refetch.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/unsub-refetch.xml" });
       await createTestSubscription(userId, feedId);
       await db
         .update(subscriptions)
@@ -1423,7 +1323,7 @@ describe("sync.events", () => {
       await db.update(entries).set({ updatedAt: NEW }).where(eq(entries.id, entryId));
       await db.update(feeds).set({ lastEntriesUpdatedAt: NEW }).where(eq(feeds.id, feedId));
 
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: CURSOR.toISOString() },
       });
       expect(result.events.filter((e) => ENTRY_EVENT_TYPES.has(e.type))).toHaveLength(0);
@@ -1436,7 +1336,7 @@ describe("sync.events", () => {
     // (on tiny test data it would otherwise seq-scan regardless of the index).
     it("candidate arms seek their indexes, not a full scan (EXPLAIN)", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/explain.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/explain.xml" });
       await createTestSubscription(userId, feedId);
       const savedFeedId = await createSavedFeed(userId);
       // Give both feeds volume with everything before the cursor, so the
@@ -1523,7 +1423,7 @@ describe("sync.events", () => {
   describe("microsecond precision", () => {
     it("sync.cursors preserves the microseconds of the newest change", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/us-cursor.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/us-cursor.xml" });
       await createTestSubscription(userId, feedId);
       const entryId = await createTestEntry(feedId);
       await createUserEntry(userId, entryId);
@@ -1540,13 +1440,13 @@ describe("sync.events", () => {
         sql`UPDATE user_entries SET updated_at = ${micros}::timestamptz WHERE entry_id = ${entryId}::uuid`
       );
 
-      const cursorResult = await createCaller(createAuthContext(userId)).sync.cursors();
+      const cursorResult = await createCaller(await createAuthContext(userId)).sync.cursors();
       expect(cursorResult.entries).toBe(micros);
     });
 
     it("sync.events emits microsecond-precise timestamps that advance the cursor", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://example.com/us-events.xml");
+      const feedId = await createFetchedFeed({ url: "https://example.com/us-events.xml" });
       await createTestSubscription(userId, feedId);
       const entryId = await createTestEntry(feedId);
       await createUserEntry(userId, entryId);
@@ -1566,7 +1466,7 @@ describe("sync.events", () => {
 
       // A cursor pinned to the microsecond just before `newer` must still surface
       // the change — a millisecond-truncated comparison would have already passed it.
-      const result = await createCaller(createAuthContext(userId)).sync.events({
+      const result = await createCaller(await createAuthContext(userId)).sync.events({
         cursors: { entries: pinned },
       });
       const stateEvents = result.events.filter((e) => e.type === "entry_state_changed");

--- a/tests/integration/tags.test.ts
+++ b/tests/integration/tags.test.ts
@@ -20,81 +20,17 @@ import {
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
+import {
+  createAuthContext,
+  createTestEntry,
+  createTestFeed,
+  createTestSubscription,
+  createTestUser,
+} from "./helpers";
 
 // ============================================================================
 // Test Helpers
 // ============================================================================
-
-/**
- * Creates a test user and returns their ID.
- * Uses a unique email based on the userId to avoid conflicts in parallel tests.
- */
-async function createTestUser(emailPrefix: string = "user"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${emailPrefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
-/**
- * Creates an authenticated context for a test user.
- */
-function createAuthContext(userId: string): Context {
-  const now = new Date();
-  return {
-    db,
-    session: {
-      session: {
-        id: generateUuidv7(),
-        userId,
-        tokenHash: "test-hash",
-        scopes: null,
-        userAgent: null,
-        ipAddress: null,
-        createdAt: now,
-        expiresAt: new Date(Date.now() + 3600000),
-        revokedAt: null,
-        lastActiveAt: now,
-      },
-      user: {
-        id: userId,
-        email: `${userId}@test.com`,
-        emailVerifiedAt: null,
-        tosAgreedAt: new Date(),
-        privacyPolicyAgreedAt: new Date(),
-        notEuAgreedAt: new Date(),
-        passwordHash: "test-hash",
-        inviteId: null,
-        showSpam: false,
-        lastActiveAt: null,
-        groqApiKey: null,
-        anthropicApiKey: null,
-        cerebrasApiKey: null,
-        summarizationModel: null,
-        summarizationMaxWords: null,
-        summarizationPrompt: null,
-        narrationModel: null,
-        savedUnreadCount: 0,
-        starredUnreadCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      },
-      hasGroqApiKey: false,
-      hasAnthropicApiKey: false,
-      hasCerebrasApiKey: false,
-    },
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
-}
 
 function createUnauthContext(): Context {
   return {
@@ -109,38 +45,6 @@ function createUnauthContext(): Context {
 }
 
 /**
- * Creates a test feed and returns its ID.
- */
-async function createTestFeed(url: string): Promise<string> {
-  const feedId = generateUuidv7();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: "web",
-    url,
-    title: `Test Feed ${feedId}`,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return feedId;
-}
-
-/**
- * Creates a test subscription for a user and feed.
- */
-async function createTestSubscription(userId: string, feedId: string): Promise<string> {
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return subscriptionId;
-}
-
-/**
  * Links a tag to a subscription.
  */
 async function linkTagToSubscription(tagId: string, subscriptionId: string): Promise<void> {
@@ -149,43 +53,6 @@ async function linkTagToSubscription(tagId: string, subscriptionId: string): Pro
     subscriptionId,
     createdAt: new Date(),
   });
-}
-
-/**
- * Creates a test entry for a feed and optionally creates user_entries for visibility.
- */
-async function createTestEntry(
-  feedId: string,
-  options: { fetchedAt?: Date; title?: string; userIds?: string[] } = {}
-): Promise<string> {
-  const entryId = generateUuidv7();
-  const now = options.fetchedAt ?? new Date();
-  await db.insert(entries).values({
-    id: entryId,
-    feedId,
-    type: "web",
-    guid: `guid-${entryId}`,
-    title: options.title ?? `Entry ${entryId}`,
-    contentHash: `hash-${entryId}`,
-    fetchedAt: now,
-    lastSeenAt: now, // Required for web entries
-    createdAt: now,
-    updatedAt: now,
-  });
-
-  // Create user_entries for visibility
-  if (options.userIds && options.userIds.length > 0) {
-    await db.insert(userEntries).values(
-      options.userIds.map((userId) => ({
-        userId,
-        entryId,
-        read: false,
-        starred: false,
-      }))
-    );
-  }
-
-  return entryId;
 }
 
 // ============================================================================
@@ -218,7 +85,7 @@ describe("Tags API", () => {
   describe("tags.list", () => {
     it("returns empty list for user with no tags", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.tags.list();
@@ -228,7 +95,7 @@ describe("Tags API", () => {
 
     it("returns tags for the authenticated user only", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
       // Create tags for both users
       const tag1Id = generateUuidv7();
@@ -241,7 +108,7 @@ describe("Tags API", () => {
         { id: tag3Id, userId: userId2, name: "Sports", color: "#45b7d1", createdAt: new Date() },
       ]);
 
-      const ctx1 = createAuthContext(userId1);
+      const ctx1 = await createAuthContext(userId1);
       const caller1 = createCaller(ctx1);
       const result1 = await caller1.tags.list();
 
@@ -249,7 +116,7 @@ describe("Tags API", () => {
       expect(result1.items).toHaveLength(2);
       expect(result1.items.map((t) => t.name).sort()).toEqual(["News", "Tech"]);
 
-      const ctx2 = createAuthContext(userId2);
+      const ctx2 = await createAuthContext(userId2);
       const caller2 = createCaller(ctx2);
       const result2 = await caller2.tags.list();
 
@@ -272,8 +139,8 @@ describe("Tags API", () => {
       });
 
       // Create feeds and subscriptions
-      const feedId1 = await createTestFeed("https://feed1.com/rss");
-      const feedId2 = await createTestFeed("https://feed2.com/rss");
+      const feedId1 = await createTestFeed({ url: "https://feed1.com/rss" });
+      const feedId2 = await createTestFeed({ url: "https://feed2.com/rss" });
       const subId1 = await createTestSubscription(userId, feedId1);
       const subId2 = await createTestSubscription(userId, feedId2);
 
@@ -281,7 +148,7 @@ describe("Tags API", () => {
       await linkTagToSubscription(tagId, subId1);
       await linkTagToSubscription(tagId, subId2);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.tags.list();
 
@@ -299,8 +166,8 @@ describe("Tags API", () => {
         { id: emptyTagId, userId, name: "Empty", createdAt: new Date() },
       ]);
 
-      const feedId1 = await createTestFeed("https://feed1.com/rss");
-      const feedId2 = await createTestFeed("https://feed2.com/rss");
+      const feedId1 = await createTestFeed({ url: "https://feed1.com/rss" });
+      const feedId2 = await createTestFeed({ url: "https://feed2.com/rss" });
       const subId1 = await createTestSubscription(userId, feedId1);
       const subId2 = await createTestSubscription(userId, feedId2);
       await linkTagToSubscription(techTagId, subId1);
@@ -316,7 +183,7 @@ describe("Tags API", () => {
         .set({ read: true })
         .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, readEntryId)));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.tags.list();
 
@@ -336,8 +203,8 @@ describe("Tags API", () => {
       // attributed to exactly one subscription (user_entries.subscription_id),
       // so an unread entry in feedB counts once for the tag even though both
       // subscriptions carry the same tag.
-      const feedIdA = await createTestFeed("https://feed-a.com/rss");
-      const feedIdB = await createTestFeed("https://feed-b.com/rss");
+      const feedIdA = await createTestFeed({ url: "https://feed-a.com/rss" });
+      const feedIdB = await createTestFeed({ url: "https://feed-b.com/rss" });
       const subId1 = await createTestSubscription(userId, feedIdA);
       const subId2 = await createTestSubscription(userId, feedIdB);
       await linkTagToSubscription(tagId, subId1);
@@ -346,7 +213,7 @@ describe("Tags API", () => {
       await createTestEntry(feedIdA, { userIds: [userId] });
       await createTestEntry(feedIdB, { userIds: [userId] });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.tags.list();
 
@@ -354,11 +221,11 @@ describe("Tags API", () => {
     });
 
     it("does not count other users' unread entries on shared feeds", async () => {
-      const userId = await createTestUser("user-a");
-      const otherUserId = await createTestUser("user-b");
+      const userId = await createTestUser({ emailPrefix: "user-a" });
+      const otherUserId = await createTestUser({ emailPrefix: "user-b" });
 
       // Both users subscribe to the same feed and tag their subscriptions
-      const feedId = await createTestFeed("https://shared.com/rss");
+      const feedId = await createTestFeed({ url: "https://shared.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
       const otherSubId = await createTestSubscription(otherUserId, feedId);
 
@@ -375,7 +242,7 @@ describe("Tags API", () => {
       await createTestEntry(feedId, { userIds: [userId, otherUserId] });
       await createTestEntry(feedId, { userIds: [otherUserId] });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.tags.list();
 
@@ -390,7 +257,7 @@ describe("Tags API", () => {
       const tagId = generateUuidv7();
       await db.insert(tags).values({ id: tagId, userId, name: "Tech", createdAt: new Date() });
 
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
       await linkTagToSubscription(tagId, subId);
       await createTestEntry(feedId, { userIds: [userId] });
@@ -400,7 +267,7 @@ describe("Tags API", () => {
         .set({ unsubscribedAt: new Date() })
         .where(eq(subscriptions.id, subId));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.tags.list();
 
@@ -416,7 +283,7 @@ describe("Tags API", () => {
       const tagId = generateUuidv7();
       await db.insert(tags).values({ id: tagId, userId, name: "Tech", createdAt: new Date() });
 
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
       await linkTagToSubscription(tagId, subId);
       const entryId = await createTestEntry(feedId, { userIds: [userId] });
@@ -429,7 +296,7 @@ describe("Tags API", () => {
         .set({ unsubscribedAt: new Date() })
         .where(eq(subscriptions.id, subId));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.tags.list();
 
@@ -442,7 +309,7 @@ describe("Tags API", () => {
       const tagId = generateUuidv7();
       await db.insert(tags).values({ id: tagId, userId, name: "Tech", createdAt: new Date() });
 
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
       await linkTagToSubscription(tagId, subId);
       const entryId = await createTestEntry(feedId, { userIds: [userId] });
@@ -451,7 +318,7 @@ describe("Tags API", () => {
         .set({ read: true })
         .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, entryId)));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.tags.list();
 
@@ -469,7 +336,7 @@ describe("Tags API", () => {
         { id: generateUuidv7(), userId, name: "Middle", createdAt: new Date() },
       ]);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.tags.list();
 
@@ -480,7 +347,7 @@ describe("Tags API", () => {
   describe("tags.create", () => {
     it("creates a tag with name only", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.tags.create({ name: "Tech" });
@@ -500,7 +367,7 @@ describe("Tags API", () => {
 
     it("creates a tag with name and color", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.tags.create({ name: "News", color: "#4ecdc4" });
@@ -511,7 +378,7 @@ describe("Tags API", () => {
 
     it("trims whitespace from tag name", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.tags.create({ name: "  Tech  " });
@@ -521,7 +388,7 @@ describe("Tags API", () => {
 
     it("rejects duplicate tag names for the same user", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       await caller.tags.create({ name: "Tech" });
@@ -533,13 +400,13 @@ describe("Tags API", () => {
 
     it("allows same tag name for different users", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
-      const ctx1 = createAuthContext(userId1);
+      const ctx1 = await createAuthContext(userId1);
       const caller1 = createCaller(ctx1);
       await caller1.tags.create({ name: "Tech" });
 
-      const ctx2 = createAuthContext(userId2);
+      const ctx2 = await createAuthContext(userId2);
       const caller2 = createCaller(ctx2);
       const result = await caller2.tags.create({ name: "Tech" });
 
@@ -548,7 +415,7 @@ describe("Tags API", () => {
 
     it("allows recreating a tag whose name was soft-deleted (#952)", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const first = await caller.tags.create({ name: "News" });
@@ -571,7 +438,7 @@ describe("Tags API", () => {
 
     it("allows renaming a tag onto a soft-deleted name (#952)", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const deleted = await caller.tags.create({ name: "Archive" });
@@ -585,7 +452,7 @@ describe("Tags API", () => {
 
     it("rejects empty tag name", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       await expect(caller.tags.create({ name: "" })).rejects.toThrow();
@@ -593,7 +460,7 @@ describe("Tags API", () => {
 
     it("rejects tag name that is too long", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const longName = "a".repeat(51);
@@ -602,7 +469,7 @@ describe("Tags API", () => {
 
     it("rejects invalid color format", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       await expect(caller.tags.create({ name: "Tech", color: "red" })).rejects.toThrow();
@@ -622,7 +489,7 @@ describe("Tags API", () => {
         createdAt: new Date(),
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.tags.update({ id: tagId, name: "Technology" });
@@ -641,7 +508,7 @@ describe("Tags API", () => {
         createdAt: new Date(),
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.tags.update({ id: tagId, color: "#4ecdc4" });
@@ -660,7 +527,7 @@ describe("Tags API", () => {
         createdAt: new Date(),
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.tags.update({ id: tagId, color: null });
@@ -679,7 +546,7 @@ describe("Tags API", () => {
         createdAt: new Date(),
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.tags.update({
@@ -703,11 +570,11 @@ describe("Tags API", () => {
       });
 
       // Create feed, subscription, and link
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
       await linkTagToSubscription(tagId, subId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.tags.update({ id: tagId, name: "Technology" });
@@ -716,16 +583,16 @@ describe("Tags API", () => {
     });
 
     it("returns unread count consistent with tags.list", async () => {
-      const userId = await createTestUser("user-a");
-      const otherUserId = await createTestUser("user-b");
+      const userId = await createTestUser({ emailPrefix: "user-a" });
+      const otherUserId = await createTestUser({ emailPrefix: "user-b" });
 
       const tagId = generateUuidv7();
       await db.insert(tags).values({ id: tagId, userId, name: "Tech", createdAt: new Date() });
 
       // Two tagged subscriptions plus a second user on the shared feed
       // (scoping case) — update must count the same way list does.
-      const feedIdA = await createTestFeed("https://feed-a.com/rss");
-      const feedIdB = await createTestFeed("https://feed-b.com/rss");
+      const feedIdA = await createTestFeed({ url: "https://feed-a.com/rss" });
+      const feedIdB = await createTestFeed({ url: "https://feed-b.com/rss" });
       const subId1 = await createTestSubscription(userId, feedIdA);
       const subId2 = await createTestSubscription(userId, feedIdB);
       await linkTagToSubscription(tagId, subId1);
@@ -735,7 +602,7 @@ describe("Tags API", () => {
       await createTestEntry(feedIdA, { userIds: [userId] });
       await createTestEntry(feedIdB, { userIds: [userId, otherUserId] });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const updateResult = await caller.tags.update({ id: tagId, name: "Technology" });
@@ -747,7 +614,7 @@ describe("Tags API", () => {
 
     it("throws error when tag not found", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const nonExistentId = generateUuidv7();
@@ -758,7 +625,7 @@ describe("Tags API", () => {
 
     it("throws error when updating another user's tag", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
       const tagId = generateUuidv7();
       await db.insert(tags).values({
@@ -769,7 +636,7 @@ describe("Tags API", () => {
       });
 
       // User 2 tries to update User 1's tag
-      const ctx = createAuthContext(userId2);
+      const ctx = await createAuthContext(userId2);
       const caller = createCaller(ctx);
 
       await expect(caller.tags.update({ id: tagId, name: "Hacked" })).rejects.toThrow(
@@ -791,7 +658,7 @@ describe("Tags API", () => {
         .where(and(eq(tags.userId, userId), eq(tags.name, "Tech")))
         .limit(1);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       await expect(caller.tags.update({ id: techTag[0].id, name: "News" })).rejects.toThrow(
@@ -809,7 +676,7 @@ describe("Tags API", () => {
         createdAt: new Date(),
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // This should not throw even though the name "Tech" exists
@@ -831,7 +698,7 @@ describe("Tags API", () => {
         createdAt: new Date(),
       });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.tags.delete({ id: tagId });
@@ -855,7 +722,7 @@ describe("Tags API", () => {
       });
 
       // Create feed, subscription, and link
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
       await linkTagToSubscription(tagId, subId);
 
@@ -866,7 +733,7 @@ describe("Tags API", () => {
         .where(eq(subscriptionTags.tagId, tagId));
       expect(linksBefore).toHaveLength(1);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       await caller.tags.delete({ id: tagId });
 
@@ -884,7 +751,7 @@ describe("Tags API", () => {
 
     it("throws error when tag not found", async () => {
       const userId = await createTestUser();
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const nonExistentId = generateUuidv7();
@@ -893,7 +760,7 @@ describe("Tags API", () => {
 
     it("throws error when deleting another user's tag", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
       const tagId = generateUuidv7();
       await db.insert(tags).values({
@@ -904,7 +771,7 @@ describe("Tags API", () => {
       });
 
       // User 2 tries to delete User 1's tag
-      const ctx = createAuthContext(userId2);
+      const ctx = await createAuthContext(userId2);
       const caller = createCaller(ctx);
 
       await expect(caller.tags.delete({ id: tagId })).rejects.toThrow("Tag not found");
@@ -952,7 +819,7 @@ describe("Tags API", () => {
   describe("subscriptions.setTags", () => {
     it("sets tags on a subscription", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
 
       // Create tags
@@ -963,7 +830,7 @@ describe("Tags API", () => {
         { id: tag2Id, userId, name: "News", color: "#4ecdc4", createdAt: new Date() },
       ]);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.subscriptions.setTags({ id: subId, tagIds: [tag1Id, tag2Id] });
@@ -981,7 +848,7 @@ describe("Tags API", () => {
 
     it("replaces existing tags", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
 
       // Create tags
@@ -998,7 +865,7 @@ describe("Tags API", () => {
       await linkTagToSubscription(tag1Id, subId);
       await linkTagToSubscription(tag2Id, subId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Replace with new tag
@@ -1015,7 +882,7 @@ describe("Tags API", () => {
 
     it("removes all tags when given empty array", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
 
       // Create and link a tag
@@ -1023,7 +890,7 @@ describe("Tags API", () => {
       await db.insert(tags).values({ id: tagId, userId, name: "Tech", createdAt: new Date() });
       await linkTagToSubscription(tagId, subId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       await caller.subscriptions.setTags({ id: subId, tagIds: [] });
@@ -1041,7 +908,7 @@ describe("Tags API", () => {
       const tagId = generateUuidv7();
       await db.insert(tags).values({ id: tagId, userId, name: "Tech", createdAt: new Date() });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       await expect(
@@ -1051,9 +918,9 @@ describe("Tags API", () => {
 
     it("throws error for another user's subscription", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       const subId = await createTestSubscription(userId1, feedId);
 
       const tagId = generateUuidv7();
@@ -1062,7 +929,7 @@ describe("Tags API", () => {
         .values({ id: tagId, userId: userId2, name: "Tech", createdAt: new Date() });
 
       // User 2 tries to set tags on User 1's subscription
-      const ctx = createAuthContext(userId2);
+      const ctx = await createAuthContext(userId2);
       const caller = createCaller(ctx);
 
       await expect(caller.subscriptions.setTags({ id: subId, tagIds: [tagId] })).rejects.toThrow(
@@ -1072,10 +939,10 @@ describe("Tags API", () => {
 
     it("throws error for invalid tag IDs", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Try to set a non-existent tag
@@ -1086,9 +953,9 @@ describe("Tags API", () => {
 
     it("throws error for another user's tags", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       const subId = await createTestSubscription(userId1, feedId);
 
       // Create tag owned by user 2
@@ -1098,7 +965,7 @@ describe("Tags API", () => {
         .values({ id: tagId, userId: userId2, name: "Tech", createdAt: new Date() });
 
       // User 1 tries to use User 2's tag
-      const ctx = createAuthContext(userId1);
+      const ctx = await createAuthContext(userId1);
       const caller = createCaller(ctx);
 
       await expect(caller.subscriptions.setTags({ id: subId, tagIds: [tagId] })).rejects.toThrow(
@@ -1110,7 +977,7 @@ describe("Tags API", () => {
   describe("subscriptions.list with tags", () => {
     it("returns subscriptions with their tags", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       const subId = await createTestSubscription(userId, feedId);
 
       // Create and link tags
@@ -1123,7 +990,7 @@ describe("Tags API", () => {
       await linkTagToSubscription(tag1Id, subId);
       await linkTagToSubscription(tag2Id, subId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.subscriptions.list();
@@ -1135,10 +1002,10 @@ describe("Tags API", () => {
 
     it("returns empty tags array for subscriptions without tags", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       await createTestSubscription(userId, feedId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       const result = await caller.subscriptions.list();
@@ -1158,8 +1025,8 @@ describe("Tags API", () => {
       // subscription; counting only the current feed_id silently undercounts.
       const userId = await createTestUser();
 
-      const feedIdA = await createTestFeed("https://feed-a.com/rss"); // current feed
-      const feedIdB = await createTestFeed("https://feed-b.com/rss"); // merged-in old feed
+      const feedIdA = await createTestFeed({ url: "https://feed-a.com/rss" }); // current feed
+      const feedIdB = await createTestFeed({ url: "https://feed-b.com/rss" }); // merged-in old feed
       const subId = await createTestSubscription(userId, feedIdA);
 
       // 2 unread under the current feed, 1 unread under the merged-in feed.
@@ -1173,7 +1040,7 @@ describe("Tags API", () => {
         .set({ subscriptionId: subId })
         .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, mergedEntry)));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.subscriptions.list();
 
@@ -1185,10 +1052,10 @@ describe("Tags API", () => {
       // The per-subscription count must stay user-scoped: user_entries
       // attribution is per-user and feeds are shared, so a missing user filter
       // would leak other users' unread counts.
-      const userId = await createTestUser("user-a");
-      const otherUserId = await createTestUser("user-b");
+      const userId = await createTestUser({ emailPrefix: "user-a" });
+      const otherUserId = await createTestUser({ emailPrefix: "user-b" });
 
-      const feedId = await createTestFeed("https://shared.com/rss");
+      const feedId = await createTestFeed({ url: "https://shared.com/rss" });
       await createTestSubscription(userId, feedId);
       await createTestSubscription(otherUserId, feedId);
 
@@ -1196,7 +1063,7 @@ describe("Tags API", () => {
       await createTestEntry(feedId, { userIds: [userId] });
       await createTestEntry(feedId, { userIds: [otherUserId] });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
       const result = await caller.subscriptions.list();
 
@@ -1210,8 +1077,8 @@ describe("Tags API", () => {
       const userId = await createTestUser();
 
       // One tagged subscription, one untagged (uncategorized) subscription.
-      const taggedFeed = await createTestFeed("https://tagged.com/rss");
-      const untaggedFeed = await createTestFeed("https://untagged.com/rss");
+      const taggedFeed = await createTestFeed({ url: "https://tagged.com/rss" });
+      const untaggedFeed = await createTestFeed({ url: "https://untagged.com/rss" });
       const taggedSub = await createTestSubscription(userId, taggedFeed);
       await createTestSubscription(userId, untaggedFeed);
 
@@ -1223,7 +1090,7 @@ describe("Tags API", () => {
       await createTestEntry(untaggedFeed, { userIds: [userId] }); // uncategorized
       await createTestEntry(untaggedFeed, { userIds: [userId] }); // uncategorized
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const result = await createCaller(ctx).tags.list();
 
       expect(result.uncategorized.feedCount).toBe(1);
@@ -1233,8 +1100,8 @@ describe("Tags API", () => {
     it("counts uncategorized unread entries reachable through a merged feed", async () => {
       const userId = await createTestUser();
 
-      const feedIdA = await createTestFeed("https://feed-a.com/rss");
-      const feedIdB = await createTestFeed("https://feed-b.com/rss");
+      const feedIdA = await createTestFeed({ url: "https://feed-a.com/rss" });
+      const feedIdB = await createTestFeed({ url: "https://feed-b.com/rss" });
       const subId = await createTestSubscription(userId, feedIdA); // untagged
 
       await createTestEntry(feedIdA, { userIds: [userId] });
@@ -1245,7 +1112,7 @@ describe("Tags API", () => {
         .set({ subscriptionId: subId })
         .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, mergedEntry)));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const result = await createCaller(ctx).tags.list();
 
       expect(result.uncategorized.unreadCount).toBe(2);
@@ -1257,11 +1124,11 @@ describe("Tags API", () => {
       // to Starred, not Uncategorized — the count must stay scoped to active subs.
       const userId = await createTestUser();
 
-      const activeFeed = await createTestFeed("https://active.com/rss");
+      const activeFeed = await createTestFeed({ url: "https://active.com/rss" });
       await createTestSubscription(userId, activeFeed);
       await createTestEntry(activeFeed, { userIds: [userId] }); // 1 active uncategorized unread
 
-      const goneFeed = await createTestFeed("https://gone.com/rss");
+      const goneFeed = await createTestFeed({ url: "https://gone.com/rss" });
       const goneSub = await createTestSubscription(userId, goneFeed);
       await db
         .update(subscriptions)
@@ -1273,7 +1140,7 @@ describe("Tags API", () => {
         .set({ starred: true })
         .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, starredEntry)));
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const result = await createCaller(ctx).tags.list();
 
       // Only the active subscription's unread entry — not the starred orphan.
@@ -1287,8 +1154,8 @@ describe("Tags API", () => {
       const userId = await createTestUser();
 
       // Create two feeds with subscriptions
-      const feedId1 = await createTestFeed("https://feed1.com/rss");
-      const feedId2 = await createTestFeed("https://feed2.com/rss");
+      const feedId1 = await createTestFeed({ url: "https://feed1.com/rss" });
+      const feedId2 = await createTestFeed({ url: "https://feed2.com/rss" });
       const subId1 = await createTestSubscription(userId, feedId1);
       await createTestSubscription(userId, feedId2);
 
@@ -1304,7 +1171,7 @@ describe("Tags API", () => {
       });
       await createTestEntry(feedId2, { title: "Entry from Feed 2", userIds: [userId] });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Filter by tag - should only return entries from feed 1
@@ -1319,7 +1186,7 @@ describe("Tags API", () => {
       const userId = await createTestUser();
 
       // Create a feed with subscription
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       await createTestSubscription(userId, feedId);
 
       // Create a tag with no subscriptions linked
@@ -1329,7 +1196,7 @@ describe("Tags API", () => {
       // Create an entry
       await createTestEntry(feedId, { title: "Test Entry" });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Filter by empty tag - should return empty
@@ -1341,11 +1208,11 @@ describe("Tags API", () => {
     it("returns empty list for non-existent tag", async () => {
       const userId = await createTestUser();
 
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       await createTestSubscription(userId, feedId);
       await createTestEntry(feedId);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Filter by non-existent tag
@@ -1356,10 +1223,10 @@ describe("Tags API", () => {
 
     it("returns empty list for another user's tag", async () => {
       const userId1 = await createTestUser();
-      const userId2 = await createTestUser("other");
+      const userId2 = await createTestUser({ emailPrefix: "other" });
 
       // User 1 has a feed and subscription
-      const feedId = await createTestFeed("https://feed1.com/rss");
+      const feedId = await createTestFeed({ url: "https://feed1.com/rss" });
       await createTestSubscription(userId1, feedId);
       await createTestEntry(feedId);
 
@@ -1370,7 +1237,7 @@ describe("Tags API", () => {
         .values({ id: tagId, userId: userId2, name: "Tech", createdAt: new Date() });
 
       // User 1 tries to filter by user 2's tag
-      const ctx = createAuthContext(userId1);
+      const ctx = await createAuthContext(userId1);
       const caller = createCaller(ctx);
 
       const result = await caller.entries.list({ tagId });
@@ -1382,8 +1249,8 @@ describe("Tags API", () => {
       const userId = await createTestUser();
 
       // Create two feeds with subscriptions
-      const feedId1 = await createTestFeed("https://feed1.com/rss");
-      const feedId2 = await createTestFeed("https://feed2.com/rss");
+      const feedId1 = await createTestFeed({ url: "https://feed1.com/rss" });
+      const feedId2 = await createTestFeed({ url: "https://feed2.com/rss" });
       const subId1 = await createTestSubscription(userId, feedId1);
       const subId2 = await createTestSubscription(userId, feedId2);
 
@@ -1400,7 +1267,7 @@ describe("Tags API", () => {
       });
       await createTestEntry(feedId2, { title: "Entry from Feed 2", userIds: [userId] });
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Filter by tag AND subscriptionId - should only return entries from subscription 1
@@ -1414,8 +1281,8 @@ describe("Tags API", () => {
       const userId = await createTestUser();
 
       // Create two feeds with subscriptions
-      const feedId1 = await createTestFeed("https://feed1.com/rss");
-      const feedId2 = await createTestFeed("https://feed2.com/rss");
+      const feedId1 = await createTestFeed({ url: "https://feed1.com/rss" });
+      const feedId2 = await createTestFeed({ url: "https://feed2.com/rss" });
       const subId1 = await createTestSubscription(userId, feedId1);
       const subId2 = await createTestSubscription(userId, feedId2);
 
@@ -1428,7 +1295,7 @@ describe("Tags API", () => {
       await createTestEntry(feedId1);
       await createTestEntry(feedId2);
 
-      const ctx = createAuthContext(userId);
+      const ctx = await createAuthContext(userId);
       const caller = createCaller(ctx);
 
       // Filter by tag AND subscriptionId (where subscription for feed2 is not in tag)

--- a/tests/integration/token-scopes.test.ts
+++ b/tests/integration/token-scopes.test.ts
@@ -18,79 +18,14 @@ import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
 import type { ApiTokenScope } from "../../src/server/auth/api-token";
 import { TRPCError } from "@trpc/server";
+import { createAuthContext, createTestUser } from "./helpers";
 
 const createdUserIds: string[] = [];
 
-async function createTestUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `scope-${userId}@test.com`,
-    passwordHash: "test-hash",
-    tosAgreedAt: new Date(),
-    privacyPolicyAgreedAt: new Date(),
-    notEuAgreedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
+async function createUser(): Promise<string> {
+  const userId = await createTestUser({ emailPrefix: "scope" });
   createdUserIds.push(userId);
   return userId;
-}
-
-function buildSession(userId: string): NonNullable<Context["session"]> {
-  const now = new Date();
-  return {
-    session: {
-      id: generateUuidv7(),
-      userId,
-      tokenHash: "test-hash",
-      scopes: null,
-      userAgent: null,
-      ipAddress: null,
-      createdAt: now,
-      expiresAt: new Date(Date.now() + 3600000),
-      revokedAt: null,
-      lastActiveAt: now,
-    },
-    user: {
-      id: userId,
-      email: `${userId}@test.com`,
-      emailVerifiedAt: null,
-      tosAgreedAt: now,
-      privacyPolicyAgreedAt: now,
-      notEuAgreedAt: now,
-      passwordHash: "test-hash",
-      inviteId: null,
-      showSpam: false,
-      lastActiveAt: null,
-      groqApiKey: null,
-      anthropicApiKey: null,
-      cerebrasApiKey: null,
-      summarizationModel: null,
-      summarizationMaxWords: null,
-      summarizationPrompt: null,
-      narrationModel: null,
-      savedUnreadCount: 0,
-      starredUnreadCount: 0,
-      createdAt: now,
-      updatedAt: now,
-    },
-    hasGroqApiKey: false,
-    hasAnthropicApiKey: false,
-    hasCerebrasApiKey: false,
-  };
-}
-
-function createSessionContext(userId: string): Context {
-  return {
-    db,
-    session: buildSession(userId),
-    apiToken: null,
-    authType: "session",
-    scopes: [],
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
 }
 
 function createAnonymousContext(): Context {
@@ -105,17 +40,13 @@ function createAnonymousContext(): Context {
   };
 }
 
-function createTokenContext(userId: string, scopes: ApiTokenScope[]): Context {
-  return {
-    db,
-    // Synthetic session (matches what createContext builds for API tokens).
-    session: buildSession(userId),
-    apiToken: null,
-    authType: "api_token",
-    scopes,
-    sessionToken: "test-token",
-    headers: new Headers(),
-  };
+/**
+ * An API-token context carries the same synthetic session a browser gets (that's
+ * what `createContext` builds for tokens); only `authType` and `scopes` differ,
+ * which is exactly what the scope gate is supposed to key off.
+ */
+async function createTokenContext(userId: string, scopes: ApiTokenScope[]): Promise<Context> {
+  return { ...(await createAuthContext(userId)), authType: "api_token", scopes };
 }
 
 async function expectForbidden(promise: Promise<unknown>): Promise<void> {
@@ -145,16 +76,16 @@ afterAll(async () => {
 describe("API token scope enforcement", () => {
   describe("mcp-scoped token", () => {
     it("can access MCP-surface endpoints (entries.list, tags.list)", async () => {
-      const userId = await createTestUser();
-      const caller = createCaller(createTokenContext(userId, ["mcp"]));
+      const userId = await createUser();
+      const caller = createCaller(await createTokenContext(userId, ["mcp"]));
 
       await expect(caller.entries.list({})).resolves.toBeDefined();
       await expect(caller.tags.list()).resolves.toBeDefined();
     });
 
     it("cannot access session-only endpoints (sessions, narration)", async () => {
-      const userId = await createTestUser();
-      const caller = createCaller(createTokenContext(userId, ["mcp"]));
+      const userId = await createUser();
+      const caller = createCaller(await createTokenContext(userId, ["mcp"]));
 
       await expectForbidden(caller.users["me.sessions"]());
       await expectForbidden(caller.narration.isAiTextProcessingAvailable());
@@ -163,8 +94,8 @@ describe("API token scope enforcement", () => {
 
   describe("saved:write-only token", () => {
     it("cannot access mcp-scoped endpoints", async () => {
-      const userId = await createTestUser();
-      const caller = createCaller(createTokenContext(userId, ["saved:write"]));
+      const userId = await createUser();
+      const caller = createCaller(await createTokenContext(userId, ["saved:write"]));
 
       await expectForbidden(caller.entries.list({}));
       await expectForbidden(caller.tags.list());
@@ -173,8 +104,8 @@ describe("API token scope enforcement", () => {
 
   describe("token with no scopes", () => {
     it("cannot access mcp-scoped endpoints", async () => {
-      const userId = await createTestUser();
-      const caller = createCaller(createTokenContext(userId, []));
+      const userId = await createUser();
+      const caller = createCaller(await createTokenContext(userId, []));
 
       await expectForbidden(caller.entries.list({}));
     });
@@ -185,18 +116,18 @@ describe("API token scope enforcement", () => {
     // fails input validation (BAD_REQUEST) *after* the scope gate, proving the
     // gate allowed the request without performing a real network fetch.
     it("saved.save accepts both saved:write and mcp tokens", async () => {
-      const writeUser = await createTestUser();
-      const mcpUser = await createTestUser();
-      const writeCaller = createCaller(createTokenContext(writeUser, ["saved:write"]));
-      const mcpCaller = createCaller(createTokenContext(mcpUser, ["mcp"]));
+      const writeUser = await createUser();
+      const mcpUser = await createUser();
+      const writeCaller = createCaller(await createTokenContext(writeUser, ["saved:write"]));
+      const mcpCaller = createCaller(await createTokenContext(mcpUser, ["mcp"]));
 
       await expectPassedScopeGate(writeCaller.saved.save({ url: "not-a-url" }), "BAD_REQUEST");
       await expectPassedScopeGate(mcpCaller.saved.save({ url: "not-a-url" }), "BAD_REQUEST");
     });
 
     it("saved.save rejects a token with no scopes", async () => {
-      const userId = await createTestUser();
-      const caller = createCaller(createTokenContext(userId, []));
+      const userId = await createUser();
+      const caller = createCaller(await createTokenContext(userId, []));
 
       await expectForbidden(caller.saved.save({ url: "not-a-url" }));
     });
@@ -204,10 +135,10 @@ describe("API token scope enforcement", () => {
     // saved.delete requires the mcp scope. A non-existent id yields NOT_FOUND for
     // an mcp token (gate passed) but FORBIDDEN for a saved:write-only token.
     it("saved.delete requires mcp; saved:write is rejected", async () => {
-      const mcpUser = await createTestUser();
-      const writeUser = await createTestUser();
-      const mcpCaller = createCaller(createTokenContext(mcpUser, ["mcp"]));
-      const writeCaller = createCaller(createTokenContext(writeUser, ["saved:write"]));
+      const mcpUser = await createUser();
+      const writeUser = await createUser();
+      const mcpCaller = createCaller(await createTokenContext(mcpUser, ["mcp"]));
+      const writeCaller = createCaller(await createTokenContext(writeUser, ["saved:write"]));
 
       await expectPassedScopeGate(mcpCaller.saved.delete({ id: generateUuidv7() }), "NOT_FOUND");
       await expectForbidden(writeCaller.saved.delete({ id: generateUuidv7() }));
@@ -230,8 +161,8 @@ describe("API token scope enforcement", () => {
     });
 
     it("rejects API tokens (session-only)", async () => {
-      const userId = await createTestUser();
-      const caller = createCaller(createTokenContext(userId, ["mcp"]));
+      const userId = await createUser();
+      const caller = createCaller(await createTokenContext(userId, ["mcp"]));
 
       await expectForbidden(caller.feeds.preview({ url: "https://example.com/feed.xml" }));
       await expectForbidden(caller.feeds.discover({ url: "https://example.com/" }));
@@ -240,8 +171,8 @@ describe("API token scope enforcement", () => {
 
   describe("browser session", () => {
     it("retains full access to both mcp-surface and session-only endpoints", async () => {
-      const userId = await createTestUser();
-      const caller = createCaller(createSessionContext(userId));
+      const userId = await createUser();
+      const caller = createCaller(await createAuthContext(userId));
 
       await expect(caller.entries.list({})).resolves.toBeDefined();
       await expect(caller.users["me.sessions"]()).resolves.toBeDefined();

--- a/tests/integration/unread-counters.test.ts
+++ b/tests/integration/unread-counters.test.ts
@@ -30,79 +30,11 @@ import {
 import { createUploadedArticle, deleteSavedArticle } from "../../src/server/services/saved";
 import { reconcileCounters } from "../../src/server/services/reconcile-counters";
 import { getBulkEntryRelatedCounts } from "../../src/server/services/counts";
+import { createTestEntry, createTestFeed, createTestSubscription, createTestUser } from "./helpers";
 
 // ============================================================================
 // Helpers
 // ============================================================================
-
-async function createTestUser(prefix = "counters-user"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${prefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
-async function createTestFeed(options: {
-  url?: string;
-  type?: "web" | "email" | "saved";
-  lastEntriesUpdatedAt?: Date | null;
-  userId?: string;
-}): Promise<string> {
-  const feedId = generateUuidv7();
-  const now = new Date();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: options.type ?? "web",
-    url: options.url ?? `https://example.com/feed-${feedId}.xml`,
-    userId: options.userId ?? null,
-    title: `Test Feed ${feedId}`,
-    lastEntriesUpdatedAt: options.lastEntriesUpdatedAt ?? null,
-    createdAt: now,
-    updatedAt: now,
-  });
-  return feedId;
-}
-
-async function createTestSubscription(userId: string, feedId: string): Promise<string> {
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return subscriptionId;
-}
-
-async function createTestEntry(
-  feedId: string,
-  options: { isSpam?: boolean; lastSeenAt?: Date | null; type?: "web" | "email" | "saved" } = {}
-): Promise<string> {
-  const entryId = generateUuidv7();
-  const now = new Date();
-  const type = options.type ?? "web";
-  await db.insert(entries).values({
-    id: entryId,
-    feedId,
-    type,
-    guid: `guid-${entryId}`,
-    title: `Entry ${entryId}`,
-    contentHash: `hash-${entryId}`,
-    isSpam: options.isSpam ?? false,
-    fetchedAt: now,
-    lastSeenAt: type === "web" ? (options.lastSeenAt ?? now) : null,
-    createdAt: now,
-    updatedAt: now,
-  });
-  return entryId;
-}
 
 async function subscriptionCounters(subscriptionId: string) {
   const [row] = await db
@@ -187,7 +119,7 @@ describe("unread counters (triggers + reconciliation)", () => {
 
   it("tracks read / unread flips and ignores stale changedAt replays", async () => {
     const userId = await createTestUser();
-    const feedId = await createTestFeed({});
+    const feedId = await createTestFeed();
     const subId = await createTestSubscription(userId, feedId);
     const entryId = await createTestEntry(feedId);
     await db.insert(userEntries).values({ userId, entryId });
@@ -212,7 +144,7 @@ describe("unread counters (triggers + reconciliation)", () => {
 
   it("tracks starring, and reading a starred entry decrements both counters", async () => {
     const userId = await createTestUser();
-    const feedId = await createTestFeed({});
+    const feedId = await createTestFeed();
     const subId = await createTestSubscription(userId, feedId);
     const entryId = await createTestEntry(feedId);
     // starredChangedAt in the past — see the note in the merge test below.
@@ -234,7 +166,7 @@ describe("unread counters (triggers + reconciliation)", () => {
 
   it("mark-all-read zeroes the subscription counter in one statement", async () => {
     const userId = await createTestUser();
-    const feedId = await createTestFeed({});
+    const feedId = await createTestFeed();
     const subId = await createTestSubscription(userId, feedId);
     for (let i = 0; i < 5; i++) {
       const entryId = await createTestEntry(feedId);
@@ -293,7 +225,7 @@ describe("unread counters (triggers + reconciliation)", () => {
 
   it("keeps dead-subscription counters accurate (starred-orphan term of the all badge)", async () => {
     const userId = await createTestUser();
-    const feedId = await createTestFeed({});
+    const feedId = await createTestFeed();
     const subId = await createTestSubscription(userId, feedId);
     const entryId = await createTestEntry(feedId);
     // starredChangedAt in the past: the insert default is now() at microsecond
@@ -325,7 +257,7 @@ describe("unread counters (triggers + reconciliation)", () => {
     const userId = await createTestUser();
 
     // Active subscription with 2 unread entries.
-    const activeFeedId = await createTestFeed({});
+    const activeFeedId = await createTestFeed();
     await createTestSubscription(userId, activeFeedId);
     for (let i = 0; i < 2; i++) {
       const entryId = await createTestEntry(activeFeedId);
@@ -333,7 +265,7 @@ describe("unread counters (triggers + reconciliation)", () => {
     }
 
     // Unsubscribed subscription with 1 starred unread orphan (still visible).
-    const goneFeedId = await createTestFeed({});
+    const goneFeedId = await createTestFeed();
     const goneSubId = await createTestSubscription(userId, goneFeedId);
     const orphanId = await createTestEntry(goneFeedId);
     // starredChangedAt in the past — see the note in the merge test above.
@@ -389,7 +321,7 @@ describe("unread counters (triggers + reconciliation)", () => {
 
   it("reconcileCounters detects and repairs corruption", async () => {
     const userId = await createTestUser();
-    const feedId = await createTestFeed({});
+    const feedId = await createTestFeed();
     const subId = await createTestSubscription(userId, feedId);
     const entryId = await createTestEntry(feedId);
     // starredChangedAt in the past: the insert default is now() at microsecond

--- a/tests/integration/user-entries-subscription-id.test.ts
+++ b/tests/integration/user-entries-subscription-id.test.ts
@@ -28,87 +28,11 @@ import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createUserEntriesForFeed } from "../../src/server/feed/entry-processor";
 import { migrateSubscriptionsToExistingFeed } from "../../src/server/jobs/handlers";
 import { createSubscription } from "../../src/server/services/subscriptions";
+import { createTestEntry, createTestFeed, createTestSubscription, createTestUser } from "./helpers";
 
 // ============================================================================
 // Test Helpers
 // ============================================================================
-
-async function createTestUser(prefix = "sub-id-user"): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `${prefix}-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return userId;
-}
-
-async function createTestFeed(options: {
-  url?: string;
-  type?: "web" | "email" | "saved";
-  lastEntriesUpdatedAt?: Date | null;
-  /** Required for email/saved feeds (feed_type_user_id check constraint). */
-  userId?: string;
-}): Promise<string> {
-  const feedId = generateUuidv7();
-  const now = new Date();
-  await db.insert(feeds).values({
-    id: feedId,
-    type: options.type ?? "web",
-    url: options.url ?? `https://example.com/feed-${feedId}.xml`,
-    userId: options.userId ?? null,
-    title: `Test Feed ${feedId}`,
-    lastEntriesUpdatedAt: options.lastEntriesUpdatedAt ?? null,
-    createdAt: now,
-    updatedAt: now,
-  });
-  return feedId;
-}
-
-async function createTestSubscription(
-  userId: string,
-  feedId: string,
-  options?: { unsubscribedAt?: Date | null }
-): Promise<string> {
-  const subscriptionId = generateUuidv7();
-  await db.insert(subscriptions).values({
-    id: subscriptionId,
-    userId,
-    feedId,
-    subscribedAt: new Date(),
-    unsubscribedAt: options?.unsubscribedAt ?? null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return subscriptionId;
-}
-
-async function createTestEntry(
-  feedId: string,
-  options: { isSpam?: boolean; lastSeenAt?: Date | null; type?: "web" | "email" | "saved" } = {}
-): Promise<string> {
-  const entryId = generateUuidv7();
-  const now = new Date();
-  const type = options.type ?? "web";
-  await db.insert(entries).values({
-    id: entryId,
-    feedId,
-    type,
-    guid: `guid-${entryId}`,
-    title: `Entry ${entryId}`,
-    contentHash: `hash-${entryId}`,
-    isSpam: options.isSpam ?? false,
-    fetchedAt: now,
-    // last_seen_at is only valid on fetched (web) entries
-    // (entries_last_seen_only_fetched check constraint).
-    lastSeenAt: type === "web" ? (options.lastSeenAt ?? now) : null,
-    createdAt: now,
-    updatedAt: now,
-  });
-  return entryId;
-}
 
 async function getUserEntry(userId: string, entryId: string) {
   const [row] = await db
@@ -175,7 +99,7 @@ describe("user_entries.subscription_id / is_spam denormalization", () => {
       // Attribution is to the (user, feed) subscription whether or not it is
       // active — visibility rules, not attribution, decide what the user sees.
       const userId = await createTestUser();
-      const feedId = await createTestFeed({});
+      const feedId = await createTestFeed();
       const subscriptionId = await createTestSubscription(userId, feedId, {
         unsubscribedAt: new Date(),
       });
@@ -189,9 +113,9 @@ describe("user_entries.subscription_id / is_spam denormalization", () => {
 
     it("does not override explicitly provided values", async () => {
       const userId = await createTestUser();
-      const feedId = await createTestFeed({});
+      const feedId = await createTestFeed();
       await createTestSubscription(userId, feedId);
-      const otherFeedId = await createTestFeed({});
+      const otherFeedId = await createTestFeed();
       const otherSubscriptionId = await createTestSubscription(userId, otherFeedId);
       const entryId = await createTestEntry(feedId, { isSpam: false });
 
@@ -210,9 +134,9 @@ describe("user_entries.subscription_id / is_spam denormalization", () => {
 
   describe("feed fanout (createUserEntriesForFeed)", () => {
     it("stamps each subscriber's own subscription", async () => {
-      const feedId = await createTestFeed({});
-      const user1 = await createTestUser("fanout-1");
-      const user2 = await createTestUser("fanout-2");
+      const feedId = await createTestFeed();
+      const user1 = await createTestUser({ emailPrefix: "fanout-1" });
+      const user2 = await createTestUser({ emailPrefix: "fanout-2" });
       const sub1 = await createTestSubscription(user1, feedId);
       const sub2 = await createTestSubscription(user2, feedId);
       const entryId = await createTestEntry(feedId);
@@ -227,7 +151,7 @@ describe("user_entries.subscription_id / is_spam denormalization", () => {
     });
 
     it("copies is_spam from the entry", async () => {
-      const userId = await createTestUser("fanout-spam");
+      const userId = await createTestUser({ emailPrefix: "fanout-spam" });
       // Email feed (user-owned) so the spam entry passes entries_spam_only_email.
       const feedId = await createTestFeed({ type: "email", userId });
       await createTestSubscription(userId, feedId);
@@ -243,7 +167,7 @@ describe("user_entries.subscription_id / is_spam denormalization", () => {
 
   describe("subscribe-time populate (createSubscription)", () => {
     it("stamps the new subscription on the populated entries", async () => {
-      const userId = await createTestUser("subscribe");
+      const userId = await createTestUser({ emailPrefix: "subscribe" });
       const now = new Date();
       const url = `https://example.com/populate-${generateUuidv7()}.xml`;
       const feedId = await createTestFeed({ url, lastEntriesUpdatedAt: now });
@@ -259,7 +183,7 @@ describe("user_entries.subscription_id / is_spam denormalization", () => {
 
   describe("feed merge re-stamp (migrateSubscriptionsToExistingFeed)", () => {
     it("re-stamps old-feed entries to the newly created subscription", async () => {
-      const userId = await createTestUser("merge-new");
+      const userId = await createTestUser({ emailPrefix: "merge-new" });
       const oldFeedId = await createTestFeed({ url: "https://old.example.com/feed.xml" });
       const newFeedId = await createTestFeed({ url: "https://new.example.com/feed.xml" });
       const oldSubId = await createTestSubscription(userId, oldFeedId);
@@ -283,7 +207,7 @@ describe("user_entries.subscription_id / is_spam denormalization", () => {
     });
 
     it("re-stamps old-feed entries to the user's existing subscription to the target feed", async () => {
-      const userId = await createTestUser("merge-existing");
+      const userId = await createTestUser({ emailPrefix: "merge-existing" });
       const oldFeedId = await createTestFeed({ url: "https://old2.example.com/feed.xml" });
       const newFeedId = await createTestFeed({ url: "https://new2.example.com/feed.xml" });
       const oldSubId = await createTestSubscription(userId, oldFeedId);
@@ -318,8 +242,8 @@ describe("user_entries.subscription_id / is_spam denormalization", () => {
     it("re-stamps every affected user in a multi-subscriber merge", async () => {
       const oldFeedId = await createTestFeed({ url: "https://old3.example.com/feed.xml" });
       const newFeedId = await createTestFeed({ url: "https://new3.example.com/feed.xml" });
-      const userA = await createTestUser("merge-a");
-      const userB = await createTestUser("merge-b");
+      const userA = await createTestUser({ emailPrefix: "merge-a" });
+      const userB = await createTestUser({ emailPrefix: "merge-b" });
       await createTestSubscription(userA, oldFeedId);
       await createTestSubscription(userB, oldFeedId);
       const existingBSub = await createTestSubscription(userB, newFeedId);

--- a/tests/integration/user-entries-subscription-id.test.ts
+++ b/tests/integration/user-entries-subscription-id.test.ts
@@ -71,7 +71,13 @@ describe("user_entries.subscription_id / is_spam denormalization", () => {
       // (entries_spam_only_email check constraint).
       const feedId = await createTestFeed({ type: "email", userId });
       const subscriptionId = await createTestSubscription(userId, feedId);
-      const entryId = await createTestEntry(feedId, { isSpam: true, type: "email" });
+      // publishedAt stays null so the sort key has to come from the trigger's
+      // fetched_at arm — the point of the assertion below.
+      const entryId = await createTestEntry(feedId, {
+        isSpam: true,
+        type: "email",
+        publishedAt: null,
+      });
 
       // Insert the way email ingest / saved articles / seeds do: identity only.
       await db.insert(userEntries).values({ userId, entryId });
@@ -86,7 +92,7 @@ describe("user_entries.subscription_id / is_spam denormalization", () => {
       const userId = await createTestUser();
       // Saved-articles feed: per-user, no subscription row.
       const feedId = await createTestFeed({ type: "saved", userId });
-      const entryId = await createTestEntry(feedId, { type: "saved" });
+      const entryId = await createTestEntry(feedId, { type: "saved", publishedAt: null });
 
       await db.insert(userEntries).values({ userId, entryId });
 

--- a/tests/integration/wallabag-auth.test.ts
+++ b/tests/integration/wallabag-auth.test.ts
@@ -19,21 +19,21 @@ import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createTokens, validateAccessToken } from "../../src/server/oauth/service";
 import { requireAuth, passwordGrant } from "../../src/server/wallabag/auth";
 import { OAUTH_SCOPES } from "../../src/server/oauth/utils";
+import { createTestUser } from "./helpers";
 
 const createdUserIds: string[] = [];
 
-async function createTestUser(password?: string): Promise<{ id: string; email: string }> {
+/**
+ * A confirmed user. Pass `password` when the test signs in through the password
+ * grant, which needs a hash it can actually verify.
+ */
+async function createUser(password?: string): Promise<{ id: string; email: string }> {
   const id = generateUuidv7();
   const email = `wallabag-${id}@test.com`;
-  await db.insert(users).values({
+  await createTestUser({
     id,
     email,
     passwordHash: password ? await argon2.hash(password) : "test-hash",
-    tosAgreedAt: new Date(),
-    privacyPolicyAgreedAt: new Date(),
-    notEuAgreedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
   });
   createdUserIds.push(id);
   return { id, email };
@@ -58,7 +58,7 @@ afterAll(async () => {
 
 describe("Wallabag requireAuth scope enforcement", () => {
   it("accepts a reader:full-access token", async () => {
-    const user = await createTestUser();
+    const user = await createUser();
     const token = await mintToken(user.id, [OAUTH_SCOPES.READER_FULL_ACCESS]);
 
     const result = await requireAuth(bearerRequest(token));
@@ -70,7 +70,7 @@ describe("Wallabag requireAuth scope enforcement", () => {
   });
 
   it("rejects a saved:write-only token with 403 insufficient_scope", async () => {
-    const user = await createTestUser();
+    const user = await createUser();
     const token = await mintToken(user.id, [OAUTH_SCOPES.SAVED_WRITE]);
 
     const result = await requireAuth(bearerRequest(token));
@@ -82,7 +82,7 @@ describe("Wallabag requireAuth scope enforcement", () => {
   });
 
   it("rejects an mcp-scoped token with 403 (audience/scope confinement)", async () => {
-    const user = await createTestUser();
+    const user = await createUser();
     const token = await mintToken(user.id, [OAUTH_SCOPES.MCP]);
 
     const result = await requireAuth(bearerRequest(token));
@@ -132,7 +132,7 @@ describe("Wallabag requireAuth scope enforcement", () => {
 describe("Wallabag passwordGrant", () => {
   it("mints a reader:full-access token that requireAuth accepts", async () => {
     const password = "correct-horse-battery-staple";
-    const user = await createTestUser(password);
+    const user = await createUser(password);
 
     const grant = await passwordGrant(user.email, password, "wallabag");
     expect(grant).not.toBeNull();
@@ -148,7 +148,7 @@ describe("Wallabag passwordGrant", () => {
   });
 
   it("returns null for a wrong password", async () => {
-    const user = await createTestUser("the-right-password");
+    const user = await createUser("the-right-password");
     const grant = await passwordGrant(user.email, "the-wrong-password", "wallabag");
     expect(grant).toBeNull();
   });

--- a/tests/integration/wallabag-ids.test.ts
+++ b/tests/integration/wallabag-ids.test.ts
@@ -13,18 +13,12 @@ import { db } from "../../src/server/db";
 import { users, entries, userEntries, feeds } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { resolveWallabagEntry, entryIdToWallabagId } from "../../src/server/wallabag/id";
+import { createTestUser } from "./helpers";
 
 const createdUserIds: string[] = [];
 
-async function createTestUser(): Promise<string> {
-  const userId = generateUuidv7();
-  await db.insert(users).values({
-    id: userId,
-    email: `wallabag-ids-${userId}@test.com`,
-    passwordHash: "test-hash",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
+async function createUser(): Promise<string> {
+  const userId = await createTestUser({ emailPrefix: "wallabag-ids" });
   createdUserIds.push(userId);
   return userId;
 }
@@ -77,20 +71,20 @@ afterAll(async () => {
 
 describe("entryIdToWallabagId", () => {
   it("returns the entry's stored serial as a number", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const { entryId, serial } = await createTestSavedArticle(userId);
 
     expect(await entryIdToWallabagId(db, userId, entryId)).toBe(Number(serial));
   });
 
   it("returns null for an unknown entry", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     expect(await entryIdToWallabagId(db, userId, generateUuidv7())).toBeNull();
   });
 
   it("returns null for another user's entry (visibility scoping)", async () => {
-    const owner = await createTestUser();
-    const other = await createTestUser();
+    const owner = await createUser();
+    const other = await createUser();
     const { entryId } = await createTestSavedArticle(owner);
 
     expect(await entryIdToWallabagId(db, other, entryId)).toBeNull();
@@ -99,7 +93,7 @@ describe("entryIdToWallabagId", () => {
 
 describe("resolveWallabagEntry", () => {
   it("resolves a numeric Wallabag id to the entry UUID + serial", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const { entryId, serial } = await createTestSavedArticle(userId);
 
     const resolved = await resolveWallabagEntry(db, userId, serial.toString());
@@ -107,7 +101,7 @@ describe("resolveWallabagEntry", () => {
   });
 
   it("resolves a UUID param to the same entry", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const { entryId, serial } = await createTestSavedArticle(userId);
 
     const resolved = await resolveWallabagEntry(db, userId, entryId);
@@ -115,8 +109,8 @@ describe("resolveWallabagEntry", () => {
   });
 
   it("does not resolve another user's entry (visibility scoping)", async () => {
-    const owner = await createTestUser();
-    const other = await createTestUser();
+    const owner = await createUser();
+    const other = await createUser();
     const { entryId, serial } = await createTestSavedArticle(owner);
 
     expect(await resolveWallabagEntry(db, other, serial.toString())).toBeNull();
@@ -124,7 +118,7 @@ describe("resolveWallabagEntry", () => {
   });
 
   it("returns null for malformed or out-of-range params without erroring", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
 
     // Not a serial or UUID
     expect(await resolveWallabagEntry(db, userId, "not-an-id")).toBeNull();
@@ -138,7 +132,7 @@ describe("resolveWallabagEntry", () => {
   });
 
   it("does not resolve an unknown serial", async () => {
-    const userId = await createTestUser();
+    const userId = await createUser();
     const { serial } = await createTestSavedArticle(userId);
 
     const unknown = (serial + BigInt(1000000)).toString();

--- a/tests/integration/websub.test.ts
+++ b/tests/integration/websub.test.ts
@@ -29,6 +29,7 @@ import {
   recordHubAnnouncedEntries,
   recordBackupPollNewEntries,
 } from "../../src/server/feed/websub-hub-stats";
+import { createTestFeed as insertTestFeed } from "./helpers";
 
 // Sample RSS feed content for testing content notifications
 const SAMPLE_RSS_FEED = `<?xml version="1.0" encoding="UTF-8"?>
@@ -47,20 +48,16 @@ const SAMPLE_RSS_FEED = `<?xml version="1.0" encoding="UTF-8"?>
   </channel>
 </rss>`;
 
-// Helper to create a test feed in the database
+// Wraps the shared factory because these call sites want the feed row
+// (feed.url, feed.selfUrl), not just its id.
 async function createTestFeed(overrides: Partial<typeof feeds.$inferInsert> = {}) {
-  const [feed] = await db
-    .insert(feeds)
-    .values({
-      id: generateUuidv7(),
-      type: "web",
-      url: `https://example.com/feed-${generateUuidv7()}.xml`,
-      title: "Test Feed",
-      hubUrl: "https://hub.example.com/",
-      selfUrl: `https://example.com/feed-${generateUuidv7()}.xml`,
-      ...overrides,
-    })
-    .returning();
+  const feedId = await insertTestFeed({
+    title: "Test Feed",
+    hubUrl: "https://hub.example.com/",
+    selfUrl: `https://example.com/feed-${generateUuidv7()}.xml`,
+    ...overrides,
+  });
+  const [feed] = await db.select().from(feeds).where(eq(feeds.id, feedId));
   return feed;
 }
 


### PR DESCRIPTION
Closes #1466.

31 of 55 integration files hand-rolled `createTestUser` and 15 hand-rolled `createTestFeed`, so any change to how a user or feed row is built meant touching dozens of files. This adds `tests/integration/helpers.ts` — mirroring the pattern `tests/e2e/helpers.ts` already uses — and migrates the whole suite onto it.

**Net: 47 files changed, ~2200 lines of duplicated setup removed. Zero local `createTestUser`/`createAuthContext` definitions remain.**

## What's in the new module

`createTestUser`, `createTestFeed`, `createTestSubscription`, `createTestEntry`, and `createAuthContext`. Each row factory returns the new row's id and takes Drizzle insert overrides, so a test needing an unusual column passes it instead of the factory growing a per-caller option.

Two things the factories centralize that were previously re-derived per file:

- **Check constraints.** `last_seen_at` is web-only (`entries_last_seen_only_fetched`) and `is_spam` is email-only. `createTestEntry` forces `lastSeenAt` null for non-web entries so a caller passing `type: "saved"` can't accidentally violate the constraint.
- **Signup confirmation.** Most routers sit behind `confirmedMiddleware`, so `createTestUser` accepts the agreements by default. Pass them as null to test an unconfirmed account.

## `createAuthContext` is now DB-backed

It was duplicated 15 times as a ~45-line literal user row that every new `users` column had to be added to. The shared version reads the real row from the DB instead, so it can't drift — which also means it's now `async`, and each caller gained an `await`.

This is a genuine behavior change, and it surfaced a latent gap: the old literal hardcoded the tos/privacy/notEu timestamps even when the DB row had them null, so tests were passing through `confirmedMiddleware` on fabricated state. Defaulting them in `createTestUser` restores that behavior honestly rather than by fiction.

## What deliberately wasn't collapsed

A few files keep a thin local wrapper over a shared factory, each documenting why in a comment: a feed that must look already-polled (`sync-events`, `entries`), a feed that must not look due for a refetch (`subscriptions` — otherwise `subscriptions.create` attempts a real network fetch), an entry whose `contentCleaned` default is load-bearing for the #1249 search_vector fallback, and the two files (`entry-processor`, `websub`) whose ~25 call sites want the feed *row* rather than its id.

Job rows, `ingest_addresses`, `oauth_accounts` and `websub_subscriptions` stay inline — no factories for those tables.

## Verification

- `pnpm test:integration` — 742 passed | 15 skipped, identical to the pre-change baseline on the same machine
- `pnpm test:unit` — 3123 passed
- `pnpm typecheck` and eslint clean

The equal pass/skip counts before and after are the main evidence here: this is a refactor with no intended behavior change, and each factory default that differed from a local one was checked against the query that consumes it (e.g. feed-stats aggregates `COUNT(*)`/`MIN(fetched_at)` and never reads `published_at`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)