### PR TITLE
fix: Correctness bugs in summarization, OPML import, admin and feed-stats

### DIFF
--- a/src/server/services/imports.ts
+++ b/src/server/services/imports.ts
@@ -209,10 +209,14 @@ async function ensureImportTags(
     return tagNameToInfo;
   }
 
+  // Only live tags: `deleteTag` tombstones, and `uq_tags_user_name` is partial
+  // (`WHERE deleted_at IS NULL`), so a deleted tag can share a name with a live
+  // one. Reusing a tombstone would attach the imported subscriptions to a tag
+  // that no sidebar group lists.
   const existingTags = await db
     .select({ id: tags.id, name: tags.name, color: tags.color })
     .from(tags)
-    .where(eq(tags.userId, userId));
+    .where(and(eq(tags.userId, userId), isNull(tags.deletedAt)));
 
   for (const existingTag of existingTags) {
     if (tagNames.has(existingTag.name)) {

--- a/src/server/trpc/routers/admin.ts
+++ b/src/server/trpc/routers/admin.ts
@@ -434,7 +434,16 @@ const feedHealthEndpoints = {
         })
         .from(feeds)
         .where(whereClause)
-        .orderBy(desc(feeds.consecutiveFailures), asc(feeds.title), asc(feeds.id))
+        // Must match the cursor comparison above exactly: the cursor compares
+        // COALESCE(title, ''), so ordering by the bare column (Postgres
+        // `ASC` = NULLS LAST) would sort untitled feeds after every titled one
+        // while the cursor sorts them first, making them unreachable past the
+        // first page.
+        .orderBy(
+          desc(feeds.consecutiveFailures),
+          sql`COALESCE(${feeds.title}, '') ASC`,
+          asc(feeds.id)
+        )
         .limit(limit + 1);
 
       const hasMore = rows.length > limit;
@@ -785,7 +794,9 @@ const overviewEndpoints = {
         ctx.db
           .select({
             active7d: sql<number>`COUNT(*) FILTER (WHERE ${users.lastActiveAt} > ${sevenDaysAgo})`,
-            active30d: sql<number>`COUNT(*) FILTER (WHERE ${users.lastActiveAt} > ${thirtyDaysAgo})`,
+            // No FILTER needed: the WHERE below already restricts the scan to
+            // the 30-day window (and `gt` excludes NULL last_active_at).
+            active30d: count(),
           })
           .from(users)
           .where(gt(users.lastActiveAt, thirtyDaysAgo)),

--- a/src/server/trpc/routers/feedStats.ts
+++ b/src/server/trpc/routers/feedStats.ts
@@ -71,7 +71,10 @@ export const feedStatsRouter = createTRPCRouter({
     .input(
       z
         .object({
-          cursor: z.string().optional(),
+          // Validated as a UUID so a malformed cursor is a 400 rather than a
+          // Postgres `invalid input syntax for type uuid` 500 from the keyset
+          // comparison below.
+          cursor: z.string().uuid().optional(),
           limit: z.number().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
         })
         .optional()
@@ -97,20 +100,22 @@ export const feedStatsRouter = createTRPCRouter({
       // Cursor-based pagination matching ORDER BY (resolved_title ASC, id DESC).
       // We need composite logic since the primary sort (title) differs from the cursor column (id).
       if (cursor) {
+        // The boundary-row lookups are scoped to the requesting user: never
+        // resolve a caller-supplied id without a user predicate.
         conditions.push(
           sql`(
             COALESCE(${subscriptions.customTitle}, ${feeds.title}, ${feeds.url}) > (
               SELECT COALESCE(s2.custom_title, f2.title, f2.url)
               FROM subscriptions s2
               JOIN feeds f2 ON f2.id = s2.feed_id
-              WHERE s2.id = ${cursor}
+              WHERE s2.id = ${cursor} AND s2.user_id = ${userId}
             )
             OR (
               COALESCE(${subscriptions.customTitle}, ${feeds.title}, ${feeds.url}) = (
                 SELECT COALESCE(s2.custom_title, f2.title, f2.url)
                 FROM subscriptions s2
                 JOIN feeds f2 ON f2.id = s2.feed_id
-                WHERE s2.id = ${cursor}
+                WHERE s2.id = ${cursor} AND s2.user_id = ${userId}
               )
               AND ${subscriptions.id} < ${cursor}
             )

--- a/src/server/trpc/routers/summarization.ts
+++ b/src/server/trpc/routers/summarization.ts
@@ -163,6 +163,12 @@ export const summarizationRouter = createTRPCRouter({
       // - undefined: return any cached summary, or generate from feed content
       let sourceContent: string;
       let contentHash: string;
+      /**
+       * The `(userId, contentHash)` row the `undefined` branch already looked
+       * up, carried forward so the generation path below doesn't re-run the
+       * byte-identical query.
+       */
+      let cachedFeedSummary: (typeof entrySummaries.$inferSelect)[] | undefined;
 
       if (input.useFullContent === true) {
         // Explicit full content request
@@ -179,9 +185,12 @@ export const summarizationRouter = createTRPCRouter({
         sourceContent = entry.contentCleaned || entry.contentOriginal || "";
         contentHash = entry.contentHash;
       } else {
-        // undefined: try to return whichever cached summary exists, preferring full content
+        // undefined: try to return whichever cached summary exists, preferring
+        // full content. `regenerate` means the caller explicitly asked to skip
+        // the cache, so don't serve (or even look up) a stored summary here —
+        // fall through to generating from feed content.
         // Check full content summary first (if available)
-        if (entry.fullContentHash) {
+        if (!input.regenerate && entry.fullContentHash) {
           const fullSummary = await ctx.db
             .select()
             .from(entrySummaries)
@@ -224,7 +233,7 @@ export const summarizationRouter = createTRPCRouter({
           .limit(1);
 
         const feedRecord = feedSummary[0];
-        if (feedRecord?.summaryText) {
+        if (!input.regenerate && feedRecord?.summaryText) {
           return {
             summary: sanitizeEntryHtml(feedRecord.summaryText) ?? "",
             cached: true,
@@ -234,9 +243,10 @@ export const summarizationRouter = createTRPCRouter({
           };
         }
 
-        // No cached summary found — generate from feed content
+        // No usable cached summary — generate from feed content
         sourceContent = entry.contentCleaned || entry.contentOriginal || "";
         contentHash = entry.contentHash;
+        cachedFeedSummary = feedSummary;
       }
 
       // Handle empty content
@@ -245,11 +255,15 @@ export const summarizationRouter = createTRPCRouter({
       }
 
       // Look up existing summary by user + content hash
-      let summary = await ctx.db
-        .select()
-        .from(entrySummaries)
-        .where(and(eq(entrySummaries.userId, userId), eq(entrySummaries.contentHash, contentHash)))
-        .limit(1);
+      let summary =
+        cachedFeedSummary ??
+        (await ctx.db
+          .select()
+          .from(entrySummaries)
+          .where(
+            and(eq(entrySummaries.userId, userId), eq(entrySummaries.contentHash, contentHash))
+          )
+          .limit(1));
 
       // Create placeholder record if not found
       if (summary.length === 0) {

--- a/tests/integration/admin.test.ts
+++ b/tests/integration/admin.test.ts
@@ -26,6 +26,8 @@ import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
 import { createTestFeed, createTestUser } from "./helpers";
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 // ============================================================================
 // Test Helpers
 // ============================================================================
@@ -301,6 +303,67 @@ describe("Admin API", () => {
 
       const feedIds = result.items.map((f) => f.feedId);
       expect(feedIds).toContain(brokenId);
+    });
+  });
+
+  describe("admin.listFeeds pagination", () => {
+    // The keyset cursor compares COALESCE(title, ''), so the ORDER BY has to
+    // do the same: with a bare `ASC` (Postgres NULLS LAST) an untitled feed
+    // sorts after every titled one while the cursor puts it first, and it
+    // becomes unreachable past the first page. Untitled feeds are exactly the
+    // never-successfully-fetched ones this admin page exists to surface.
+    it("reaches an untitled feed while paging", async () => {
+      const ctx = createAdminContext();
+      const caller = createCaller(ctx);
+
+      const untitledId = await createTestFeed({
+        url: "https://example.com/untitled.xml",
+        title: null,
+        consecutiveFailures: 0,
+      });
+      const alphaId = await createTestFeed({
+        url: "https://example.com/alpha.xml",
+        title: "Alpha",
+        consecutiveFailures: 0,
+      });
+      const zetaId = await createTestFeed({
+        url: "https://example.com/zeta.xml",
+        title: "Zeta",
+        consecutiveFailures: 0,
+      });
+
+      const seen: string[] = [];
+      let cursor: string | undefined;
+      for (let page = 0; page < 10; page++) {
+        const result = await caller.admin.listFeeds({ limit: 1, cursor });
+        seen.push(...result.items.map((f) => f.feedId));
+        cursor = result.nextCursor;
+        if (!cursor) break;
+      }
+
+      // Untitled first (COALESCE(title, '') sorts '' before every title), then
+      // alphabetically — and every feed is returned exactly once.
+      expect(seen).toEqual([untitledId, alphaId, zetaId]);
+    });
+  });
+
+  describe("admin.getOverview", () => {
+    it("counts active users in the 7- and 30-day windows", async () => {
+      const ctx = createAdminContext();
+      const caller = createCaller(ctx);
+
+      const now = Date.now();
+      await createTestUser({ emailPrefix: "recent", lastActiveAt: new Date(now - 3 * DAY_MS) });
+      await createTestUser({ emailPrefix: "midway", lastActiveAt: new Date(now - 20 * DAY_MS) });
+      await createTestUser({ emailPrefix: "stale", lastActiveAt: new Date(now - 40 * DAY_MS) });
+      // Never active: excluded from both windows (NULL fails the > comparison).
+      await createTestUser({ emailPrefix: "never", lastActiveAt: null });
+
+      const stats = await caller.admin.getOverview();
+
+      expect(stats.totalUsers).toBe(4);
+      expect(stats.activeUsersLast7Days).toBe(1);
+      expect(stats.activeUsersLast30Days).toBe(2);
     });
   });
 

--- a/tests/integration/feed-stats.test.ts
+++ b/tests/integration/feed-stats.test.ts
@@ -97,6 +97,40 @@ describe("Feed Stats API", () => {
     expect(result.items[0].entriesPerWeek).toBeNull();
   });
 
+  // A cursor reaches the SQL as a `uuid` comparison, so an unparseable value
+  // used to surface as a Postgres "invalid input syntax for type uuid" 500
+  // instead of a validation error.
+  it("rejects a malformed cursor as a validation error", async () => {
+    const userId = await createTestUser({ emailPrefix: "feedstats" });
+    const caller = createCaller(await createAuthContext(userId));
+
+    await expect(caller.feedStats.list({ cursor: "not-a-uuid" })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
+  // The boundary-row subquery resolves a caller-supplied subscription id, so it
+  // must carry a user predicate: a subscription belonging to somebody else is
+  // not a valid pagination boundary and must not decide what this user sees.
+  it("does not resolve a foreign subscription as the pagination boundary", async () => {
+    const userId = await createTestUser({ emailPrefix: "feedstats" });
+    const otherUserId = await createTestUser({ emailPrefix: "feedstats-other" });
+
+    await createTestSubscription(userId, await createTestFeed({ title: "AAA Feed" }));
+    await createTestSubscription(userId, await createTestFeed({ title: "ZZZ Feed" }));
+    const foreignSubscriptionId = await createTestSubscription(
+      otherUserId,
+      await createTestFeed({ title: "MMM Feed" })
+    );
+
+    const caller = createCaller(await createAuthContext(userId));
+    const result = await caller.feedStats.list({ cursor: foreignSubscriptionId });
+
+    // Without the user predicate the boundary resolves to "MMM Feed" and this
+    // user gets back everything sorted after it ("ZZZ Feed").
+    expect(result.items).toEqual([]);
+  });
+
   it("computes stats independently per feed across multiple subscriptions", async () => {
     const userId = await createTestUser({ emailPrefix: "feedstats" });
     const feedA = await createTestFeed({ title: "AAA Feed" });

--- a/tests/integration/opml-import.test.ts
+++ b/tests/integration/opml-import.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import Redis from "ioredis";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import {
   users,
@@ -23,6 +23,7 @@ import {
 import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { getUserEventsChannel } from "../../src/server/redis/pubsub";
 import { processOpmlImport } from "../../src/server/services/imports";
+import { createTag, deleteTag, listTags } from "../../src/server/services/tags";
 import { createCaller } from "../../src/server/trpc/root";
 import { waitForMessages } from "../utils/pubsub";
 import {
@@ -416,6 +417,46 @@ describe("OPML Import", () => {
       expect(record.importedCount).toBe(3);
       expect(record.completedAt).not.toBeNull();
       expect(record.results.map((r) => r.status)).toEqual(["imported", "imported", "imported"]);
+    });
+
+    // `deleteTag` only tombstones, and `uq_tags_user_name` is partial
+    // (`WHERE deleted_at IS NULL`), so a live and a deleted tag can share a
+    // name. Reusing the tombstone would attach the imported subscriptions to a
+    // tag `listTags` hides — and `buildUncategorizedSubscriptionIdsSubquery`
+    // excludes anything with a subscription_tags row, so the feeds would show
+    // up in no sidebar group at all.
+    it("creates a new tag rather than reusing a soft-deleted one of the same name", async () => {
+      const userId = await createTestUser();
+      const created = await createTag(db, userId, { name: "News" });
+      await deleteTag(db, userId, created.id);
+
+      const importId = await seedImport(userId, [
+        { xmlUrl: "https://a.example.com/feed.xml", title: "A", category: ["News"] },
+      ]);
+      await processOpmlImport(db, importId);
+
+      const newsTags = await db
+        .select()
+        .from(tags)
+        .where(and(eq(tags.userId, userId), eq(tags.name, "News")));
+      expect(newsTags).toHaveLength(2);
+
+      const liveTags = newsTags.filter((t) => t.deletedAt === null);
+      expect(liveTags).toHaveLength(1);
+      expect(liveTags[0].id).not.toBe(created.id);
+
+      // The imported subscription is attached to the live tag, so it appears
+      // under "News" in the sidebar.
+      const associations = await db
+        .select({ tagId: subscriptionTags.tagId })
+        .from(subscriptionTags)
+        .innerJoin(subscriptions, eq(subscriptionTags.subscriptionId, subscriptions.id))
+        .where(eq(subscriptions.userId, userId));
+      expect(associations).toEqual([{ tagId: liveTags[0].id }]);
+
+      const listed = await listTags(db, userId);
+      expect(listed.items.map((t) => t.name)).toEqual(["News"]);
+      expect(listed.items[0].id).toBe(liveTags[0].id);
     });
 
     it("skips feeds the user is already subscribed to", async () => {

--- a/tests/integration/summarization.test.ts
+++ b/tests/integration/summarization.test.ts
@@ -35,7 +35,7 @@ import {
 async function createVisibleEntry(
   userId: string,
   contentHash: string,
-  options: { unsubscribed?: boolean; saved?: boolean } = {}
+  options: { unsubscribed?: boolean; saved?: boolean; fullContentHash?: string } = {}
 ): Promise<string> {
   const now = new Date();
   let feedId: string;
@@ -59,6 +59,12 @@ async function createVisibleEntry(
     contentCleaned: "<p>Some article content to summarize.</p>",
     // The summary cache is keyed off this, so it's the caller's value verbatim.
     contentHash,
+    ...(options.fullContentHash
+      ? {
+          fullContentHash: options.fullContentHash,
+          fullContentCleaned: "<p>The full article body, fetched from the site.</p>",
+        }
+      : {}),
     fetchedAt: now,
   });
   // Not createTestEntry's `userIds`, which can't express the explicit change
@@ -78,12 +84,18 @@ async function createVisibleEntry(
 
 const createdUserIds: string[] = [];
 let previousAnthropicKey: string | undefined;
+let previousGroqKey: string | undefined;
 
 beforeAll(() => {
   // Make summarization "available" via the server key so the router reaches the
   // cached read path (no real LLM call — a cached summary is returned first).
   previousAnthropicKey = process.env.ANTHROPIC_API_KEY;
   process.env.ANTHROPIC_API_KEY = "sk-ant-test-server-key";
+  // ...and make sure Groq is *not* configured: the regenerate tests below point
+  // the user at a Groq model so the generation path fails at "no key" instead
+  // of making a real network call.
+  previousGroqKey = process.env.GROQ_API_KEY;
+  delete process.env.GROQ_API_KEY;
 });
 
 afterAll(async () => {
@@ -91,6 +103,11 @@ afterAll(async () => {
     delete process.env.ANTHROPIC_API_KEY;
   } else {
     process.env.ANTHROPIC_API_KEY = previousAnthropicKey;
+  }
+  if (previousGroqKey === undefined) {
+    delete process.env.GROQ_API_KEY;
+  } else {
+    process.env.GROQ_API_KEY = previousGroqKey;
   }
   for (const userId of createdUserIds) {
     await db.delete(users).where(eq(users.id, userId));
@@ -184,5 +201,98 @@ describe("summarization.generate entry visibility", () => {
 
     expect(result.cached).toBe(true);
     expect(result.summary).toContain("Saved article summary");
+  });
+});
+
+/**
+ * `regenerate: true` is documented as "skip the cache and regenerate", and the
+ * REST/OpenAPI and MCP surfaces can send it without `useFullContent` (the web
+ * client always sends the flag). These lock in that the `useFullContent`-omitted
+ * branch honours it too.
+ *
+ * The user is pointed at a Groq model while only the Anthropic server key is
+ * set, so once the router gets past the cache it fails deterministically with
+ * "Groq API key not configured" — no network call, and reaching that error is
+ * itself the proof that the cached summary was not served.
+ */
+describe("summarization.generate regenerate bypasses the cache", () => {
+  const UNCONFIGURED_MODEL = "groq:llama-3.3-70b-versatile";
+
+  async function createUser(): Promise<string> {
+    const userId = await createTestUser({
+      emailPrefix: "summ",
+      summarizationModel: UNCONFIGURED_MODEL,
+    });
+    createdUserIds.push(userId);
+    return userId;
+  }
+
+  async function cacheSummary(userId: string, contentHash: string, text: string): Promise<void> {
+    await db.insert(entrySummaries).values({
+      id: generateUuidv7(),
+      userId,
+      contentHash,
+      summaryText: text,
+      modelId: UNCONFIGURED_MODEL,
+      promptVersion: CURRENT_PROMPT_VERSION,
+      generatedAt: new Date(),
+      createdAt: new Date(),
+    });
+  }
+
+  it("serves the cached feed summary when regenerate is not set", async () => {
+    const userId = await createUser();
+    const contentHash = `hash-${generateUuidv7()}`;
+    const entryId = await createVisibleEntry(userId, contentHash);
+    await cacheSummary(userId, contentHash, "<p>Cached feed summary</p>");
+
+    const caller = createCaller(await createAuthContext(userId));
+    const result = await caller.summarization.generate({ entryId });
+
+    expect(result.cached).toBe(true);
+    expect(result.summary).toContain("Cached feed summary");
+  });
+
+  it("skips the cached feed summary when regenerate is true", async () => {
+    const userId = await createUser();
+    const contentHash = `hash-${generateUuidv7()}`;
+    const entryId = await createVisibleEntry(userId, contentHash);
+    await cacheSummary(userId, contentHash, "<p>Cached feed summary</p>");
+
+    const caller = createCaller(await createAuthContext(userId));
+
+    await expect(caller.summarization.generate({ entryId, regenerate: true })).rejects.toThrow(
+      "Groq API key not configured"
+    );
+
+    // The generation attempt is recorded on the cached row, so the request
+    // really reached the LLM call rather than short-circuiting on the cache.
+    const [row] = await db
+      .select()
+      .from(entrySummaries)
+      .where(eq(entrySummaries.userId, userId))
+      .limit(1);
+    expect(row.errorAt).not.toBeNull();
+    // The stored summary is left alone for the next non-regenerate read.
+    expect(row.summaryText).toContain("Cached feed summary");
+  });
+
+  it("skips the cached full-content summary when regenerate is true", async () => {
+    const userId = await createUser();
+    const contentHash = `hash-${generateUuidv7()}`;
+    const fullContentHash = `full-hash-${generateUuidv7()}`;
+    const entryId = await createVisibleEntry(userId, contentHash, { fullContentHash });
+    await cacheSummary(userId, fullContentHash, "<p>Cached full-content summary</p>");
+
+    const caller = createCaller(await createAuthContext(userId));
+
+    // Control: without the flag the full-content summary is served.
+    const cached = await caller.summarization.generate({ entryId });
+    expect(cached.cached).toBe(true);
+    expect(cached.summary).toContain("Cached full-content summary");
+
+    await expect(caller.summarization.generate({ entryId, regenerate: true })).rejects.toThrow(
+      "Groq API key not configured"
+    );
   });
 });


### PR DESCRIPTION
Six small, independently verified correctness fixes across four backend files. Each behavioral fix has an integration test that fails without it.

## `summarization.generate` ignored `regenerate` when `useFullContent` was omitted

`regenerate` is documented as "skip the cache and regenerate", but the two cached-summary early returns in the `useFullContent`-omitted branch didn't consult it — only the later check did. **Symptom:** `POST /summarization/generate {entryId, regenerate: true}` returned the stale summary with `cached: true` and made no LLM call. The web client always sends `useFullContent`, so this was reachable through the REST/OpenAPI and MCP surfaces. Both early returns are now gated on `!input.regenerate`.

## The same summary row was SELECTed twice per uncached summarize

The `(userId, contentHash)` lookup in the `undefined` branch ran again, byte-identical, a few lines later with no write in between. **Symptom:** one wasted round-trip on every uncached summarize. The first result is now carried forward.

## OPML import reused soft-deleted tags

The existing-tag lookup filtered only on `user_id`. `deleteTag` merely tombstones, and `uq_tags_user_name` is partial (`WHERE deleted_at IS NULL`), so a live and a deleted tag can share a name. **Symptom:** create tag "News", delete it, import OPML with `category="News"` → the tombstone is reused. `listTags` hides it, and `buildUncategorizedSubscriptionIdsSubquery` excludes any subscription that has a `subscription_tags` row, so the imported feeds ended up in **no** sidebar group. With both a live and a tombstoned "News" the outcome was row-order dependent.

## `admin.listFeeds`: untitled feeds vanished after page 1

The keyset cursor compares `COALESCE(title, '')` (NULLs first) while the ORDER BY used the bare column — Drizzle's `asc` emits a plain `ASC`, i.e. Postgres `NULLS LAST`. **Symptom:** with two web feeds, `Alpha` and an untitled one, `listFeeds({limit: 1})` returned `Alpha` and the next page came back empty; the untitled feed was unreachable. Untitled feeds are exactly the never-successfully-fetched ones this admin page exists to surface. The ORDER BY now matches the cursor.

## `admin.getOverview`: redundant aggregate FILTER

`active30d`'s `FILTER` duplicated the query's own `.where(gt(users.lastActiveAt, thirtyDaysAgo))` — every aggregated row already satisfies it, and `gt` excludes NULLs. Simplified to `count()`; a new test locks in both windows.

## `feedStats.list`: unvalidated cursor 500'd, and the boundary lookup wasn't user-scoped

`cursor: z.string().optional()` was interpolated into `uuid` comparisons, so `feedStats.list({cursor: "abc"})` raised `invalid input syntax for type uuid` → **500 instead of a validation error**. Separately, the two `SELECT … FROM subscriptions s2 WHERE s2.id = ${cursor}` boundary lookups resolved a caller-supplied id with no `user_id` predicate — it leaks only an ordering comparison, but `SECURITY.md` §5 forbids it and the predicate is free. Now `z.string().uuid()` plus `AND s2.user_id = ${userId}` on both subqueries.

Per the note on the existing broader cursor issue, the four hand-rolled cursors are deliberately **not** migrated to `createCursorCodec` here.

## Verification

- `pnpm typecheck`, `pnpm lint`: clean
- `pnpm test:unit`: 161 files, 3222 passed
- `pnpm test:integration:local`: 57 passed / 2 skipped files, **804 passed** / 15 skipped
- Each behavioral fix was reverted individually to confirm its new test fails without it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
