### PR TITLE
fix: Resolve relative URLs against the right base in three paths

### DIFF
--- a/src/server/services/full-content.ts
+++ b/src/server/services/full-content.ts
@@ -126,17 +126,21 @@ export async function fetchFullContent(
     // separate chrome from content is already gone.
     if (result.isMarkdown) {
       logger.debug("Converting Markdown to HTML (skipping Readability)", { url });
-      const { html: contentCleaned } = await processMarkdown(result.content, {
+      const { html } = await processMarkdown(result.content, {
         offload: offloadClean,
       });
 
-      // Absolutize URLs in the original HTML (before title stripping)
-      const contentOriginal = absolutizeUrls(contentCleaned, resolveUrl);
+      // Readability is what absolutizes on the other branches, and it didn't
+      // run here — neither the Markdown renderer nor the sanitizer resolves
+      // relative URLs, so do it once and store the same copy in both fields.
+      // Markdown has no "original" HTML distinct from the rendered output, and
+      // the cleaned copy is the one that gets displayed.
+      const content = absolutizeUrls(html, resolveUrl);
 
       return {
         success: true,
-        contentOriginal,
-        contentCleaned,
+        contentOriginal: content,
+        contentCleaned: content,
       };
     }
 

--- a/src/server/services/saved.ts
+++ b/src/server/services/saved.ts
@@ -379,11 +379,14 @@ async function buildArticleFields(
     : await cleanContentAsync(html, { url: baseUrl, ...cleanOptions });
 
   // When Readability ran, its output already has absolutized URLs; when it was
-  // skipped for plugin/pre-cleaned content, absolutize here. When neither produced
-  // anything (Readability failed on a plain page), store NULL rather than the raw
-  // full page — readers fall back to the sanitized original content.
+  // skipped for plugin/pre-cleaned content, absolutize here (neither the Markdown
+  // renderer nor the sanitizer resolves relative URLs, so nothing else will —
+  // and for an upload that means a relative link would otherwise point back into
+  // Lion Reader itself, which is what UPLOAD_BASE_URL exists to prevent). When
+  // neither produced anything (Readability failed on a plain page), store NULL
+  // rather than the raw full page — readers fall back to the sanitized original.
   const contentCleaned =
-    preCleanedContent?.html ??
+    (preCleanedContent ? absolutizeUrls(preCleanedContent.html, baseUrl) : null) ??
     cleaned?.content ??
     (pluginContent ? absolutizeUrls(pluginContent.html, baseUrl) : null);
 

--- a/src/server/trpc/routers/feeds.ts
+++ b/src/server/trpc/routers/feeds.ts
@@ -455,11 +455,12 @@ export const feedsRouter = createTRPCRouter({
 
       // Step 3: Fetch the URL and try to discover feeds from HTML
       try {
-        const { text: content, contentType } = await fetchUrl(inputUrl);
+        const { text: content, contentType, finalUrl } = await fetchUrl(inputUrl);
 
         if (isHtmlContent(contentType, content)) {
-          // Look for <link rel="alternate"> tags in the HTML
-          const htmlFeeds = discoverFeeds(content, inputUrl);
+          // Resolve relative hrefs against the URL the HTML actually came from,
+          // not the one we asked for — a redirect can change host and path.
+          const htmlFeeds = discoverFeeds(content, finalUrl);
           for (const feed of htmlFeeds) {
             addFeed(feed);
           }

--- a/tests/integration/feed-discovery-redirect.test.ts
+++ b/tests/integration/feed-discovery-redirect.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Integration tests for `feeds.discover` against a redirecting page.
+ *
+ * A blog URL that redirects (http → https, apex → subdomain, a moved path) is
+ * the common case, and `<link rel="alternate" href="feed.xml">` is relative to
+ * the page it was served from. Resolving it against the requested URL instead of
+ * the post-redirect one yields a feed URL on the wrong host/path, and the user
+ * subscribes to a 404 — so this drives real HTTP redirects against loopback
+ * servers (`.env.test` sets ALLOW_PRIVATE_NETWORK_FETCH).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+import { type AddressInfo } from "node:net";
+import { eq } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users } from "../../src/server/db/schema";
+import { createCaller } from "../../src/server/trpc/root";
+import { createAuthContext, createTestUser } from "./helpers";
+
+const PAGE_HTML = (href: string) =>
+  `<!doctype html><html><head><title>A Blog</title>
+<link rel="alternate" type="application/rss+xml" title="A Blog Feed" href="${href}">
+</head><body><h1>A Blog</h1></body></html>`;
+
+/** The page the request is redirected to; serves the relative feed link. */
+let targetServer: Server;
+let targetBaseUrl: string;
+/** The URL the user types; redirects to the other origin. */
+let originServer: Server;
+let originBaseUrl: string;
+
+const createdUserIds: string[] = [];
+
+async function createUser(): Promise<string> {
+  const userId = await createTestUser({ emailPrefix: "discover-redirect" });
+  createdUserIds.push(userId);
+  return userId;
+}
+
+beforeAll(async () => {
+  targetServer = createServer((req, res) => {
+    const path = req.url ?? "/";
+    if (path === "/writing/") {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(PAGE_HTML("feed.xml"));
+    } else {
+      // Everything else (including the feed itself and the common-path probes)
+      // 404s: discovery must report the link it found, not fetch it.
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  await new Promise<void>((resolve) => targetServer.listen(0, "127.0.0.1", resolve));
+  targetBaseUrl = `http://127.0.0.1:${(targetServer.address() as AddressInfo).port}`;
+
+  originServer = createServer((req, res) => {
+    if ((req.url ?? "/") === "/blog") {
+      res.writeHead(301, { Location: `${targetBaseUrl}/writing/` });
+      res.end();
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  await new Promise<void>((resolve) => originServer.listen(0, "127.0.0.1", resolve));
+  originBaseUrl = `http://127.0.0.1:${(originServer.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => originServer.close(() => resolve()));
+  await new Promise<void>((resolve) => targetServer.close(() => resolve()));
+  for (const id of createdUserIds) {
+    await db.delete(users).where(eq(users.id, id));
+  }
+});
+
+describe("feeds.discover", () => {
+  it("resolves relative feed links against the post-redirect URL", async () => {
+    const userId = await createUser();
+    const caller = createCaller(await createAuthContext(userId));
+
+    const { feeds } = await caller.feeds.discover({ url: `${originBaseUrl}/blog` });
+
+    // `feed.xml` is relative to the page that was actually served, so it lives
+    // on the redirect target's host and directory — not the requested origin.
+    expect(feeds.map((f) => f.url)).toEqual([`${targetBaseUrl}/writing/feed.xml`]);
+  });
+});

--- a/tests/integration/markdown-url-content.test.ts
+++ b/tests/integration/markdown-url-content.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Integration tests for URLs that serve Markdown instead of HTML.
+ *
+ * We ask for HTML (#1280), but a raw `.md` URL answers with `text/markdown`
+ * anyway. Both entry points that fetch article content — `fetchFullContent`
+ * (the per-subscription "fetch full content" path) and `saveArticle` (read it
+ * later) — render that Markdown and skip Readability, which is the pass that
+ * absolutizes relative URLs everywhere else. Neither the Markdown renderer nor
+ * the sanitizer resolves relative URLs, so these tests pin that the stored
+ * content resolves them against the source URL rather than leaving `img/x.png`
+ * to resolve against Lion Reader's own origin in the browser.
+ *
+ * These drive real HTTP requests against a loopback server so the content-type
+ * detection and redirect handling are covered too (`.env.test` sets
+ * ALLOW_PRIVATE_NETWORK_FETCH).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+import { type AddressInfo } from "node:net";
+import { eq } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { entries, users } from "../../src/server/db/schema";
+import { fetchFullContent } from "../../src/server/services/full-content";
+import { saveArticle } from "../../src/server/services/saved";
+import { createTestUser } from "./helpers";
+
+const MARKDOWN_BODY = [
+  "# Deep Dive",
+  "",
+  "An opening paragraph with enough prose that every length threshold in the",
+  "pipeline is comfortably cleared and the body is treated as real content.",
+  "",
+  "![A figure](img/fig.png)",
+  "",
+  "See the [companion post](other/post.md) and the [index](/index.md).",
+  "",
+  "A closing paragraph so the document is unambiguously article-sized.",
+].join("\n");
+
+let server: Server;
+let baseUrl: string;
+
+const createdUserIds: string[] = [];
+
+async function createUser(): Promise<string> {
+  const userId = await createTestUser({ emailPrefix: "md-url" });
+  createdUserIds.push(userId);
+  return userId;
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const path = req.url ?? "/";
+    if (path === "/docs/post.md") {
+      res.writeHead(200, { "Content-Type": "text/markdown; charset=utf-8" });
+      res.end(MARKDOWN_BODY);
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  for (const id of createdUserIds) {
+    await db.delete(users).where(eq(users.id, id));
+  }
+});
+
+describe("fetchFullContent on a Markdown URL", () => {
+  it("absolutizes relative URLs in the content that gets displayed", async () => {
+    const result = await fetchFullContent(`${baseUrl}/docs/post.md`);
+
+    expect(result.success).toBe(true);
+    // `selectDisplayedContent` prefers the cleaned variant, so that is the one
+    // that must carry absolute URLs.
+    expect(result.contentCleaned).toContain(`${baseUrl}/docs/img/fig.png`);
+    expect(result.contentCleaned).toContain(`${baseUrl}/docs/other/post.md`);
+    expect(result.contentCleaned).toContain(`${baseUrl}/index.md`);
+    expect(result.contentCleaned).not.toContain('src="img/fig.png"');
+    expect(result.contentCleaned).not.toContain('href="other/post.md"');
+  });
+
+  it("stores the same absolutized content as the original variant", async () => {
+    const result = await fetchFullContent(`${baseUrl}/docs/post.md`);
+
+    // Markdown has no "original" HTML distinct from the rendered output, so both
+    // stored variants are the same absolutized string — "show original" must not
+    // fall back to relative URLs.
+    expect(result.contentOriginal).toBe(result.contentCleaned);
+  });
+
+  it("runs identically with the background worker's inline cleaning", async () => {
+    const result = await fetchFullContent(`${baseUrl}/docs/post.md`, { offloadClean: false });
+
+    expect(result.success).toBe(true);
+    expect(result.contentCleaned).toContain(`${baseUrl}/docs/img/fig.png`);
+  });
+});
+
+describe("saveArticle on a Markdown URL", () => {
+  it("absolutizes relative URLs in the stored cleaned content", async () => {
+    const userId = await createUser();
+    const article = await saveArticle(db, userId, { url: `${baseUrl}/docs/post.md` });
+
+    const [stored] = await db
+      .select({ contentCleaned: entries.contentCleaned })
+      .from(entries)
+      .where(eq(entries.id, article.id))
+      .limit(1);
+
+    // Readability is skipped for Markdown (it is already clean), so the
+    // absolutize pass has to happen on the pre-cleaned HTML itself.
+    expect(stored.contentCleaned).toContain(`${baseUrl}/docs/img/fig.png`);
+    expect(stored.contentCleaned).toContain(`${baseUrl}/docs/other/post.md`);
+    expect(stored.contentCleaned).toContain(`${baseUrl}/index.md`);
+    expect(stored.contentCleaned).not.toContain('src="img/fig.png"');
+  });
+});

--- a/tests/integration/saved-uploads.test.ts
+++ b/tests/integration/saved-uploads.test.ts
@@ -256,6 +256,31 @@ describe("uploadArticle (Markdown)", () => {
     expect(article.title).toBe("Explicit Title");
   });
 
+  it("rewrites relative URLs against the dummy upload base (not Lion Reader)", async () => {
+    const userId = await createUser();
+    const md = [
+      "# Uploaded Notes",
+      "",
+      "A paragraph with enough prose that the content is unambiguously an article.",
+      "",
+      "![A figure](img/fig.png)",
+      "",
+      "Go to [settings](/settings) or the [next note](notes/next.md).",
+    ].join("\n");
+
+    const article = await uploadArticle(db, userId, { content: md, title: "" });
+
+    const stored = await readStored(article.id);
+    // Readability is skipped for Markdown, so nothing downstream resolves these
+    // — a root-relative link left as-is would point back into the Lion Reader
+    // app, which is exactly what the deliberately-broken upload base prevents.
+    expect(stored.contentCleaned).toContain("https://uploaded.invalid/settings");
+    expect(stored.contentCleaned).toContain("https://uploaded.invalid/img/fig.png");
+    expect(stored.contentCleaned).toContain("https://uploaded.invalid/notes/next.md");
+    expect(stored.contentCleaned).not.toContain('href="/settings"');
+    expect(stored.contentCleaned).not.toContain('src="img/fig.png"');
+  });
+
   it("prefers the provided author/excerpt over frontmatter", async () => {
     const userId = await createUser();
     const md = [


### PR DESCRIPTION
Three URL-resolution bugs, all in branches where Readability — the pass that absolutizes relative URLs everywhere else — was skipped, and nothing downstream picked up the job (neither the Markdown renderer nor the sanitizer resolves relative URLs).

## 1. `fetchFullContent` absolutized the wrong copy for Markdown

`src/server/services/full-content.ts`

The Markdown branch absolutized `contentOriginal` and returned the raw rendered HTML as `contentCleaned` — but `contentCleaned` is what `selectDisplayedContent` prefers and the reader actually renders. Both sibling branches (plugin, HTML) absolutize what's displayed.

**Symptom:** a `fetchFullContent` subscription whose entry URL serves Markdown containing `![](img/x.png)` rendered images and links resolved against Lion Reader's own origin instead of the source site.

**Fix:** absolutize once and store the same copy in both fields — Markdown has no "original" HTML distinct from the rendered output.

## 2. `buildArticleFields` never absolutized pre-cleaned content

`src/server/services/saved.ts`

The expression was `preCleanedContent?.html ?? cleaned?.content ?? (pluginContent ? absolutizeUrls(...) : null)` — the first arm went through unprocessed, contradicting the comment three lines above it.

**Symptom:** saving `https://example.com/docs/post.md` containing `![](img/fig.png)` stored a relative `src`. For **uploads**, where the base is the deliberately-broken `UPLOAD_BASE_URL` (`https://uploaded.invalid/`), a `[link](/settings)` became a link back into the Lion Reader app — exactly what that `.invalid` base exists to prevent.

**Fix:** absolutize the first arm too.

## 3. `feeds.discover` resolved feed hrefs against the pre-redirect URL

`src/server/trpc/routers/feeds.ts`

It discarded `fetchUrl`'s `finalUrl` and passed the requested URL to `discoverFeeds`. The sibling `preview` handler already gets this right.

**Symptom:** `discover("http://example.com/blog")` that redirects to `https://blog.example.net/` with `<link href="feed.xml">` yielded `http://example.com/feed.xml` — wrong host and path — and the user subscribed to a 404.

**Fix:** destructure `finalUrl` and pass it to `discoverFeeds`.

## Tests

All three are fetch-shaped, so they're integration tests driving real HTTP against loopback servers (the pattern from `saved-feed-detection.test.ts`).

- `tests/integration/markdown-url-content.test.ts` (new) — a loopback server serving `text/markdown`, covering both entry points: `fetchFullContent` (cleaned variant absolutized, both variants identical, and the worker's `offloadClean: false` path) and `saveArticle` (stored `content_cleaned` absolutized).
- `tests/integration/feed-discovery-redirect.test.ts` (new) — two loopback servers; the requested one 301s to the other, which serves `<link rel="alternate" href="feed.xml">`. Asserts the discovered URL is on the redirect target's host and directory.
- `tests/integration/saved-uploads.test.ts` — a Markdown upload with a relative image, a relative link and a root-relative `/settings`, asserting all three resolve against `https://uploaded.invalid/`.

Verified each test fails on the unfixed code: reverting the three source files turns all 6 new assertions red (`6 failed | 13 passed`), and green with the fixes.

`pnpm typecheck`, `pnpm lint` clean. `pnpm test:unit`: 161 files / 3222 tests passed. Full integration suite: 801 passed, 1 unrelated timeout flake in `sync-events.test.ts` under parallel load that passes on its own (3.5s against a 30s timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)