### PR TITLE
Stop arXiv saves waiting 10s on a throttled metadata API

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,7 +108,7 @@ Entry bodies, saved articles, and AI summaries are rendered with
 - Applies to: feed polling/discovery, WebSub hub subscribe, full-content/save
   fetches, and content-source plugins. The content-source plugins that fetch
   hardcoded public hosts (`plugins/github.ts`, `plugins/bluesky.ts`,
-  `feed/arxiv.ts`, `feed/lesswrong.ts`, Google Docs/Drive) route through the guard
+  `plugins/arxiv.ts`, `feed/lesswrong.ts`, Google Docs/Drive) route through the guard
   too, so a future refactor that makes one of those hosts user-influenced can't
   silently regress into SSRF (#1265). Keep it that way; don't call `fetch`/`undici`
   directly on any content-source URL.

--- a/docs/diagrams/feed-fetcher.d2
+++ b/docs/diagrams/feed-fetcher.d2
@@ -126,7 +126,7 @@ pipeline: {
     details: |md
       - Streaming XML parser
       - RSS, Atom, JSON Feed
-      - Custom parsers (LessWrong, arXiv)
+      - Custom parsers (LessWrong)
     |
   }
 

--- a/src/server/feed/arxiv.ts
+++ b/src/server/feed/arxiv.ts
@@ -6,15 +6,14 @@
  * - /pdf/XXXX.XXXXX - PDF version
  * - /html/XXXX.XXXXX - HTML version (not available for all papers)
  *
- * This module transforms abstract and PDF URLs to their HTML equivalents
- * when the HTML version is available, providing a better reading experience.
+ * URL helpers here let the saved-article plugin address a paper in either form,
+ * and `parseArxivAbsMetadata` reads the paper's title/abstract/authors off the
+ * abstract page — the plugin fetches both forms in parallel and picks the HTML
+ * render for content when it exists. Pure functions only; the plugin owns the
+ * fetching.
  */
 
 import { Parser } from "htmlparser2";
-import { logger } from "@/lib/logger";
-import { FEED_FETCH_TIMEOUT_MS, readResponseWithSizeLimit } from "@/server/http/fetch";
-import { fetchWithSsrfProtection } from "@/server/http/ssrf";
-import { USER_AGENT } from "@/server/http/user-agent";
 
 // ============================================================================
 // URL Parsing
@@ -41,23 +40,16 @@ export function isArxivUrl(url: string): boolean {
 }
 
 /**
- * Checks if a URL is an ArXiv abstract or PDF URL that could be transformed to HTML.
- * Excludes URLs that are already HTML.
- */
-export function isArxivTransformableUrl(url: string): boolean {
-  const match = url.match(ARXIV_URL_PATTERN);
-  if (!match) return false;
-  const type = match[1];
-  return type === "abs" || type === "pdf";
-}
-
-/**
  * Extracts the paper ID from an ArXiv URL.
  * Returns null if the URL is not a valid ArXiv paper URL.
  *
+ * The version suffix is **preserved**, and that is load-bearing: the id is fed
+ * straight back into `buildArxivHtmlUrl`/`buildArxivAbsUrl`, and a paper's
+ * abstract differs between versions, so dropping `v2` would save the wrong one.
+ *
  * @example
  * extractPaperId("https://arxiv.org/abs/2601.04649") // "2601.04649"
- * extractPaperId("https://arxiv.org/pdf/2601.04649v2") // "2601.04649"
+ * extractPaperId("https://arxiv.org/pdf/2601.04649v2") // "2601.04649v2"
  * extractPaperId("https://arxiv.org/abs/hep-th/9901001") // "hep-th/9901001"
  */
 export function extractPaperId(url: string): string | null {
@@ -86,114 +78,16 @@ export function buildArxivAbsUrl(paperId: string): string {
 }
 
 // ============================================================================
-// HTML Version Detection
+// Paper metadata (title / abstract / authors)
 // ============================================================================
 
-/**
- * Result of checking for ArXiv HTML version.
- */
-interface ArxivHtmlCheckResult {
-  /** Whether the HTML version exists */
-  exists: boolean;
-  /** The HTML URL (set regardless of whether it exists) */
-  htmlUrl: string;
-  /** The fallback URL to use if HTML doesn't exist (original URL) */
-  fallbackUrl: string;
-}
-
-/**
- * Checks if the HTML version of an ArXiv paper exists.
- *
- * Not all ArXiv papers have HTML versions - it depends on the source format
- * (TeX papers are more likely to have HTML versions).
- *
- * @param url - The ArXiv URL (abs or pdf)
- * @returns Result indicating if HTML version exists
- */
-async function checkArxivHtmlExists(url: string): Promise<ArxivHtmlCheckResult | null> {
-  const paperId = extractPaperId(url);
-  if (!paperId) {
-    logger.debug("Not a valid ArXiv URL", { url });
-    return null;
-  }
-
-  const htmlUrl = buildArxivHtmlUrl(paperId);
-  const fallbackUrl = buildArxivAbsUrl(paperId);
-
-  try {
-    // Use HEAD request to check if HTML version exists without downloading it
-    const response = await fetchWithSsrfProtection(htmlUrl, {
-      method: "HEAD",
-      headers: {
-        "User-Agent": USER_AGENT,
-      },
-      signal: AbortSignal.timeout(FEED_FETCH_TIMEOUT_MS),
-      redirect: "follow",
-    });
-
-    const exists = response.ok;
-    logger.debug("ArXiv HTML version check", {
-      paperId,
-      htmlUrl,
-      exists,
-      status: response.status,
-    });
-
-    return { exists, htmlUrl, fallbackUrl };
-  } catch (error) {
-    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
-      logger.warn("ArXiv HTML check timed out", { paperId, htmlUrl });
-    } else {
-      logger.warn("ArXiv HTML check failed", {
-        paperId,
-        htmlUrl,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-    // On error, assume HTML doesn't exist and fall back
-    return { exists: false, htmlUrl, fallbackUrl };
-  }
-}
-
-/**
- * Gets the best URL to fetch for an ArXiv paper.
- *
- * If the paper has an HTML version, returns that URL.
- * Otherwise, returns the original URL for normal fetching.
- *
- * @param url - The ArXiv URL (abs or pdf)
- * @returns The best URL to fetch, or null if not an ArXiv URL
- */
-export async function getArxivFetchUrl(url: string): Promise<string | null> {
-  if (!isArxivTransformableUrl(url)) {
-    return null;
-  }
-
-  const result = await checkArxivHtmlExists(url);
-  if (!result) {
-    return null;
-  }
-
-  return result.exists ? result.htmlUrl : result.fallbackUrl;
-}
-
-// ============================================================================
-// arXiv API metadata (title / abstract / authors)
-// ============================================================================
-
-/**
- * A single-entry Atom document from the arXiv API is a few KB; cap the read so a
- * misbehaving/hijacked response can't be buffered without bound.
- */
-const ARXIV_API_MAX_BYTES = 1024 * 1024;
-
-/** Structured metadata scraped from the arXiv Atom API for one paper. */
-export interface ArxivApiMetadata {
-  /** The paper title (feed-level query title is ignored). */
+/** Structured metadata for one paper, scraped from its arXiv abstract page. */
+export interface ArxivPaperMetadata {
+  /** The paper title, from `citation_title`. */
   title: string | null;
-  /** The abstract, from Atom `<summary>` — a far better excerpt than a scrape. */
+  /** The abstract, from `citation_abstract` — a far better excerpt than a scrape. */
   summary: string | null;
-  /** Author display names, in order, from `<author><name>`. */
+  /** Author display names, in order, from the repeated `citation_author` tags. */
   authors: string[];
 }
 
@@ -203,76 +97,75 @@ function normalizeArxivText(text: string): string {
 }
 
 /**
- * Parse an arXiv Atom API response (from `export.arxiv.org/api/query`) into the
+ * Convert a Highwire `citation_author` value to normal reading order.
+ *
+ * The abstract page emits authors surname-first ("Tay, Yi"), which is wrong for
+ * a byline. Split on the *first* comma only, so multi-part given names survive
+ * ("Tran, Vinh Q." -> "Vinh Q. Tran"). Values with no comma are group or
+ * collaboration names ("ATLAS Collaboration") and are left alone.
+ */
+function normalizeAuthorName(raw: string): string {
+  const name = normalizeArxivText(raw);
+  const comma = name.indexOf(",");
+  if (comma === -1) return name;
+
+  const surname = name.slice(0, comma).trim();
+  const given = name.slice(comma + 1).trim();
+  if (!surname || !given) return name;
+
+  return `${given} ${surname}`;
+}
+
+/**
+ * Parse an arXiv abstract page's Highwire `citation_*` meta tags into the
  * paper's title, abstract, and author names.
  *
- * SAX-parsed (xmlMode) for the same reasons the rest of the codebase prefers it.
- * Only the **first** `<entry>` is read, and feed-level `<title>`/`<author>`
- * elements (the query echo) are ignored — we only capture inside `<entry>`.
+ * The abstract page carries everything the `export.arxiv.org` Atom API returns,
+ * so reading it here means the save never touches that host — which throttles
+ * per source IP and, once throttled, stalls for 15-30s before returning 429.
+ * Behind a shared egress IP that made every arXiv save wait out the full fetch
+ * timeout and then discard the result.
  *
- * Pure (no network) so it can be unit-tested directly against fixture XML.
+ * SAX-parsed (and stopped at `</head>`, where the tags live) for the same
+ * reasons the rest of the codebase prefers it. Pure (no network) so it can be
+ * unit-tested directly against fixture HTML.
  */
-export function parseArxivApiResponse(xml: string): ArxivApiMetadata {
+export function parseArxivAbsMetadata(html: string): ArxivPaperMetadata {
   let title: string | null = null;
   let summary: string | null = null;
   const authors: string[] = [];
 
-  let inEntry = false;
-  let entryDone = false; // Stop capturing once the first <entry> closes.
-  let inAuthor = false;
-  let capture: "title" | "summary" | "name" | null = null;
-  let buffer = "";
-
   const parser = new Parser(
     {
-      onopentag(name) {
-        const tag = name.toLowerCase();
-        if (tag === "entry") {
-          if (!entryDone) inEntry = true;
-          return;
+      onopentag(name, attribs) {
+        if (name.toLowerCase() !== "meta") return;
+
+        const content = attribs.content;
+        if (!content) return;
+
+        switch (attribs.name?.toLowerCase()) {
+          case "citation_title":
+            title ??= normalizeArxivText(content) || null;
+            break;
+          case "citation_abstract":
+            summary ??= normalizeArxivText(content) || null;
+            break;
+          case "citation_author": {
+            const author = normalizeAuthorName(content);
+            if (author) authors.push(author);
+            break;
+          }
         }
-        if (!inEntry) return;
-        if (tag === "author") {
-          inAuthor = true;
-        } else if (tag === "title") {
-          capture = "title";
-          buffer = "";
-        } else if (tag === "summary") {
-          capture = "summary";
-          buffer = "";
-        } else if (tag === "name" && inAuthor) {
-          capture = "name";
-          buffer = "";
-        }
-      },
-      ontext(text) {
-        if (capture) buffer += text;
       },
       onclosetag(name) {
-        const tag = name.toLowerCase();
-        if (!inEntry) return;
-        if (tag === "entry") {
-          inEntry = false;
-          entryDone = true;
-        } else if (tag === "author") {
-          inAuthor = false;
-        } else if (tag === "title" && capture === "title") {
-          title = normalizeArxivText(buffer) || null;
-          capture = null;
-        } else if (tag === "summary" && capture === "summary") {
-          summary = normalizeArxivText(buffer) || null;
-          capture = null;
-        } else if (tag === "name" && capture === "name") {
-          const authorName = normalizeArxivText(buffer);
-          if (authorName) authors.push(authorName);
-          capture = null;
-        }
+        // Every citation_* tag lives in <head>; don't parse the whole document.
+        if (name.toLowerCase() === "head") parser.pause();
       },
     },
-    { decodeEntities: true, xmlMode: true }
+    { decodeEntities: true }
   );
 
-  parser.write(xml);
+  parser.write(html);
   parser.end();
 
   return { title, summary, authors };
@@ -288,53 +181,4 @@ export function formatArxivAuthors(authors: string[]): string | null {
   if (authors.length === 1) return authors[0];
   if (authors.length === 2) return `${authors[0]} and ${authors[1]}`;
   return `${authors[0]} et al.`;
-}
-
-/**
- * Fetch a paper's structured metadata (title / abstract / authors) from the
- * arXiv Atom API. Returns null on any failure so the caller falls back to the
- * scraped HTML / Readability metadata.
- *
- * All outbound traffic goes through `fetchWithSsrfProtection` with our custom
- * User-Agent. This is one request per save (not bulk harvesting), so it stays
- * well within arXiv's API rate limits.
- */
-export async function fetchArxivMetadata(paperId: string): Promise<ArxivApiMetadata | null> {
-  const apiUrl = `https://export.arxiv.org/api/query?id_list=${encodeURIComponent(paperId)}`;
-  try {
-    const response = await fetchWithSsrfProtection(apiUrl, {
-      headers: {
-        "User-Agent": USER_AGENT,
-      },
-      signal: AbortSignal.timeout(FEED_FETCH_TIMEOUT_MS),
-      redirect: "follow",
-    });
-
-    if (!response.ok) {
-      logger.warn("ArXiv API request failed", { paperId, status: response.status });
-      return null;
-    }
-
-    const xml = await readResponseWithSizeLimit(response, ARXIV_API_MAX_BYTES, apiUrl);
-    const metadata = parseArxivApiResponse(xml);
-
-    // A malformed / not-found response yields an empty entry — treat as a miss.
-    if (!metadata.title && !metadata.summary && metadata.authors.length === 0) {
-      logger.debug("ArXiv API returned no usable metadata", { paperId });
-      return null;
-    }
-
-    logger.debug("Fetched ArXiv API metadata", {
-      paperId,
-      hasSummary: metadata.summary !== null,
-      authorCount: metadata.authors.length,
-    });
-    return metadata;
-  } catch (error) {
-    logger.warn("ArXiv API request errored", {
-      paperId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return null;
-  }
 }

--- a/src/server/feed/arxiv.ts
+++ b/src/server/feed/arxiv.ts
@@ -111,7 +111,9 @@ function normalizeAuthorName(raw: string): string {
 
   const surname = name.slice(0, comma).trim();
   const given = name.slice(comma + 1).trim();
-  if (!surname || !given) return name;
+  // One side empty ("Smith," / ", John") — no swap to make, but don't hand back
+  // the stray comma either.
+  if (!surname || !given) return surname || given;
 
   return `${given} ${surname}`;
 }

--- a/src/server/plugins/arxiv.ts
+++ b/src/server/plugins/arxiv.ts
@@ -6,7 +6,7 @@ import {
   formatArxivAuthors,
   parseArxivAbsMetadata,
 } from "@/server/feed/arxiv";
-import { fetchHtmlPage, HttpFetchError } from "@/server/http/fetch";
+import { fetchPluginPage } from "./fetch-page";
 import { logger } from "@/lib/logger";
 
 /**
@@ -41,47 +41,16 @@ export const arxivPlugin: UrlPlugin = {
   capabilities: {
     savedArticle: {
       async fetchContent(url: URL): Promise<SavedArticleContent | null> {
+        // `matchUrl` is a looser path test than the id pattern, so the id can
+        // fail to parse. An /html/ URL is still fetchable as given (it is
+        // already the render); the other forms need the id to build a URL.
         const paperId = extractPaperId(url.href);
-        if (!paperId) {
-          return null;
-        }
-
-        // An /html/ URL is fetched as given; /abs/ and /pdf/ are mapped to the
-        // render, which may not exist (404 -> fall back to the abstract page).
         const isHtmlUrl = /^\/html\//.test(url.pathname);
-        const renderUrl = isHtmlUrl ? url.href : buildArxivHtmlUrl(paperId);
-        const absUrl = buildArxivAbsUrl(paperId);
 
-        const [render, abs] = await Promise.all([
-          fetchArxivPage(renderUrl, "html render"),
-          fetchArxivPage(absUrl, "abstract page"),
-        ]);
+        const renderUrl = isHtmlUrl ? url.href : paperId ? buildArxivHtmlUrl(paperId) : null;
+        const absUrl = paperId ? buildArxivAbsUrl(paperId) : null;
 
-        // The render is the better read, but the abstract page is a fine
-        // article in its own right when there is no render.
-        const content = render ?? abs;
-        if (!content) {
-          return null;
-        }
-
-        logger.debug("Fetched ArXiv paper", {
-          paperId,
-          usedRender: render !== null,
-          hasMetadata: abs !== null,
-        });
-
-        // Prefer the abstract page's structured fields; each falls back to null
-        // so Readability/metadata still fill them when that fetch failed.
-        const metadata = abs ? parseArxivAbsMetadata(abs.content) : null;
-
-        return {
-          html: content.content,
-          title: metadata?.title ?? null,
-          author: metadata ? formatArxivAuthors(metadata.authors) : null,
-          excerpt: metadata?.summary ?? null,
-          publishedAt: null,
-          canonicalUrl: content.finalUrl,
-        };
+        return fetchArxivPaper(renderUrl, absUrl);
       },
 
       skipReadability: false, // Still want cleanup with Readability
@@ -91,35 +60,72 @@ export const arxivPlugin: UrlPlugin = {
 };
 
 /**
- * Fetch one of a paper's two pages, returning null if it isn't there.
+ * Fetch a paper's render and abstract page concurrently and combine them.
  *
- * A 404 on the render is the ordinary case for older papers, so it isn't worth
- * a warning. Rate limiting is rethrown per the convention in `fetch-page.ts`:
- * swallowing it would drop us into `acquireArticleContent`'s generic fetch,
- * re-requesting the host that just throttled us.
+ * Exported for the integration test, which drives the combination rules — which
+ * page wins, and when a rate limit is fatal — against a loopback server.
+ *
+ * Rate limiting is held rather than thrown eagerly: `Promise.all` would abandon
+ * a render we had already fetched just because the abstract page came back 429,
+ * failing a save that could have succeeded with Readability-derived metadata.
+ * The convention exists to stop us re-requesting a throttled host, and with a
+ * body in hand there is nothing to re-request — so the rejection only surfaces
+ * when neither page produced content.
+ *
+ * A render that blows the size cap likewise falls back to the abstract page
+ * rather than failing the save. This is a deliberate exception to
+ * `acquireArticleContent`'s "a size-limit violation is a hard failure" rule,
+ * which exists to stop us silently degrading to a scrape of *the same*
+ * oversized page; here the abstract page is a different, perfectly good
+ * representation of the paper.
  */
-async function fetchArxivPage(
-  url: string,
-  what: string
-): Promise<{ content: string; finalUrl: string } | null> {
-  try {
-    const result = await fetchHtmlPage(url);
-    return { content: result.content, finalUrl: result.finalUrl };
-  } catch (error) {
-    if (error instanceof HttpFetchError) {
-      if (error.isRateLimited()) {
-        throw error;
-      }
-      if (error.status === 404) {
-        logger.debug("ArXiv page not available", { url, what });
-        return null;
-      }
-    }
-    logger.warn("ArXiv page fetch failed", {
-      url,
-      what,
-      error: error instanceof Error ? error.message : String(error),
-    });
+export async function fetchArxivPaper(
+  renderUrl: string | null,
+  absUrl: string | null
+): Promise<SavedArticleContent | null> {
+  if (!renderUrl && !absUrl) {
     return null;
   }
+
+  const [renderResult, absResult] = await Promise.allSettled([
+    renderUrl
+      ? fetchPluginPage(new URL(renderUrl), "arxiv", { notFoundIsExpected: true })
+      : Promise.resolve(null),
+    absUrl ? fetchPluginPage(new URL(absUrl), "arxiv") : Promise.resolve(null),
+  ]);
+
+  const render = renderResult.status === "fulfilled" ? renderResult.value : null;
+  const abs = absResult.status === "fulfilled" ? absResult.value : null;
+
+  // The render is the better read, but the abstract page is a fine article in
+  // its own right when there is no render.
+  const content = render ?? abs;
+  if (!content) {
+    // Nothing to save. If a fetch was rejected (only rate limiting rejects),
+    // surface that so the save reports `upstreamRateLimited` instead of
+    // falling through to a generic fetch of the same throttled host.
+    const rejected = [renderResult, absResult].find((r) => r.status === "rejected");
+    if (rejected) {
+      throw rejected.reason;
+    }
+    return null;
+  }
+
+  logger.debug("Fetched ArXiv paper", {
+    usedRender: render !== null,
+    hasMetadata: abs !== null,
+  });
+
+  // Prefer the abstract page's structured fields; each falls back to null so
+  // Readability/metadata still fill them when that fetch failed.
+  const metadata = abs ? parseArxivAbsMetadata(abs.html) : null;
+
+  return {
+    html: content.html,
+    title: metadata?.title ?? null,
+    author: metadata ? formatArxivAuthors(metadata.authors) : null,
+    excerpt: metadata?.summary ?? null,
+    publishedAt: null,
+    canonicalUrl: content.finalUrl,
+  };
 }

--- a/src/server/plugins/arxiv.ts
+++ b/src/server/plugins/arxiv.ts
@@ -1,11 +1,12 @@
 import type { UrlPlugin, SavedArticleContent } from "./types";
 import {
+  buildArxivAbsUrl,
+  buildArxivHtmlUrl,
   extractPaperId,
-  fetchArxivMetadata,
   formatArxivAuthors,
-  getArxivFetchUrl,
+  parseArxivAbsMetadata,
 } from "@/server/feed/arxiv";
-import { fetchHtmlPage } from "@/server/http/fetch";
+import { fetchHtmlPage, HttpFetchError } from "@/server/http/fetch";
 import { logger } from "@/lib/logger";
 
 /**
@@ -14,9 +15,19 @@ import { logger } from "@/lib/logger";
  * Provides capability for:
  * - SavedArticle: Fetch ArXiv papers, preferring HTML version when available
  *
- * ArXiv papers are available in multiple formats (abs, pdf, html).
- * The plugin attempts to fetch the HTML version for better reading,
- * falling back to the abstract page if HTML isn't available.
+ * A paper is addressable two ways, and we want one thing from each: the HTML
+ * render (`/html/`) reads far better than the abstract page but only exists for
+ * papers submitted as TeX since late 2023, while the abstract page (`/abs/`)
+ * always exists and carries the Highwire `citation_*` tags with the real title,
+ * author list, and abstract. So fetch **both in parallel** and combine them —
+ * content from the render when it exists, metadata always from the abstract
+ * page.
+ *
+ * Both requests go to arxiv.org and take ~50ms each. Deliberately *not* used:
+ * `export.arxiv.org/api/query`, which returns the same metadata but throttles
+ * per source IP and, once throttled, stalls 15-30s before answering 429 — from
+ * a shared egress IP that cost every save the full fetch timeout and then threw
+ * the result away.
  */
 export const arxivPlugin: UrlPlugin = {
   name: "arxiv",
@@ -30,59 +41,47 @@ export const arxivPlugin: UrlPlugin = {
   capabilities: {
     savedArticle: {
       async fetchContent(url: URL): Promise<SavedArticleContent | null> {
-        try {
-          // For /html/ URLs, fetch directly; for /abs/ and /pdf/, try to find the HTML version
-          const isHtmlUrl = /^\/html\//.test(url.pathname);
-          let fetchUrl: string;
-
-          if (isHtmlUrl) {
-            // Already an HTML URL - fetch it directly
-            fetchUrl = url.href;
-          } else {
-            // Try to transform abs/pdf to HTML
-            const transformed = await getArxivFetchUrl(url.href);
-            if (!transformed) {
-              return null;
-            }
-            fetchUrl = transformed;
-          }
-
-          logger.debug("Fetching ArXiv paper", {
-            originalUrl: url.href,
-            fetchUrl: fetchUrl,
-            isHtmlVersion: fetchUrl.includes("/html/"),
-          });
-
-          // Fetch the HTML render and the structured API metadata concurrently
-          // (different hosts: arxiv.org vs export.arxiv.org). The API gives us
-          // the real title, author list, and abstract — much better than
-          // Readability's scrape of the HTML render.
-          const paperId = extractPaperId(url.href);
-          const [result, metadata] = await Promise.all([
-            fetchHtmlPage(fetchUrl),
-            paperId ? fetchArxivMetadata(paperId) : Promise.resolve(null),
-          ]);
-          if (!result.content) {
-            return null;
-          }
-
-          // Prefer the API's structured fields; each falls back to null so
-          // Readability/metadata still fill them when the API call failed.
-          return {
-            html: result.content,
-            title: metadata?.title ?? null,
-            author: metadata ? formatArxivAuthors(metadata.authors) : null,
-            excerpt: metadata?.summary ?? null,
-            publishedAt: null,
-            canonicalUrl: result.finalUrl,
-          };
-        } catch (error) {
-          logger.warn("Failed to fetch ArXiv paper", {
-            url: url.href,
-            error: error instanceof Error ? error.message : String(error),
-          });
+        const paperId = extractPaperId(url.href);
+        if (!paperId) {
           return null;
         }
+
+        // An /html/ URL is fetched as given; /abs/ and /pdf/ are mapped to the
+        // render, which may not exist (404 -> fall back to the abstract page).
+        const isHtmlUrl = /^\/html\//.test(url.pathname);
+        const renderUrl = isHtmlUrl ? url.href : buildArxivHtmlUrl(paperId);
+        const absUrl = buildArxivAbsUrl(paperId);
+
+        const [render, abs] = await Promise.all([
+          fetchArxivPage(renderUrl, "html render"),
+          fetchArxivPage(absUrl, "abstract page"),
+        ]);
+
+        // The render is the better read, but the abstract page is a fine
+        // article in its own right when there is no render.
+        const content = render ?? abs;
+        if (!content) {
+          return null;
+        }
+
+        logger.debug("Fetched ArXiv paper", {
+          paperId,
+          usedRender: render !== null,
+          hasMetadata: abs !== null,
+        });
+
+        // Prefer the abstract page's structured fields; each falls back to null
+        // so Readability/metadata still fill them when that fetch failed.
+        const metadata = abs ? parseArxivAbsMetadata(abs.content) : null;
+
+        return {
+          html: content.content,
+          title: metadata?.title ?? null,
+          author: metadata ? formatArxivAuthors(metadata.authors) : null,
+          excerpt: metadata?.summary ?? null,
+          publishedAt: null,
+          canonicalUrl: content.finalUrl,
+        };
       },
 
       skipReadability: false, // Still want cleanup with Readability
@@ -90,3 +89,37 @@ export const arxivPlugin: UrlPlugin = {
     },
   },
 };
+
+/**
+ * Fetch one of a paper's two pages, returning null if it isn't there.
+ *
+ * A 404 on the render is the ordinary case for older papers, so it isn't worth
+ * a warning. Rate limiting is rethrown per the convention in `fetch-page.ts`:
+ * swallowing it would drop us into `acquireArticleContent`'s generic fetch,
+ * re-requesting the host that just throttled us.
+ */
+async function fetchArxivPage(
+  url: string,
+  what: string
+): Promise<{ content: string; finalUrl: string } | null> {
+  try {
+    const result = await fetchHtmlPage(url);
+    return { content: result.content, finalUrl: result.finalUrl };
+  } catch (error) {
+    if (error instanceof HttpFetchError) {
+      if (error.isRateLimited()) {
+        throw error;
+      }
+      if (error.status === 404) {
+        logger.debug("ArXiv page not available", { url, what });
+        return null;
+      }
+    }
+    logger.warn("ArXiv page fetch failed", {
+      url,
+      what,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}

--- a/src/server/plugins/fetch-page.ts
+++ b/src/server/plugins/fetch-page.ts
@@ -7,9 +7,20 @@ interface PluginPage {
   finalUrl: string;
 }
 
+interface FetchPluginPageOptions {
+  /**
+   * Treat a 404 as an ordinary outcome and log it at debug rather than warn.
+   *
+   * For a plugin that probes one of several representations of the same thing
+   * (arXiv's HTML render, which only exists for papers submitted as TeX since
+   * late 2023), a miss is the common case, not a fault worth a warning.
+   */
+  notFoundIsExpected?: boolean;
+}
+
 /**
  * Fetch a page on behalf of a plugin whose only source is the public HTML
- * (LinkedIn, Threads).
+ * (LinkedIn, Threads, arXiv).
  *
  * Returns null when the page couldn't be fetched or wasn't HTML, so the plugin
  * returns null in turn and the save falls back to normal handling. That is the
@@ -19,14 +30,21 @@ interface PluginPage {
  * **Rate limiting is the exception and is rethrown.** Falling back would
  * immediately re-request the very host that just throttled us; `saveArticle`'s
  * `acquireArticleContent` catches it and surfaces `upstreamRateLimited`
- * instead. `lesswrong.ts` rethrows for the same reason.
+ * instead. `lesswrong.ts` rethrows for the same reason. A caller that fetches
+ * several pages concurrently should hold the rejection until it knows it has no
+ * content — the point is to avoid *re-requesting* a throttled host, not to
+ * discard a body already in hand (see `arxiv.ts`).
  *
  * Note this deliberately does *not* rethrow a plain block (403, or LinkedIn's
  * nonstandard 999 for datacenter IPs): those aren't retry-after-a-while
  * signals, and falling back to the generic fetch is a better outcome than
  * failing the save.
  */
-export async function fetchPluginPage(url: URL, pluginName: string): Promise<PluginPage | null> {
+export async function fetchPluginPage(
+  url: URL,
+  pluginName: string,
+  options?: FetchPluginPageOptions
+): Promise<PluginPage | null> {
   try {
     const result = await fetchHtmlPage(url.href);
     if (result.isMarkdown) {
@@ -34,8 +52,14 @@ export async function fetchPluginPage(url: URL, pluginName: string): Promise<Plu
     }
     return { html: result.content, finalUrl: result.finalUrl };
   } catch (error) {
-    if (error instanceof HttpFetchError && error.isRateLimited()) {
-      throw error;
+    if (error instanceof HttpFetchError) {
+      if (error.isRateLimited()) {
+        throw error;
+      }
+      if (error.status === 404 && options?.notFoundIsExpected) {
+        logger.debug("Plugin page not available", { plugin: pluginName, url: url.href });
+        return null;
+      }
     }
     logger.warn("Plugin page fetch failed, falling back to normal handling", {
       plugin: pluginName,

--- a/src/server/plugins/types.ts
+++ b/src/server/plugins/types.ts
@@ -139,8 +139,8 @@ export interface SavedArticleContent {
   title?: string | null;
   author?: string | null;
   /**
-   * Plain-text excerpt/summary supplied by the plugin (e.g. the arXiv API
-   * abstract). When present it is preferred over Readability's extracted excerpt
+   * Plain-text excerpt/summary supplied by the plugin (e.g. the abstract off an
+   * arXiv page). When present it is preferred over Readability's extracted excerpt
    * (see {@link computeSavedArticleExcerpt}) and truncated to the summary length
    * downstream. Plain text, not HTML — it is stored/rendered as escaped text.
    */

--- a/src/server/services/saved-excerpt.ts
+++ b/src/server/services/saved-excerpt.ts
@@ -15,7 +15,7 @@ const MAX_EXCERPT_LENGTH = 300;
  * source — the same top tier a caller-provided title occupies for the title. Like
  * the plugin excerpt it's plain text, so it's just clipped to the summary length.
  *
- * A plugin-supplied `excerpt` (e.g. the arXiv API abstract) is authoritative and
+ * A plugin-supplied `excerpt` (e.g. the arXiv abstract page) is authoritative and
  * outranks everything extracted, including Readability — the whole point of
  * fetching it is that it beats any scrape of the HTML render. It's plain text, so
  * it's just clipped to the summary length (arXiv abstracts run long — see #1399).

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -295,7 +295,7 @@ interface ArticleContentBundle {
     html: string;
     title?: string | null;
     author?: string | null;
-    /** Plugin-supplied excerpt (e.g. arXiv API abstract); preferred over Readability's. */
+    /** Plugin-supplied excerpt (e.g. arXiv abstract page); preferred over Readability's. */
     excerpt?: string | null;
     siteName?: string;
     skipReadability?: boolean;
@@ -850,7 +850,7 @@ interface AcquiredArticleContent {
     html: string;
     title?: string | null;
     author?: string | null;
-    /** Plugin-supplied excerpt (e.g. arXiv API abstract); preferred over Readability's. */
+    /** Plugin-supplied excerpt (e.g. arXiv abstract page); preferred over Readability's. */
     excerpt?: string | null;
     siteName?: string;
     skipReadability?: boolean;

--- a/tests/integration/plugin-arxiv.test.ts
+++ b/tests/integration/plugin-arxiv.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Integration tests for `fetchArxivPaper`, which combines a paper's two
+ * representations into one saved article.
+ *
+ * The interesting behavior is the combination rules — which page supplies the
+ * body, which supplies the metadata, and when a rate limit is fatal. Those are
+ * decided by real fetch outcomes, so they're driven against a loopback server
+ * (`.env.test` sets ALLOW_PRIVATE_NETWORK_FETCH) rather than mocked.
+ *
+ * The rate-limit cases are the ones worth having: a 429 must not be swallowed
+ * (that re-requests a throttled host via the generic fetch), but it also must
+ * not discard a body we already hold.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+import { type AddressInfo } from "node:net";
+import { fetchArxivPaper } from "../../src/server/plugins/arxiv";
+import { HttpFetchError } from "../../src/server/http/fetch";
+
+/** Stands in for the HTML render: real body, no citation tags (as arXiv serves it). */
+const RENDER_HTML =
+  "<!doctype html><html><head><title>DeepSeek-V3 Technical Report</title></head>" +
+  "<body><p>Full paper text.</p></body></html>";
+
+/** Stands in for the abstract page: thin body, full citation metadata. */
+const ABS_HTML =
+  "<!doctype html><html><head><title>[2412.19437] DeepSeek-V3</title>" +
+  '<meta name="citation_title" content="DeepSeek-V3 Technical Report" />' +
+  '<meta name="citation_author" content="Liu, Aixin" />' +
+  '<meta name="citation_author" content="Feng, Bei" />' +
+  '<meta name="citation_abstract" content="We present DeepSeek-V3, a strong MoE model." />' +
+  "</head><body><p>Abstract page.</p></body></html>";
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const path = req.url ?? "/";
+    if (path === "/render") {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(RENDER_HTML);
+    } else if (path === "/abs") {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(ABS_HTML);
+    } else if (path === "/rate-limited") {
+      res.writeHead(429, { "Content-Type": "text/html" });
+      res.end("slow down");
+    } else {
+      // Everything else 404s — arXiv's answer for a paper with no HTML render.
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe("fetchArxivPaper", () => {
+  it("takes the body from the render and the metadata from the abstract page", async () => {
+    const result = await fetchArxivPaper(`${baseUrl}/render`, `${baseUrl}/abs`);
+
+    expect(result?.html).toContain("Full paper text.");
+    expect(result?.html).not.toContain("Abstract page.");
+    expect(result?.title).toBe("DeepSeek-V3 Technical Report");
+    expect(result?.author).toBe("Aixin Liu and Bei Feng");
+    expect(result?.excerpt).toBe("We present DeepSeek-V3, a strong MoE model.");
+    expect(result?.canonicalUrl).toBe(`${baseUrl}/render`);
+  });
+
+  it("falls back to the abstract page as the body when there is no render", async () => {
+    const result = await fetchArxivPaper(`${baseUrl}/missing`, `${baseUrl}/abs`);
+
+    expect(result?.html).toContain("Abstract page.");
+    // Metadata still comes through — it lives on the page we ended up using.
+    expect(result?.title).toBe("DeepSeek-V3 Technical Report");
+    expect(result?.canonicalUrl).toBe(`${baseUrl}/abs`);
+  });
+
+  it("uses the abstract page when the plugin was given no render URL", async () => {
+    const result = await fetchArxivPaper(null, `${baseUrl}/abs`);
+
+    expect(result?.html).toContain("Abstract page.");
+    expect(result?.title).toBe("DeepSeek-V3 Technical Report");
+  });
+
+  it("returns null when neither page exists, so the save falls back", async () => {
+    expect(await fetchArxivPaper(`${baseUrl}/missing`, `${baseUrl}/gone`)).toBeNull();
+    expect(await fetchArxivPaper(null, null)).toBeNull();
+  });
+
+  it("keeps the render when the abstract page is rate limited", async () => {
+    // The regression this guards: Promise.all would abandon a body we already
+    // hold. There is nothing to re-request, so the save should succeed with
+    // Readability filling in the metadata.
+    const result = await fetchArxivPaper(`${baseUrl}/render`, `${baseUrl}/rate-limited`);
+
+    expect(result?.html).toContain("Full paper text.");
+    expect(result?.title).toBeNull();
+    expect(result?.author).toBeNull();
+    expect(result?.excerpt).toBeNull();
+  });
+
+  it("keeps the abstract page when the render is rate limited", async () => {
+    const result = await fetchArxivPaper(`${baseUrl}/rate-limited`, `${baseUrl}/abs`);
+
+    expect(result?.html).toContain("Abstract page.");
+    expect(result?.title).toBe("DeepSeek-V3 Technical Report");
+  });
+
+  it("rethrows the rate limit when it left us with no content at all", async () => {
+    // Swallowing here would drop the save into acquireArticleContent's generic
+    // fetch, re-requesting the host that just throttled us.
+    await expect(
+      fetchArxivPaper(`${baseUrl}/rate-limited`, `${baseUrl}/rate-limited`)
+    ).rejects.toBeInstanceOf(HttpFetchError);
+
+    await expect(
+      fetchArxivPaper(`${baseUrl}/rate-limited`, `${baseUrl}/missing`)
+    ).rejects.toSatisfy((e) => e instanceof HttpFetchError && e.isRateLimited());
+  });
+});

--- a/tests/unit/arxiv.test.ts
+++ b/tests/unit/arxiv.test.ts
@@ -18,8 +18,8 @@ import {
  *
  * Faithful in the ways the parser depends on: authors are surname-first in one
  * repeated tag, the abstract is hard-wrapped across lines with a leading blank,
- * and a decoy <meta name="title"> plus an og:title sit alongside the citation
- * tags. Taken from the real markup of arxiv.org/abs/2503.11926v1.
+ * and a decoy <title> element plus an og:title sit alongside the citation tags.
+ * Taken from the real markup of arxiv.org/abs/2503.11926v1.
  */
 const ARXIV_ABS_HTML = `<!DOCTYPE html>
 <html><head>
@@ -218,6 +218,42 @@ describe("parseArxivAbsMetadata", () => {
       <meta name="citation_title" content="Second" />
     </head>`;
     expect(parseArxivAbsMetadata(html).title).toBe("First");
+  });
+
+  it("still ignores body tags when the page omits </head>", () => {
+    // htmlparser2 emits the implied close at <body>, so the pause still fires.
+    const html =
+      `<head><meta name="citation_author" content="Real, Ada" />` +
+      `<body><meta name="citation_author" content="Injected, Body" />`;
+    expect(parseArxivAbsMetadata(html).authors).toEqual(["Ada Real"]);
+  });
+
+  it("decodes HTML entities in citation values", () => {
+    const html = `<head>
+      <meta name="citation_title" content="Cats &amp; Dogs: A Study" />
+      <meta name="citation_author" content="Balázs, Csaba" />
+    </head>`;
+    const result = parseArxivAbsMetadata(html);
+    expect(result.title).toBe("Cats & Dogs: A Study");
+    expect(result.authors).toEqual(["Csaba Balázs"]);
+  });
+
+  it("matches tag names case-insensitively", () => {
+    const html = `<HEAD><META NAME="CITATION_TITLE" CONTENT="Shouty" /></HEAD>`;
+    expect(parseArxivAbsMetadata(html).title).toBe("Shouty");
+  });
+
+  it("drops a stray comma when one side of the author name is empty", () => {
+    const html = `<head>
+      <meta name="citation_author" content="Surnameonly," />
+      <meta name="citation_author" content=", Givenonly" />
+    </head>`;
+    expect(parseArxivAbsMetadata(html).authors).toEqual(["Surnameonly", "Givenonly"]);
+  });
+
+  it("keeps a suffix attached to the given name, as arXiv emits it", () => {
+    const html = `<head><meta name="citation_author" content="Galapon, Arthur Jr." /></head>`;
+    expect(parseArxivAbsMetadata(html).authors).toEqual(["Arthur Jr. Galapon"]);
   });
 
   it("returns nulls / empty authors for a page with no citation tags", () => {

--- a/tests/unit/arxiv.test.ts
+++ b/tests/unit/arxiv.test.ts
@@ -1,39 +1,45 @@
 /**
- * Unit tests for ArXiv URL detection and paper ID extraction.
- *
- * These test the pure functions that determine if a URL is from ArXiv
- * and extract the paper ID for HTML version checking.
+ * Unit tests for ArXiv URL detection, paper ID extraction, and reading a
+ * paper's metadata off its abstract page.
  */
 
 import { describe, it, expect } from "vitest";
 import {
   isArxivUrl,
-  isArxivTransformableUrl,
   extractPaperId,
   buildArxivHtmlUrl,
   buildArxivAbsUrl,
-  parseArxivApiResponse,
+  parseArxivAbsMetadata,
   formatArxivAuthors,
 } from "../../src/server/feed/arxiv";
 
-/** A trimmed-down but structurally faithful arXiv Atom API response. */
-const ARXIV_API_XML = `<?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="html">ArXiv Query: search_query=&amp;id_list=2503.11926</title>
-  <entry>
-    <id>http://arxiv.org/abs/2503.11926v1</id>
-    <title>Monitoring Reasoning Models for Misbehavior and the Risks of
-      Promoting Obfuscation</title>
-    <summary>  Mitigating reward hacking--where AI systems misbehave due to flaws
+/**
+ * A trimmed-down but structurally faithful arXiv abstract page <head>.
+ *
+ * Faithful in the ways the parser depends on: authors are surname-first in one
+ * repeated tag, the abstract is hard-wrapped across lines with a leading blank,
+ * and a decoy <meta name="title"> plus an og:title sit alongside the citation
+ * tags. Taken from the real markup of arxiv.org/abs/2503.11926v1.
+ */
+const ARXIV_ABS_HTML = `<!DOCTYPE html>
+<html><head>
+  <title>[2503.11926] Monitoring Reasoning Models for Misbehavior</title>
+  <meta name="citation_title" content="Monitoring Reasoning Models for Misbehavior and the Risks of
+      Promoting Obfuscation" />
+  <meta name="citation_author" content="Baker, Bowen" />
+  <meta name="citation_author" content="Huizinga, Joost" />
+  <meta name="citation_author" content="Gao, Leo" />
+  <meta name="citation_date" content="2025/03/11" />
+  <meta name="citation_arxiv_id" content="2503.11926" />
+  <meta name="citation_abstract" content="  Mitigating reward hacking--where AI systems misbehave due to flaws
       or misspecifications in their learning objectives--remains a key challenge.
       We show that we can monitor a frontier reasoning model, such as OpenAI
       o3-mini, for reward hacking.
-    </summary>
-    <author><name>Bowen Baker</name></author>
-    <author><name>Joost Huizinga</name></author>
-    <author><name>Leo Gao</name></author>
-  </entry>
-</feed>`;
+" />
+  <meta property="og:title" content="Some other title" />
+</head><body>
+  <meta name="citation_author" content="Ignored, Body" />
+</body></html>`;
 
 describe("ArXiv URL detection", () => {
   describe("isArxivUrl", () => {
@@ -90,25 +96,6 @@ describe("ArXiv URL detection", () => {
       expect(isArxivUrl("not a url")).toBe(false);
       expect(isArxivUrl("")).toBe(false);
       expect(isArxivUrl("arxiv.org/abs/2601.04649")).toBe(false);
-    });
-  });
-
-  describe("isArxivTransformableUrl", () => {
-    it("returns true for ArXiv abstract URLs", () => {
-      expect(isArxivTransformableUrl("https://arxiv.org/abs/2601.04649")).toBe(true);
-    });
-
-    it("returns true for ArXiv PDF URLs", () => {
-      expect(isArxivTransformableUrl("https://arxiv.org/pdf/2601.04649")).toBe(true);
-      expect(isArxivTransformableUrl("https://arxiv.org/pdf/2601.04649.pdf")).toBe(true);
-    });
-
-    it("returns false for ArXiv HTML URLs (already HTML)", () => {
-      expect(isArxivTransformableUrl("https://arxiv.org/html/2601.04649")).toBe(false);
-    });
-
-    it("returns false for non-ArXiv URLs", () => {
-      expect(isArxivTransformableUrl("https://example.com/abs/2601.04649")).toBe(false);
     });
   });
 
@@ -186,9 +173,9 @@ describe("ArXiv URL detection", () => {
   });
 });
 
-describe("parseArxivApiResponse", () => {
-  it("extracts the title, abstract, and author names from the entry", () => {
-    const result = parseArxivApiResponse(ARXIV_API_XML);
+describe("parseArxivAbsMetadata", () => {
+  it("extracts the title, abstract, and author names from the citation tags", () => {
+    const result = parseArxivAbsMetadata(ARXIV_ABS_HTML);
     // Whitespace (including the line wrapping arXiv uses) is collapsed.
     expect(result.title).toBe(
       "Monitoring Reasoning Models for Misbehavior and the Risks of Promoting Obfuscation"
@@ -198,32 +185,44 @@ describe("parseArxivApiResponse", () => {
         "misspecifications in their learning objectives--remains a key challenge. We show " +
         "that we can monitor a frontier reasoning model, such as OpenAI o3-mini, for reward hacking."
     );
+  });
+
+  it("rewrites surname-first author names into reading order, preserving order", () => {
+    const result = parseArxivAbsMetadata(ARXIV_ABS_HTML);
     expect(result.authors).toEqual(["Bowen Baker", "Joost Huizinga", "Leo Gao"]);
   });
 
-  it("ignores the feed-level query title (only reads inside <entry>)", () => {
-    const result = parseArxivApiResponse(ARXIV_API_XML);
-    expect(result.title).not.toContain("ArXiv Query");
+  it("keeps multi-part given names together when swapping", () => {
+    const html = `<head><meta name="citation_author" content="Tran, Vinh Q." /></head>`;
+    expect(parseArxivAbsMetadata(html).authors).toEqual(["Vinh Q. Tran"]);
   });
 
-  it("only reads the first entry when the API returns several", () => {
-    const multi = `<feed xmlns="http://www.w3.org/2005/Atom">
-      <entry><title>First</title><summary>First abstract</summary>
-        <author><name>Author One</name></author></entry>
-      <entry><title>Second</title><summary>Second abstract</summary>
-        <author><name>Author Two</name></author></entry>
-    </feed>`;
-    const result = parseArxivApiResponse(multi);
-    expect(result.title).toBe("First");
-    expect(result.summary).toBe("First abstract");
-    expect(result.authors).toEqual(["Author One"]);
+  it("leaves collaboration names without a comma alone", () => {
+    const html = `<head><meta name="citation_author" content="ATLAS Collaboration" /></head>`;
+    expect(parseArxivAbsMetadata(html).authors).toEqual(["ATLAS Collaboration"]);
   });
 
-  it("returns nulls / empty authors for a response with no entry", () => {
-    const empty = `<feed xmlns="http://www.w3.org/2005/Atom">
-      <title>ArXiv Query: id_list=9999.99999</title>
-    </feed>`;
-    expect(parseArxivApiResponse(empty)).toEqual({
+  it("prefers citation_title over the page title and og:title", () => {
+    const result = parseArxivAbsMetadata(ARXIV_ABS_HTML);
+    expect(result.title).not.toContain("[2503.11926]");
+    expect(result.title).not.toBe("Some other title");
+  });
+
+  it("stops at </head> so body content cannot inject authors", () => {
+    expect(parseArxivAbsMetadata(ARXIV_ABS_HTML).authors).not.toContain("Body Ignored");
+  });
+
+  it("keeps the first value when a tag is repeated", () => {
+    const html = `<head>
+      <meta name="citation_title" content="First" />
+      <meta name="citation_title" content="Second" />
+    </head>`;
+    expect(parseArxivAbsMetadata(html).title).toBe("First");
+  });
+
+  it("returns nulls / empty authors for a page with no citation tags", () => {
+    const html = `<head><title>arXiv is down</title></head>`;
+    expect(parseArxivAbsMetadata(html)).toEqual({
       title: null,
       summary: null,
       authors: [],


### PR DESCRIPTION
Saving an arXiv paper like `https://arxiv.org/abs/2106.12672v3` took ~10 seconds.

## Cause

`fetchArxivMetadata` called `export.arxiv.org/api/query` for the title/authors/abstract. That host throttles **per source IP** and, once throttled, does not reject fast — it stalls 15–30s and then returns 429:

```
GET export.arxiv.org/api/query?id_list=2106.12672v3  →  15.6s, HTTP 429
repeat runs: 0.2s/429, 30.6s/429, 30.9s/429
```

Behind Fly's shared egress IP, every save waited out the full 10s `FEED_FETCH_TIMEOUT_MS` and then threw the result away. Both failure modes are in production logs today:

```
warn "ArXiv API request failed"  paperId:2403.14541 status:429
warn "ArXiv API request errored" paperId:2506.03149 error:"The operation was aborted due to timeout"
```

The old comment claiming "one request per save … well within arXiv's API rate limits" was wrong twice over: it was three requests to arXiv-operated hosts, and the limit is per IP, not per user.

## Fix

The abstract page already carries the same metadata in its Highwire `citation_*` tags (`citation_title`, repeated `citation_author`, `citation_abstract`), so the API call bought nothing. The `/html/` render has **no** citation tags (checked 2412.19437, 2503.01234) — only a `<title>` — which is why we fetch both.

Now: fetch the HTML render and the abstract page **in parallel**, take content from the render when it exists (else the abstract page), and metadata always from the abstract page.

| | before | after |
|---|---|---|
| requests | 3, across 2 hosts, in 2 sequential rounds | 2, one host, parallel |
| HEAD probe | yes (then GET the same URL) | gone |
| throttled dependency | `export.arxiv.org` | none |
| reported URL | ~10s | **110ms** |

No cache or circuit breaker needed, since nothing in the path rate-limits us anymore.

## Also in here

- **Removed the plugin's blanket `catch`.** It swallowed 429s into `return null`, which defeated the rate-limit rethrow convention documented in `plugins/fetch-page.ts:29` — a throttled fetch fell through to `acquireArticleContent`'s generic fetch and re-requested the host that had just throttled us. Rate limits now propagate to `upstreamRateLimited`; a 404 on the render is the ordinary case for pre-2024 papers and is logged at debug, not warn.
- **Author names** come from `citation_author`, which is surname-first, so they're swapped back into reading order on the first comma only ("Tay, Yi" → "Yi Tay", "Tran, Vinh Q." → "Vinh Q. Tran"). Comma-less collaboration names ("ATLAS Collaboration") are left alone.
- **Fixed a wrong docstring** on `extractPaperId`: it claimed the version suffix was stripped, but it is preserved — and that is load-bearing, since a paper's abstract differs between versions.
- `SECURITY.md` now points at `plugins/arxiv.ts` for the SSRF-guard invariant, since `feed/arxiv.ts` no longer fetches anything.

**Not changed:** the User-Agent contact address. `fly.toml` already sets `FETCHER_CONTACT_EMAIL = "self@brendanlong.com"` and `buildUserAgent` already includes it on every outbound request, arXiv's included.

## Verification

Ran the plugin against real arXiv URLs covering each branch:

| case | elapsed | render used | metadata |
|---|---|---|---|
| `/abs/2106.12672v3` (no render) | 110ms | no | ✅ Yi Tay et al. |
| `/abs/2412.19437v1` (has render) | 41ms | yes | ✅ DeepSeek-AI et al. |
| `/html/2503.01234v1` (direct) | 245ms | yes | ✅ Sijin Sun et al. |
| `/pdf/2106.12672v3` | 10ms | no | ✅ |
| `/abs/hep-th/9901001` (old-format id) | 76ms | no | ✅ Yosuke Imamura |

`pnpm typecheck`, `pnpm test:unit` (3123 passed), and eslint all clean. Unit tests for `parseArxivApiResponse` were replaced with `parseArxivAbsMetadata` tests against a fixture taken from real abs-page markup, including the `</head>` early-stop (verified it actually bites — body `citation_author` tags leak in without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)