### PR TITLE
Group react and react-dom in Dependabot so they bump together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,26 @@ updates:
     # https://daniakash.com/posts/simplest-supply-chain-defense/
     cooldown:
       default-days: 7
+    # React refuses to run unless react and react-dom are the *exact* same
+    # version, so a PR that bumps one and not the other fails every React
+    # unit test with "Incompatible React versions". Group them (plus their
+    # types) so they always move together. Groups default to version
+    # updates, so security updates need their own entry.
+    groups:
+      react:
+        applies-to: version-updates
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      react-security:
+        applies-to: security-updates
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Problem

React refuses to run unless `react` and `react-dom` are the **exact** same version, and we pin both exactly in `package.json`. Dependabot opens one PR per package, so a react-only bump lands a version mismatch that fails every React unit test at import time:

```
Error: Incompatible React versions: The "react" and "react-dom" packages
must have the exact same version. Instead got:
  - react:      19.2.8
  - react-dom:  19.2.7
```

The failure mode is nasty: the throw happens while loading `react-dom-client`, so 31 suites collect **zero** tests rather than reporting a real assertion failure.

This has now happened twice — c3d56089 (react 19.2.7 vs react-dom 19.2.4) and #1476 (19.2.8 vs 19.2.7) — each needing a manual follow-up commit.

## Fix

Group `react`, `react-dom`, `@types/react`, and `@types/react-dom` into one Dependabot PR so they always move together.

Dependabot groups [apply to version updates only by default](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--), so security updates get a second entry with the same patterns — otherwise a React security patch would reintroduce the exact same breakage.

Patterns without `*` are exact name matches, so `react` won't sweep in `react-hotkeys-hook` or `@tanstack/react-query`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)