### PR TITLE
fix: Stop narration on variant switch and compare paragraph indices in one space

### DIFF
--- a/src/components/entries/EntryContentBody.tsx
+++ b/src/components/entries/EntryContentBody.tsx
@@ -413,12 +413,7 @@ export function EntryContentBody({
 
           {/* Narration controls - pass narration state for controlled mode */}
           {!hideNarration && narrationSettings.enabled && (
-            <NarrationControls
-              articleId={articleId}
-              title={title}
-              feedTitle={source}
-              narration={narration}
-            />
+            <NarrationControls narration={narration} />
           )}
 
           {/* Summarize button */}

--- a/src/components/narration/NarrationControls.tsx
+++ b/src/components/narration/NarrationControls.tsx
@@ -16,17 +16,13 @@
  * ```tsx
  * import { NarrationControls } from "@/components/narration";
  *
- * <NarrationControls
- *   articleId="..."
- *   title="Article Title"
- *   feedTitle="Feed Name"
- * />
+ * <NarrationControls narration={narration} />
  * ```
  */
 
 "use client";
 
-import { useNarration } from "./useNarration";
+import type { UseNarrationReturn } from "./useNarrationTypes";
 import { useNarrationKeyboardShortcuts } from "@/lib/hooks/useNarrationKeyboardShortcuts";
 import { Button } from "@/components/ui/button";
 import {
@@ -42,25 +38,12 @@ import {
  * Props for the NarrationControls component.
  */
 export interface NarrationControlsProps {
-  /** The article ID (entry or saved article) */
-  articleId: string;
-  /** Title of the article (for Media Session) */
-  title: string;
-  /** Feed or site name (for Media Session) */
-  feedTitle: string;
-  /** Optional artwork URL for Media Session */
-  artwork?: string;
   /**
-   * Optional HTML content for client-side processing.
-   * Used in uncontrolled mode when LLM normalization is disabled.
+   * The narration engine to drive. Owned by the parent because it also needs
+   * the state for highlighting, and because a second `useNarration` would mean
+   * a second speech engine for the same article.
    */
-  content?: string | null;
-  /**
-   * Optional external narration state for controlled mode.
-   * When provided, the component won't create its own useNarration hook.
-   * This is used when the parent needs access to narration state (e.g., for highlighting).
-   */
-  narration?: ReturnType<typeof useNarration>;
+  narration: UseNarrationReturn;
 }
 
 /**
@@ -71,32 +54,9 @@ export interface NarrationControlsProps {
  *
  * Renders playback controls for article narration. Only renders
  * if the Web Speech API is supported in the current browser.
- *
- * Can be used in two modes:
- * 1. Uncontrolled: Component manages its own narration state
- * 2. Controlled: Parent provides narration state via the `narration` prop
- *    (used when parent needs access to state for highlighting)
  */
-export function NarrationControlsImpl({
-  articleId,
-  title,
-  feedTitle,
-  artwork,
-  content,
-  narration: externalNarration,
-}: NarrationControlsProps) {
-  // Use internal narration hook only when external state is not provided
-  const internalNarration = useNarration({
-    id: articleId,
-    title,
-    feedTitle,
-    artwork,
-    content,
-  });
-
-  // Use external narration if provided, otherwise use internal
-  const { state, isLoading, play, pause, skipForward, skipBackward, isSupported } =
-    externalNarration ?? internalNarration;
+export function NarrationControlsImpl({ narration }: NarrationControlsProps) {
+  const { state, isLoading, play, pause, skipForward, skipBackward, isSupported } = narration;
 
   // Enable keyboard shortcuts for narration (must be called before early return)
   useNarrationKeyboardShortcuts({
@@ -112,7 +72,11 @@ export function NarrationControlsImpl({
     return null;
   }
 
-  const { status, currentParagraph, totalParagraphs } = state;
+  // `currentNarrationParagraph`, not `currentParagraph`: the skip bounds and the
+  // readout below are all relative to `totalParagraphs`, which counts narration
+  // paragraphs, while `currentParagraph` is a DOM element index (see
+  // `UseNarrationState`).
+  const { status, currentNarrationParagraph, totalParagraphs } = state;
   const isPlaying = status === "playing";
   const isPaused = status === "paused";
   // "loading" once we already have paragraphs means we're generating the next
@@ -166,7 +130,7 @@ export function NarrationControlsImpl({
           variant="ghost"
           size="sm"
           onClick={skipBackward}
-          disabled={currentParagraph === 0}
+          disabled={currentNarrationParagraph === 0}
           aria-label="Previous paragraph"
           className="min-w-[36px] px-2"
         >
@@ -192,7 +156,7 @@ export function NarrationControlsImpl({
           variant="ghost"
           size="sm"
           onClick={skipForward}
-          disabled={currentParagraph >= totalParagraphs - 1}
+          disabled={currentNarrationParagraph >= totalParagraphs - 1}
           aria-label="Next paragraph"
           className="min-w-[36px] px-2"
         >
@@ -203,7 +167,7 @@ export function NarrationControlsImpl({
       {/* Paragraph indicator - only show when active */}
       {isActive && totalParagraphs > 0 && (
         <span className="ui-text-xs text-muted tabular-nums">
-          {currentParagraph + 1} of {totalParagraphs}
+          {currentNarrationParagraph + 1} of {totalParagraphs}
         </span>
       )}
     </div>

--- a/src/components/narration/useNarration.ts
+++ b/src/components/narration/useNarration.ts
@@ -5,21 +5,14 @@
  * or Piper TTS (enhanced voices). Handles narration generation, playback controls,
  * and Media Session integration.
  *
- * Usage:
+ * The owning component holds the hook (it also needs `state.currentParagraph`
+ * for highlighting) and hands the whole thing to the controls:
+ *
  * ```tsx
  * function ArticleView({ articleId }: { articleId: string }) {
  *   const narration = useNarration({ id: articleId, title: 'Article Title', feedTitle: 'Feed' });
  *
- *   return (
- *     <NarrationControls
- *       state={narration.state}
- *       isLoading={narration.isLoading}
- *       onPlay={narration.play}
- *       onPause={narration.pause}
- *       onSkipForward={narration.skipForward}
- *       onSkipBackward={narration.skipBackward}
- *     />
- *   );
+ *   return <NarrationControls narration={narration} />;
  * }
  * ```
  */
@@ -28,7 +21,7 @@
 
 import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from "react";
 import { trpc } from "@/lib/trpc/client";
-import { ArticleNarrator, type NarrationState } from "@/lib/narration/ArticleNarrator";
+import { ArticleNarrator } from "@/lib/narration/ArticleNarrator";
 import { useNarrationSettings } from "@/lib/narration/settings";
 import { findVoiceByUri, waitForVoices } from "@/lib/narration/voices";
 import { isNarrationSupported } from "@/lib/narration/feature-detection";
@@ -49,6 +42,7 @@ import {
 import {
   type UseNarrationConfig,
   type UseNarrationReturn,
+  type UseNarrationState,
   DEFAULT_NARRATION_STATE,
   splitIntoParagraphs,
   mapPlaybackStatus,
@@ -74,7 +68,7 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
   const { id, title, feedTitle, artwork, content, showFullContent, showOriginal } = config;
 
   // State
-  const [state, setState] = useState<NarrationState>(DEFAULT_NARRATION_STATE);
+  const [state, setState] = useState<UseNarrationState>(DEFAULT_NARRATION_STATE);
   const [isLoading, setIsLoading] = useState(false);
   const [narrationText, setNarrationText] = useState<string | null>(null);
   // Defer browser support check until after hydration to avoid SSR mismatch
@@ -123,6 +117,7 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
         setState({
           ...newState,
           currentParagraph: domElementIndex,
+          currentNarrationParagraph: newState.currentParagraph,
         });
       }
     });
@@ -198,6 +193,7 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
           setState((prev) => ({
             ...prev,
             currentParagraph: domElementIndex,
+            currentNarrationParagraph: position.paragraph,
             totalParagraphs,
           }));
         },
@@ -210,6 +206,7 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
             ...prev,
             status: "idle",
             currentParagraph: 0,
+            currentNarrationParagraph: 0,
           }));
         },
       });
@@ -523,6 +520,11 @@ export function useNarration(config: UseNarrationConfig): UseNarrationReturn {
   // Clear audio cache and refs when the article, voice, or displayed content
   // variant changes
   useEffect(() => {
+    // Stop the Web Speech utterance too, not just the streaming player: toggling
+    // the content variant does not remount this hook (EntryContent is keyed only
+    // by the entry id), so without this the browser voice keeps reading the old
+    // variant while the paragraph map below is cleared out from under it.
+    narratorRef.current?.stop();
     // Stop and clear the streaming player
     if (streamingPlayerRef.current) {
       streamingPlayerRef.current.stop();

--- a/src/components/narration/useNarrationTypes.ts
+++ b/src/components/narration/useNarrationTypes.ts
@@ -40,11 +40,32 @@ export interface UseNarrationConfig {
 }
 
 /**
+ * The state `useNarration` exposes, which spans **two index spaces**.
+ *
+ * The player (`ArticleNarrator` or `StreamingAudioPlayer`) counts *narration
+ * paragraphs* — the segments `splitIntoParagraphs` produces — while highlighting
+ * needs the *DOM element* the current segment came from. The paragraph map
+ * translates one to the other, and it is not the identity: one element can
+ * narrate as several paragraphs and an element can narrate as none (see
+ * `@/lib/narration/paragraph-map`).
+ *
+ * So `currentParagraph` is a DOM element index and `currentNarrationParagraph`
+ * is the untranslated player index. `totalParagraphs` is a count of *narration*
+ * paragraphs, so anything comparing a position against it (skip bounds, the
+ * "X of Y" readout) must use `currentNarrationParagraph`; only highlighting uses
+ * `currentParagraph`.
+ */
+export interface UseNarrationState extends NarrationState {
+  /** Index of the current paragraph in the player's own (narration) space. */
+  currentNarrationParagraph: number;
+}
+
+/**
  * Return type for the useNarration hook.
  */
 export interface UseNarrationReturn {
   /** Current narration state */
-  state: NarrationState;
+  state: UseNarrationState;
   /** Whether narration text is being generated */
   isLoading: boolean;
   /** Start or resume playback */
@@ -70,9 +91,10 @@ export interface UseNarrationReturn {
 /**
  * Default narration state when no article is loaded.
  */
-export const DEFAULT_NARRATION_STATE: NarrationState = {
+export const DEFAULT_NARRATION_STATE: UseNarrationState = {
   status: "idle",
   currentParagraph: 0,
+  currentNarrationParagraph: 0,
   totalParagraphs: 0,
   selectedVoice: null,
 };

--- a/src/lib/hooks/useNarrationKeyboardShortcuts.ts
+++ b/src/lib/hooks/useNarrationKeyboardShortcuts.ts
@@ -26,8 +26,12 @@ import { useKeyboardShortcutsContext } from "@/components/keyboard/KeyboardShort
 interface NarrationShortcutState {
   /** Current playback status */
   status: "idle" | "loading" | "playing" | "paused";
-  /** Current paragraph index (0-based) */
-  currentParagraph: number;
+  /**
+   * Current paragraph index (0-based) in the player's own space — the one
+   * `totalParagraphs` counts. Not the DOM element index (`currentParagraph`),
+   * which highlighting uses and which does not share these bounds.
+   */
+  currentNarrationParagraph: number;
   /** Total number of paragraphs */
   totalParagraphs: number;
 }
@@ -93,7 +97,7 @@ export function useNarrationKeyboardShortcuts(options: UseNarrationKeyboardShort
   const { state, controls, isLoading, isSupported } = options;
   const { enabled: keyboardShortcutsEnabled, isModalOpen } = useKeyboardShortcutsContext();
 
-  const { status, currentParagraph, totalParagraphs } = state;
+  const { status, currentNarrationParagraph, totalParagraphs } = state;
   const { play, pause, skipForward, skipBackward } = controls;
 
   const isPlaying = status === "playing";
@@ -134,10 +138,20 @@ export function useNarrationKeyboardShortcuts(options: UseNarrationKeyboardShort
     },
     {
       enabled:
-        baseEnabled && !isLoading && isControllable && currentParagraph < totalParagraphs - 1,
+        baseEnabled &&
+        !isLoading &&
+        isControllable &&
+        currentNarrationParagraph < totalParagraphs - 1,
       enableOnFormTags: false,
     },
-    [skipForward, isLoading, isControllable, currentParagraph, totalParagraphs, baseEnabled]
+    [
+      skipForward,
+      isLoading,
+      isControllable,
+      currentNarrationParagraph,
+      totalParagraphs,
+      baseEnabled,
+    ]
   );
 
   // Shift+P - Skip to previous paragraph
@@ -148,9 +162,9 @@ export function useNarrationKeyboardShortcuts(options: UseNarrationKeyboardShort
       skipBackward();
     },
     {
-      enabled: baseEnabled && !isLoading && isControllable && currentParagraph > 0,
+      enabled: baseEnabled && !isLoading && isControllable && currentNarrationParagraph > 0,
       enableOnFormTags: false,
     },
-    [skipBackward, isLoading, isControllable, currentParagraph, baseEnabled]
+    [skipBackward, isLoading, isControllable, currentNarrationParagraph, baseEnabled]
   );
 }

--- a/tests/unit/frontend/components/NarrationControls.test.tsx
+++ b/tests/unit/frontend/components/NarrationControls.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Narration playback controls, driven through the real `useNarration` engine.
+ *
+ * Narration spans two index spaces and the controls are where they meet:
+ * `state.currentParagraph` is a **DOM element** index (translated through the
+ * paragraph map so highlighting lands on the right element), while
+ * `state.totalParagraphs` counts **narration paragraphs** — the segments the
+ * player actually speaks. The map is not the identity (one element can narrate
+ * as several paragraphs, and an element can narrate as none), so the skip
+ * bounds and the "X of Y" readout must use `state.currentNarrationParagraph`.
+ *
+ * These tests use the real hook, the real `ArticleNarrator`, and real HTML with
+ * a deliberately non-identity paragraph map; the only stand-ins are the browser
+ * primitives jsdom lacks (`speechSynthesis`, `SpeechSynthesisUtterance`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Mock } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { KeyboardShortcutsProvider } from "@/components/keyboard/KeyboardShortcutsProvider";
+import { NarrationControlsImpl } from "@/components/narration/NarrationControls";
+import { useNarration } from "@/components/narration/useNarration";
+import { htmlToClientNarration } from "@/lib/narration/client-paragraph-ids";
+import { renderWithTrpc, stubMemoryLocalStorage } from "../../../utils/component-test-helpers";
+
+/**
+ * Two `<p>` elements that each narrate as several paragraphs (`<br><br>` splits
+ * one element's text) and two that narrate as none (they are still numbered as
+ * highlight targets), so the map is `o = [0, 0, 2, 3, 3, 3, 5]` over 7 narration
+ * paragraphs — the DOM index runs behind the narration index throughout.
+ */
+const SKEWED_HTML =
+  "<p>Alpha<br><br>Beta</p>" +
+  "<p></p>" +
+  "<p>Gamma</p>" +
+  "<p>Delta<br><br>Epsilon<br><br>Zeta</p>" +
+  "<p></p>" +
+  "<p>Eta</p>";
+
+/**
+ * The opposite skew: silent elements between spoken ones push the DOM index
+ * *ahead* of the narration index (`o = [0, 3, 6]` over 3 narration paragraphs).
+ */
+const SPARSE_HTML = "<p>One</p><p></p><p></p><p>Two</p><p></p><p></p><p>Three</p>";
+
+interface SpeechStub {
+  speak: Mock;
+  cancel: Mock;
+  pause: Mock;
+  resume: Mock;
+  getVoices: Mock;
+  onvoiceschanged: (() => void) | null;
+}
+
+let speech: SpeechStub;
+
+beforeEach(() => {
+  stubMemoryLocalStorage();
+
+  const voice = {
+    voiceURI: "test-voice",
+    name: "Test Voice",
+    lang: "en-US",
+    default: true,
+    localService: true,
+  };
+
+  speech = {
+    speak: vi.fn(),
+    cancel: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    getVoices: vi.fn(() => [voice]),
+    onvoiceschanged: null,
+  };
+  vi.stubGlobal("speechSynthesis", speech);
+  vi.stubGlobal(
+    "SpeechSynthesisUtterance",
+    class {
+      text: string;
+      voice: unknown = null;
+      rate = 1;
+      pitch = 1;
+      onend: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      constructor(text: string) {
+        this.text = text;
+      }
+    }
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * The real wiring: the owner holds `useNarration` (it needs the DOM index for
+ * highlighting) and hands the whole engine to the controls.
+ */
+function NarrationHarness({
+  content,
+  showFullContent = false,
+}: {
+  content: string;
+  showFullContent?: boolean;
+}) {
+  const narration = useNarration({
+    id: "entry-1",
+    title: "Test article",
+    feedTitle: "Test feed",
+    content,
+    showFullContent,
+  });
+  return <NarrationControlsImpl narration={narration} />;
+}
+
+function renderHarness(content: string, showFullContent = false) {
+  return renderWithTrpc(<NarrationHarness content={content} showFullContent={showFullContent} />, {
+    wrapper: (children) => <KeyboardShortcutsProvider>{children}</KeyboardShortcutsProvider>,
+  });
+}
+
+/** Clicks "Listen" and waits for the first paragraph to be speaking. */
+async function startNarration() {
+  fireEvent.click(screen.getByRole("button", { name: "Listen" }));
+  await waitFor(() => expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument());
+}
+
+const nextButton = () => screen.getByRole("button", { name: "Next paragraph" });
+const previousButton = () => screen.getByRole("button", { name: "Previous paragraph" });
+
+describe("narration paragraph fixtures", () => {
+  it("SKEWED_HTML narrates 7 paragraphs over a non-identity map", () => {
+    const { narrationText, paragraphMap } = htmlToClientNarration(SKEWED_HTML);
+
+    expect(narrationText.split("\n\n")).toEqual([
+      "Alpha",
+      "Beta",
+      "Gamma",
+      "Delta",
+      "Epsilon",
+      "Zeta",
+      "Eta",
+    ]);
+    expect(paragraphMap.map((entry) => entry.o)).toEqual([0, 0, 2, 3, 3, 3, 5]);
+  });
+
+  it("SPARSE_HTML narrates 3 paragraphs whose DOM indices run ahead", () => {
+    const { narrationText, paragraphMap } = htmlToClientNarration(SPARSE_HTML);
+
+    expect(narrationText.split("\n\n")).toEqual(["One", "Two", "Three"]);
+    expect(paragraphMap.map((entry) => entry.o)).toEqual([0, 3, 6]);
+  });
+});
+
+describe("NarrationControls paragraph position", () => {
+  it("counts narration paragraphs, not the DOM elements they highlight", async () => {
+    renderHarness(SKEWED_HTML);
+    await startNarration();
+
+    // Narration paragraph 0 ("Alpha") — nothing before it.
+    expect(screen.getByText("1 of 7")).toBeInTheDocument();
+    expect(previousButton()).toBeDisabled();
+    expect(nextButton()).toBeEnabled();
+
+    // Narration paragraph 1 ("Beta") still highlights DOM element 0, so a
+    // DOM-index comparison would call this the very first paragraph.
+    fireEvent.click(nextButton());
+    await waitFor(() => expect(screen.getByText("2 of 7")).toBeInTheDocument());
+    expect(previousButton()).toBeEnabled();
+  });
+
+  it("keeps Next live until the last narration paragraph", async () => {
+    renderHarness(SKEWED_HTML);
+    await startNarration();
+
+    for (let i = 1; i < 6; i++) {
+      fireEvent.click(nextButton());
+      await waitFor(() => expect(screen.getByText(`${i + 1} of 7`)).toBeInTheDocument());
+      expect(nextButton()).toBeEnabled();
+    }
+
+    // Narration paragraph 6 ("Eta") is the last one, even though it highlights
+    // DOM element 5.
+    fireEvent.click(nextButton());
+    await waitFor(() => expect(screen.getByText("7 of 7")).toBeInTheDocument());
+    expect(nextButton()).toBeDisabled();
+  });
+
+  it("does not disable Next early when DOM indices run ahead of narration ones", async () => {
+    renderHarness(SPARSE_HTML);
+    await startNarration();
+
+    // Narration paragraph 1 ("Two") highlights DOM element 3, which is already
+    // past `totalParagraphs - 1` (2) — but "Three" is still to come.
+    fireEvent.click(nextButton());
+    await waitFor(() => expect(screen.getByText("2 of 3")).toBeInTheDocument());
+    expect(nextButton()).toBeEnabled();
+
+    fireEvent.click(nextButton());
+    await waitFor(() => expect(screen.getByText("3 of 3")).toBeInTheDocument());
+    expect(nextButton()).toBeDisabled();
+  });
+
+  it("enables Shift+P once a narration paragraph has been played", async () => {
+    renderHarness(SKEWED_HTML);
+    await startNarration();
+
+    fireEvent.keyDown(document, { key: "N", code: "KeyN", shiftKey: true });
+    await waitFor(() => expect(screen.getByText("2 of 7")).toBeInTheDocument());
+
+    // The DOM index is still 0 here, which would leave Shift+P disabled.
+    fireEvent.keyDown(document, { key: "P", code: "KeyP", shiftKey: true });
+    await waitFor(() => expect(screen.getByText("1 of 7")).toBeInTheDocument());
+  });
+});
+
+describe("NarrationControls content variant switching", () => {
+  it("stops speaking the old variant when the displayed variant changes", async () => {
+    const { rerender } = renderHarness(SKEWED_HTML);
+    await startNarration();
+    expect(speech.speak).toHaveBeenCalledTimes(1);
+
+    const cancelsBefore = speech.cancel.mock.calls.length;
+
+    // Toggling "Full Content" does not remount the entry (EntryContent is keyed
+    // only by the entry id), so the hook has to stop the utterance itself.
+    rerender(<NarrationHarness content={SKEWED_HTML} showFullContent={true} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Listen" })).toBeInTheDocument());
+    expect(speech.cancel.mock.calls.length).toBeGreaterThan(cancelsBefore);
+    expect(speech.speak).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Three narration-control bugs, all living in the seam between two index spaces.

### The two index spaces (the subtle part)

Narration has **narration paragraphs** — the segments `splitNarrationParagraphs` produces, which the player (`ArticleNarrator` or `StreamingAudioPlayer`) actually advances through — and **DOM elements**, the `data-para-id` targets highlighting paints. The paragraph map translates one to the other and it is *not* the identity: a single element can narrate as several paragraphs (a `<p>` split by `<br><br>`), and an element can narrate as none (an empty block that is still numbered as a highlight target).

`useNarration` translated the player index through the map and stored the result as `state.currentParagraph` — so that field is a **DOM element index**. `state.totalParagraphs`, meanwhile, is an untranslated **narration paragraph count**. Everything that compared the two was comparing across spaces.

### 1. Switching content variant mid-narration kept speaking the old text

**Symptom:** click "Full Content" (or "Original") while narration is playing and `speechSynthesis` keeps reading the previous variant, while the paragraph map is emptied underneath it and highlighting is applied to the new DOM with stale indices.

The reset effect keyed on `id`/voice/`showFullContent`/`showOriginal` stopped and cleared the streaming player but never called `narratorRef.current.stop()`. The only place that ran was the unmount cleanup — and toggling those flags does not remount: `EntryContent` is keyed only by `openEntryId`.

**Fix:** stop the narrator alongside the streaming player in that effect.

### 2. Skip buttons, hotkeys and the "X of Y" readout used the wrong index space

**Symptom:** with a real map like `o = [0, 0, 2, 3, 3, 3, 5]` (7 narration paragraphs), while speaking narration paragraph 1 the DOM index is still 0, so `disabled={currentParagraph === 0}` greys out **Previous** and Shift+P goes dead even though the player can step back. In the other direction, `currentParagraph >= totalParagraphs - 1` disables **Next** several paragraphs early when silent elements push the DOM index ahead (`o = [0, 3, 6]`), and never disables it at all on the first map — the DOM index never reaches `totalParagraphs - 1`. The readout counts elements, not paragraphs.

**Fix:** `useNarration` now keeps the untranslated player index alongside the DOM one as `state.currentNarrationParagraph` (new `UseNarrationState`, documented with the two spaces). The two `disabled` props, the two hotkey `enabled` conditions and the readout all read it. `currentParagraph` is untouched and still feeds `useNarrationHighlight`, which needs the DOM index.

### 3. `NarrationControls`' unused "uncontrolled mode" built a whole second narration engine per render

The sole call site always passed `narration={narration}` and never passed `content`/`artwork`. Because hooks can't be conditional, every render also constructed a second `ArticleNarrator`, a second `trpc.narration.generate` mutation and a second (inert) `useMediaSession` — all thrown away by `externalNarration ?? internalNarration`.

**Fix:** `narration` is now required and the dead `articleId`/`title`/`feedTitle`/`artwork`/`content` props are gone (three of them were still being passed at the call site). Verified there is no other consumer.

### Tests

New `tests/unit/frontend/components/NarrationControls.test.tsx` (jsdom) drives the **real** `useNarration` + `ArticleNarrator` + `NarrationControlsImpl` wiring over real HTML; the only stand-ins are the browser primitives jsdom lacks (`speechSynthesis`, `SpeechSynthesisUtterance`). Two fixtures pin non-identity maps in both directions and are asserted against `htmlToClientNarration` so they can't silently become identity:

- `o = [0, 0, 2, 3, 3, 3, 5]` over 7 narration paragraphs (DOM index lags)
- `o = [0, 3, 6]` over 3 (DOM index runs ahead)

Cases: Previous stays live once a paragraph has been played; Next stays live to the last narration paragraph and is disabled there; Next is not disabled early when DOM indices run ahead; Shift+P works at narration paragraph 1; and switching the variant mid-playback cancels the utterance and returns the controls to "Listen".

All five behavior tests were confirmed to fail against the pre-fix comparisons and the pre-fix reset effect.

### Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test:unit` — 162 files, 3229 tests passed
- `pnpm test:e2e:local` — 76 passed (includes `narration-highlighting.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
