### PR TITLE
fix: Report spam-free unread counts on every subscription surface

### DIFF
--- a/src/server/services/subscriptions.ts
+++ b/src/server/services/subscriptions.ts
@@ -7,15 +7,7 @@
 import { z } from "zod";
 import { eq, and, gt, isNull, sql } from "drizzle-orm";
 import type { db as dbType } from "@/server/db";
-import {
-  feeds,
-  entries,
-  subscriptions,
-  userEntries,
-  tags,
-  subscriptionTags,
-  userFeeds,
-} from "@/server/db/schema";
+import { feeds, subscriptions, tags, subscriptionTags, userFeeds } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
 import { logger } from "@/lib/logger";
 import { usageLimitsConfig } from "@/server/config/env";
@@ -328,7 +320,7 @@ export interface CreateSubscriptionResult {
   subscriptionId: string;
   /** When the subscription was created */
   subscribedAt: Date;
-  /** Number of unread entries populated */
+  /** Unread count for the subscription (trigger-maintained counter, spam excluded) */
   unreadCount: number;
   /** True if the subscription already existed and was active (idempotent return) */
   alreadyActive: boolean;
@@ -451,7 +443,6 @@ export async function createSubscription(
         kind: "created";
         subscriptionId: string;
         subscribedAt: Date;
-        unreadCount: number;
         customTitle: string | null;
         fetchFullContent: boolean;
       };
@@ -586,20 +577,10 @@ export async function createSubscription(
       `);
     }
 
-    // Count unread entries (rowCount may be 0 for reactivations where entries already exist)
-    const [{ count }] = await tx
-      .select({ count: sql<number>`count(*)::int` })
-      .from(userEntries)
-      .innerJoin(entries, eq(entries.id, userEntries.entryId))
-      .where(
-        and(eq(userEntries.userId, userId), eq(entries.feedId, feedId), eq(userEntries.read, false))
-      );
-
     return {
       kind: "created",
       subscriptionId,
       subscribedAt,
-      unreadCount: count,
       customTitle,
       fetchFullContent,
     };
@@ -623,13 +604,7 @@ export async function createSubscription(
     };
   }
 
-  const { subscriptionId, subscribedAt, unreadCount, customTitle, fetchFullContent } = txResult;
-
-  logger.debug("Populated initial user entries via lastSeenAt", {
-    userId,
-    feedId,
-    entryCount: unreadCount,
-  });
+  const { subscriptionId, subscribedAt, customTitle, fetchFullContent } = txResult;
 
   // 7. Compute absolute unread counts for the affected lists. A newly created
   // or reactivated subscription is untagged, so it only moves All Articles and
@@ -637,6 +612,18 @@ export async function createSubscription(
   const counts = await getBulkEntryRelatedCounts(db, userId, [
     { subscriptionId, type: feedData.type },
   ]);
+
+  // The subscription's own badge is the trigger-maintained counter this bulk
+  // read already returned (spam excluded), never a scan — see "Unread Counts"
+  // in `src/server/CLAUDE.md`. `getBulkEntryRelatedCounts` zero-fills every
+  // requested subscription, so the entry for ours is always present.
+  const unreadCount = counts.subscriptions.find((s) => s.id === subscriptionId)?.unread ?? 0;
+
+  logger.debug("Populated initial user entries via lastSeenAt", {
+    userId,
+    feedId,
+    entryCount: unreadCount,
+  });
 
   // 8. Publish SSE event for new/reactivated subscriptions
   publishSubscriptionCreated(

--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -19,14 +19,7 @@ import { API_TOKEN_SCOPES } from "@/server/auth/api-token";
 import { errors } from "../errors";
 import { feedUrlSchema, uuidSchema } from "../validation";
 import { fetchUrl, isHtmlContent } from "@/server/http/fetch";
-import {
-  feeds,
-  subscriptions,
-  tags,
-  subscriptionTags,
-  blockedSenders,
-  visibleEntries,
-} from "@/server/db/schema";
+import { feeds, subscriptions, tags, subscriptionTags, blockedSenders } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
 import { parseFeedAsync } from "@/server/feed/parser";
 import { discoverFeeds } from "@/server/feed/discovery";
@@ -427,6 +420,7 @@ export const subscriptionsRouter = createTRPCRouter({
           customTitle: subscriptions.customTitle,
           fetchFullContent: subscriptions.fetchFullContent,
           subscribedAt: subscriptions.subscribedAt,
+          unreadCount: subscriptions.unreadCount,
           changed: sql<boolean>`${meaningfulChange}`,
         });
 
@@ -436,9 +430,10 @@ export const subscriptionsRouter = createTRPCRouter({
 
       const subscription = updateResult[0];
 
-      // Fetch feed, tags, and unread count in separate queries to avoid
-      // cross-join between tags and entries that multiplies COUNT results (#680).
-      const [feedResult, tagsResult, unreadResult] = await Promise.all([
+      // Fetch feed and tags in separate queries to avoid a cross-join that
+      // multiplies rows (#680). The unread count comes off the UPDATE's
+      // RETURNING — the trigger-maintained counter, not a scan.
+      const [feedResult, tagsResult] = await Promise.all([
         // Feed metadata
         ctx.db
           .select({
@@ -463,22 +458,6 @@ export const subscriptionsRouter = createTRPCRouter({
           .from(subscriptionTags)
           .innerJoin(tags, eq(tags.id, subscriptionTags.tagId))
           .where(eq(subscriptionTags.subscriptionId, subscription.id)),
-
-        // Unread count (use visibleEntries view to include entries from redirected feeds).
-        // read=false lives in WHERE (not a FILTER over all entries) so the partial
-        // idx_user_entries_unread index can drive the scan, matching counts.ts.
-        ctx.db
-          .select({
-            count: sql<number>`COUNT(*)::int`,
-          })
-          .from(visibleEntries)
-          .where(
-            and(
-              eq(visibleEntries.userId, userId),
-              eq(visibleEntries.subscriptionId, subscription.id),
-              eq(visibleEntries.read, false)
-            )
-          ),
       ]);
 
       const result = feedResult[0];
@@ -491,7 +470,6 @@ export const subscriptionsRouter = createTRPCRouter({
         name: t.name,
         color: t.color,
       }));
-      const unreadCount = unreadResult[0]?.count ?? 0;
 
       // Publish SSE event for other tabs/devices — only when something
       // actually changed. A no-op re-save (identical customTitle /
@@ -522,7 +500,7 @@ export const subscriptionsRouter = createTRPCRouter({
         description: result.description,
         siteUrl: result.siteUrl,
         subscribedAt: subscription.subscribedAt,
-        unreadCount,
+        unreadCount: subscription.unreadCount,
         tags: subscriptionTagsList,
         fetchFullContent: subscription.fetchFullContent,
       };

--- a/src/server/trpc/routers/sync.ts
+++ b/src/server/trpc/routers/sync.ts
@@ -17,7 +17,6 @@ import {
   subscriptionTags,
   userEntries,
   tags,
-  visibleEntries,
 } from "@/server/db/schema";
 import { syncTagSchema, serverSyncEventSchema, toNewEntryListData } from "@/lib/events/schemas";
 import type { Database } from "@/server/db";
@@ -617,7 +616,7 @@ export const syncRouter = createTRPCRouter({
           )
           .orderBy(subscriptions.updatedAt);
 
-        // Collect active subscription IDs for batch tag/unread fetching
+        // Collect active subscription IDs for batch tag fetching
         const activeSubscriptions = subscriptionResults.filter(
           ({ subscription }) => subscription.unsubscribedAt === null
         );
@@ -627,34 +626,6 @@ export const syncRouter = createTRPCRouter({
           ctx.db,
           activeSubscriptions.map(({ subscription }) => subscription.id)
         );
-
-        // Batch-fetch unread counts for all active subscriptions in one query
-        const unreadBySubscription = new Map<string, number>();
-        if (activeSubscriptions.length > 0) {
-          const activeSubscriptionIds = activeSubscriptions.map(
-            ({ subscription }) => subscription.id
-          );
-
-          const unreadResults = await ctx.db
-            .select({
-              subscriptionId: visibleEntries.subscriptionId,
-              count: sql<number>`count(*)::int`,
-            })
-            .from(visibleEntries)
-            .where(
-              and(
-                eq(visibleEntries.userId, userId),
-                eq(visibleEntries.read, false),
-                inArray(visibleEntries.subscriptionId, activeSubscriptionIds)
-              )
-            )
-            .groupBy(visibleEntries.subscriptionId);
-
-          for (const { subscriptionId, count } of unreadResults) {
-            // subscriptionId is guaranteed non-null by the inArray filter above
-            unreadBySubscription.set(subscriptionId!, count);
-          }
-        }
 
         const subscriptionsCursorDate = new Date(subscriptionsCursor);
         for (const { subscription, feed, updatedAtInstant } of subscriptionResults) {
@@ -676,7 +647,7 @@ export const syncRouter = createTRPCRouter({
                   feedId: subscription.feedId,
                   customTitle: subscription.customTitle,
                   subscribedAt: subscription.subscribedAt.toISOString(),
-                  unreadCount: unreadBySubscription.get(subscription.id) ?? 0,
+                  unreadCount: subscription.unreadCount,
                   tags: tagsBySubscription.get(subscription.id) ?? [],
                 },
                 feed: {

--- a/tests/integration/spam-unread-counts.test.ts
+++ b/tests/integration/spam-unread-counts.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Every surface that reports a subscription's unread badge must agree with
+ * `subscriptions.list`.
+ *
+ * `subscriptions.list` reads `user_feeds.unread_count` — the trigger-maintained
+ * counter, which permanently excludes spam (see "Unread Counts" in
+ * `src/server/CLAUDE.md`). Three other surfaces used to hand-roll a `count(*)`
+ * over `visible_entries` / `user_entries` with no `is_spam` predicate, so a
+ * subscription with spam reported a larger number and the sidebar badge
+ * contradicted the list it sits next to. These tests pin all of them to the
+ * counter by construction: each asserts equality with `subscriptions.list`
+ * rather than a hard-coded number, so a future scan-based reimplementation
+ * fails here no matter what it counts.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import {
+  users,
+  feeds,
+  entries,
+  subscriptions,
+  subscriptionTags,
+  userEntries,
+  tags,
+} from "../../src/server/db/schema";
+import { createCaller } from "../../src/server/trpc/root";
+import { createSubscription } from "../../src/server/services/subscriptions";
+import {
+  createAuthContext,
+  createTestEntry,
+  createTestFeed,
+  createTestSubscription,
+  createTestUser,
+} from "./helpers";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+interface SpamFixture {
+  userId: string;
+  feedId: string;
+  feedUrl: string;
+  subscriptionId: string;
+}
+
+/**
+ * A subscription to an email feed holding one ordinary unread entry and one
+ * unread *spam* entry, both visible to the user.
+ *
+ * Spam only exists on email entries (`entries_spam_only_email`), and email
+ * entries must have a NULL `last_seen_at` (`entries_last_seen_only_fetched`),
+ * so the feed is an email feed throughout. `createTestEntry`'s `userIds`
+ * inserts the `user_entries` rows; the `user_entries_fill_denormalized` trigger
+ * copies `is_spam` off the entry.
+ */
+async function seedSpammySubscription(): Promise<SpamFixture> {
+  const userId = await createTestUser();
+  const feedId = await createTestFeed({ type: "email", userId });
+  const [feed] = await db.select().from(feeds).where(eq(feeds.id, feedId));
+  const subscriptionId = await createTestSubscription(userId, feedId);
+
+  await createTestEntry(feedId, { type: "email", title: "Real mail", userIds: [userId] });
+  await createTestEntry(feedId, {
+    type: "email",
+    title: "Spam mail",
+    isSpam: true,
+    userIds: [userId],
+  });
+
+  return { userId, feedId, feedUrl: feed.url!, subscriptionId };
+}
+
+/** The unread count `subscriptions.list` shows — the reference every surface must match. */
+async function listedUnreadCount(userId: string, subscriptionId: string): Promise<number> {
+  const { items } = await createCaller(await createAuthContext(userId)).subscriptions.list({});
+  const item = items.find((s) => s.id === subscriptionId);
+  if (!item) {
+    throw new Error(`subscriptions.list did not return ${subscriptionId}`);
+  }
+  return item.unreadCount;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("unread counts exclude spam on every surface", () => {
+  beforeEach(async () => {
+    await db.delete(userEntries);
+    await db.delete(subscriptionTags);
+    await db.delete(entries);
+    await db.delete(subscriptions);
+    await db.delete(tags);
+    await db.delete(feeds);
+    await db.delete(users);
+  });
+
+  afterAll(async () => {
+    await db.delete(userEntries);
+    await db.delete(subscriptionTags);
+    await db.delete(entries);
+    await db.delete(subscriptions);
+    await db.delete(tags);
+    await db.delete(feeds);
+    await db.delete(users);
+  });
+
+  it("subscriptions.list reports only the non-spam unread entry", async () => {
+    const { userId, subscriptionId } = await seedSpammySubscription();
+
+    // The baseline the other three assertions compare against: 1 of the 2
+    // unread rows is spam, so the counter says 1.
+    expect(await listedUnreadCount(userId, subscriptionId)).toBe(1);
+  });
+
+  it("sync.events subscription_created matches subscriptions.list", async () => {
+    const { userId, subscriptionId } = await seedSpammySubscription();
+
+    // The SSE-down polling fallback replays the subscription as "created"
+    // because it was subscribed after the cursor.
+    const result = await createCaller(await createAuthContext(userId)).sync.events({
+      cursors: { subscriptions: new Date("2020-01-01T00:00:00Z").toISOString() },
+    });
+
+    const created = result.events.filter((e) => e.type === "subscription_created");
+    expect(created).toHaveLength(1);
+    const event = created[0];
+    if (event.type !== "subscription_created") throw new Error("unreachable");
+
+    expect(event.subscription.id).toBe(subscriptionId);
+    expect(event.subscription.unreadCount).toBe(await listedUnreadCount(userId, subscriptionId));
+  });
+
+  it("subscriptions.update matches subscriptions.list", async () => {
+    const { userId, subscriptionId } = await seedSpammySubscription();
+
+    const updated = await createCaller(await createAuthContext(userId)).subscriptions.update({
+      id: subscriptionId,
+      customTitle: "Renamed",
+    });
+
+    expect(updated.unreadCount).toBe(await listedUnreadCount(userId, subscriptionId));
+  });
+
+  it("resubscribing matches subscriptions.list", async () => {
+    const { userId, feedUrl, subscriptionId } = await seedSpammySubscription();
+
+    // Soft-delete, then resubscribe: the reactivation path reuses the existing
+    // user_entries rows (an email feed populates nothing at subscribe time,
+    // since its entries have no last_seen_at), so this is the case where the
+    // old count(*) saw the spam row.
+    await db
+      .update(subscriptions)
+      .set({ unsubscribedAt: new Date() })
+      .where(eq(subscriptions.id, subscriptionId));
+
+    const result = await createSubscription(db, userId, { url: feedUrl });
+
+    expect(result.subscriptionId).toBe(subscriptionId);
+    expect(result.alreadyActive).toBe(false);
+    expect(result.unreadCount).toBe(await listedUnreadCount(userId, subscriptionId));
+    // The bulk counts published alongside the SSE event must agree too.
+    expect(result.counts?.subscriptions).toEqual([{ id: subscriptionId, unread: 1 }]);
+  });
+});


### PR DESCRIPTION
## The bug

Three surfaces hand-rolled a `count(*)` unread scan over `visible_entries` / `user_entries` with **no `is_spam` predicate**. `subscriptions.list` reads `user_feeds.unread_count` — the trigger-maintained counter, which excludes spam permanently — so the two disagreed.

**User-visible symptom:** for a subscription holding spam, the sidebar badge showed a larger number than the subscription list sitting right next to it. Verified against a real DB: a subscription with 1 normal + 1 spam unread gave `COUNTER: 1 | SYNC EVENT: 2`.

## The three sites

1. **`sync.events`** (`src/server/trpc/routers/sync.ts`) — the SSE-down polling fallback batch-counted unread per subscription and set the `subscription_created` payload's badge from it. The query already selects the whole `subscriptions` row, so this is just `subscription.unreadCount`.
2. **`subscriptions.update`** (`src/server/trpc/routers/subscriptions.ts`) — the same scan in its response fan-out. Now takes the counter off the UPDATE's `RETURNING`. Its comment claimed the scan "matched counts.ts"; `counts.ts` never scans `visible_entries` for unread, so that comment is gone too.
3. **`createSubscription`** (`src/server/services/subscriptions.ts`) — counted unread inside the transaction keyed on `entries.feed_id`, which additionally swept in rows attributed to a *different, merged* subscription on the same feed. The function already calls `getBulkEntryRelatedCounts` immediately after the commit, so the count is derived from that (the same counter, zero-filled per requested subscription).

Every fix **removes** a query — the correct counter was already in hand at each site. This restores the invariant documented under "Unread Counts" in `src/server/CLAUDE.md`: badges are counter arithmetic, **not** entry scans. (That section's claim that only the generic filtered counts still scan `visible_entries` is now actually true.)

## Test

New `tests/integration/spam-unread-counts.test.ts` seeds a subscription with one ordinary and one **spam** unread entry, then asserts each of the three surfaces reports the *same* number as `subscriptions.list` — by comparison rather than against a literal, so a future scan-based reimplementation fails here regardless of what it counts. All three of those assertions fail on `master` (`expected 2 to be 1`) and pass here.

Spam only exists on email entries (`entries_spam_only_email`) and email entries have a NULL `last_seen_at` (`entries_last_seen_only_fetched`), so subscribe-time populate can never fan out spam — site 3 is reached through the **reactivation** path, which is what the test exercises.

## Verification

- `pnpm typecheck`, `pnpm lint` — clean
- `pnpm test:unit` — 161 files, 3222 passed
- `pnpm test:integration:local` (full suite) — 58 files passed / 2 skipped, 800 passed / 15 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
