### PR TITLE
fix: Revoke other sessions when setting a password

### DIFF
--- a/src/server/trpc/routers/users.ts
+++ b/src/server/trpc/routers/users.ts
@@ -176,6 +176,7 @@ export const usersRouter = createTRPCRouter({
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
+      const currentSessionId = ctx.session.session.id;
       const { newPassword } = input;
 
       // Hash the new password
@@ -194,6 +195,11 @@ export const usersRouter = createTRPCRouter({
       if (updated.length === 0) {
         throw errors.validation("Account already has a password. Use change password instead.");
       }
+
+      // Adding a credential is a credential change: an OAuth-only user securing a
+      // possibly-compromised account expects it to take effect everywhere, so
+      // revoke every other session just as a password change does.
+      await revokeOtherUserSessions(userId, currentSessionId);
 
       return { success: true };
     }),

--- a/tests/integration/password-session-revocation.test.ts
+++ b/tests/integration/password-session-revocation.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Integration tests for session revocation on credential changes.
+ *
+ * SECURITY.md §4: "Password change (and any credential change) must revoke other
+ * sessions." Both `users."me.setPassword"` (an OAuth-only account adding a
+ * password) and `users."me.changePassword"` are credential changes, so both must
+ * leave only the calling session alive — otherwise an attacker holding a leaked
+ * session token survives the very action the user took to secure the account.
+ *
+ * The sessions here are real rows validated through `validateSession`, so the
+ * test covers the Redis cache eviction too: a cached session still validates
+ * until its key is deleted, so revoking in Postgres alone would not be enough.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import * as argon2 from "argon2";
+import { db } from "../../src/server/db";
+import { sessions, users } from "../../src/server/db/schema";
+import { createSession, validateSession } from "../../src/server/auth/session";
+import { createCaller } from "../../src/server/trpc/root";
+import type { Context } from "../../src/server/trpc/context";
+import { createAuthContext, createTestUser } from "./helpers";
+
+const createdUserIds: string[] = [];
+
+/** Creates a user and remembers it for cleanup. */
+async function createUser(overrides: Partial<typeof users.$inferInsert> = {}): Promise<string> {
+  const userId = await createTestUser({ emailPrefix: "pw-revoke", ...overrides });
+  createdUserIds.push(userId);
+  return userId;
+}
+
+/**
+ * Builds a context whose `session.session` is a **real** `sessions` row, so the
+ * procedure's "keep the current session" argument refers to something the test
+ * can then validate. `createAuthContext` alone invents a synthetic session id,
+ * which would make every real session look like an "other" session.
+ */
+async function createSessionContext(userId: string, sessionId: string): Promise<Context> {
+  const base = await createAuthContext(userId);
+  if (!base.session) {
+    throw new Error("createAuthContext returned no session");
+  }
+  const [row] = await db.select().from(sessions).where(eq(sessions.id, sessionId)).limit(1);
+  if (!row) {
+    throw new Error(`no session row with id ${sessionId}`);
+  }
+  return { ...base, session: { ...base.session, session: row } };
+}
+
+afterAll(async () => {
+  if (createdUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, createdUserIds));
+  }
+});
+
+describe("credential changes revoke other sessions", () => {
+  it("me.setPassword revokes other sessions and keeps the caller's", async () => {
+    // An OAuth-only account: no password yet.
+    const userId = await createUser({ passwordHash: null });
+    const current = await createSession(db, { userId });
+    const other = await createSession(db, { userId });
+
+    // Warm both through the real validation path (this also fills the Redis
+    // cache, so the revoke has to evict it to take effect).
+    expect(await validateSession(current.token)).not.toBeNull();
+    expect(await validateSession(other.token)).not.toBeNull();
+
+    const caller = createCaller(await createSessionContext(userId, current.sessionId));
+    await expect(
+      caller.users["me.setPassword"]({ newPassword: "a-new-password" })
+    ).resolves.toEqual({ success: true });
+
+    // The leaked/lingering session is dead...
+    expect(await validateSession(other.token)).toBeNull();
+    // ...and the session that set the password is still usable.
+    expect(await validateSession(current.token)).not.toBeNull();
+  });
+
+  it("me.changePassword revokes other sessions and keeps the caller's", async () => {
+    const userId = await createUser({ passwordHash: await argon2.hash("old-password") });
+    const current = await createSession(db, { userId });
+    const other = await createSession(db, { userId });
+
+    expect(await validateSession(current.token)).not.toBeNull();
+    expect(await validateSession(other.token)).not.toBeNull();
+
+    const caller = createCaller(await createSessionContext(userId, current.sessionId));
+    await expect(
+      caller.users["me.changePassword"]({
+        currentPassword: "old-password",
+        newPassword: "a-new-password",
+      })
+    ).resolves.toEqual({ success: true });
+
+    expect(await validateSession(other.token)).toBeNull();
+    expect(await validateSession(current.token)).not.toBeNull();
+  });
+
+  it("a rejected me.setPassword leaves other sessions alone", async () => {
+    // Already has a password, so setPassword must fail — and a failed credential
+    // change must not log the user's other devices out.
+    const userId = await createUser({ passwordHash: await argon2.hash("existing-password") });
+    const current = await createSession(db, { userId });
+    const other = await createSession(db, { userId });
+
+    const caller = createCaller(await createSessionContext(userId, current.sessionId));
+    await expect(caller.users["me.setPassword"]({ newPassword: "a-new-password" })).rejects.toThrow(
+      /already has a password/i
+    );
+
+    expect(await validateSession(other.token)).not.toBeNull();
+    expect(await validateSession(current.token)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## The gap

`users."me.setPassword"` added a credential to the account and returned without touching the user's other sessions.

**Threat model:** an OAuth-only user whose session token has leaked goes to Settings → Account and adds a password, reasonably expecting that to secure the account. It doesn't — the attacker's session survives, and the user has no signal that anything is still wrong. `me.setPassword` is exactly the procedure such a user reaches for, because `me.changePassword` is unavailable to them (no current password to supply).

## Why this counts

`SECURITY.md` §4 (Sessions & authentication):

> Password change (and any credential change) must revoke other sessions (`revokeOtherUserSessions`).

Adding a first password is a credential change — the account gains a login method it did not have. The adjacent `me.changePassword` already does this, with the comment "so a stolen/lingering credential can't survive a password change"; this makes the two consistent.

## Ruling out a deliberate omission

Checked whether `setPassword` runs inside some onboarding or account-linking sequence that revoking would break:

- The only caller is `PasswordForm` in `src/components/settings/pages/AccountSettingsContent.tsx` (Settings → Account), a standalone user-initiated form. Its `onSuccess` only refetches `me.linkedAccounts`; it is not part of a multi-step flow.
- Signup onboarding runs through `runPostSignupTasks` (`src/server/auth/signup.ts`) and does not touch this procedure; neither do the OAuth callback/link paths or any job.
- The REST/OpenAPI mirror is `POST /api/v1/users/me/set-password` on the same procedure, so it inherits the fix. The procedure is `expensiveConfirmedProtectedProcedure`, i.e. session-only — no API token can call it, so nothing can be revoked out from under a token integration.

The calling session is kept alive (`revokeOtherUserSessions(userId, currentSessionId)`), so the user is not logged out of the tab they are using.

## Sibling procedures

`users.ts` has no other credential-mutating procedure — `me.setPassword` and `me.changePassword` are the only two. (`me.linkedAccounts` is a read; `me.updatePreferences` handles LLM API keys, which are third-party secrets, not login credentials; `me.deleteAccount` clears the session cookie and deletes the user.) The OAuth `linkGoogle`/`linkApple`/`linkDiscord`/`unlinkProvider` procedures live in `auth.ts` and arguably deserve the same treatment; that's left out of this PR to keep it to the reported gap and is worth a separate look.

## Tests

New `tests/integration/password-session-revocation.test.ts` creates **real** `sessions` rows and validates them through `validateSession`, so the Redis cache eviction is covered too (a cached session keeps validating until its key is deleted, so a DB-only revoke would not be enough):

- `me.setPassword` on an OAuth-only account: the second session no longer validates, the calling session still does.
- `me.changePassword`: same, pinning the existing precedent so it can't regress either.
- A rejected `me.setPassword` (account already has a password) leaves both sessions alive — a failed credential change must not log the user's other devices out.

Verified the first test fails on `master`'s behavior (`expect(await validateSession(other.token)).toBeNull()`) and passes with the change.

```
pnpm typecheck                 clean
pnpm test:unit                 Test Files 161 passed (161) | Tests 3222 passed (3222)
pnpm test:integration:local    Test Files 58 passed | 2 skipped (60) | Tests 799 passed | 15 skipped (814)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
