### PR TITLE
docs: Trim DESIGN.md and DEPLOYMENT.md to decisions and pointers

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,7 +13,6 @@ This guide covers deploying Lion Reader to [Fly.io](https://fly.io), including p
 7. [First Deployment](#first-deployment)
 8. [Verification](#verification)
 9. [Ongoing Operations](#ongoing-operations)
-10. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -277,7 +276,7 @@ The deployment workflow is already configured in `.github/workflows/deploy.yml`.
 - **Concurrency**: `group: deploy` with `cancel-in-progress: false`, so deploys **queue** instead of cancelling each other — cancelling an in-flight `flyctl deploy` could kill a mid-flight canary rollout and leave a partial deployment.
 - **Checkout**: `ref: ${{ github.event.workflow_run.head_sha || github.sha }}` — deploys the exact commit CI validated, since `workflow_run` runs against the branch tip, which may have moved on.
 - **Deploy**: `flyctl deploy --remote-only` with `FLY_API_TOKEN` from GitHub secrets.
-- **CDN**: the deploy workflow has no CDN steps. A single Bunny pull zone (`https://cdn.lionreader.com`, a custom hostname on the zone) has the app as origin and wraps the **whole site**, but honors origin `Cache-Control`, so what it caches is decided by our headers — configured by the `ASSET_PREFIX` build arg set in `[build.args]` in `fly.toml` (the `Dockerfile` leaves it unset, so non-Fly/local builds stay origin-served). It serves the hashed `/_next/static` assets via Next's `assetPrefix`, content-hashed + `immutable`, so no purging or upload ordering is needed. The demo hero/OG images fall under this too: they're `import`ed by the article files (from `src/app/(public)/demo/articles/images/`), so Next hashes them into `/_next/static/media` and serves them immutable from the CDN automatically — no manifest, `?v=` buster, or Bunny query-string config. HTML/RSC is never CDN-cached: dynamic pages keep Next's default `private, no-store`, and the statically-prerendered public pages' `s-maxage` is overridden to `private, no-cache` in `src/proxy.ts` (see below). The pull zone must send CORS headers (Bunny's "CORS headers" option) so cross-origin font loads work.
+- **CDN**: the deploy workflow has no CDN steps — a single Bunny pull zone (`https://cdn.lionreader.com`) fronts the whole site but honors origin `Cache-Control`, so our headers decide what it caches; see "Why HTML and RSC are not CDN-cached" below and the CDN section of `src/server/http/CLAUDE.md` for the per-path rules. It is wired up by the `ASSET_PREFIX` build arg in `fly.toml`, which the `Dockerfile` leaves unset so non-Fly/local builds stay origin-served. The pull zone must send CORS headers (Bunny's "CORS headers" option) so cross-origin font loads work.
 
 ### Why HTML and RSC are not CDN-cached
 
@@ -348,47 +347,12 @@ failing component reports `status: "unhealthy"` with an `error` message.
 
 ## Verification
 
-After deployment, verify the application works end-to-end:
-
-### 1. Health Check
+After deployment, confirm the health endpoint reports `healthy` (see the contract
+above):
 
 ```bash
 curl https://your-app.com/api/health
 ```
-
-### 2. Create a Test Account
-
-1. Open `https://your-app.com`
-2. Click "Register" or navigate to `/register`
-3. Create an account with a test email and password
-4. Verify you're redirected to the main app
-
-### 3. Subscribe to a Feed
-
-1. Click the "+ Subscribe" button
-2. Enter a test feed URL, for example:
-   - `https://feeds.bbci.co.uk/news/rss.xml` (BBC News)
-   - `https://xkcd.com/atom.xml` (XKCD)
-   - `https://blog.cloudflare.com/rss/` (Cloudflare Blog)
-3. Preview the feed and confirm subscription
-4. Verify entries appear after a few moments
-
-### 4. Verify Core Features
-
-- [ ] Entries load in the feed list
-- [ ] Clicking an entry shows full content
-- [ ] Mark read/unread works
-- [ ] Starring entries works
-- [ ] Sidebar shows unread counts
-- [ ] Real-time updates work (new entries appear without refresh)
-
-### 5. Check Logs for Errors
-
-```bash
-flyctl logs --app lion-reader
-```
-
-Look for any errors or warnings.
 
 ---
 
@@ -396,21 +360,28 @@ Look for any errors or warnings.
 
 ### Scaling
 
-**Increase VM resources:**
+Both scale commands take `--process-group`; **without it they apply to every
+process group**. The app runs three (`app`, `worker`, `discord` — see the
+Architecture Overview), sized in `fly.toml` (`app`: 2 CPU / 512MB, `worker`: 1 CPU
+/ 512MB, `discord`: 1 CPU / 256MB).
+
+**Increase VM resources** — pass a size at least as large as that group's current one:
 
 ```bash
-flyctl scale vm shared-cpu-2x --memory 1024
+flyctl scale vm shared-cpu-2x --memory 1024 --process-group app
 ```
 
-**Add more instances:**
-
-The app runs three process groups (`app`, `worker`, `discord` — see the Architecture
-Overview). Scale a specific group with `--process-group`; keep `app` at 2 or more for
-zero-downtime deploys:
+**Add more instances** — keep `app` at 2 or more for zero-downtime deploys:
 
 ```bash
 flyctl scale count 3 --process-group app
 ```
+
+### Slow Cold Starts
+
+The app uses `auto_stop_machines = "stop"`, which stops idle app machines. The first request after an idle period can be slow while a machine wakes.
+
+`fly.toml` already sets `min_machines_running = 2`. **Keep it at 2 or more** — the canary rolling-deploy strategy needs at least two app machines for zero-downtime deploys, so this also keeps a warm machine ready. Do **not** lower it to 1 (that reintroduces cold starts and breaks zero-downtime rollout). If you need more warm capacity, raise the app machine count (see Scaling above).
 
 ### Database Maintenance
 
@@ -463,159 +434,6 @@ flyctl machine update <machine-id> --vm-size shared-cpu-8x --vm-memory 2048 --ap
 Pick the tier by the migration's bottleneck, not by "bigger is better" — see the
 scaling guidance in `../migrations/CLAUDE.md`. Note the web dashboard's scale button
 is disabled for Postgres apps; the CLI is the supported path.
-
-### Viewing Logs
-
-```bash
-# Live logs
-flyctl logs
-
-# Recent logs
-flyctl logs --no-tail
-
-# Filter by type
-flyctl logs --instance <instance-id>
-```
-
-### SSH into Running Machine
-
-```bash
-flyctl ssh console
-```
-
-### Restarting the App
-
-```bash
-flyctl apps restart lion-reader
-```
-
-### Custom Domains
-
-1. Add your domain:
-
-```bash
-flyctl certs create yourdomain.com
-```
-
-2. Follow the DNS instructions provided
-3. Verify certificate:
-
-```bash
-flyctl certs show yourdomain.com
-```
-
----
-
-## Troubleshooting
-
-### Deployment Fails
-
-**"Release command failed"**
-
-This usually means database migrations failed.
-
-```bash
-# Check logs for migration errors
-flyctl logs | grep -i migration
-
-# Connect to database and check state
-flyctl postgres connect -a lion-reader-pg
-```
-
-**"Health check failed"**
-
-The app isn't responding on `/api/health`.
-
-```bash
-# Check app logs
-flyctl logs
-
-# SSH and check process
-flyctl ssh console
-ps aux | grep node
-```
-
-### Database Connection Issues
-
-**"Connection refused"**
-
-Ensure the database is attached:
-
-```bash
-flyctl secrets list
-# Should show DATABASE_URL
-
-# Re-attach if needed
-flyctl postgres attach lion-reader-pg
-```
-
-**"Authentication failed"**
-
-The database user credentials may be wrong. Detach and reattach:
-
-```bash
-flyctl postgres detach lion-reader-pg
-flyctl postgres attach lion-reader-pg
-```
-
-### Redis Connection Issues
-
-**"Connection timeout"**
-
-Check if Redis is accessible:
-
-```bash
-# Verify secret is set
-flyctl secrets list | grep REDIS
-
-# Check if using correct protocol (redis:// vs rediss://)
-```
-
-For Upstash, ensure you're using TLS (`rediss://`).
-
-### Application Errors
-
-**"500 Internal Server Error"**
-
-Check logs for the actual error:
-
-```bash
-flyctl logs --no-tail | tail -100
-```
-
-Common causes:
-
-- Missing environment variables
-- Database connection issues
-- Redis connection issues
-
-### Memory Issues
-
-**"Out of memory"**
-
-Scale up the VM:
-
-```bash
-flyctl scale vm shared-cpu-1x --memory 1024
-```
-
-### Slow Cold Starts
-
-The app uses `auto_stop_machines = "stop"`, which stops idle app machines. The first request after an idle period can be slow while a machine wakes.
-
-`fly.toml` already sets `min_machines_running = 2`. **Keep it at 2 or more** — the canary rolling-deploy strategy needs at least two app machines for zero-downtime deploys, so this also keeps a warm machine ready. Do **not** lower it to 1 (that reintroduces cold starts and breaks zero-downtime rollout):
-
-```toml
-[http_service]
-  # Need at least 2 machines for zero-downtime rolling deploys
-  min_machines_running = 2
-```
-
-If you need more warm capacity, raise the app machine count (`processes = ["app"]`):
-
-```bash
-flyctl scale count 3 --process-group app
-```
 
 ---
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -170,20 +170,13 @@ When a feed advertises a hub, we subscribe via WebSub and drop the feed to a 24h
 
 ### SSRF Protection
 
-All server-side fetches of user-influenced URLs go through `fetchWithSsrfProtection` (`src/server/http/ssrf.ts`), which blocks private/reserved addresses, pins DNS resolution to a vetted address (closing DNS-rebinding TOCTOU), and validates every redirect hop. Mechanics: `src/server/http/CLAUDE.md`.
+Every server-side fetch of a user-influenced URL goes through `fetchWithSsrfProtection`, never bare `fetch`. Why it is security-critical: `SECURITY.md` §2. Mechanics: `src/server/http/CLAUDE.md`.
 
 ---
 
 ## Real-time Updates
 
-### Architecture
-
-1. Feed worker fetches feed, finds new entry
-2. Worker publishes to per-feed Redis channel: `PUBLISH feed:{feedId}:events {type, entryId, ...}`
-3. SSE connections subscribe only to channels for feeds their user cares about
-4. App server receives message, forwards to client
-5. Client receives event, patches the React Query cache (see `src/FRONTEND_STATE.md`)
-6. UI updates automatically
+The end-to-end flow (worker → Redis channel → SSE → React Query cache) is drawn in [sse-cache-updates.d2](diagrams/sse-cache-updates.d2) and specified in `src/FRONTEND_STATE.md`.
 
 ### Channel Design
 
@@ -234,10 +227,6 @@ Token bucket via Redis, per-user, applied only to expensive/abusable operations.
 
 Errors use tRPC's standard error envelope, extended by the `errorFormatter` in `src/server/trpc/trpc.ts`: `data` carries the tRPC error code and HTTP status, an optional app-specific `appErrorCode` (set via `createError` in `errors.ts`, e.g. `SIGNUP_CONFIRMATION_REQUIRED`, `INVITE_REQUIRED`, `CONTENT_TOO_LARGE`), and flattened Zod issues in `zodError` when input validation failed.
 
-### Services Layer
-
-Business logic is extracted into reusable service functions in `src/server/services/`: pure functions accepting `db` and parameters, returning plain data objects, shared across tRPC routers, the MCP server, compat APIs, and background jobs. Entry content is sanitized in the services layer so every consumer gets the same guarantee. Module list and conventions: `src/server/CLAUDE.md`.
-
 ---
 
 ## Frontend Architecture
@@ -257,27 +246,11 @@ components to use, `useParams()` not updating on `pushState`) are in `src/CLAUDE
 
 ### Route Structure
 
-```
-app/
-  (auth)/                     # Login, register, forgot password
-  (app)/                      # Main app (requires auth)
-    all/                      # All entries timeline
-    starred/                  # Starred entries
-    saved/                    # Saved articles
-    recently-read/            # Recently-read timeline (sortBy: readChanged)
-    uncategorized/            # Entries from untagged subscriptions
-    subscription/[id]/        # Single subscription entries (uses subscription ID)
-    tag/[tagId]/              # Entries filtered by tag
-    settings/                 # User settings (rendered by UnifiedSettingsContent)
-    subscribe/                # Add subscription flow
-  save/                       # Bookmarklet landing page (top-level, no auth layout)
-  extension/save/             # Browser extension save page
-  demo/                       # Interactive demo (no auth required)
-```
+Routes are split across two root layouts, `src/app/(public)/` and `src/app/(spa)/` — see "Two root layouts" in `src/CLAUDE.md` for what belongs in each and the constraints that follow. The `src/app/` directory listing is the source of truth for the routes themselves.
 
 ### Component Architecture
 
-Components live in `src/components/` grouped by domain (`layout/`, `entries/`, `feeds/`, `narration/`, `saved/`, `settings/`, `subscribe/`, `summarization/`, `keyboard/`, `auth/`, `app/`, and generic primitives in `ui/`). Component guidelines, the UI-primitive/icon/color-token reference, and the narration media-controls design are in `src/components/CLAUDE.md`.
+Components live in `src/components/`, grouped by domain, with generic primitives in `ui/`. Component guidelines, the UI-primitive/icon/color-token reference, and the narration media-controls design are in `src/components/CLAUDE.md`.
 
 ---
 
@@ -288,7 +261,7 @@ Lion Reader exposes functionality to AI assistants via the [Model Context Protoc
 - **Streamable HTTP** at `POST /api/mcp` — for remote clients such as claude.ai. Authenticated with OAuth 2.1 access tokens (with the `mcp` scope) or legacy API tokens. Runs statelessly inside the Next.js route handler via `WebStandardStreamableHTTPServerTransport`, creating a fresh server+transport pair per request.
 - **stdio** (`pnpm mcp:serve`) — for local clients such as Claude Desktop.
 
-Both transports register the same tools (defined once in `src/server/mcp/tools.ts`) and call the same services layer, exactly mirroring the `mcp`-scoped tRPC endpoints: entries list/get/mark-read/star/count, saved-article save/delete/upload, subscriptions list/get, and tag CRUD. See `src/server/mcp/README.md`.
+Both transports register the same tools and call the same services layer, mirroring the `mcp`-scoped tRPC endpoints. `src/server/mcp/tools.ts` defines the tools once and is the source of truth for the list; see `src/server/mcp/README.md`.
 
 The OAuth 2.1 authorization surface backing remote MCP auth (discovery documents, audience binding) is specified in `src/server/oauth/CLAUDE.md`.
 
@@ -317,14 +290,7 @@ Some sources have no usable public read API and are scraped instead, from the st
 
 ### Fly.io Deployment
 
-- Single region (sjc) with canary deployment strategy
-- Three process types:
-  - `app` - Next.js web server (min 2 machines for zero-downtime deploys)
-  - `worker` - Background job processor (feed fetching)
-  - `discord` - Discord bot (lightweight, single Gateway connection)
-- Postgres managed database
-- Redis for caching and pub/sub
-- Release command runs migrations automatically before deploy
+`fly.toml` is the source of truth for regions, process groups, machine sizes, and the release command; the provisioning and operations runbook is `docs/DEPLOYMENT.md`. Postgres is **unmanaged** Fly Postgres Flex (single node), so we own its upgrades, backups, and monitoring — `docs/fly-postgres-ops.md` is the runbook for that. Redis (Upstash) backs caching and pub/sub.
 
 ### Migration Compatibility (Expand/Contract)
 


### PR DESCRIPTION
Docs-only. Applies the "say each thing once, closest to the code" rubric from the root `CLAUDE.md` to the two largest docs. Every claim below was re-verified against the code/config before editing.

## docs/DESIGN.md

- **Route Structure** — the tree was wrong (`(auth)/`, `(app)/`, `save/`, `extension/`, `demo/` at top level, a "forgot password" route; no `admin`, `oauth`, `complete-signup`). Verified: `src/app/` is `(public)/` + `(spa)/`. Replaced the tree with a pointer to the "Two root layouts" rule in `src/CLAUDE.md` and to the `src/app/` listing as the source of truth. `src/CLAUDE.md` not touched.
- **"Postgres managed database"** — wrong. Verified against `docs/DEPLOYMENT.md` ("Database Provisioning") and `docs/fly-postgres-ops.md`: production is **unmanaged** Fly Postgres Flex, single node, and we own upgrades/backups/monitoring. Fixed, with a link to the ops runbook.
- **Fly.io Deployment bullet list** — restated `fly.toml` (`primary_region`, `strategy = "canary"`, `[processes]`, `release_command`, `min_machines_running`), which DEPLOYMENT.md's Architecture Overview states a third time. Replaced with one sentence naming `fly.toml` as the source of truth. `### Migration Compatibility` and `### Maintenance Mode` kept — those are decisions.
- **SSRF section** — third copy of `SECURITY.md` §2 / `src/server/http/CLAUDE.md`. Reduced to the invariant plus links; neither of those files touched.
- **Services Layer** — duplicated the root `CLAUDE.md` and `src/server/CLAUDE.md`. Deleted; `src/server/CLAUDE.md` is the home.
- **Real-time Updates 6-step walkthrough** — mechanics already drawn in `docs/diagrams/sse-cache-updates.d2` and specified in `src/FRONTEND_STATE.md`. Replaced with a one-line pointer to both. `### Channel Design` and `### Connection Efficiency` kept.
- **Component Architecture** — the directory list had drifted (missing `admin/`, `analytics/`, `legal/` — verified against `src/components/`). Replaced with "grouped by domain, generic primitives in `ui/`" plus the existing pointer.
- **MCP tool list** — replaced with a pointer to `src/server/mcp/tools.ts`, the source of truth. `src/server/auth/CLAUDE.md` not touched.
- **Feed Fetch Health** — left intact as instructed.

## docs/DEPLOYMENT.md

- **Deleted ~135 lines of flyctl man page** — `### Viewing Logs`, `### SSH into Running Machine`, `### Restarting the App`, `### Custom Domains`, and the whole `## Troubleshooting` section (generic advice: "Check logs for the actual error"). Dropped the now-dead Troubleshooting TOC entry; no other file linked to it (grepped for `#troubleshooting` / `#verification`).
- **Kept `### Slow Cold Starts`** — the `min_machines_running = 2` rule and its zero-downtime rationale is a real decision. Since its `## Troubleshooting` parent is gone, it now sits under `## Ongoing Operations`, moved up next to `### Scaling` where it belongs. Trimmed the `fly.toml` snippet it echoed and the duplicate `flyctl scale count` block (both live in Scaling / `fly.toml`); the rule and the "don't lower it to 1" warning are unchanged.
- **Fixed a dangerous scaling example** — `flyctl scale vm shared-cpu-2x --memory 1024` with no `--process-group` applies to *every* group, and `fly.toml` sizes app VMs at 2 CPU / 512MB. Rewrote it to pass `--process-group` and state the current per-group sizes, consistent with the `scale count` example below it.
- **`## Verification`** — the BBC/XKCD/Cloudflare smoke test and 6-checkbox list duplicated the health-check contract specified immediately above. Reduced to the health-check curl.
- **CDN bullet** — repeated `src/server/http/CLAUDE.md` and `src/app/(public)/demo/articles/CLAUDE.md` on demo images hashed into `/_next/static/media`, plus the `proxy.ts` `private, no-cache` override that the section right below explains at length. Cut to: no CDN steps in the deploy workflow, a pointer to "Why HTML and RSC are not CDN-cached" and to `src/server/http/CLAUDE.md`, and the two facts unique to it (the `ASSET_PREFIX` build arg that the `Dockerfile` leaves unset, and the pull zone needing CORS headers for cross-origin font loads). Neither of the other two docs touched.

## Nothing skipped

All 12 items held up on re-verification. Two adjacent nits found but **not** fixed, since they're in files this PR is not allowed to touch (other agents are editing docs concurrently):

- `README.md:163` points at `docs/DESIGN.md#mcp-server` "for the tool list and setup" — with the list now delegated to `src/server/mcp/tools.ts`, that phrasing is stale (the anchor itself still resolves).
- `src/server/http/CLAUDE.md:12` cites `docs/DEPLOYMENT.md`, "Why HTML is not CDN-cached"; the heading is "Why HTML **and RSC** are not CDN-cached". Pre-existing, unchanged by this PR.

Net: **-216 lines** (23 added, 239 removed). No links or anchors elsewhere in the repo pointed at anything deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
