### PR TITLE
Fix broken pnpm-lock.yaml (duplicated postcss@8.5.25 key)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5052,10 +5052,6 @@ packages:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.25:
-    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
@@ -11618,12 +11614,6 @@ snapshots:
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.14
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.25:
-    dependencies:
-      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Problem

`master` CI has been red since 53231e0c (the #1495 merge). Merging #1495 and #1496 combined two dependabot lockfile edits textually — git reported no conflict, but the result declares `postcss@8.5.25` twice, in both the `packages` and `snapshots` blocks. YAML rejects duplicate mapping keys, so every install fails:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at ".../pnpm-lock.yaml" is broken: duplicated mapping key (5055:3)
```

Consequences: CI red on master, Deploy skipped, and the last several **Dependabot Updates** runs failed for the same reason.

## Fix

Both duplicated blocks are byte-identical, so this drops one copy of each. No resolved version changes — `git diff` is 10 deleted lines and nothing else.

Verified locally: `pnpm install --frozen-lockfile` succeeds (4.8s), and a scan for duplicate top-level entry keys across the `packages`/`snapshots` blocks now reports 0.

## Note for the open dependabot PRs

This failure mode recurs on any stale dependabot branch, because GitHub's `MERGEABLE` is textual. I simulated merging #1497 (htmlparser2) into current master: it merges "cleanly" and yields **three** copies of `postcss@8.5.25`. Those PRs need `@dependabot recreate` (a rebase) after this lands, not a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)