### PR TITLE
Demo: credit Brendan Long on the welcome article

### DIFF
--- a/src/app/(public)/demo/articles/welcome.ts
+++ b/src/app/(public)/demo/articles/welcome.ts
@@ -50,6 +50,8 @@ const article: DemoArticle = {
       <li><strong>Integrations &amp; Sync</strong> &mdash; MCP, WebSub push, the PWA, real-time updates, and compatibility APIs</li>
     </ul>
 
+    <p>Lion Reader is designed and built by <a href="https://www.brendanlong.com/pages/about-me.html" target="_blank" rel="noopener noreferrer">Brendan Long</a>.</p>
+
     <p>Ready to take control of your reading? Sign up to start using the full app, or <a href="https://github.com/brendanlong/lion-reader" target="_blank" rel="noopener noreferrer">check out the source code on GitHub</a> to self-host your own instance.</p>
 
   `,


### PR DESCRIPTION
Adds a one-line credit to the welcome demo article linking to https://www.brendanlong.com/pages/about-me.html.

> Lion Reader is designed and built by [Brendan Long](https://www.brendanlong.com/pages/about-me.html).

It sits just above the closing "Ready to take control of your reading?" call-to-action. Left `author` as `null` for consistency with every other demo article (a byline on only one would look odd in the entry list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)