### PR TITLE
fix: Ensure the surviving feed always has a job after a redirect merge

### DIFF
--- a/src/server/jobs/handlers/fetch-feed.ts
+++ b/src/server/jobs/handlers/fetch-feed.ts
@@ -10,6 +10,7 @@
 
 import { createHash } from "crypto";
 import { eq, and, isNull, inArray, count } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import { db } from "../../db";
 import { feeds, subscriptions, entries, userEntries, type Feed } from "../../db/schema";
 import { fetchFullContent, persistFullContentResult } from "../../services/full-content";
@@ -1164,43 +1165,45 @@ export async function migrateSubscriptionsToExistingFeed(
     }
   }
 
-  // Surviving subscription per user, for re-stamping user_entries.subscription_id
-  const survivorByUser = new Map<string, string>();
-
-  // For users with existing subscriptions: reactivate if needed
-  for (const user of usersWithExisting) {
-    survivorByUser.set(user.userId, user.existingSubId);
-    if (user.wasUnsubscribed) {
-      await db
-        .update(subscriptions)
-        .set({
-          unsubscribedAt: null,
-          subscribedAt: now,
-          updatedAt: now,
-        })
-        .where(eq(subscriptions.id, user.existingSubId));
-    }
+  // Batch update: reactivate every previously-unsubscribed subscription to the
+  // new feed. The SET is the same for all of them, so one statement does it.
+  const subIdsToReactivate = usersWithExisting
+    .filter((u) => u.wasUnsubscribed)
+    .map((u) => u.existingSubId);
+  if (subIdsToReactivate.length > 0) {
+    await db
+      .update(subscriptions)
+      .set({
+        unsubscribedAt: null,
+        subscribedAt: now,
+        updatedAt: now,
+      })
+      .where(inArray(subscriptions.id, subIdsToReactivate));
   }
 
   // Batch insert: For users without existing subscriptions, create new ones
   if (usersWithoutExisting.length > 0) {
-    const newSubscriptions = usersWithoutExisting.map((userId) => ({
-      id: generateUuidv7(),
-      userId,
-      feedId: newFeed.id,
-      subscribedAt: now,
-      createdAt: now,
-      updatedAt: now,
-    }));
-    for (const sub of newSubscriptions) {
-      survivorByUser.set(sub.userId, sub.id);
-    }
-
-    await db.insert(subscriptions).values(newSubscriptions);
-
-    // Ensure a job exists for the new feed (will be claimed via data-driven eligibility)
-    await ensureFeedJob(newFeed.id);
+    await db.insert(subscriptions).values(
+      usersWithoutExisting.map((userId) => ({
+        id: generateUuidv7(),
+        userId,
+        feedId: newFeed.id,
+        subscribedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      }))
+    );
   }
+
+  // Ensure a job exists for the new feed (will be claimed via data-driven
+  // eligibility). Unconditional, not just for brand-new subscriptions:
+  // retention deletes the `fetch_feed` job of any feed with no active
+  // subscriber, so a user resubscribing via a redirect merge onto a feed they
+  // had previously left can be the one that brings the feed back to life --
+  // with no job, it would never be fetched again. `ensureFeedJob` is an
+  // idempotent upsert that keeps an existing `next_run_at`, so running it for
+  // an already-scheduled feed is a no-op (issue #952).
+  await ensureFeedJob(newFeed.id);
 
   // Re-stamp user_entries attribution from each old subscription to its survivor.
   // user_entries.subscription_id is stamped at insert (issue #1117) and is what
@@ -1208,14 +1211,21 @@ export async function migrateSubscriptionsToExistingFeed(
   // entries would vanish with the about-to-be-unsubscribed subscription.
   // Deliberately leaves updated_at alone: nothing user-visible changes, and
   // bumping it would flood every affected user's delta sync.
-  for (const oldSub of activeSubscriptions) {
-    const survivorId = survivorByUser.get(oldSub.userId);
-    if (!survivorId) continue;
-    await db
-      .update(userEntries)
-      .set({ subscriptionId: survivorId })
-      .where(eq(userEntries.subscriptionId, oldSub.id));
-  }
+  // The survivor is looked up by joining the user's subscription to the new
+  // feed (unique per user/feed via uq_subscriptions_user_feed), which is what
+  // the reactivate/insert above just guaranteed exists for every affected user.
+  const survivorSub = alias(subscriptions, "survivor_sub");
+  await db
+    .update(userEntries)
+    .set({ subscriptionId: survivorSub.id })
+    .from(survivorSub)
+    .where(
+      and(
+        inArray(userEntries.subscriptionId, oldSubIds),
+        eq(survivorSub.userId, userEntries.userId),
+        eq(survivorSub.feedId, newFeed.id)
+      )
+    );
 
   // Batch update: Unsubscribe all old subscriptions at once
   await db

--- a/tests/integration/feed-redirect.test.ts
+++ b/tests/integration/feed-redirect.test.ts
@@ -7,10 +7,12 @@
  * 3. User read/starred state is preserved through the migration
  * 4. Users see entries from both old and new feeds without duplicates
  *    (attribution via user_entries.subscription_id, re-stamped by the merge job)
+ * 5. The surviving feed always ends up with a fetch_feed job, even when no new
+ *    subscription row had to be created
  */
 
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
-import { eq, and, isNull } from "drizzle-orm";
+import { eq, and, isNull, sql } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import {
   users,
@@ -30,6 +32,7 @@ import {
   createTestUser,
 } from "./helpers";
 import { ensureFeedJob } from "../../src/server/jobs/queue";
+import { runRetentionCleanup } from "../../src/server/services/retention";
 import { migrateSubscriptionsToExistingFeed } from "../../src/server/jobs/handlers/fetch-feed";
 import { createUserEntriesForFeed } from "../../src/server/feed/entry-processor";
 
@@ -128,6 +131,18 @@ async function getStampedSubscriptionId(userId: string, entryId: string): Promis
     .where(and(eq(userEntries.userId, userId), eq(userEntries.entryId, entryId)))
     .limit(1);
   return row?.subscriptionId ?? null;
+}
+
+/**
+ * Gets the single fetch_feed job for a feed, if one exists.
+ */
+async function getFeedJob(feedId: string): Promise<{ id: string; nextRunAt: Date | null } | null> {
+  const [row] = await db
+    .select({ id: jobs.id, nextRunAt: jobs.nextRunAt })
+    .from(jobs)
+    .where(and(eq(jobs.type, "fetch_feed"), sql`${jobs.payload}->>'feedId' = ${feedId}`))
+    .limit(1);
+  return row ?? null;
 }
 
 /**
@@ -352,6 +367,82 @@ describe("Feed Redirect Handling", () => {
       expect(newSub).not.toBeNull();
       expect(newSub!.unsubscribedAt).toBeNull(); // Reactivated
       expect(await getStampedSubscriptionId(userId, oldEntry)).toBe(newSub!.id);
+    });
+  });
+
+  describe("fetch_feed job for the surviving feed", () => {
+    it("recreates a reaped job when every migrated user already had a subscription", async () => {
+      const userId = await createTestUser();
+
+      const oldFeedId = await createTestFeed({
+        url: "https://old-domain.com/feed.xml",
+        title: "Old Feed",
+      });
+      const newFeedId = await createTestFeed({
+        url: "https://new-domain.com/feed.xml",
+        title: "New Feed",
+      });
+
+      // The user subscribed to the new feed once and left. Retention deletes
+      // the fetch_feed job of a feed with no active subscriber, so run the real
+      // sweep here - backdating created_at past DEAD_FEED_JOB_GRACE_MS (1h) is
+      // all it takes for the job to be eligible.
+      const staleSubId = await createTestSubscription(userId, newFeedId);
+      await ensureFeedJob(newFeedId);
+      await db
+        .update(jobs)
+        .set({ createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000) })
+        .where(eq(jobs.type, "fetch_feed"));
+      await db
+        .update(subscriptions)
+        .set({ unsubscribedAt: new Date() })
+        .where(eq(subscriptions.id, staleSubId));
+
+      await runRetentionCleanup(db);
+      expect(await getFeedJob(newFeedId)).toBeNull();
+
+      // Now the user subscribes to a different feed, which 301s onto that one.
+      // The merge finds an existing (unsubscribed) subscription row to
+      // reactivate, so it creates no new subscription rows at all.
+      await createTestSubscription(userId, oldFeedId);
+      await ensureFeedJob(oldFeedId);
+
+      await migrateSubscriptionsToExistingFeed(await getFeed(oldFeedId), await getFeed(newFeedId));
+
+      // The user's only active subscription is now to the new feed, so the new
+      // feed must have a job - without one it would never be fetched again.
+      const activeSubs = await getActiveSubscriptions(userId);
+      expect(activeSubs.map((s) => s.feedId)).toEqual([newFeedId]);
+      expect(await getFeedJob(newFeedId)).not.toBeNull();
+    });
+
+    it("does not disturb the schedule of a feed that already has a job", async () => {
+      const userId = await createTestUser();
+
+      const oldFeedId = await createTestFeed({
+        url: "https://old-domain.com/feed.xml",
+        title: "Old Feed",
+      });
+      const newFeedId = await createTestFeed({
+        url: "https://new-domain.com/feed.xml",
+        title: "New Feed",
+      });
+
+      // The new feed has a live subscriber and is scheduled well into the future.
+      const otherUserId = await createTestUser({ emailPrefix: "other" });
+      await createTestSubscription(otherUserId, newFeedId);
+      const scheduledFor = new Date(Date.now() + 6 * 60 * 60 * 1000);
+      await ensureFeedJob(newFeedId, scheduledFor);
+
+      await createTestSubscription(userId, oldFeedId);
+      await migrateSubscriptionsToExistingFeed(await getFeed(oldFeedId), await getFeed(newFeedId));
+
+      // ensureFeedJob is an idempotent upsert that keeps a non-null
+      // next_run_at, so calling it unconditionally can't pull a backing-off
+      // feed forward.
+      const job = await getFeedJob(newFeedId);
+      expect(job).not.toBeNull();
+      expect(job!.nextRunAt?.getTime()).toBe(scheduledFor.getTime());
     });
   });
 


### PR DESCRIPTION
## The bug

`migrateSubscriptionsToExistingFeed` (the feed-redirect merge in `src/server/jobs/handlers/fetch-feed.ts`) called `ensureFeedJob(newFeed.id)` **inside** the `if (usersWithoutExisting.length > 0)` branch — i.e. only when the merge had to create at least one brand-new subscription row. When every migrated user already had a subscription row to the target feed (active or soft-deleted), no job was ensured.

That is reachable because of retention. `runRetentionCleanup` deletes the `fetch_feed` job of any feed with no active subscriber (issue #1085), explicitly on the grounds that "a new subscriber recreates the job via `ensureFeedJob`'s idempotent upsert". The redirect-merge path is a way to become a new subscriber that did **not** hold up that end of the bargain:

1. User U subscribes to feed B, then unsubscribes. B now has no active subscriber.
2. The retention sweep deletes B's `fetch_feed` job.
3. U subscribes to feed A.
4. A responds `301` to B's URL. The merge runs: U's soft-deleted subscription to B is found, so `usersWithExisting = [U]` and `usersWithoutExisting = []`.
5. U's subscription to B is reactivated, U's subscription to A is unsubscribed — and `ensureFeedJob` never runs.

U now holds an active subscription to a feed that will never be fetched again. Nothing else recreates the job: `claimFeedJob` only claims existing rows, and A's job stops being claimed once A has no active subscriber.

## The fix

Move `await ensureFeedJob(newFeed.id)` out of the branch. `createSubscription` already calls it unconditionally for exactly this reason; this path had drifted from it.

Calling it unconditionally is safe: `ensureFeedJob` is a single `INSERT ... ON CONFLICT DO UPDATE` keyed on the per-feed partial unique index, and on conflict it sets `next_run_at = COALESCE(next_run_at, runAt)` — an already-scheduled or backing-off feed keeps its schedule.

## Also in this PR: two N+1 loops in the same function

Both were per-row `await`s in a loop over subscribers of the redirected feed:

- The **reactivation** UPDATE had a constant `SET`, so it collapses to one statement with `inArray` over the ids that need reactivating.
- The **`user_entries` re-stamp** needed a different `SET` per row, so it isn't an `inArray` — it became a single `UPDATE ... FROM` that joins each `user_entries` row to its owner's subscription to the surviving feed. That's well-defined because of `uq_subscriptions_user_feed (user_id, feed_id)`, and the reactivate/insert immediately above guarantees the row exists for every affected user. It also lets the `survivorByUser` map go away entirely, so the batched version is a net simplification rather than a trade.

Neither statement is inside a transaction (they weren't before either), and the ordering between them is unchanged.

## Tests

`tests/integration/feed-redirect.test.ts` already walked the "user previously unsubscribed from the target feed" scenario but asserted nothing about jobs. Added a `fetch_feed job for the surviving feed` describe with two cases:

- **`recreates a reaped job when every migrated user already had a subscription`** — reproduces the sequence above end to end, including running the *real* `runRetentionCleanup` (with the job's `created_at` backdated past `DEAD_FEED_JOB_GRACE_MS`) to reap the target feed's job, then asserts the merge leaves the surviving feed with a job. Verified it fails on the pre-fix code with `expected null not to be null`.
- **`does not disturb the schedule of a feed that already has a job`** — pins the idempotence claim: a target feed already scheduled 6h out keeps its `next_run_at` after the merge.

Results:

```
pnpm typecheck            clean
pnpm lint                 clean
pnpm test:unit            Test Files 161 passed (161) | Tests 3222 passed (3222)
pnpm test:integration     Test Files 57 passed | 2 skipped (59) | Tests 798 passed | 15 skipped (813)
```

## Known adjacent scope, deliberately not taken on

A prior review flagged that this same redirect-merge path hand-rolls subscription lifecycle that `createSubscription` owns, and separately **never migrates `subscription_tags`** — so a merged feed silently loses the user's tags and leaves orphan `subscription_tags` rows pointing at the unsubscribed old subscription, which makes `tags.feedCount` over-report. That is a real bug but a different one, with its own data-migration question for existing orphan rows; it is being filed as a separate issue rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
