### PR TITLE
chore: Remove the dead jsdom build externals and dedupe the esbuild scripts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -212,7 +212,7 @@ const nextConfig: NextConfig = {
   ],
   // Handle piper-tts-web which has conditional Node.js code (require('fs'))
   // that the bundler tries to resolve even though it only runs in Node.js
-  webpack: (config, { isServer, nextRuntime }) => {
+  webpack: (config, { isServer }) => {
     if (!isServer) {
       // Stub out Node.js modules for client bundles
       config.resolve.fallback = {
@@ -235,20 +235,6 @@ const nextConfig: NextConfig = {
         ...config.resolve.alias,
         "onnxruntime-web$": "onnxruntime-web/wasm",
       };
-    }
-    // isomorphic-dompurify pulls in jsdom during SSR of `"use client"` components
-    // (e.g. EntryContentBody). jsdom reads browser/default-stylesheet.css via
-    // `path.resolve(__dirname, ...)` at runtime; bundling breaks __dirname so the
-    // read resolves to a bogus path (e.g. /app/browser/default-stylesheet.css) and
-    // throws ENOENT mid-stream, producing a 500 status even though the shell already
-    // rendered. `serverExternalPackages` doesn't cover deps reached through the
-    // client-component SSR graph, so force-externalize jsdom on the Node server build
-    // to load it from node_modules where the __dirname-relative read resolves.
-    if (isServer && nextRuntime === "nodejs") {
-      // Bare string (not { jsdom: "commonjs jsdom" }) so webpack emits the external
-      // in whatever module format the server build uses, staying correct if Next
-      // ever switches the Node server output to ESM.
-      config.externals.push("jsdom");
     }
     // Silence known-benign "Critical dependency" warnings from Sentry's Node SDK.
     // @sentry/node pulls in OpenTelemetry auto-instrumentation, which uses

--- a/scripts/build-bundle.mjs
+++ b/scripts/build-bundle.mjs
@@ -1,0 +1,107 @@
+/**
+ * Shared esbuild driver for the deployable bundles (server, worker, Discord bot,
+ * migrate). Each `build-*.mjs` is just an entry point + outfile + its own
+ * `external` list; everything else — path-alias resolution, esbuild options,
+ * the CommonJS marker, error handling — lives here so the four can't drift.
+ *
+ * Bundles are emitted as CommonJS on purpose; see the "Module System (ESM)"
+ * section of CLAUDE.md and scripts/dist-cjs-marker.mjs before changing `format`.
+ */
+
+import * as esbuild from "esbuild";
+import { readFileSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { writeDistCjsMarker } from "./dist-cjs-marker.mjs";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Convert the TypeScript path aliases in tsconfig.json to esbuild's alias map,
+ * so bundled imports resolve the way `tsc` resolves them: `"@/*" -> "./src/*"`
+ * becomes `"@" -> "<rootDir>/src"`.
+ */
+function tsconfigAliases() {
+  const tsconfig = JSON.parse(readFileSync(resolve(rootDir, "tsconfig.json"), "utf8"));
+  const paths = tsconfig.compilerOptions?.paths || {};
+
+  const alias = {};
+  for (const [key, values] of Object.entries(paths)) {
+    alias[key.replace("/*", "")] = resolve(rootDir, values[0].replace("/*", ""));
+  }
+  return alias;
+}
+
+function formatSize(bytes) {
+  return bytes >= 1024 * 1024
+    ? `${(bytes / 1024 / 1024).toFixed(2)} MB`
+    : `${(bytes / 1024).toFixed(2)} KB`;
+}
+
+/**
+ * Bundle one entry point and exit non-zero if esbuild fails.
+ *
+ * @param {object} options
+ * @param {string} options.label Human-readable name used in the build logs.
+ * @param {string} options.entryPoint Entry file, relative to the repo root.
+ * @param {string} options.outfile Output file, relative to the repo root.
+ * @param {string[]} [options.external] Packages to leave as runtime requires.
+ */
+export async function buildBundle({ label, entryPoint, outfile, external = [] }) {
+  console.log(`Building ${label} bundle...`);
+  const startTime = Date.now();
+  const outPath = resolve(rootDir, outfile);
+
+  try {
+    const result = await esbuild.build({
+      entryPoints: [resolve(rootDir, entryPoint)],
+      bundle: true,
+      platform: "node",
+      target: "node26",
+      format: "cjs",
+      outfile: outPath,
+
+      // Resolve TypeScript path aliases
+      alias: tsconfigAliases(),
+
+      external,
+
+      // Source maps for debugging production issues
+      sourcemap: true,
+
+      // Minify for smaller bundle size
+      minify: true,
+
+      // Keep names for better error stack traces
+      keepNames: true,
+
+      // Tree-shake unused code
+      treeShaking: true,
+
+      // Define environment for dead code elimination
+      define: {
+        "process.env.NODE_ENV": '"production"',
+      },
+
+      // Banner to make the output executable
+      banner: {
+        js: "#!/usr/bin/env node",
+      },
+
+      // Log level
+      logLevel: "info",
+    });
+    writeDistCjsMarker(dirname(outPath));
+
+    console.log(`${label} bundle built in ${Date.now() - startTime}ms`);
+
+    if (result.warnings.length > 0) {
+      console.warn("Warnings:", result.warnings);
+    }
+
+    console.log(`Bundle size: ${formatSize(statSync(outPath).size)}`);
+  } catch (error) {
+    console.error("Build failed:", error);
+    process.exit(1);
+  }
+}

--- a/scripts/build-discord-bot.mjs
+++ b/scripts/build-discord-bot.mjs
@@ -9,39 +9,12 @@
  * and most of node_modules in the production Docker image.
  */
 
-import * as esbuild from "esbuild";
-import { readFileSync } from "fs";
-import { dirname, resolve } from "path";
-import { fileURLToPath } from "url";
-import { writeDistCjsMarker } from "./dist-cjs-marker.mjs";
+import { buildBundle } from "./build-bundle.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const rootDir = resolve(__dirname, "..");
-
-// Read tsconfig to get path aliases
-const tsconfig = JSON.parse(readFileSync(resolve(rootDir, "tsconfig.json"), "utf8"));
-const paths = tsconfig.compilerOptions?.paths || {};
-
-// Convert TypeScript path aliases to esbuild alias format
-// "@/*" -> "./src/*" becomes "@" -> "./src"
-const alias = {};
-for (const [key, values] of Object.entries(paths)) {
-  const aliasKey = key.replace("/*", "");
-  const aliasValue = values[0].replace("/*", "");
-  alias[aliasKey] = resolve(rootDir, aliasValue);
-}
-
-// Build configuration
-const buildOptions = {
-  entryPoints: [resolve(rootDir, "scripts/discord-bot.ts")],
-  bundle: true,
-  platform: "node",
-  target: "node26",
-  format: "cjs",
-  outfile: resolve(rootDir, "dist/discord-bot.js"),
-
-  // Resolve TypeScript path aliases
-  alias,
+await buildBundle({
+  label: "Discord bot",
+  entryPoint: "scripts/discord-bot.ts",
+  outfile: "dist/discord-bot.js",
 
   // External packages that can't/shouldn't be bundled:
   // - Native modules (argon2 uses node-gyp bindings)
@@ -55,57 +28,4 @@ const buildOptions = {
     "@lion-reader/feed-parser",
     "@lion-reader/markdown",
   ],
-
-  // Source maps for debugging production issues
-  sourcemap: true,
-
-  // Minify for smaller bundle size
-  minify: true,
-
-  // Keep names for better error stack traces
-  keepNames: true,
-
-  // Tree-shake unused code
-  treeShaking: true,
-
-  // Define environment for dead code elimination
-  define: {
-    "process.env.NODE_ENV": '"production"',
-  },
-
-  // Banner to make the output executable
-  banner: {
-    js: "#!/usr/bin/env node",
-  },
-
-  // Log level
-  logLevel: "info",
-};
-
-async function build() {
-  console.log("Building Discord bot bundle...");
-  const startTime = Date.now();
-
-  try {
-    const result = await esbuild.build(buildOptions);
-    writeDistCjsMarker(resolve(rootDir, "dist"));
-
-    const duration = Date.now() - startTime;
-    console.log(`Discord bot bundle built in ${duration}ms`);
-
-    if (result.warnings.length > 0) {
-      console.warn("Warnings:", result.warnings);
-    }
-
-    // Report bundle size
-    const { statSync } = await import("fs");
-    const stats = statSync(resolve(rootDir, "dist/discord-bot.js"));
-    const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
-    console.log(`Bundle size: ${sizeMB} MB`);
-  } catch (error) {
-    console.error("Build failed:", error);
-    process.exit(1);
-  }
-}
-
-build();
+});

--- a/scripts/build-migrate.mjs
+++ b/scripts/build-migrate.mjs
@@ -8,92 +8,13 @@
  * This eliminates the need for tsx, dotenv, and pnpm in the production Docker image.
  */
 
-import * as esbuild from "esbuild";
-import { readFileSync, statSync } from "fs";
-import { dirname, resolve } from "path";
-import { fileURLToPath } from "url";
-import { writeDistCjsMarker } from "./dist-cjs-marker.mjs";
+import { buildBundle } from "./build-bundle.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const rootDir = resolve(__dirname, "..");
-
-// Read tsconfig to get path aliases
-const tsconfig = JSON.parse(readFileSync(resolve(rootDir, "tsconfig.json"), "utf8"));
-const paths = tsconfig.compilerOptions?.paths || {};
-
-// Convert TypeScript path aliases to esbuild alias format
-// "@/*" -> "./src/*" becomes "@" -> "./src"
-const alias = {};
-for (const [key, values] of Object.entries(paths)) {
-  const aliasKey = key.replace("/*", "");
-  const aliasValue = values[0].replace("/*", "");
-  alias[aliasKey] = resolve(rootDir, aliasValue);
-}
-
-// Build configuration
-const buildOptions = {
-  entryPoints: [resolve(rootDir, "scripts/migrate.ts")],
-  bundle: true,
-  platform: "node",
-  target: "node26",
-  format: "cjs",
-  outfile: resolve(rootDir, "dist/migrate.js"),
-
-  // Resolve TypeScript path aliases
-  alias,
+await buildBundle({
+  label: "Migration",
+  entryPoint: "scripts/migrate.ts",
+  outfile: "dist/migrate.js",
 
   // No external dependencies needed - pg and ioredis can be bundled
   external: [],
-
-  // Source maps for debugging production issues
-  sourcemap: true,
-
-  // Minify for smaller bundle size
-  minify: true,
-
-  // Keep names for better error stack traces
-  keepNames: true,
-
-  // Tree-shake unused code
-  treeShaking: true,
-
-  // Define environment for dead code elimination
-  define: {
-    "process.env.NODE_ENV": '"production"',
-  },
-
-  // Banner to make the output executable
-  banner: {
-    js: "#!/usr/bin/env node",
-  },
-
-  // Log level
-  logLevel: "info",
-};
-
-async function build() {
-  console.log("Building migration bundle...");
-  const startTime = Date.now();
-
-  try {
-    const result = await esbuild.build(buildOptions);
-    writeDistCjsMarker(resolve(rootDir, "dist"));
-
-    const duration = Date.now() - startTime;
-    console.log(`Migration bundle built in ${duration}ms`);
-
-    if (result.warnings.length > 0) {
-      console.warn("Warnings:", result.warnings);
-    }
-
-    // Report bundle size
-    const stats = statSync(resolve(rootDir, "dist/migrate.js"));
-    const sizeKB = (stats.size / 1024).toFixed(2);
-    console.log(`Bundle size: ${sizeKB} KB`);
-  } catch (error) {
-    console.error("Build failed:", error);
-    process.exit(1);
-  }
-}
-
-build();
+});

--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -8,39 +8,12 @@
  * The server wraps Next.js with streaming compression (zstd/brotli/gzip).
  */
 
-import * as esbuild from "esbuild";
-import { readFileSync } from "fs";
-import { dirname, resolve } from "path";
-import { fileURLToPath } from "url";
-import { writeDistCjsMarker } from "./dist-cjs-marker.mjs";
+import { buildBundle } from "./build-bundle.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const rootDir = resolve(__dirname, "..");
-
-// Read tsconfig to get path aliases
-const tsconfig = JSON.parse(readFileSync(resolve(rootDir, "tsconfig.json"), "utf8"));
-const paths = tsconfig.compilerOptions?.paths || {};
-
-// Convert TypeScript path aliases to esbuild alias format
-// "@/*" -> "./src/*" becomes "@" -> "./src"
-const alias = {};
-for (const [key, values] of Object.entries(paths)) {
-  const aliasKey = key.replace("/*", "");
-  const aliasValue = values[0].replace("/*", "");
-  alias[aliasKey] = resolve(rootDir, aliasValue);
-}
-
-// Build configuration
-const buildOptions = {
-  entryPoints: [resolve(rootDir, "scripts/server.ts")],
-  bundle: true,
-  platform: "node",
-  target: "node26",
-  format: "cjs",
-  outfile: resolve(rootDir, "dist/server.js"),
-
-  // Resolve TypeScript path aliases
-  alias,
+await buildBundle({
+  label: "Server",
+  entryPoint: "scripts/server.ts",
+  outfile: "dist/server.js",
 
   // External packages that can't/shouldn't be bundled:
   // - next: loaded from node_modules at runtime (needs .next build output)
@@ -55,57 +28,4 @@ const buildOptions = {
     "@lion-reader/feed-parser",
     "@lion-reader/markdown",
   ],
-
-  // Source maps for debugging production issues
-  sourcemap: true,
-
-  // Minify for smaller bundle size
-  minify: true,
-
-  // Keep names for better error stack traces
-  keepNames: true,
-
-  // Tree-shake unused code
-  treeShaking: true,
-
-  // Define environment for dead code elimination
-  define: {
-    "process.env.NODE_ENV": '"production"',
-  },
-
-  // Banner to make the output executable
-  banner: {
-    js: "#!/usr/bin/env node",
-  },
-
-  // Log level
-  logLevel: "info",
-};
-
-async function build() {
-  console.log("Building server bundle...");
-  const startTime = Date.now();
-
-  try {
-    const result = await esbuild.build(buildOptions);
-    writeDistCjsMarker(resolve(rootDir, "dist"));
-
-    const duration = Date.now() - startTime;
-    console.log(`Server bundle built in ${duration}ms`);
-
-    if (result.warnings.length > 0) {
-      console.warn("Warnings:", result.warnings);
-    }
-
-    // Report bundle size
-    const { statSync } = await import("fs");
-    const stats = statSync(resolve(rootDir, "dist/server.js"));
-    const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
-    console.log(`Bundle size: ${sizeMB} MB`);
-  } catch (error) {
-    console.error("Build failed:", error);
-    process.exit(1);
-  }
-}
-
-build();
+});

--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -46,13 +46,10 @@ const buildOptions = {
   // - next: loaded from node_modules at runtime (needs .next build output)
   // - Native modules (argon2 uses node-gyp bindings)
   // - html-rewriter-wasm has WASM files and internal requires that break when bundled
-  // - jsdom uses __dirname-relative fs.readFileSync for browser/default-stylesheet.css;
-  //   bundling breaks the path resolution (required at runtime by isomorphic-dompurify)
   external: [
     "next",
     "argon2",
     "html-rewriter-wasm",
-    "jsdom",
     "@lion-reader/sanitizer",
     "@lion-reader/readability",
     "@lion-reader/feed-parser",

--- a/scripts/build-worker.mjs
+++ b/scripts/build-worker.mjs
@@ -9,39 +9,12 @@
  * and most of node_modules in the production Docker image.
  */
 
-import * as esbuild from "esbuild";
-import { readFileSync } from "fs";
-import { dirname, resolve } from "path";
-import { fileURLToPath } from "url";
-import { writeDistCjsMarker } from "./dist-cjs-marker.mjs";
+import { buildBundle } from "./build-bundle.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const rootDir = resolve(__dirname, "..");
-
-// Read tsconfig to get path aliases
-const tsconfig = JSON.parse(readFileSync(resolve(rootDir, "tsconfig.json"), "utf8"));
-const paths = tsconfig.compilerOptions?.paths || {};
-
-// Convert TypeScript path aliases to esbuild alias format
-// "@/*" -> "./src/*" becomes "@" -> "./src"
-const alias = {};
-for (const [key, values] of Object.entries(paths)) {
-  const aliasKey = key.replace("/*", "");
-  const aliasValue = values[0].replace("/*", "");
-  alias[aliasKey] = resolve(rootDir, aliasValue);
-}
-
-// Build configuration
-const buildOptions = {
-  entryPoints: [resolve(rootDir, "scripts/worker.ts")],
-  bundle: true,
-  platform: "node",
-  target: "node26",
-  format: "cjs",
-  outfile: resolve(rootDir, "dist/worker.js"),
-
-  // Resolve TypeScript path aliases
-  alias,
+await buildBundle({
+  label: "Worker",
+  entryPoint: "scripts/worker.ts",
+  outfile: "dist/worker.js",
 
   // External packages that can't/shouldn't be bundled:
   // - Native modules (argon2 uses node-gyp bindings)
@@ -55,57 +28,4 @@ const buildOptions = {
     "@lion-reader/feed-parser",
     "@lion-reader/markdown",
   ],
-
-  // Source maps for debugging production issues
-  sourcemap: true,
-
-  // Minify for smaller bundle size
-  minify: true,
-
-  // Keep names for better error stack traces
-  keepNames: true,
-
-  // Tree-shake unused code
-  treeShaking: true,
-
-  // Define environment for dead code elimination
-  define: {
-    "process.env.NODE_ENV": '"production"',
-  },
-
-  // Banner to make the output executable
-  banner: {
-    js: "#!/usr/bin/env node",
-  },
-
-  // Log level
-  logLevel: "info",
-};
-
-async function build() {
-  console.log("Building worker bundle...");
-  const startTime = Date.now();
-
-  try {
-    const result = await esbuild.build(buildOptions);
-    writeDistCjsMarker(resolve(rootDir, "dist"));
-
-    const duration = Date.now() - startTime;
-    console.log(`Worker bundle built in ${duration}ms`);
-
-    if (result.warnings.length > 0) {
-      console.warn("Warnings:", result.warnings);
-    }
-
-    // Report bundle size
-    const { statSync } = await import("fs");
-    const stats = statSync(resolve(rootDir, "dist/worker.js"));
-    const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
-    console.log(`Bundle size: ${sizeMB} MB`);
-  } catch (error) {
-    console.error("Build failed:", error);
-    process.exit(1);
-  }
-}
-
-build();
+});


### PR DESCRIPTION
## 1. Remove the dead jsdom externals

`next.config.ts` and `scripts/build-server.mjs` each force-externalize `jsdom`, with a long comment blaming **`isomorphic-dompurify`** for pulling jsdom into the client-component SSR graph.

**Evidence that this is dead:**

- `isomorphic-dompurify` is **not a dependency anywhere in the repo**. `grep -rn "isomorphic-dompurify"` over the tree (excluding `node_modules`) returned exactly two hits — the two stale comments this PR deletes. Sanitization is the native Rust module now.
- `jsdom` is a **devDependency only**. `pnpm why jsdom` shows only the direct devDep plus vitest's peer; no production dependency reaches it.
- Nothing in `src/` or `scripts/` imports jsdom. The only `jsdom` strings in `.next/server` after a build are our own source comments in `src/lib/narration/*.ts`, carried in sourcemaps — no `node_modules/jsdom` path appears anywhere in the build output.

**Safety argument:** if anything still reached jsdom from the server graph, production would *already* be broken, since jsdom is not installed there (prod installs skip devDependencies). Externalizing a package nothing imports is a no-op. The stale rationale is worse than no comment, because it points a future reader at a package that no longer exists.

Removing the block leaves `nextRuntime` unused in the webpack callback, so it's dropped from the destructure.

## 2. Consolidate the four esbuild build scripts

`build-server.mjs`, `build-worker.mjs`, `build-discord-bot.mjs` and `build-migrate.mjs` were ~450 lines that differed **only** in entry point, outfile, `external` list, log label, and KB-vs-MB size formatting. The tsconfig path-alias→esbuild-alias conversion, the entire `buildOptions` object, the `build()` wrapper and the error handling were copy-pasted four times — and had already drifted (the stale jsdom comment lived in exactly one of the four).

`scripts/build-bundle.mjs` now owns the shared driver; each `build-*.mjs` is a small config. Size formatting picks KB or MB from the actual size, reproducing what each script printed before without four copies of the arithmetic.

Per `CLAUDE.md`'s "Module System (ESM)" section, `format: "cjs"` is unchanged and `writeDistCjsMarker` still runs after every build — `dist/package.json` is still written as `{"type":"commonjs"}` (verified).

## Verification

Bundles built on `origin/master` and again on this branch. **All four are byte-identical** (sha256 match), which is the strongest possible evidence that neither change altered deploy output:

| Bundle | Before | After | sha256 |
| --- | ---: | ---: | --- |
| `dist/server.js` | 2,024,142 B (1.93 MB) | 2,024,142 B (1.93 MB) | unchanged |
| `dist/worker.js` | 4,552,717 B (4.34 MB) | 4,552,717 B (4.34 MB) | unchanged |
| `dist/discord-bot.js` | 5,861,154 B (5.59 MB) | 5,861,154 B (5.59 MB) | unchanged |
| `dist/migrate.js` | 295,830 B (288.90 KB) | 295,830 B (288.90 KB) | unchanged |

Also run:

- `pnpm build` (Next, webpack) — succeeds; this is the real test of the `next.config.ts` change. (`✓ Compiled successfully`, `Finished TypeScript`, exit 0.)
- `pnpm typecheck` — clean
- `pnpm lint` / `pnpm format:check` — clean
- `pnpm test:unit` — `Test Files 161 passed (161)`, `Tests 3222 passed (3222)`
- `node dist/migrate.js` still loads and runs (fails on DB connect, not on module format), confirming the CommonJS marker still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
