### PR TITLE
Keep the newest entries at the feed limit, and report ingest anomalies (#1500)

### DIFF
--- a/src/server/feed/CLAUDE.md
+++ b/src/server/feed/CLAUDE.md
@@ -16,6 +16,12 @@ This file governs feed fetching, scheduling, entry processing, and WebSub push. 
    - 4xx/5xx: increment failures, backoff. This includes a 404/410 with no tracked redirect: a single 404 is **not** proof the feed is gone (YouTube returns 404 for all of its feeds for a few hours most days — issue #1114), so instead of jumping straight to a 7-day next fetch, the ordinary backoff ladder applies — it converges to the same 7-day cadence if the 404 persists, and one success resets it. A 404/410 with a tracked redirect URL still applies the redirect immediately
 5. Calculate `next_fetch_at` based on Cache-Control (10min with cache hint, 60min default min, 7day max). A URL plugin can raise the minimum for its source (`FeedCapability.minFetchIntervalSeconds`): YouTube serves `max-age=900` but rate-limits RSS fetches per IP, so its plugin floors polling at 1 hour
 
+## Entry Limit & Ingest Anomalies
+
+A single parse keeps at most `MAX_FEED_ENTRIES` (100) entries, and picks them by **publication date, newest first** — not by document position (`selectEntriesWithinLimit`, `parser.ts`). Feeds are only conventionally newest-first; for an oldest-first feed, taking the first N kept the archive and dropped everything recent, so an over-long fetch imported old articles and hid the new ones (#1500). Entries with no usable date can't be ranked, so a feed containing any of those falls back to document order.
+
+Both truncation and **backfill** (a feed we already poll introducing entries published long before the previous poll) are reported by `reportFeedIngestAnomalies` (`ingest-anomalies.ts`) from the poll path and the WebSub ingest path: a warning with the feed context, plus the `feed_entries_dropped_total` / `feed_backfilled_entries_total` counters, which are steady-state zero and outlive log retention. Neither is necessarily our bug — a publisher lengthening their feed, re-issuing guids after a platform migration, or briefly serving an archive all produce them — but without this they are invisible, which is what made #1500 undiagnosable after the fact. Keep both ingest paths reporting; a push is measured against the last real poll (`last_fetched_at`, which pushes deliberately never advance).
+
 ## WebSub Push & Backup Polling
 
 When a feed advertises a hub, we subscribe via WebSub and drop the feed to a 24h **backup poll** cadence (`reason: "websub_backup"`), trusting the hub to push new content in real time. A hub can silently stop delivering while we still believe it's active, so two mechanisms bound how long a dead hub can keep a feed stale:

--- a/src/server/feed/ingest-anomalies.ts
+++ b/src/server/feed/ingest-anomalies.ts
@@ -1,0 +1,170 @@
+/**
+ * Detection and reporting for the two ways a feed can quietly hand us content
+ * we didn't expect (issue #1500):
+ *
+ * - **Truncation**: the publisher served more entries than `MAX_FEED_ENTRIES`,
+ *   so we discarded some. Whichever entries lose, content is being dropped on
+ *   the floor, and a feed that suddenly serves its whole archive shows up here
+ *   first.
+ * - **Backfill**: a feed we have polled before introduced entries published long
+ *   before that previous poll. Those land in every subscriber's unread list even
+ *   though they are years old.
+ *
+ * Neither is necessarily a bug on our side — a publisher raising their feed
+ * length, re-issuing guids after a platform migration, or serving an archive
+ * page all produce them — but both are invisible without this, which is what
+ * made #1500 undiagnosable after the fact. Report them as warnings (with the
+ * feed context needed to investigate) plus Prometheus counters that survive log
+ * retention.
+ */
+
+import type { ParsedFeed } from "./types";
+import type { ProcessEntriesResult } from "./entry-processor";
+import {
+  trackFeedBackfilledEntries,
+  trackFeedEntriesDropped,
+  type FeedIngestSource,
+} from "../metrics/metrics";
+import { logger } from "@/lib/logger";
+
+/**
+ * How far before the previous fetch an entry's publication date has to sit
+ * before we call it a backfill rather than ordinary publishing lag.
+ *
+ * A feed we already poll should only ever introduce entries published since the
+ * last poll, but plenty of publishers backdate slightly (editorial pipelines,
+ * timezone-less dates, an item added a few days late), and a feed coming back
+ * from an outage legitimately carries entries older than its last successful
+ * fetch. A week of slack keeps those quiet while still catching the case that
+ * matters: an archive dump of articles months or years old.
+ */
+export const BACKFILL_AGE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * What a single ingest (poll or push) did that is worth reporting.
+ */
+export interface FeedIngestAnomalies {
+  /** Entries the publisher served that the `MAX_FEED_ENTRIES` limit discarded. */
+  droppedItemCount: number;
+  /** New entries published more than {@link BACKFILL_AGE_THRESHOLD_MS} before the previous fetch. */
+  backfilledCount: number;
+  /** Oldest publication date among the backfilled entries, if any. */
+  oldestBackfilledPublishedAt: Date | null;
+  /** Newest publication date among the backfilled entries, if any. */
+  newestBackfilledPublishedAt: Date | null;
+}
+
+/**
+ * Classifies one ingest. Pure — no logging, no metrics, no I/O.
+ *
+ * @param parsedFeed - The parsed feed, whose `totalItemCount` reveals truncation
+ * @param processed - The result of storing that feed's entries
+ * @param previousFetchAt - `feeds.last_fetched_at` from *before* this ingest, or
+ *   null if we have never fetched this feed. Backfill is meaningless on a first
+ *   fetch (every entry is legitimately older than us), so it reports zero.
+ * @returns The anomalies found; all-zero when the ingest was unremarkable
+ */
+export function detectFeedIngestAnomalies(
+  parsedFeed: ParsedFeed,
+  processed: ProcessEntriesResult,
+  previousFetchAt: Date | null
+): FeedIngestAnomalies {
+  const droppedItemCount = Math.max(
+    0,
+    (parsedFeed.totalItemCount ?? parsedFeed.items.length) - parsedFeed.items.length
+  );
+
+  const anomalies: FeedIngestAnomalies = {
+    droppedItemCount,
+    backfilledCount: 0,
+    oldestBackfilledPublishedAt: null,
+    newestBackfilledPublishedAt: null,
+  };
+
+  if (!previousFetchAt) {
+    return anomalies;
+  }
+
+  const cutoff = previousFetchAt.getTime() - BACKFILL_AGE_THRESHOLD_MS;
+
+  for (const entry of processed.entries) {
+    // Only newly-created entries matter: re-seeing an old entry we already store
+    // is normal, and an update never changes published_at.
+    const publishedAt = entry.isNew ? entry.newEntryData?.publishedAt : null;
+    if (!publishedAt || publishedAt.getTime() >= cutoff) {
+      continue;
+    }
+
+    anomalies.backfilledCount++;
+    if (
+      !anomalies.oldestBackfilledPublishedAt ||
+      publishedAt < anomalies.oldestBackfilledPublishedAt
+    ) {
+      anomalies.oldestBackfilledPublishedAt = publishedAt;
+    }
+    if (
+      !anomalies.newestBackfilledPublishedAt ||
+      publishedAt > anomalies.newestBackfilledPublishedAt
+    ) {
+      anomalies.newestBackfilledPublishedAt = publishedAt;
+    }
+  }
+
+  return anomalies;
+}
+
+/**
+ * Context identifying the ingest being reported.
+ */
+export interface FeedIngestContext {
+  feedId: string;
+  feedUrl: string | null;
+  /** Whether the entries arrived via a scheduled/backup poll or a WebSub push. */
+  source: FeedIngestSource;
+  /** `feeds.last_fetched_at` as it was before this ingest. */
+  previousFetchAt: Date | null;
+}
+
+/**
+ * Detects and reports anomalies for one ingest: a warning per anomaly kind with
+ * enough context to investigate, plus the Prometheus counters.
+ *
+ * @returns The detected anomalies, so callers can surface them in job metadata
+ */
+export function reportFeedIngestAnomalies(
+  context: FeedIngestContext,
+  parsedFeed: ParsedFeed,
+  processed: ProcessEntriesResult
+): FeedIngestAnomalies {
+  const { feedId, feedUrl, source, previousFetchAt } = context;
+  const anomalies = detectFeedIngestAnomalies(parsedFeed, processed, previousFetchAt);
+
+  if (anomalies.droppedItemCount > 0) {
+    trackFeedEntriesDropped(source, anomalies.droppedItemCount);
+    logger.warn("Feed served more entries than the limit keeps", {
+      feedId,
+      feedUrl,
+      source,
+      servedItems: parsedFeed.totalItemCount,
+      keptItems: parsedFeed.items.length,
+      droppedItems: anomalies.droppedItemCount,
+    });
+  }
+
+  if (anomalies.backfilledCount > 0) {
+    trackFeedBackfilledEntries(source, anomalies.backfilledCount);
+    logger.warn("Feed introduced entries published long before the previous fetch", {
+      feedId,
+      feedUrl,
+      source,
+      backfilledEntries: anomalies.backfilledCount,
+      newEntries: processed.newCount,
+      feedItems: parsedFeed.items.length,
+      previousFetchAt: previousFetchAt?.toISOString(),
+      oldestBackfilledPublishedAt: anomalies.oldestBackfilledPublishedAt?.toISOString(),
+      newestBackfilledPublishedAt: anomalies.newestBackfilledPublishedAt?.toISOString(),
+    });
+  }
+
+  return anomalies;
+}

--- a/src/server/feed/parser.ts
+++ b/src/server/feed/parser.ts
@@ -5,7 +5,7 @@
  * Uses SAX-style parsing for memory efficiency.
  */
 
-import type { ParsedFeed } from "./types";
+import type { ParsedEntry, ParsedFeed } from "./types";
 import type { FeedParseResult } from "./streaming/types";
 import {
   parseFeed as parseFeedInternal,
@@ -20,9 +20,52 @@ import { startFeedParseTimer } from "../metrics/metrics";
 // Re-export for backwards compatibility
 export { UnknownFeedFormatError };
 /**
+ * Picks which entries survive the `MAX_FEED_ENTRIES` limit.
+ *
+ * Rank by publication date, newest first, and keep the winners in the
+ * publisher's original document order so downstream code still sees the feed's
+ * ordering. Ties (identical dates) break on document position.
+ *
+ * We used to just take the first N, assuming newest-first document order. Plenty
+ * of feeds aren't: WordPress serves an ascending feed for `?order=ASC`, and
+ * generators emit oldest-first often enough to matter. For those, taking the
+ * first N kept the archive and dropped everything recent — an over-long fetch
+ * would import a pile of old articles and hide the new ones (issue #1500).
+ *
+ * Entries with no (or an unparseable) date can't be ranked, so a feed with any
+ * such entry falls back to document order — the same assumption as before, but
+ * now only where there is nothing better to go on.
+ *
+ * @param entries - All entries the parser found, in document order
+ * @param limit - Maximum number of entries to keep
+ * @returns At most `limit` entries, in document order
+ */
+export function selectEntriesWithinLimit(entries: ParsedEntry[], limit: number): ParsedEntry[] {
+  if (entries.length <= limit) {
+    return entries;
+  }
+
+  const ranked: Array<{ entry: ParsedEntry; index: number; time: number }> = [];
+  for (const [index, entry] of entries.entries()) {
+    const time = entry.pubDate?.getTime();
+    if (time === undefined || Number.isNaN(time)) {
+      return entries.slice(0, limit);
+    }
+    ranked.push({ entry, index, time });
+  }
+
+  return ranked
+    .sort((a, b) => b.time - a.time || a.index - b.index)
+    .slice(0, limit)
+    .sort((a, b) => a.index - b.index)
+    .map((ranked) => ranked.entry);
+}
+
+/**
  * Converts a FeedParseResult to a ParsedFeed, applying the entry count limit.
- * Entries beyond the limit are silently dropped (we keep the most recent ones,
- * which are typically at the top of the feed).
+ * Entries beyond the limit are dropped (see `selectEntriesWithinLimit`);
+ * `totalItemCount` records how many there were so callers with feed context can
+ * report the truncation.
  */
 function resultToParsedFeed(result: FeedParseResult, maxEntries?: number): ParsedFeed {
   const limit = maxEntries ?? usageLimitsConfig.maxFeedEntries;
@@ -35,7 +78,8 @@ function resultToParsedFeed(result: FeedParseResult, maxEntries?: number): Parse
     selfUrl: result.selfUrl,
     ttlMinutes: result.ttlMinutes,
     syndication: result.syndication,
-    items: result.entries.slice(0, limit),
+    items: selectEntriesWithinLimit(result.entries, limit),
+    totalItemCount: result.entries.length,
   };
 }
 

--- a/src/server/feed/types.ts
+++ b/src/server/feed/types.ts
@@ -114,6 +114,16 @@ export interface ParsedFeed {
   /** Feed entries */
   items: ParsedEntry[];
 
+  /**
+   * How many entries the feed actually contained, before `MAX_FEED_ENTRIES`
+   * truncated `items`. Set by `parseFeed` and friends; omitted by the synthetic
+   * feeds plugins and tests build by hand. `totalItemCount > items.length` means
+   * the publisher served more than we keep — worth reporting, because a feed
+   * that suddenly serves its whole archive is how subscribers get flooded with
+   * old articles (issue #1500).
+   */
+  totalItemCount?: number;
+
   /** WebSub hub URL for push notifications */
   hubUrl?: string;
   /** Self link URL (canonical URL of the feed) */

--- a/src/server/feed/websub-notification.ts
+++ b/src/server/feed/websub-notification.ts
@@ -9,6 +9,7 @@ import { db } from "../db";
 import { feeds, type Feed } from "../db/schema";
 import { parseFeedAsync } from "./parser";
 import { processEntries } from "./entry-processor";
+import { reportFeedIngestAnomalies } from "./ingest-anomalies";
 import { recordHubAnnouncedEntries } from "./websub-hub-stats";
 import { WEBSUB_BACKUP_POLL_INTERVAL_SECONDS } from "./scheduling";
 import { updateFeedJobNextRun } from "../jobs/queue";
@@ -73,6 +74,20 @@ export async function ingestWebsubNotification(feed: Feed, bodyText: string): Pr
       // same title a later entries.list refetch would return.
       feedTitle: parsedFeed.title || feed.title,
     });
+
+    // A hub can push whatever it likes, so the same truncation/backfill checks a
+    // poll runs apply here (a push is measured against the last real poll, which
+    // is what `last_fetched_at` means — pushes deliberately never advance it).
+    reportFeedIngestAnomalies(
+      {
+        feedId,
+        feedUrl: feed.url,
+        source: "websub",
+        previousFetchAt: feed.lastFetchedAt,
+      },
+      parsedFeed,
+      result
+    );
 
     // Refresh feed metadata, but deliberately do NOT touch `last_fetched_at`: a
     // push is not a full poll, so `last_fetched_at` must keep meaning "last time

--- a/src/server/jobs/handlers/fetch-feed.ts
+++ b/src/server/jobs/handlers/fetch-feed.ts
@@ -17,6 +17,7 @@ import { fetchFeed, type FetchFeedResult, type RedirectInfo } from "../../feed/f
 import type { WebSubLinkHeaders } from "../../feed/link-header";
 import { parseFeed } from "../../feed/parser";
 import { processEntries } from "../../feed/entry-processor";
+import { reportFeedIngestAnomalies } from "../../feed/ingest-anomalies";
 import { calculateNextFetch } from "../../feed/scheduling";
 import {
   canUseWebSub,
@@ -415,6 +416,14 @@ async function processSuccessfulFetch(
     alwaysUpdateVisibility: forceReprocess,
   });
 
+  // Report truncated feeds and old-article backfills. `feed` was read before the
+  // fetch, so `feed.lastFetchedAt` is still the *previous* fetch here.
+  const anomalies = reportFeedIngestAnomalies(
+    { feedId: feed.id, feedUrl: feed.url, source: "poll", previousFetchAt: feed.lastFetchedAt },
+    parsedFeed,
+    processResult
+  );
+
   // Fetch full content for new entries if any subscriber has fetchFullContent
   // enabled. This is done after processEntries so entries exist in the database.
   const newEntries = processResult.entries.filter((e) => e.isNew);
@@ -565,6 +574,8 @@ async function processSuccessfulFetch(
       updatedEntries: processResult.updatedCount,
       unchangedEntries: processResult.unchangedCount,
       disappearedEntries: processResult.disappearedCount,
+      ...(anomalies.droppedItemCount > 0 ? { droppedEntries: anomalies.droppedItemCount } : {}),
+      ...(anomalies.backfilledCount > 0 ? { backfilledEntries: anomalies.backfilledCount } : {}),
       nextFetchReason: nextFetch.reason,
       ...websubMetadata,
       ...fullContentMetadata,

--- a/src/server/metrics/metrics.ts
+++ b/src/server/metrics/metrics.ts
@@ -274,6 +274,58 @@ function trackFeedFetch(status: FeedFetchStatus, durationMs: number): void {
 }
 
 /**
+ * Where a batch of entries reached us: a scheduled/backup poll or a WebSub push.
+ */
+export type FeedIngestSource = "poll" | "websub";
+
+/**
+ * Counter for entries dropped by the MAX_FEED_ENTRIES limit.
+ * Labels: source (poll, websub)
+ *
+ * Steady state is zero: normal feeds serve far fewer entries than the limit. A
+ * non-zero rate means some publisher is serving more than we keep, so we are
+ * silently discarding content — the state that precedes a flood of old articles
+ * (issue #1500).
+ */
+const feedEntriesDroppedTotal = getOrCreateCounter({
+  name: "feed_entries_dropped_total",
+  help: "Feed entries discarded because the feed exceeded MAX_FEED_ENTRIES",
+  labelNames: ["source"] as const,
+});
+
+/**
+ * Counter for newly-created entries published long before our previous fetch of
+ * the same feed — i.e. old articles a feed we were already polling handed us.
+ * Labels: source (poll, websub)
+ *
+ * Also steady-state zero: a feed we poll should only ever introduce entries
+ * published since the last poll. See `reportFeedIngestAnomalies`.
+ */
+const feedBackfilledEntriesTotal = getOrCreateCounter({
+  name: "feed_backfilled_entries_total",
+  help: "Newly-created feed entries published well before the previous fetch of that feed",
+  labelNames: ["source"] as const,
+});
+
+/**
+ * Records entries dropped by the feed entry limit.
+ * Zero overhead when metrics are disabled.
+ */
+export function trackFeedEntriesDropped(source: FeedIngestSource, count: number): void {
+  if (!metricsEnabled || count <= 0) return;
+  feedEntriesDroppedTotal?.inc({ source }, count);
+}
+
+/**
+ * Records newly-created entries that predate the feed's previous fetch.
+ * Zero overhead when metrics are disabled.
+ */
+export function trackFeedBackfilledEntries(source: FeedIngestSource, count: number): void {
+  if (!metricsEnabled || count <= 0) return;
+  feedBackfilledEntriesTotal?.inc({ source }, count);
+}
+
+/**
  * Creates a timer for tracking feed fetch duration.
  * Returns a function to call when the fetch completes.
  * Returns a no-op function when metrics are disabled.

--- a/tests/unit/feed-ingest-anomalies.test.ts
+++ b/tests/unit/feed-ingest-anomalies.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for feed ingest anomaly detection (issue #1500): a feed serving
+ * more entries than we keep, and a feed we already poll introducing articles
+ * published long before the previous poll.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  detectFeedIngestAnomalies,
+  BACKFILL_AGE_THRESHOLD_MS,
+} from "../../src/server/feed/ingest-anomalies";
+import type { ProcessEntriesResult, ProcessedEntry } from "../../src/server/feed/entry-processor";
+import type { ParsedFeed } from "../../src/server/feed/types";
+
+const PREVIOUS_FETCH = new Date("2026-08-01T00:00:00Z");
+
+function parsedFeed(itemCount: number, totalItemCount?: number): ParsedFeed {
+  return {
+    title: "Test Feed",
+    items: Array.from({ length: itemCount }, (_, i) => ({ guid: `guid-${i}` })),
+    totalItemCount,
+  };
+}
+
+function newEntry(guid: string, publishedAt: Date | null): ProcessedEntry {
+  return {
+    id: `id-${guid}`,
+    guid,
+    isNew: true,
+    isUpdated: false,
+    updatedAt: PREVIOUS_FETCH,
+    newEntryData: {
+      url: null,
+      title: guid,
+      author: null,
+      summary: null,
+      publishedAt,
+      fetchedAt: PREVIOUS_FETCH,
+      siteName: null,
+    },
+  };
+}
+
+function existingEntry(guid: string): ProcessedEntry {
+  return { id: `id-${guid}`, guid, isNew: false, isUpdated: false };
+}
+
+function processed(entries: ProcessedEntry[]): ProcessEntriesResult {
+  const newCount = entries.filter((e) => e.isNew).length;
+  return {
+    newCount,
+    updatedCount: entries.filter((e) => e.isUpdated).length,
+    unchangedCount: entries.filter((e) => !e.isNew && !e.isUpdated).length,
+    disappearedCount: 0,
+    hasChanges: newCount > 0,
+    entries,
+  };
+}
+
+/** A date `days` before the previous fetch. */
+function daysBeforePreviousFetch(days: number): Date {
+  return new Date(PREVIOUS_FETCH.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+describe("detectFeedIngestAnomalies", () => {
+  describe("truncation", () => {
+    it("reports nothing when the feed fit within the limit", () => {
+      const anomalies = detectFeedIngestAnomalies(
+        parsedFeed(10, 10),
+        processed([]),
+        PREVIOUS_FETCH
+      );
+
+      expect(anomalies.droppedItemCount).toBe(0);
+    });
+
+    it("counts the entries the limit discarded", () => {
+      const anomalies = detectFeedIngestAnomalies(
+        parsedFeed(100, 628),
+        processed([]),
+        PREVIOUS_FETCH
+      );
+
+      expect(anomalies.droppedItemCount).toBe(528);
+    });
+
+    it("reports nothing for a synthetic feed that carries no total", () => {
+      const anomalies = detectFeedIngestAnomalies(parsedFeed(5), processed([]), PREVIOUS_FETCH);
+
+      expect(anomalies.droppedItemCount).toBe(0);
+    });
+  });
+
+  describe("backfill", () => {
+    it("reports nothing when every new entry is recent", () => {
+      const anomalies = detectFeedIngestAnomalies(
+        parsedFeed(2, 2),
+        processed([newEntry("a", new Date("2026-08-02T00:00:00Z"))]),
+        PREVIOUS_FETCH
+      );
+
+      expect(anomalies.backfilledCount).toBe(0);
+      expect(anomalies.oldestBackfilledPublishedAt).toBeNull();
+      expect(anomalies.newestBackfilledPublishedAt).toBeNull();
+    });
+
+    it("counts new entries published well before the previous fetch", () => {
+      const anomalies = detectFeedIngestAnomalies(
+        parsedFeed(3, 3),
+        processed([
+          newEntry("old", new Date("2022-03-14T00:00:00Z")),
+          newEntry("older", new Date("2022-03-01T00:00:00Z")),
+          newEntry("recent", new Date("2026-08-02T00:00:00Z")),
+        ]),
+        PREVIOUS_FETCH
+      );
+
+      expect(anomalies.backfilledCount).toBe(2);
+      expect(anomalies.oldestBackfilledPublishedAt).toEqual(new Date("2022-03-01T00:00:00Z"));
+      expect(anomalies.newestBackfilledPublishedAt).toEqual(new Date("2022-03-14T00:00:00Z"));
+    });
+
+    it("ignores entries we already had", () => {
+      const anomalies = detectFeedIngestAnomalies(
+        parsedFeed(1, 1),
+        processed([existingEntry("known")]),
+        PREVIOUS_FETCH
+      );
+
+      expect(anomalies.backfilledCount).toBe(0);
+    });
+
+    it("ignores new entries with no publication date", () => {
+      const anomalies = detectFeedIngestAnomalies(
+        parsedFeed(1, 1),
+        processed([newEntry("undated", null)]),
+        PREVIOUS_FETCH
+      );
+
+      expect(anomalies.backfilledCount).toBe(0);
+    });
+
+    // Publishers backdate a little all the time; only an entry older than the
+    // grace window counts.
+    it("allows ordinary publishing lag inside the grace window", () => {
+      const justInside = new Date(PREVIOUS_FETCH.getTime() - BACKFILL_AGE_THRESHOLD_MS + 1000);
+      const justOutside = new Date(PREVIOUS_FETCH.getTime() - BACKFILL_AGE_THRESHOLD_MS - 1000);
+
+      expect(
+        detectFeedIngestAnomalies(
+          parsedFeed(1, 1),
+          processed([newEntry("lagging", justInside)]),
+          PREVIOUS_FETCH
+        ).backfilledCount
+      ).toBe(0);
+
+      expect(
+        detectFeedIngestAnomalies(
+          parsedFeed(1, 1),
+          processed([newEntry("backfilled", justOutside)]),
+          PREVIOUS_FETCH
+        ).backfilledCount
+      ).toBe(1);
+    });
+
+    // A feed's first fetch legitimately brings in its whole current window,
+    // however old that is.
+    it("reports nothing on the first fetch of a feed", () => {
+      const anomalies = detectFeedIngestAnomalies(
+        parsedFeed(2, 2),
+        processed([
+          newEntry("ancient", daysBeforePreviousFetch(1500)),
+          newEntry("old", daysBeforePreviousFetch(300)),
+        ]),
+        null
+      );
+
+      expect(anomalies.backfilledCount).toBe(0);
+    });
+  });
+});

--- a/tests/unit/feed-parser.test.ts
+++ b/tests/unit/feed-parser.test.ts
@@ -7,8 +7,10 @@ import {
   parseFeed,
   parseFeedWithFormat,
   detectFeedType,
+  selectEntriesWithinLimit,
   UnknownFeedFormatError,
 } from "../../src/server/feed/parser";
+import type { ParsedEntry } from "../../src/server/feed/types";
 
 describe("detectFeedType", () => {
   describe("RSS detection", () => {
@@ -488,5 +490,78 @@ Links: https://example.com/sponsor &amp; more</media:description>
     // masquerade as either (it's plain text, not HTML).
     expect(entry.content).toBeUndefined();
     expect(entry.summary).toBeUndefined();
+  });
+});
+
+describe("selectEntriesWithinLimit", () => {
+  const entry = (guid: string, pubDate?: string): ParsedEntry => ({
+    guid,
+    title: guid,
+    ...(pubDate ? { pubDate: new Date(pubDate) } : {}),
+  });
+
+  it("returns every entry when the feed is within the limit", () => {
+    const entries = [entry("a", "2026-01-03"), entry("b", "2026-01-02")];
+
+    expect(selectEntriesWithinLimit(entries, 10)).toEqual(entries);
+  });
+
+  it("keeps the newest entries from a newest-first feed", () => {
+    const entries = [
+      entry("newest", "2026-01-03"),
+      entry("middle", "2026-01-02"),
+      entry("oldest", "2026-01-01"),
+    ];
+
+    expect(selectEntriesWithinLimit(entries, 2).map((e) => e.guid)).toEqual(["newest", "middle"]);
+  });
+
+  // The #1500 case: an oldest-first feed used to lose everything recent and keep
+  // its archive, so an over-long fetch imported old articles and hid the new ones.
+  it("keeps the newest entries from an oldest-first feed", () => {
+    const entries = [
+      entry("oldest", "2022-03-01"),
+      entry("middle", "2024-06-01"),
+      entry("newest", "2026-01-01"),
+    ];
+
+    expect(selectEntriesWithinLimit(entries, 2).map((e) => e.guid)).toEqual(["middle", "newest"]);
+  });
+
+  it("preserves the publisher's document order among the entries it keeps", () => {
+    const entries = [
+      entry("second-newest", "2026-01-02"),
+      entry("oldest", "2026-01-01"),
+      entry("newest", "2026-01-03"),
+    ];
+
+    expect(selectEntriesWithinLimit(entries, 2).map((e) => e.guid)).toEqual([
+      "second-newest",
+      "newest",
+    ]);
+  });
+
+  it("breaks ties on document position", () => {
+    const entries = [
+      entry("first", "2026-01-01"),
+      entry("second", "2026-01-01"),
+      entry("third", "2026-01-01"),
+    ];
+
+    expect(selectEntriesWithinLimit(entries, 2).map((e) => e.guid)).toEqual(["first", "second"]);
+  });
+
+  // Undated entries can't be ranked, so we fall back to the old assumption
+  // (document order is newest-first) rather than guessing.
+  it("falls back to document order when any entry has no date", () => {
+    const entries = [entry("a", "2022-01-01"), entry("b"), entry("c", "2026-01-01")];
+
+    expect(selectEntriesWithinLimit(entries, 2).map((e) => e.guid)).toEqual(["a", "b"]);
+  });
+
+  it("falls back to document order when a date is unparseable", () => {
+    const entries = [entry("a", "2022-01-01"), entry("b", "not a date"), entry("c", "2026-01-01")];
+
+    expect(selectEntriesWithinLimit(entries, 2).map((e) => e.guid)).toEqual(["a", "b"]);
   });
 });


### PR DESCRIPTION
Investigation + partial fix for #1500 ("Fetch pulled a number of old articles" on `https://thezvi.wordpress.com/feed/`).

## What I found

**The feed looks normal today.** I sampled it 25 times: 10 items, reverse-chronological, stable `<guid>`s (`http://thezvi.wordpress.com/?p=NNNNN`), WordPress.com `pushpress` hub advertised. Wayback captures from June/July/August 2026 are all normal-sized, so there's no surviving evidence of an archive dump — but there's also no capture from Aug 8–10 when this happened.

**One real defect, and it matches the issue title exactly.** `resultToParsedFeed` truncated an over-long feed with `entries.slice(0, MAX_FEED_ENTRIES)` — "we keep the most recent ones, which are typically at the top of the feed". Feeds are only *conventionally* newest-first. WordPress itself serves an ascending feed for `?order=ASC` (verified against this exact blog), and plenty of generators emit oldest-first. For any of those, a feed longer than 100 items had its newest entries dropped and its **oldest** 100 imported — literally "fetch pulled a number of old articles". Fixed: rank by publication date, keep the newest, preserve the publisher's document order among the survivors, and fall back to document order when any entry is undated (nothing better to rank on).

**We had no way to see any of this.** That's the bigger problem. The parser dropped entries silently, and the fetch handler only logged aggregate counts at info level, which have long since rolled out of Fly's retention. So this change also reports, from **both** the poll path and the WebSub push path:

- **truncation** — the publisher served more entries than we keep
- **backfill** — a feed we have polled before introduced entries published more than 7 days before that previous poll (the grace window keeps ordinary publishing lag quiet)

Each is a `logger.warn` with the feed context (URL, served/kept/dropped counts, backfilled count, oldest/newest backfilled publish dates, previous fetch time), plus `feed_entries_dropped_total` and `feed_backfilled_entries_total` Prometheus counters — both steady-state zero, and both outlive log retention.

## What this does *not* explain

I could not confirm the root cause, and I want to be explicit about that:

- `MAX_FEED_ENTRIES` is 100 (no prod override), so **a single fetch cannot create 628 entries**. Either the 628 is the subscription's total rather than one fetch's contribution, or this accumulated over several fetches.
- The blog has 1211 posts total and 819 published since March 2022, so the reported set isn't "everything since Ukraine Post #5" either — 628 is some other subset.
- The "double posts / updates treated as new" symptom needs a different mechanism: `(feed_id, guid)` is uniquely constrained and WordPress `?p=` ids are stable, so duplicates require the guid to have changed (a delete-and-repost, or the feed switching between `http://` and `https://` guid prefixes) — worth checking against the actual rows.

## Data that would settle it

I don't have production DB access from here (`flyctl ssh` isn't authorized for this org). These queries against prod would answer it:

```sql
-- Feed row: is it WebSub-active, how big was the last fetch?
SELECT id, url, websub_active, hub_url, last_fetched_at, last_entries_updated_at,
       last_fetch_entry_count, last_fetch_size_bytes, consecutive_failures, last_error
FROM feeds WHERE url LIKE '%thezvi.wordpress.com%';

-- When did the old entries actually land, and in what batches?
SELECT date_trunc('hour', created_at) AS ingested_hour, count(*),
       min(published_at), max(published_at)
FROM entries WHERE feed_id = '<id>'
GROUP BY 1 ORDER BY 1;

-- Duplicates: same URL, different guid
SELECT url, count(*), array_agg(guid) FROM entries
WHERE feed_id = '<id>' GROUP BY url HAVING count(*) > 1;
```

The `created_at` histogram is the decisive one: a single spike means one bad response, a long tail of ~100-entry batches means repeated ingest, and the guid grouping settles the duplicate complaint.

Once this ships, a recurrence logs itself with all of that inline.

## Testing

- `pnpm typecheck`, `pnpm lint` clean
- `pnpm test:unit` — 3181 passed (new: 15 cases covering newest-first selection incl. the ascending-feed regression, and anomaly detection)
- `pnpm test:integration:local` — 783 passed / 15 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
