### PR TITLE
fix: Find <link> feeds with mixed-case attributes, drop dead code

### DIFF
--- a/src/server/feed/arxiv.ts
+++ b/src/server/feed/arxiv.ts
@@ -33,13 +33,6 @@ const ARXIV_URL_PATTERN =
   /^https?:\/\/(?:www\.)?arxiv\.org\/(abs|pdf|html)\/([a-zA-Z0-9.\-/]+?(?:v\d+)?)(?:\.pdf)?(?:[?#].*)?$/;
 
 /**
- * Checks if a URL is an ArXiv paper URL (abs, pdf, or html).
- */
-export function isArxivUrl(url: string): boolean {
-  return ARXIV_URL_PATTERN.test(url);
-}
-
-/**
  * Extracts the paper ID from an ArXiv URL.
  * Returns null if the URL is not a valid ArXiv paper URL.
  *

--- a/src/server/feed/cache-headers.ts
+++ b/src/server/feed/cache-headers.ts
@@ -165,7 +165,9 @@ export function parseCacheHeaders(headers: Headers): ParsedCacheHeaders {
  * @returns The effective max-age in seconds, or undefined if not cacheable
  */
 export function getEffectiveMaxAge(cacheControl: CacheControl): number | undefined {
-  // If no-store or no-cache, don't cache
+  // Only no-store suppresses a max-age here. `no-cache` deliberately doesn't:
+  // it means "revalidate before reuse", and every poll already sends a
+  // conditional GET, so the max-age still tells us how often to do that.
   if (cacheControl.noStore) {
     return undefined;
   }

--- a/src/server/feed/discovery.ts
+++ b/src/server/feed/discovery.ts
@@ -56,24 +56,6 @@ export const COMMON_FEED_PATHS = [
 ];
 
 /**
- * Gets an attribute value case-insensitively from an attributes object.
- *
- * @param attribs - The attributes object from htmlparser2
- * @param name - The attribute name (lowercase)
- * @returns The attribute value, or undefined if not found
- */
-function getAttributeCI(attribs: Record<string, string>, name: string): string | undefined {
-  // Try lowercase first (most common case)
-  if (name in attribs) return attribs[name];
-
-  // Try uppercase
-  const upperName = name.toUpperCase();
-  if (upperName in attribs) return attribs[upperName];
-
-  return undefined;
-}
-
-/**
  * Checks if a rel attribute value indicates an alternate link.
  * The rel attribute can contain multiple space-separated values.
  *
@@ -151,26 +133,21 @@ export function discoverFeeds(html: string, baseUrl: string): DiscoveredFeed[] {
   const parser = new Parser(
     {
       onopentag(name, attribs) {
-        const tagName = name.toLowerCase();
-
-        // Check for link tags
-        if (tagName === "link") {
+        // Check for link tags (htmlparser2 lowercases tag and attribute names)
+        if (name === "link") {
           // Check if this is a rel="alternate" link
-          const rel = getAttributeCI(attribs, "rel");
-          if (!isAlternateRel(rel)) {
+          if (!isAlternateRel(attribs.rel)) {
             return;
           }
 
           // Check if the type is a feed type
-          const type = getAttributeCI(attribs, "type");
-          const feedType = getFeedTypeFromMime(type);
+          const feedType = getFeedTypeFromMime(attribs.type);
           if (feedType === null) {
             return;
           }
 
           // Extract and resolve the href
-          const href = getAttributeCI(attribs, "href");
-          const resolvedUrl = resolveUrl(href, baseUrl);
+          const resolvedUrl = resolveUrl(attribs.href, baseUrl);
           if (!resolvedUrl) {
             return;
           }
@@ -181,24 +158,22 @@ export function discoverFeeds(html: string, baseUrl: string): DiscoveredFeed[] {
           }
           seenUrls.add(resolvedUrl);
 
-          // Extract title if present
-          const title = getAttributeCI(attribs, "title");
-
           feeds.push({
             url: resolvedUrl,
             type: feedType,
-            title: title || undefined,
+            // Extract title if present
+            title: attribs.title || undefined,
           });
         }
       },
       onclosetag(name) {
         // Exit early after </head> - no feed links in body
-        if (name.toLowerCase() === "head") {
+        if (name === "head") {
           parser.pause();
         }
       },
     },
-    { decodeEntities: true, lowerCaseTags: false, lowerCaseAttributeNames: false }
+    { decodeEntities: true }
   );
 
   parser.write(html);

--- a/src/server/feed/entry-processor.ts
+++ b/src/server/feed/entry-processor.ts
@@ -15,7 +15,6 @@ import { publishNewEntry, publishEntryUpdatedFromEntry } from "../redis/pubsub";
 import { toNewEntryListData, type NewEntryListDataSource } from "@/lib/events/schemas";
 import { deriveEntryUrl, type ParsedEntry, type ParsedFeed } from "./types";
 import { cleanEntryContent } from "./content-utils";
-import { generateSummary } from "../html/strip-html";
 import { logger } from "@/lib/logger";
 
 /**
@@ -95,8 +94,8 @@ export interface ProcessEntriesOptions {
  * The hash covers title, content, author, and URL — the fields that
  * `updateEntryContent` actually rewrites when the hash changes. Previously only
  * title+content were hashed, so a feed correcting an entry's URL or author
- * without touching its text was silently ignored (see `processEntry`, which only
- * updates on a hash change).
+ * without touching its text was silently ignored (see `processEntryWithCache`,
+ * which only updates on a hash change).
  *
  * `pubDate` is deliberately NOT hashed: `updateEntryContent` never rewrites
  * `published_at` because it is denormalized into `user_entries.published_or_fetched_at`
@@ -170,24 +169,6 @@ export function deriveGuid(entry: ParsedEntry): string {
   }
 
   throw new Error("Cannot derive GUID: entry has no guid, link, or title");
-}
-
-/**
- * Generates a summary from entry content.
- *
- * Prefers the feed-provided summary (from <description> or <summary> elements)
- * when available, as that's what the publisher intended as the excerpt.
- * Falls back to generating from full content if no summary is provided.
- *
- * Strips HTML and truncates to 300 characters.
- *
- * @param entry - The parsed entry
- * @returns Summary string
- */
-export function generateEntrySummary(entry: ParsedEntry): string {
-  // Prefer explicit summary from feed, fall back to content
-  const source = entry.summary ?? entry.content ?? "";
-  return generateSummary(source);
 }
 
 /**
@@ -302,83 +283,6 @@ export async function updateEntryContent(
     .returning();
 
   return entry;
-}
-
-/**
- * Processes a single entry from a feed.
- * Creates new entries or updates existing ones based on content hash.
- *
- * @param feedId - The feed's UUID
- * @param feedType - The feed type
- * @param parsedEntry - The parsed entry from the feed
- * @param fetchedAt - Timestamp when the entry was fetched
- * @param feedUrl - The URL of the feed (for feed-specific cleaning)
- * @returns Processing result for this entry
- */
-export async function processEntry(
-  feedId: string,
-  feedType: "web" | "email" | "saved",
-  parsedEntry: ParsedEntry,
-  fetchedAt: Date,
-  feedUrl?: string
-): Promise<ProcessedEntry> {
-  const guid = deriveGuid(parsedEntry);
-  const contentHash = generateContentHash(parsedEntry);
-
-  // Check if entry already exists
-  const existing = await findEntryByGuid(feedId, guid);
-
-  if (!existing) {
-    // New entry - create it.
-    // Note: the new_entry event is NOT published here. It's published by
-    // processEntries AFTER createUserEntriesForFeed, because the SSE endpoint
-    // computes per-user absolute counts from visible_entries when the event
-    // arrives — publishing before the user_entries fanout would produce counts
-    // that exclude this entry.
-    const entry = await createEntry(feedId, feedType, parsedEntry, contentHash, fetchedAt, feedUrl);
-
-    return {
-      id: entry.id,
-      guid,
-      isNew: true,
-      isUpdated: false,
-      updatedAt: entry.updatedAt,
-      newEntryData: toNewEntryData(entry),
-    };
-  }
-
-  // Entry exists - check if content changed
-  if (existing.contentHash !== contentHash) {
-    // Content changed - update it
-    const entry = await updateEntryContent(existing.id, parsedEntry, contentHash, feedUrl);
-
-    // Publish entry_updated event for real-time updates (safe to publish here:
-    // subscribers' user_entries rows already exist for a previously-seen entry).
-    // Fire and forget - we don't want publishing failures to affect entry processing
-    publishEntryUpdatedFromEntry(feedId, entry).catch((err) => {
-      logger.error("Failed to publish entry_updated event", {
-        feedId,
-        entryId: entry.id,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
-
-    return {
-      id: entry.id,
-      guid,
-      isNew: false,
-      isUpdated: true,
-      updatedAt: entry.updatedAt,
-    };
-  }
-
-  // Content unchanged
-  return {
-    id: existing.id,
-    guid,
-    isNew: false,
-    isUpdated: false,
-  };
 }
 
 /**

--- a/src/server/feed/lesswrong.ts
+++ b/src/server/feed/lesswrong.ts
@@ -111,13 +111,6 @@ export function extractCommentId(url: string): string | null {
 }
 
 /**
- * Checks if a LessWrong URL points to a specific comment.
- */
-export function isLessWrongCommentUrl(url: string): boolean {
-  return isLessWrongUrl(url) && extractCommentId(url) !== null;
-}
-
-/**
  * Checks if a URL is a LessWrong user profile URL.
  */
 export function isLessWrongUserUrl(url: string): boolean {

--- a/src/server/feed/opml.ts
+++ b/src/server/feed/opml.ts
@@ -45,8 +45,6 @@ export interface OpmlSubscription {
   xmlUrl: string;
   /** URL to the feed's website */
   htmlUrl?: string;
-  /** Category/folder name (optional, single folder) */
-  folder?: string;
   /** Tags/folders the feed belongs to (optional, multiple tags) */
   tags?: string[];
 }
@@ -92,27 +90,6 @@ export function parseOpml(xml: string): OpmlFeed[] {
 export async function parseOpmlAsync(xml: string): Promise<OpmlFeed[]> {
   const result = await parseOpmlAsyncInternal(xml);
   return result.feeds as OpmlFeed[];
-}
-
-/**
- * Groups subscriptions by folder (legacy single-folder support).
- */
-function groupByFolder(
-  subscriptions: OpmlSubscription[]
-): Map<string | undefined, OpmlSubscription[]> {
-  const groups = new Map<string | undefined, OpmlSubscription[]>();
-
-  for (const sub of subscriptions) {
-    const folder = sub.folder;
-    const existing = groups.get(folder);
-    if (existing) {
-      existing.push(sub);
-    } else {
-      groups.set(folder, [sub]);
-    }
-  }
-
-  return groups;
 }
 
 /**
@@ -190,13 +167,9 @@ interface OpmlDocument {
 /**
  * Generates OPML XML from a list of subscriptions.
  *
- * When subscriptions have `tags`, the export format is:
+ * The export format is:
  * - All feeds listed at top level (no folder)
  * - Feeds re-listed inside each tag folder they belong to
- *
- * When subscriptions use `folder` (legacy), the format is:
- * - Feeds without folder at top level
- * - Feeds with folder inside their respective folder
  *
  * @param subscriptions - Array of subscriptions to export
  * @param metadata - Optional document metadata
@@ -216,51 +189,24 @@ export function generateOpml(
 ): string {
   const dateCreated = new Date().toISOString();
 
-  // Check if any subscriptions use the new tags format
-  const hasTagsFormat = subscriptions.some((sub) => sub.tags !== undefined);
-
-  // Build outline elements
+  // Build outline elements: all feeds at top level + re-listed in tag folders
   const outlines: OutlineElement[] = [];
 
-  if (hasTagsFormat) {
-    // New format: all feeds at top level + re-listed in tag folders
-    // First, add ALL subscriptions at top level
-    for (const sub of subscriptions) {
-      outlines.push(buildOutlineObject(sub));
-    }
+  // First, add ALL subscriptions at top level
+  for (const sub of subscriptions) {
+    outlines.push(buildOutlineObject(sub));
+  }
 
-    // Then, add tag folders with their subscriptions
-    const tagGroups = groupByTags(subscriptions);
-    // Sort tag folders alphabetically for consistent output
-    const sortedTags = Array.from(tagGroups.keys()).sort();
-    for (const tag of sortedTags) {
-      const subs = tagGroups.get(tag)!;
-      outlines.push({
-        "@_text": tag,
-        outline: subs.map((sub) => buildOutlineObject(sub)),
-      });
-    }
-  } else {
-    // Legacy format: group by single folder
-    const grouped = groupByFolder(subscriptions);
-
-    // First, add subscriptions without folders
-    const noFolder = grouped.get(undefined);
-    if (noFolder) {
-      for (const sub of noFolder) {
-        outlines.push(buildOutlineObject(sub));
-      }
-    }
-
-    // Then, add folders with their subscriptions
-    for (const [folder, subs] of grouped) {
-      if (folder === undefined) continue;
-
-      outlines.push({
-        "@_text": folder,
-        outline: subs.map((sub) => buildOutlineObject(sub)),
-      });
-    }
+  // Then, add tag folders with their subscriptions
+  const tagGroups = groupByTags(subscriptions);
+  // Sort tag folders alphabetically for consistent output
+  const sortedTags = Array.from(tagGroups.keys()).sort();
+  for (const tag of sortedTags) {
+    const subs = tagGroups.get(tag)!;
+    outlines.push({
+      "@_text": tag,
+      outline: subs.map((sub) => buildOutlineObject(sub)),
+    });
   }
 
   const title = metadata.title || "Lion Reader Subscriptions";
@@ -297,17 +243,4 @@ export function generateOpml(
   });
 
   return builder.build(doc) as string;
-}
-
-/**
- * Validates that a string is valid OPML.
- * Returns true if valid, false otherwise.
- */
-export function isValidOpml(xml: string): boolean {
-  try {
-    parseOpml(xml);
-    return true;
-  } catch {
-    return false;
-  }
 }

--- a/src/server/feed/scheduling.ts
+++ b/src/server/feed/scheduling.ts
@@ -372,7 +372,9 @@ export function calculateNextFetch(options: CalculateNextFetchOptions = {}): Nex
  * - 5 failures: 8 hours
  * - 6 failures: 16 hours
  * - 7 failures: 32 hours (~1.3 days)
- * - 8+ failures: 7 days (max)
+ * - 8 failures: 64 hours (~2.7 days)
+ * - 9 failures: 128 hours (~5.3 days)
+ * - 10+ failures: 7 days (max)
  *
  * @param consecutiveFailures - Number of consecutive failures (1 or more)
  * @returns Backoff interval in seconds
@@ -386,11 +388,10 @@ export function calculateFailureBackoff(consecutiveFailures: number): number {
     return MAX_FETCH_INTERVAL_SECONDS;
   }
 
-  // Exponential backoff: base * 2^(failures-1)
-  const backoffSeconds = FAILURE_BASE_BACKOFF_SECONDS * Math.pow(2, cappedFailures - 1);
-
-  // Cap at max interval
-  return Math.min(backoffSeconds, MAX_FETCH_INTERVAL_SECONDS);
+  // Exponential backoff: base * 2^(failures-1). The early return above caps the
+  // exponent at 8, so the largest value here (1800 * 2^8 = 128 h) is already
+  // below MAX_FETCH_INTERVAL_SECONDS — no further clamp is needed.
+  return FAILURE_BASE_BACKOFF_SECONDS * Math.pow(2, cappedFailures - 1);
 }
 
 /**

--- a/src/server/html/youtube-embed.ts
+++ b/src/server/html/youtube-embed.ts
@@ -1,14 +1,11 @@
 /**
- * YouTube embed URL handling, shared by the sanitizer's embed allow-list
- * (`embed-providers.ts`, which registers YouTube as one provider and validates
- * iframes found in feed content) and the YouTube plugin (which synthesizes
- * embed iframes for YouTube's own feeds).
+ * YouTube embed pieces used by the YouTube plugin, which synthesizes embed
+ * iframes for YouTube's own feeds.
  *
- * Iframes are the sanitizer's only cross-origin escape hatch, so everything
- * here is allow-list based: only known YouTube embed hosts and the /embed/
- * path shape are accepted, every src is rewritten to the privacy-enhanced
- * youtube-nocookie.com host, and only a small set of playback-related query
- * params survives (autoplay/mute/JS-API flags are dropped).
+ * Validating/normalizing embed srcs found in *feed* content is the sanitizer's
+ * job and lives in Rust (`normalize_youtube_embed_url` in
+ * `native/sanitizer/core/src/embeds.rs`) — don't add a second TypeScript copy
+ * of that rule here.
  */
 
 // Hosts that serve the YouTube embed player.
@@ -18,27 +15,6 @@ const YOUTUBE_EMBED_HOSTS = new Set([
   "m.youtube.com",
   "youtube-nocookie.com",
   "www.youtube-nocookie.com",
-]);
-
-// A single path segment after /embed/: an 11-char video id in practice, or
-// the literal "videoseries" for playlist embeds. Bounded so a pathological
-// path can't smuggle arbitrary content into the normalized URL.
-const EMBED_PATH_RE = /^\/embed\/([A-Za-z0-9_-]{1,64})$/;
-
-// Query params preserved on embed URLs: playback position, playlists, and
-// captions/localization. Everything else (autoplay, mute, enablejsapi,
-// origin, widget_referrer, ...) is dropped.
-const ALLOWED_EMBED_PARAMS = new Set([
-  "start",
-  "end",
-  "list",
-  "listType",
-  "loop",
-  "playlist",
-  "rel",
-  "cc_load_policy",
-  "cc_lang_pref",
-  "hl",
 ]);
 
 /**
@@ -52,39 +28,6 @@ export const YOUTUBE_IFRAME_SANDBOX =
 
 /** Permissions-policy grants for the embed (no autoplay). */
 export const YOUTUBE_IFRAME_ALLOW = "fullscreen; encrypted-media; picture-in-picture";
-
-/**
- * Validates an iframe src as a YouTube embed and returns the normalized
- * https://www.youtube-nocookie.com/embed/... URL, or null if the src is not a
- * YouTube embed.
- */
-export function normalizeYouTubeEmbedUrl(src: string | null | undefined): string | null {
-  if (!src) return null;
-  const trimmed = src.trim();
-  // Feeds commonly use protocol-relative embed srcs.
-  const absolute = trimmed.startsWith("//") ? `https:${trimmed}` : trimmed;
-
-  let url: URL;
-  try {
-    url = new URL(absolute);
-  } catch {
-    return null;
-  }
-
-  if (url.protocol !== "https:" && url.protocol !== "http:") return null;
-  if (!YOUTUBE_EMBED_HOSTS.has(url.hostname.toLowerCase())) return null;
-
-  const match = EMBED_PATH_RE.exec(url.pathname);
-  if (!match) return null;
-
-  const normalized = new URL(`https://www.youtube-nocookie.com/embed/${match[1]}`);
-  for (const [key, value] of url.searchParams) {
-    if (ALLOWED_EMBED_PARAMS.has(key)) {
-      normalized.searchParams.set(key, value);
-    }
-  }
-  return normalized.toString();
-}
 
 /**
  * Extracts a YouTube video id from a video page URL (watch, youtu.be, shorts,

--- a/src/server/plugins/bluesky.ts
+++ b/src/server/plugins/bluesky.ts
@@ -448,10 +448,8 @@ export const blueskyPlugin: UrlPlugin = {
   // new subscriptions default to full content — the savedArticle capability
   // hydrates the real embedded content on open.
   feedDefaultsToFullContent(feedUrl: URL): boolean {
-    const host = feedUrl.hostname.toLowerCase();
-    if (host !== "bsky.app" && host !== "www.bsky.app") {
-      return false;
-    }
+    // The registry only calls this for URLs on one of `hosts`, so the host
+    // needs no re-check here.
     const parts = feedUrl.pathname.split("/").filter(Boolean);
     return parts.length === 3 && parts[0] === "profile" && parts[2] === "rss";
   },

--- a/src/server/plugins/github.ts
+++ b/src/server/plugins/github.ts
@@ -95,11 +95,7 @@ export function parseGitHubUrl(url: URL): GitHubUrlType | null {
     }
 
     // gist.github.com/{user}/{gist_id}
-    if (parts.length >= 2) {
-      return { type: "gist", gistId: parts[1], filename };
-    }
-
-    return null;
+    return { type: "gist", gistId: parts[1], filename };
   }
 
   // Raw URLs: raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}

--- a/src/server/plugins/google-docs.ts
+++ b/src/server/plugins/google-docs.ts
@@ -1,10 +1,5 @@
 import type { UrlPlugin, SavedArticleContent } from "./types";
-import {
-  isGoogleDocsUrl,
-  extractDocId,
-  normalizeGoogleDocsUrl,
-  fetchGoogleDocsFromUrl,
-} from "@/server/google/docs";
+import { extractDocId, normalizeGoogleDocsUrl, fetchGoogleDocsFromUrl } from "@/server/google/docs";
 import { logger } from "@/lib/logger";
 
 /**
@@ -30,11 +25,8 @@ export const googleDocsPlugin: UrlPlugin = {
     savedArticle: {
       async fetchContent(url: URL): Promise<SavedArticleContent | null> {
         try {
-          // Validate it's a Google Docs URL
-          if (!isGoogleDocsUrl(url.href)) {
-            return null;
-          }
-
+          // Validates it's a Google Docs URL: extractDocId matches the same
+          // pattern isGoogleDocsUrl tests, and returns null when it doesn't.
           const docId = extractDocId(url.href);
           if (!docId) {
             return null;

--- a/tests/integration/entry-processor.test.ts
+++ b/tests/integration/entry-processor.test.ts
@@ -15,11 +15,9 @@ import {
   generateContentHash,
   clampPublishedAt,
   deriveGuid,
-  generateEntrySummary,
   findEntryByGuid,
   createEntry,
   updateEntryContent,
-  processEntry,
   processEntries,
 } from "../../src/server/feed/entry-processor";
 import type { ParsedEntry, ParsedFeed } from "../../src/server/feed/types";
@@ -205,52 +203,6 @@ describe("Entry Processor", () => {
     });
   });
 
-  describe("generateEntrySummary", () => {
-    it("strips HTML tags", () => {
-      const entry: ParsedEntry = {
-        content: "<p>This is <strong>bold</strong> text.</p>",
-      };
-
-      expect(generateEntrySummary(entry)).toBe("This is bold text.");
-    });
-
-    it("removes style tags and their content", () => {
-      const entry: ParsedEntry = {
-        content: "<style>#content img { max-width: 100% }</style><p>Actual content here.</p>",
-      };
-
-      expect(generateEntrySummary(entry)).toBe("Actual content here.");
-    });
-
-    it("removes script tags and their content", () => {
-      const entry: ParsedEntry = {
-        content:
-          '<script>alert("bad")</script><p>Visible text.</p><script type="text/javascript">more code</script>',
-      };
-
-      expect(generateEntrySummary(entry)).toBe("Visible text.");
-    });
-
-    it("truncates long content to 300 characters", () => {
-      const longContent = "A".repeat(500);
-      const entry: ParsedEntry = {
-        content: longContent,
-      };
-
-      const summary = generateEntrySummary(entry);
-      expect(summary).toHaveLength(300);
-      expect(summary.endsWith("...")).toBe(true);
-    });
-
-    it("uses summary when content is missing", () => {
-      const entry: ParsedEntry = {
-        summary: "This is the summary.",
-      };
-
-      expect(generateEntrySummary(entry)).toBe("This is the summary.");
-    });
-  });
-
   describe("findEntryByGuid", () => {
     it("finds existing entry by feed ID and GUID", async () => {
       const feed = await createTestFeed();
@@ -383,7 +335,7 @@ describe("Entry Processor", () => {
     });
   });
 
-  describe("processEntry", () => {
+  describe("processEntries per-entry results", () => {
     it("creates new entry when not exists", async () => {
       const feed = await createTestFeed();
 
@@ -393,12 +345,16 @@ describe("Entry Processor", () => {
         content: "New content",
       };
 
-      const result = await processEntry(feed.id, "web", parsedEntry, new Date());
+      const { entries: results } = await processEntries(feed.id, feed.type, {
+        title: "Test Feed",
+        items: [parsedEntry],
+      });
 
-      expect(result.isNew).toBe(true);
-      expect(result.isUpdated).toBe(false);
-      expect(result.guid).toBe("new-entry-1");
-      expect(result.id).toBeDefined();
+      expect(results).toHaveLength(1);
+      expect(results[0].isNew).toBe(true);
+      expect(results[0].isUpdated).toBe(false);
+      expect(results[0].guid).toBe("new-entry-1");
+      expect(results[0].id).toBeDefined();
 
       // Verify entry exists in database
       const found = await findEntryByGuid(feed.id, "new-entry-1");
@@ -415,8 +371,11 @@ describe("Entry Processor", () => {
         content: "Original content",
       };
 
-      const createResult = await processEntry(feed.id, "web", initialEntry, new Date());
-      expect(createResult.isNew).toBe(true);
+      const createResult = await processEntries(feed.id, feed.type, {
+        title: "Test Feed",
+        items: [initialEntry],
+      });
+      expect(createResult.entries[0].isNew).toBe(true);
 
       // Process with different content
       const updatedEntry: ParsedEntry = {
@@ -425,11 +384,14 @@ describe("Entry Processor", () => {
         content: "New content here",
       };
 
-      const updateResult = await processEntry(feed.id, "web", updatedEntry, new Date());
+      const updateResult = await processEntries(feed.id, feed.type, {
+        title: "Test Feed",
+        items: [updatedEntry],
+      });
 
-      expect(updateResult.isNew).toBe(false);
-      expect(updateResult.isUpdated).toBe(true);
-      expect(updateResult.id).toBe(createResult.id); // Same entry ID
+      expect(updateResult.entries[0].isNew).toBe(false);
+      expect(updateResult.entries[0].isUpdated).toBe(true);
+      expect(updateResult.entries[0].id).toBe(createResult.entries[0].id); // Same entry ID
 
       // Verify content was updated
       const found = await findEntryByGuid(feed.id, "entry-to-update");
@@ -446,15 +408,21 @@ describe("Entry Processor", () => {
       };
 
       // First process
-      const result1 = await processEntry(feed.id, "web", entry, new Date());
-      expect(result1.isNew).toBe(true);
+      const result1 = await processEntries(feed.id, feed.type, {
+        title: "Test Feed",
+        items: [entry],
+      });
+      expect(result1.entries[0].isNew).toBe(true);
 
       // Second process with same content
-      const result2 = await processEntry(feed.id, "web", entry, new Date());
+      const result2 = await processEntries(feed.id, feed.type, {
+        title: "Test Feed",
+        items: [entry],
+      });
 
-      expect(result2.isNew).toBe(false);
-      expect(result2.isUpdated).toBe(false);
-      expect(result2.id).toBe(result1.id);
+      expect(result2.entries[0].isNew).toBe(false);
+      expect(result2.entries[0].isUpdated).toBe(false);
+      expect(result2.entries[0].id).toBe(result1.entries[0].id);
     });
   });
 

--- a/tests/unit/arxiv.test.ts
+++ b/tests/unit/arxiv.test.ts
@@ -5,7 +5,6 @@
 
 import { describe, it, expect } from "vitest";
 import {
-  isArxivUrl,
   extractPaperId,
   buildArxivHtmlUrl,
   buildArxivAbsUrl,
@@ -42,63 +41,6 @@ const ARXIV_ABS_HTML = `<!DOCTYPE html>
 </body></html>`;
 
 describe("ArXiv URL detection", () => {
-  describe("isArxivUrl", () => {
-    it("returns true for ArXiv abstract URLs with new format IDs", () => {
-      expect(isArxivUrl("https://arxiv.org/abs/2601.04649")).toBe(true);
-      expect(isArxivUrl("https://www.arxiv.org/abs/2601.04649")).toBe(true);
-    });
-
-    it("returns true for ArXiv PDF URLs", () => {
-      expect(isArxivUrl("https://arxiv.org/pdf/2601.04649")).toBe(true);
-      expect(isArxivUrl("https://arxiv.org/pdf/2601.04649.pdf")).toBe(true);
-    });
-
-    it("returns true for ArXiv HTML URLs", () => {
-      expect(isArxivUrl("https://arxiv.org/html/2601.04649")).toBe(true);
-    });
-
-    it("returns true for ArXiv URLs with version numbers", () => {
-      expect(isArxivUrl("https://arxiv.org/abs/2601.04649v1")).toBe(true);
-      expect(isArxivUrl("https://arxiv.org/abs/2601.04649v2")).toBe(true);
-      expect(isArxivUrl("https://arxiv.org/pdf/2601.04649v3")).toBe(true);
-    });
-
-    it("returns true for ArXiv URLs with old format IDs (category/number)", () => {
-      expect(isArxivUrl("https://arxiv.org/abs/hep-th/9901001")).toBe(true);
-      expect(isArxivUrl("https://arxiv.org/pdf/math.GT/0309136")).toBe(true);
-      expect(isArxivUrl("https://arxiv.org/abs/cond-mat/0001234")).toBe(true);
-    });
-
-    it("returns true for HTTP URLs (not just HTTPS)", () => {
-      expect(isArxivUrl("http://arxiv.org/abs/2601.04649")).toBe(true);
-    });
-
-    it("returns true for URLs with query parameters", () => {
-      expect(isArxivUrl("https://arxiv.org/abs/2601.04649?ref=foo")).toBe(true);
-    });
-
-    it("returns true for URLs with hash fragments", () => {
-      expect(isArxivUrl("https://arxiv.org/abs/2601.04649#section")).toBe(true);
-    });
-
-    it("returns false for non-ArXiv URLs", () => {
-      expect(isArxivUrl("https://example.com/abs/2601.04649")).toBe(false);
-      expect(isArxivUrl("https://google.com")).toBe(false);
-    });
-
-    it("returns false for ArXiv non-paper URLs", () => {
-      expect(isArxivUrl("https://arxiv.org")).toBe(false);
-      expect(isArxivUrl("https://arxiv.org/list/cs.AI/recent")).toBe(false);
-      expect(isArxivUrl("https://arxiv.org/search/?query=test")).toBe(false);
-    });
-
-    it("returns false for invalid URLs", () => {
-      expect(isArxivUrl("not a url")).toBe(false);
-      expect(isArxivUrl("")).toBe(false);
-      expect(isArxivUrl("arxiv.org/abs/2601.04649")).toBe(false);
-    });
-  });
-
   describe("extractPaperId", () => {
     it("extracts paper ID from ArXiv abstract URLs", () => {
       expect(extractPaperId("https://arxiv.org/abs/2601.04649")).toBe("2601.04649");

--- a/tests/unit/feed-discovery.test.ts
+++ b/tests/unit/feed-discovery.test.ts
@@ -410,6 +410,19 @@ describe("discoverFeeds", () => {
       expect(feeds[0].title).toBe("Uppercase");
     });
 
+    it("handles mixed-case tags and attributes", () => {
+      const html = `
+        <Link Rel="alternate" Type="application/rss+xml" Href="/feed.xml" Title="MixedCase">
+      `;
+
+      const feeds = discoverFeeds(html, "https://example.com");
+
+      expect(feeds).toHaveLength(1);
+      expect(feeds[0].url).toBe("https://example.com/feed.xml");
+      expect(feeds[0].type).toBe("rss");
+      expect(feeds[0].title).toBe("MixedCase");
+    });
+
     it("handles link tags mixed with other content", () => {
       const html = `
         <!DOCTYPE html>

--- a/tests/unit/lesswrong.test.ts
+++ b/tests/unit/lesswrong.test.ts
@@ -10,7 +10,6 @@ import {
   isLessWrongUrl,
   extractPostId,
   extractCommentId,
-  isLessWrongCommentUrl,
   isLessWrongUserUrl,
   extractUserSlug,
   isLessWrongUserFeedUrl,
@@ -165,26 +164,6 @@ describe("LessWrong URL detection", () => {
     it("returns null for invalid URLs", () => {
       expect(extractCommentId("not a url")).toBe(null);
       expect(extractCommentId("")).toBe(null);
-    });
-  });
-
-  describe("isLessWrongCommentUrl", () => {
-    it("returns true for LessWrong post URLs with commentId", () => {
-      expect(
-        isLessWrongCommentUrl(
-          "https://www.lesswrong.com/posts/ZnNeKw2Be8BR7bmeN/adamzerner-s-shortform?commentId=F2mFKsTHbt24KeLNT"
-        )
-      ).toBe(true);
-    });
-
-    it("returns false for LessWrong post URLs without commentId", () => {
-      expect(isLessWrongCommentUrl("https://www.lesswrong.com/posts/WQFioaudEH8R7fyhm/slug")).toBe(
-        false
-      );
-    });
-
-    it("returns false for non-LessWrong URLs even with commentId", () => {
-      expect(isLessWrongCommentUrl("https://example.com/posts/abc?commentId=123")).toBe(false);
     });
   });
 

--- a/tests/unit/opml.test.ts
+++ b/tests/unit/opml.test.ts
@@ -6,7 +6,6 @@ import { describe, it, expect } from "vitest";
 import {
   parseOpml,
   generateOpml,
-  isValidOpml,
   OpmlParseError,
   type OpmlSubscription,
 } from "../../src/server/feed/opml";
@@ -467,27 +466,27 @@ describe("generateOpml", () => {
     });
   });
 
-  describe("folder grouping", () => {
-    it("groups subscriptions by folder", () => {
+  describe("tag grouping", () => {
+    it("groups subscriptions by tag", () => {
       const subscriptions: OpmlSubscription[] = [
-        { title: "Tech Blog", xmlUrl: "https://tech.example.com/feed", folder: "Technology" },
-        { title: "News Site", xmlUrl: "https://news.example.com/feed", folder: "News" },
+        { title: "Tech Blog", xmlUrl: "https://tech.example.com/feed", tags: ["Technology"] },
+        { title: "News Site", xmlUrl: "https://news.example.com/feed", tags: ["News"] },
         { title: "Ungrouped", xmlUrl: "https://other.example.com/feed" },
       ];
 
       const xml = generateOpml(subscriptions);
 
-      // Should have folder outlines
+      // Should have tag folder outlines
       expect(xml).toContain('text="Technology"');
       expect(xml).toContain('text="News"');
-      // Ungrouped should be at top level
+      // Every feed, tagged or not, is also listed at top level
       expect(xml).toMatch(/<outline type="rss" text="Ungrouped"/);
     });
 
-    it("places multiple feeds in the same folder", () => {
+    it("places multiple feeds in the same tag folder", () => {
       const subscriptions: OpmlSubscription[] = [
-        { title: "Blog 1", xmlUrl: "https://blog1.example.com/feed", folder: "Blogs" },
-        { title: "Blog 2", xmlUrl: "https://blog2.example.com/feed", folder: "Blogs" },
+        { title: "Blog 1", xmlUrl: "https://blog1.example.com/feed", tags: ["Blogs"] },
+        { title: "Blog 2", xmlUrl: "https://blog2.example.com/feed", tags: ["Blogs"] },
       ];
 
       const xml = generateOpml(subscriptions);
@@ -523,9 +522,9 @@ describe("generateOpml", () => {
       expect(xml).toContain("https://example.com/feed?a=1&amp;b=2");
     });
 
-    it("escapes special characters in folder names", () => {
+    it("escapes special characters in tag folder names", () => {
       const subscriptions: OpmlSubscription[] = [
-        { title: "Blog", xmlUrl: "https://example.com/feed", folder: "Tech & News" },
+        { title: "Blog", xmlUrl: "https://example.com/feed", tags: ["Tech & News"] },
       ];
 
       const xml = generateOpml(subscriptions);
@@ -542,32 +541,36 @@ describe("generateOpml", () => {
           xmlUrl: "https://blog1.example.com/feed",
           htmlUrl: "https://blog1.example.com",
         },
-        { title: "Blog Two", xmlUrl: "https://blog2.example.com/feed", folder: "Tech" },
+        { title: "Blog Two", xmlUrl: "https://blog2.example.com/feed", tags: ["Tech"] },
       ];
 
       const xml = generateOpml(subscriptions, { title: "Test Export" });
       const parsed = parseOpml(xml);
 
-      expect(parsed).toHaveLength(2);
+      // Both feeds at top level, plus Blog Two re-listed inside its "Tech" folder
+      expect(parsed).toHaveLength(3);
       expect(parsed[0].title).toBe("Blog One");
       expect(parsed[0].xmlUrl).toBe("https://blog1.example.com/feed");
       expect(parsed[0].htmlUrl).toBe("https://blog1.example.com");
       expect(parsed[1].title).toBe("Blog Two");
-      expect(parsed[1].category).toEqual(["Tech"]);
+      expect(parsed[1].category).toBeUndefined();
+      expect(parsed[2].title).toBe("Blog Two");
+      expect(parsed[2].category).toEqual(["Tech"]);
     });
 
-    it("preserves folder structure in round-trip", () => {
+    it("preserves tag folder structure in round-trip", () => {
       const subscriptions: OpmlSubscription[] = [
-        { title: "Blog 1", xmlUrl: "https://blog1.example.com/feed", folder: "Category A" },
-        { title: "Blog 2", xmlUrl: "https://blog2.example.com/feed", folder: "Category A" },
-        { title: "Blog 3", xmlUrl: "https://blog3.example.com/feed", folder: "Category B" },
+        { title: "Blog 1", xmlUrl: "https://blog1.example.com/feed", tags: ["Category A"] },
+        { title: "Blog 2", xmlUrl: "https://blog2.example.com/feed", tags: ["Category A"] },
+        { title: "Blog 3", xmlUrl: "https://blog3.example.com/feed", tags: ["Category B"] },
         { title: "Blog 4", xmlUrl: "https://blog4.example.com/feed" },
       ];
 
       const xml = generateOpml(subscriptions);
       const parsed = parseOpml(xml);
 
-      expect(parsed).toHaveLength(4);
+      // 4 at top level + 2 in "Category A" + 1 in "Category B"
+      expect(parsed).toHaveLength(7);
 
       // Check category assignments
       const categoryA = parsed.filter((f) => f.category?.includes("Category A"));
@@ -576,33 +579,7 @@ describe("generateOpml", () => {
 
       expect(categoryA).toHaveLength(2);
       expect(categoryB).toHaveLength(1);
-      expect(uncategorized).toHaveLength(1);
+      expect(uncategorized).toHaveLength(4);
     });
-  });
-});
-
-describe("isValidOpml", () => {
-  it("returns true for valid OPML", () => {
-    const xml = `<?xml version="1.0" encoding="UTF-8"?>
-      <opml version="2.0">
-        <head><title>Valid</title></head>
-        <body></body>
-      </opml>`;
-
-    expect(isValidOpml(xml)).toBe(true);
-  });
-
-  it("returns false for invalid XML", () => {
-    expect(isValidOpml("not xml")).toBe(false);
-  });
-
-  it("returns false for non-OPML XML", () => {
-    const xml = `<?xml version="1.0"?><rss><channel></channel></rss>`;
-    expect(isValidOpml(xml)).toBe(false);
-  });
-
-  it("returns false for OPML without body", () => {
-    const xml = `<?xml version="1.0"?><opml version="2.0"><head></head></opml>`;
-    expect(isValidOpml(xml)).toBe(false);
   });
 });

--- a/tests/unit/youtube-plugin.test.ts
+++ b/tests/unit/youtube-plugin.test.ts
@@ -16,7 +16,6 @@ import {
 import { getFeedPlugin } from "@/server/plugins";
 import {
   extractYouTubeVideoId,
-  normalizeYouTubeEmbedUrl,
   YOUTUBE_IFRAME_ALLOW,
   YOUTUBE_IFRAME_SANDBOX,
 } from "@/server/html/youtube-embed";
@@ -89,41 +88,6 @@ describe("getFeedPlugin resolution for YouTube", () => {
 
   it("does not resolve non-video YouTube pages", () => {
     expect(getFeedPlugin("https://www.youtube.com/@somechannel")).toBeNull();
-  });
-});
-
-describe("normalizeYouTubeEmbedUrl", () => {
-  it("rewrites youtube.com embeds to www.youtube-nocookie.com", () => {
-    expect(normalizeYouTubeEmbedUrl("https://www.youtube.com/embed/dQw4w9WgXcQ")).toBe(
-      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"
-    );
-    expect(normalizeYouTubeEmbedUrl("https://youtube.com/embed/dQw4w9WgXcQ")).toBe(
-      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"
-    );
-  });
-
-  it("accepts protocol-relative srcs", () => {
-    expect(normalizeYouTubeEmbedUrl("//www.youtube-nocookie.com/embed/dQw4w9WgXcQ")).toBe(
-      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"
-    );
-  });
-
-  it("keeps only allow-listed query params", () => {
-    expect(
-      normalizeYouTubeEmbedUrl(
-        "https://www.youtube.com/embed/dQw4w9WgXcQ?start=30&autoplay=1&enablejsapi=1&origin=https%3A%2F%2Fevil.com"
-      )
-    ).toBe("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?start=30");
-  });
-
-  it("rejects non-embed and non-YouTube URLs", () => {
-    expect(normalizeYouTubeEmbedUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ")).toBeNull();
-    expect(normalizeYouTubeEmbedUrl("https://evil.com/embed/dQw4w9WgXcQ")).toBeNull();
-    expect(normalizeYouTubeEmbedUrl("https://www.youtube.com.evil.com/embed/x")).toBeNull();
-    expect(normalizeYouTubeEmbedUrl("https://www.youtube.com/embed/a/b")).toBeNull();
-    expect(normalizeYouTubeEmbedUrl("javascript:alert(1)")).toBeNull();
-    expect(normalizeYouTubeEmbedUrl(null)).toBeNull();
-    expect(normalizeYouTubeEmbedUrl("")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Fix: `<link>` feed discovery silently missed mixed-case attributes

This is the user-visible part. `discoverFeeds` constructed its htmlparser2 parser with `lowerCaseTags: false, lowerCaseAttributeNames: false`, then compensated with a hand-rolled `getAttributeCI` that only tried the all-lowercase and all-UPPERCASE spellings of each name. Anything in between fell through, and the page came back as "we can't find a feed for this site":

```js
discoverFeeds('<link Rel="alternate" Type="application/rss+xml" Href="/feed.xml">', base)
// []            before
// [{ url: ".../feed.xml", type: "rss" }]   after
```

htmlparser2 v12 lowercases both tag and attribute names by default, so the fix is a net deletion: drop the two `lowerCase*: false` options, delete `getAttributeCI`, read `attribs.rel` / `.type` / `.href` / `.title` directly, and drop the two now-redundant `name.toLowerCase()` calls. Every casing works, including ones neither the old code nor the old test covered. The existing test only exercised the all-caps form; a mixed-case case is added next to it.

## Dead code removed

Each of these was verified to have no production caller.

**Duplicated entry processing** (`src/server/feed/entry-processor.ts`)
- `processEntry` was a near-exact duplicate of `processEntryWithCache`, the only path `processEntries` uses. They differed only in `findEntryByGuid(feedId, guid)` vs a `Map` lookup; the new/updated/unchanged branches, the fire-and-forget `publishEntryUpdatedFromEntry`, and all three return shapes were duplicated verbatim. Its only callers were five integration tests, so those tests were asserting against dead code.
- `generateEntrySummary` was not just dead but *wrong*: it used a plain `entry.summary ?? entry.content`, while the live summary comes from `cleanEntryContent` → `hasSeparateSummary` (feed summary only when content and summary both exist **and differ**). Its tests documented behavior the app does not have, so they're deleted rather than re-pointed.

**Legacy single-`folder` OPML export** (`src/server/feed/opml.ts`) — the `OpmlSubscription.folder` field, `groupByFolder`, and the `else` branch of `generateOpml`. The only production caller (`subscriptions.export`) never sets `folder`, it sets `tags`; and with no tags the legacy branch produced byte-identical output to the tags branch anyway (`groupByFolder` puts everything under the `undefined` key and emits every feed at top level), so the `hasTagsFormat` split went too.

**`normalizeYouTubeEmbedUrl`** (`src/server/html/youtube-embed.ts`) — a TypeScript duplicate of the native sanitizer's `normalize_youtube_embed_url` (`native/sanitizer/core/src/embeds.rs`), same host list, path regex and param allow-list, kept alive only by its own test. `YOUTUBE_EMBED_HOSTS`, `extractYouTubeVideoId` and the two iframe constants stay — the YouTube plugin uses them. The module docstring pointed at `src/server/html/embed-providers.ts`, which no longer exists; it now says where the live rule lives so the duplicate doesn't grow back.

**Small items**
- `isLessWrongCommentUrl` (`feed/lesswrong.ts`), `isArxivUrl` (`feed/arxiv.ts`), `isValidOpml` (`feed/opml.ts`) — no production caller.
- `plugins/bluesky.ts`: unreachable host guard in `feedDefaultsToFullContent`. The registry looks the plugin up in its exact-hostname index before calling the predicate, and the plugin's `hosts` are exactly the two hosts the guard allowed.
- `plugins/google-docs.ts`: `isGoogleDocsUrl(url.href)` was strictly subsumed by the `extractDocId` null check two lines later (same `GOOGLE_DOCS_URL_PATTERN`).
- `plugins/github.ts`: unreachable `return null` — `parts.length` is a non-negative integer and the `=== 0`, `=== 1`, `>= 2` branches all return.

## Tests re-pointed at the live path

The five `processEntry` integration tests now drive `processEntries`, so their coverage (new-entry creation, hash-change update with a stable id, unchanged skip) applies to the code that actually runs in production instead of to a dead duplicate. The `folder`-based OPML tests are rewritten in terms of `tags`, with the round-trip expectations updated for the tags format (a tagged feed is listed both at top level and inside its tag folder, so it parses back more than once).

## Doc-comment corrections

- `feed/scheduling.ts`: the backoff ladder claimed "8+ failures: 7 days (max)", but the code and `tests/unit/scheduling.test.ts` give 8 → 64 h, 9 → 128 h, 10+ → 7 days. Ladder corrected. The trailing `Math.min(backoffSeconds, MAX_FETCH_INTERVAL_SECONDS)` was also unreachable — the `cappedFailures >= 10` early return means the largest value reaching it is `1800 * 2^8 = 460800 < 604800` — so it's now a bare return with a comment saying why no clamp is needed.
- `feed/cache-headers.ts`: `getEffectiveMaxAge` said "If no-store or no-cache, don't cache" but only checks `noStore`. The behavior is right (we always send conditional GETs, so a `no-cache` max-age still tells us how often to revalidate), so the **comment** is fixed, not the behavior. The unused parsed directives are left alone; a separate issue covers those.

## Verification

`pnpm typecheck`, `pnpm lint` and `pnpm knip` are clean. `pnpm test:unit`: 161 files, 3201 passed. `pnpm test:integration:local`: 57 files passed / 2 skipped, 791 passed / 15 skipped (skips pre-existing).

Net: 120 insertions, 547 deletions.

## Reported, not fixed: `lesserwrong.com` is registered but never matches

`src/server/plugins/lesswrong.ts:32` registers `lesserwrong.com` / `www.lesserwrong.com` as plugin hosts, but every predicate in `src/server/feed/lesswrong.ts` hardcodes `(?:www\.)?lesswrong\.com` (`:44`, `:54`, `:60`, `:67`, `:754`, `:770`). So a `lesserwrong.com` URL only ever matches the `pathname === "/feed.xml"` clause, and both feed transforms are no-ops for it. Either the regexes should be widened to accept the alias or the two host entries should be dropped — that's a product call, so it's left as-is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
