### PR TITLE
Group minor/patch npm updates into one Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,29 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+      # Every npm PR rewrites pnpm-lock.yaml, and two of them merged from
+      # stale bases combine textually into a lockfile with a duplicated key
+      # that no longer parses — which took CI and deploys down (#1501). One
+      # grouped PR per week means one lockfile rewrite to land, not six
+      # racing each other. Majors stay ungrouped: they need individual
+      # review, and a single bad one shouldn't hold the rest hostage.
+      #
+      # Security updates are deliberately left ungrouped (apart from React
+      # above) so a fix can land on its own without waiting for the batch.
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+        # A dependency joins every group it matches, so React has to be
+        # excluded here or it would land in two PRs at once.
+        exclude-patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Follow-up to #1501, which fixed a `pnpm-lock.yaml` that had stopped parsing.

## The failure mode

Every npm Dependabot PR rewrites `pnpm-lock.yaml`. When two are merged from stale bases and both inserted the *same* block (a shared transitive dep moving to the same version), git's three-way merge keeps both insertions and reports no conflict. The result declares the key twice, YAML rejects duplicate mapping keys, and `pnpm install --frozen-lockfile` fails everywhere — CI, Deploy, and Dependabot's own update runs.

It took only two routine bumps merged back-to-back (`next` 16.2.11→16.2.12 and `argon2` 0.44→0.45) to do it.

## What this changes

Minor and patch npm bumps now arrive as one grouped PR per week instead of five or six. That doesn't make a stale merge safe — it means there's normally only one lockfile-rewriting PR in flight to be stale.

Deliberately **not** grouped:

- **Majors** — they need individual review (htmlparser2 12 in #1497 needed a behavioral fix alongside it), and one bad major shouldn't hold every other update hostage.
- **Security updates**, apart from the existing React pair, so a fix never waits on the batch.

React keeps its own group; `exclude-patterns` keeps it out of the new one, since a dependency joins *every* group it matches and would otherwise land in two PRs at once.

## What this does not fix

Grouping reduces exposure; it doesn't close the hole. The real gap is that **PR CI already tests the merged result** — `actions/checkout` checks out `refs/pull/N/merge`, so a run against current master would have failed at the install step — it just isn't re-run when the base branch moves after the last run.

Closing that needs a repo setting rather than a config file, either:
- a **merge queue** on `master` (re-tests each PR against current master automatically), or
- required status checks with **"require branches to be up to date"** (same protection, but a manual "Update branch" + re-run on every PR).

The current `master` ruleset has neither — it only blocks deletion and force-pushes. Happy to set either up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)