### PR TITLE
refactor: Remove duplicated and unreachable code in the worker/queue/tRPC layers

### DIFF
--- a/src/server/jobs/queue.ts
+++ b/src/server/jobs/queue.ts
@@ -605,17 +605,23 @@ export async function claimSingletonJob(type: JobType): Promise<Job | null> {
   const now = new Date();
   const staleThreshold = new Date(now.getTime() - STALE_JOB_THRESHOLD_MS);
 
+  // Claims the singleton row if it is due and not held by a live worker. Used
+  // both for the initial attempt and for the post-INSERT-race retry below, which
+  // must apply exactly the same predicate.
+  const tryClaim = () =>
+    db.execute<RawJobRow>(sql`
+      UPDATE ${jobs}
+      SET
+        running_since = ${now},
+        updated_at = ${now}
+      WHERE type = ${type}
+        AND next_run_at <= ${now}
+        AND (running_since IS NULL OR running_since < ${staleThreshold})
+      RETURNING *
+    `);
+
   // First, try to claim an existing job
-  const claimResult = await db.execute<RawJobRow>(sql`
-    UPDATE ${jobs}
-    SET
-      running_since = ${now},
-      updated_at = ${now}
-    WHERE type = ${type}
-      AND next_run_at <= ${now}
-      AND (running_since IS NULL OR running_since < ${staleThreshold})
-    RETURNING *
-  `);
+  const claimResult = await tryClaim();
 
   if (claimResult.rows.length > 0) {
     return rowToJob(claimResult.rows[0]);
@@ -656,19 +662,10 @@ export async function claimSingletonJob(type: JobType): Promise<Job | null> {
       throw error;
     }
 
-    // Another worker created the job first - try to claim it. Keep the
-    // next_run_at <= now check: if the winner already ran and rescheduled the
-    // job, we must not immediately re-run it.
-    const retryResult = await db.execute<RawJobRow>(sql`
-      UPDATE ${jobs}
-      SET
-        running_since = ${now},
-        updated_at = ${now}
-      WHERE type = ${type}
-        AND next_run_at <= ${now}
-        AND (running_since IS NULL OR running_since < ${staleThreshold})
-      RETURNING *
-    `);
+    // Another worker created the job first - try to claim it. The shared
+    // predicate keeps the next_run_at <= now check: if the winner already ran
+    // and rescheduled the job, we must not immediately re-run it.
+    const retryResult = await tryClaim();
 
     if (retryResult.rows.length > 0) {
       return rowToJob(retryResult.rows[0]);

--- a/src/server/jobs/worker-core.ts
+++ b/src/server/jobs/worker-core.ts
@@ -22,33 +22,6 @@ export type ClaimJobFn = (options?: { types?: any }) => Promise<Job | null>;
 export type ProcessJobFn = (job: Job) => Promise<void>;
 
 /**
- * Worker configuration options.
- */
-export interface WorkerConfig {
-  /** Polling interval in milliseconds (default: 5000) */
-  pollIntervalMs?: number;
-  /** Maximum concurrent jobs to process (default: 5) */
-  concurrency?: number;
-  /** Maximum time a single job can run before being timed out (default: no timeout) */
-  jobTimeoutMs?: number;
-  /** Job types to process (default: all types) */
-  jobTypes?: string[];
-  /** Logger function for worker events */
-  logger?: WorkerLogger;
-  /**
-   * Override for claiming jobs (for testing).
-   * @internal
-   */
-  _claimJob?: ClaimJobFn;
-  /**
-   * Override for processing jobs (for testing).
-   * When provided, bypasses the default job handler dispatch.
-   * @internal
-   */
-  _processJob?: ProcessJobFn;
-}
-
-/**
  * Logger interface for worker events.
  */
 export interface WorkerLogger {
@@ -143,6 +116,11 @@ interface InternalWorkerConfig {
   logger: WorkerLogger;
   claimJob: ClaimJobFn;
   processJob: ProcessJobFn;
+  /**
+   * Called once for every job that fails, whether `processJob` rejected or the
+   * job exceeded `jobTimeoutMs`. The loop already logs; this hook is for
+   * side-channel reporting (Sentry). It must not throw.
+   */
   onJobError?: (job: Job, error: unknown) => void;
   /**
    * Called when a `claimJob` attempt throws (e.g. the DB connection was dropped
@@ -272,9 +250,9 @@ export function createWorkerCore(config: InternalWorkerConfig): Worker {
         if (job === null) break;
 
         // Wrap processJob with .catch() to ensure no unhandled rejections escape
-        // into Promise.race()/Promise.all(). The error is already logged and
-        // reported to Sentry inside processJob, so we just need to prevent
-        // the rejection from propagating.
+        // into Promise.race()/Promise.all(), and to count the failure. This
+        // catch is also where a failed job is reported (via onJobError) — the
+        // one place that sees both a handler exception and a timeout.
         const promise = processJobWithTimeout(job)
           .then(() => {
             totalSucceeded++;
@@ -288,8 +266,9 @@ export function createWorkerCore(config: InternalWorkerConfig): Worker {
                 timeoutMs: jobTimeoutMs,
               });
             } else {
-              // This should rarely happen since processJob has its own try/catch,
-              // but handle it defensively
+              // The injected processJob rejected. The production one already
+              // logged the details before re-throwing; this is the loop-level
+              // record, and the only one for an injected processJob.
               logger.error("Unexpected error in job execution", {
                 jobId: job.id,
                 error: error instanceof Error ? error.message : "Unknown error",

--- a/src/server/jobs/worker.ts
+++ b/src/server/jobs/worker.ts
@@ -574,18 +574,8 @@ function createWorker(config: WorkerConfig = {}): Worker {
         error: errorMessage,
       });
 
-      // Report to Sentry with job context
-      Sentry.captureException(error, {
-        tags: { jobType: job.type },
-        extra: {
-          jobId: job.id,
-          consecutiveFailures: job.consecutiveFailures,
-          payload: job.payload,
-          durationMs: duration,
-        },
-      });
-
-      // Re-throw to let the core worker count it as a failure
+      // Re-throw so the core worker counts it as a failure and reports it via
+      // onJobError (the single Sentry reporter for job failures — see below).
       throw error;
     } finally {
       // Safety net: ensure the heartbeat is stopped even if finishWithLease was
@@ -603,10 +593,18 @@ function createWorker(config: WorkerConfig = {}): Worker {
     logger,
     claimJob: guardedClaimJob,
     processJob,
+    // The single Sentry reporter for a failed job. It covers both ways a job
+    // can fail: `processJob` finishes the job with backoff, logs, and re-throws
+    // (so the loop counts the failure), and the loop's own timeout wrapper
+    // rejects with a JobTimeoutError that never reaches `processJob`'s catch.
     onJobError: (job, error) => {
       Sentry.captureException(error, {
-        tags: { jobType: job.type, context: "executeJob-unhandled" },
-        extra: { jobId: job.id },
+        tags: { jobType: job.type, context: "job-execution" },
+        extra: {
+          jobId: job.id,
+          consecutiveFailures: job.consecutiveFailures,
+          payload: job.payload,
+        },
       });
     },
     onClaimError: (error) => {

--- a/src/server/trpc/routers/brokenFeeds.ts
+++ b/src/server/trpc/routers/brokenFeeds.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { eq, and, gt, isNull, sql } from "drizzle-orm";
 
 import { createTRPCRouter, confirmedProtectedProcedure as protectedProcedure } from "../trpc";
+import { errors } from "../errors";
 import { feeds, subscriptions, jobs } from "@/server/db/schema";
 
 // ============================================================================
@@ -142,7 +143,7 @@ export const brokenFeedsRouter = createTRPCRouter({
         .limit(1);
 
       if (subscription.length === 0) {
-        throw new Error("Feed not found or not subscribed");
+        throw errors.feedNotFound();
       }
 
       const now = new Date();

--- a/src/server/trpc/routers/saved.ts
+++ b/src/server/trpc/routers/saved.ts
@@ -259,16 +259,10 @@ export const savedRouter = createTRPCRouter({
         });
       }
 
-      // Decode base64 content
-      let fileBuffer: Buffer;
-      try {
-        fileBuffer = Buffer.from(input.content, "base64");
-      } catch {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Invalid file content encoding. Expected base64.",
-        });
-      }
+      // Decode base64 content. Node's decoder never throws — it skips
+      // non-base64 characters — so content that isn't really base64 decodes to
+      // garbage bytes and is rejected by `convertUploadedFile` below.
+      const fileBuffer = Buffer.from(input.content, "base64");
 
       // Enforce the size limit on the decoded bytes before any conversion
       // (mammoth/Readability/Markdown), so a large upload can't burn memory/CPU.

--- a/src/server/trpc/trpc.ts
+++ b/src/server/trpc/trpc.ts
@@ -348,17 +348,9 @@ function createPublicRateLimitMiddleware(type: RateLimitType) {
  */
 function createAuthenticatedRateLimitMiddleware(type: RateLimitType) {
   return t.middleware(async ({ ctx, next }) => {
-    // At this point, session is guaranteed non-null due to authMiddleware
-    const session = ctx.session;
-    const sessionToken = ctx.sessionToken;
-
-    // TypeScript guard to ensure we have authenticated context
-    if (!session || !sessionToken) {
-      throw new TRPCError({
-        code: "UNAUTHORIZED",
-        message: "Authentication required",
-      });
-    }
+    // Session and sessionToken are guaranteed non-null after authMiddleware
+    const session = ctx.session!;
+    const sessionToken = ctx.sessionToken!;
 
     const rateLimitHeaders = await performRateLimitCheck(session.user.id, ctx.headers, type);
 

--- a/tests/integration/broken-feeds.test.ts
+++ b/tests/integration/broken-feeds.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Integration tests for the Broken Feeds API.
+ *
+ * `brokenFeeds.retryFetch` is the only endpoint that mutates, and its ownership
+ * check is what keeps one user from resetting another user's feed. These tests
+ * cover that check's outcome on both sides: a subscribed feed is rescheduled,
+ * and anything else is a NOT_FOUND client error rather than a 500.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { getHTTPStatusCodeFromError } from "@trpc/server/http";
+import { eq } from "drizzle-orm";
+import { db } from "../../src/server/db";
+import { users, feeds, entries, subscriptions, userEntries } from "../../src/server/db/schema";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
+import { createCaller } from "../../src/server/trpc/root";
+import {
+  createAuthContext,
+  createTestFeed,
+  createTestSubscription,
+  createTestUser,
+} from "./helpers";
+
+async function clean(): Promise<void> {
+  await db.delete(userEntries);
+  await db.delete(entries);
+  await db.delete(subscriptions);
+  await db.delete(feeds);
+  await db.delete(users);
+}
+
+describe("Broken Feeds API", () => {
+  beforeEach(clean);
+  afterAll(clean);
+
+  it("lists and retries a broken feed the user is subscribed to", async () => {
+    const userId = await createTestUser({ emailPrefix: "brokenfeeds" });
+    const feedId = await createTestFeed({
+      title: "Failing Feed",
+      consecutiveFailures: 3,
+      lastError: "500 Server Error",
+      nextFetchAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    await createTestSubscription(userId, feedId);
+
+    const caller = createCaller(await createAuthContext(userId));
+
+    const listed = await caller.brokenFeeds.list();
+    expect(listed.items).toHaveLength(1);
+    expect(listed.items[0].feedId).toBe(feedId);
+    expect(listed.items[0].consecutiveFailures).toBe(3);
+
+    const result = await caller.brokenFeeds.retryFetch({ feedId });
+    expect(result.success).toBe(true);
+
+    // The failure counter is cleared and a fetch is due immediately.
+    const [feed] = await db.select().from(feeds).where(eq(feeds.id, feedId));
+    expect(feed.consecutiveFailures).toBe(0);
+    expect(feed.lastError).toBeNull();
+    expect(feed.nextFetchAt!.getTime()).toBeLessThanOrEqual(Date.now());
+  });
+
+  // The ownership check must produce a real 404, not an unhandled Error that
+  // tRPC would surface as a 500 (and report to Sentry as a server bug).
+  it("rejects retrying a feed the user is not subscribed to with a 404", async () => {
+    const userId = await createTestUser({ emailPrefix: "brokenfeeds-unsub" });
+    const otherUserId = await createTestUser({ emailPrefix: "brokenfeeds-other" });
+    const feedId = await createTestFeed({ consecutiveFailures: 2 });
+    // Only the *other* user is subscribed.
+    await createTestSubscription(otherUserId, feedId);
+
+    const caller = createCaller(await createAuthContext(userId));
+
+    let thrown: unknown;
+    try {
+      await caller.brokenFeeds.retryFetch({ feedId });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(TRPCError);
+    expect(getHTTPStatusCodeFromError(thrown as TRPCError)).toBe(404);
+    expect((thrown as TRPCError).cause).toMatchObject({ code: "FEED_NOT_FOUND" });
+
+    // The other user's feed was left untouched.
+    const [feed] = await db.select().from(feeds).where(eq(feeds.id, feedId));
+    expect(feed.consecutiveFailures).toBe(2);
+  });
+
+  it("rejects retrying a feed that does not exist with a 404", async () => {
+    const userId = await createTestUser({ emailPrefix: "brokenfeeds-missing" });
+    const caller = createCaller(await createAuthContext(userId));
+
+    let thrown: unknown;
+    try {
+      await caller.brokenFeeds.retryFetch({ feedId: generateUuidv7() });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(TRPCError);
+    expect(getHTTPStatusCodeFromError(thrown as TRPCError)).toBe(404);
+  });
+});

--- a/tests/integration/saved-articles.test.ts
+++ b/tests/integration/saved-articles.test.ts
@@ -13,6 +13,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { getHTTPStatusCodeFromError } from "@trpc/server/http";
 import { eq, and } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import { users, entries, userEntries, feeds } from "../../src/server/db/schema";
@@ -1262,6 +1264,44 @@ describe("Saved Articles API", () => {
       ).rejects.toThrow(/exceeds the maximum size/i);
 
       // Nothing persisted for this user.
+      const savedFeed = await db
+        .select({ id: feeds.id })
+        .from(feeds)
+        .where(and(eq(feeds.type, "saved"), eq(feeds.userId, userId)));
+      const savedEntries =
+        savedFeed.length > 0
+          ? await db
+              .select({ id: entries.id })
+              .from(entries)
+              .where(eq(entries.feedId, savedFeed[0].id))
+          : [];
+      expect(savedEntries).toHaveLength(0);
+    });
+  });
+
+  describe("saved.uploadFile content decoding", () => {
+    // Node's base64 decoder silently skips characters outside the alphabet
+    // instead of throwing, so content that isn't base64 at all decodes to
+    // garbage bytes and reaches the converter. That must still be the user's
+    // problem (a 400), never an unhandled 500.
+    it("rejects content that isn't really base64 with a client error", async () => {
+      const userId = await createTestUser();
+      const caller = createCaller(await createAuthContext(userId));
+
+      let thrown: unknown;
+      try {
+        await caller.saved.uploadFile({
+          content: "!!!not base64@@@",
+          filename: "garbage.docx",
+        });
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(TRPCError);
+      expect(getHTTPStatusCodeFromError(thrown as TRPCError)).toBe(400);
+
+      // Nothing was persisted for this user.
       const savedFeed = await db
         .select({ id: feeds.id })
         .from(feeds)

--- a/tests/unit/worker.test.ts
+++ b/tests/unit/worker.test.ts
@@ -649,6 +649,81 @@ describe("Worker", () => {
     });
   });
 
+  describe("job failure reporting", () => {
+    // onJobError is the single side-channel reporter for a failed job (the
+    // standalone worker wires it to Sentry). Both ways a job can fail must go
+    // through it exactly once — the production processJob logs and re-throws,
+    // so a second reporter anywhere would double-report every failure.
+    it("reports a rejected job to onJobError exactly once, with the job", async () => {
+      const reported: { job: Job; error: unknown }[] = [];
+      const failure = new Error("handler blew up");
+      let jobsClaimed = 0;
+
+      const worker = createWorker({
+        concurrency: 1,
+        pollIntervalMs: 10,
+        logger: silentLogger,
+        onJobError: (job, error) => reported.push({ job, error }),
+        claimJob: async () => {
+          if (jobsClaimed === 0) {
+            jobsClaimed++;
+            return createMockJob("failing-job");
+          }
+          return null;
+        },
+        processJob: async () => {
+          throw failure;
+        },
+      });
+
+      await worker.start();
+      await tick(100);
+
+      expect(reported).toHaveLength(1);
+      expect(reported[0].error).toBe(failure);
+      // The job is passed through so the reporter can attach its context
+      // (type, payload, consecutive failure count).
+      expect(reported[0].job.id).toBe("failing-job");
+      expect(reported[0].job.payload).toEqual({ feedId: "feed-failing-job" });
+      expect(worker.getStats().totalFailed).toBe(1);
+
+      await worker.stop();
+    });
+
+    it("reports a timed-out job to onJobError exactly once", async () => {
+      const reported: { job: Job; error: unknown }[] = [];
+      let jobsClaimed = 0;
+
+      const worker = createWorker({
+        concurrency: 1,
+        pollIntervalMs: 10,
+        jobTimeoutMs: 50,
+        logger: silentLogger,
+        onJobError: (job, error) => reported.push({ job, error }),
+        claimJob: async () => {
+          if (jobsClaimed === 0) {
+            jobsClaimed++;
+            return createMockJob("wedged-job");
+          }
+          return null;
+        },
+        // Never settles: the timeout wrapper rejects, and that rejection never
+        // reaches processJob's own error handling.
+        processJob: () => new Promise(() => {}),
+      });
+
+      await worker.start();
+      await tick(200);
+
+      expect(reported).toHaveLength(1);
+      expect(reported[0].job.id).toBe("wedged-job");
+      expect(reported[0].error).toBeInstanceOf(Error);
+      expect((reported[0].error as Error).message).toMatch(/timed out/);
+
+      await worker.stop();
+    });
+  });
+
   describe("liveness tracking", () => {
     it("updates lastActivityAt when polling", async () => {
       const worker = createWorker({


### PR DESCRIPTION
Six behavior-preserving deletions. No new abstractions; net -39 lines of `src/` (and most of the added lines are comments).

## 1. Job exceptions were reported to Sentry twice

`processJob` captured the exception **and** re-threw unconditionally; the core loop's catch then called `onJobError`, wired to a second `captureException`. The core's comment ("this should rarely happen since processJob has its own try/catch") was false — with the unconditional re-throw it happened on 100% of failures.

I deleted the capture inside `processJob` and kept `onJobError` as the single reporter, because it is the only site that also sees a **job timeout** (the timeout wrapper rejects in the loop, and that rejection never reaches `processJob`'s catch). To keep the merge lossless, `onJobError` now carries the richer `extra` the deleted site had (`consecutiveFailures`, `payload`). Two deliberate deltas:

- `durationMs` is no longer in the Sentry `extra` (it isn't available at the loop level, and it's still in the `Job … threw exception` error log).
- The `context` tag on job failures becomes `job-execution` instead of `executeJob-unhandled` — that value only ever meant "unhandled" for the timeout path, and now applies to every job failure.

The two error **logs** (`processJob`'s detailed one, then the loop's `Unexpected error in job execution`) stay: the loop's is the only log for an injected `processJob` and for the timeout path. Comments updated to describe the real flow.

## 2. Dead duplicate `WorkerConfig` in `worker-core.ts`

`createWorkerCore` takes `InternalWorkerConfig`; the real public config is the one in `worker.ts`. Nothing referenced the worker-core copy — its `_claimJob`/`_processJob` fields existed nowhere else, and its other five fields had to be hand-synced with the real interface. Deleted; `ClaimJobFn`/`ProcessJobFn` stay (used by `InternalWorkerConfig`).

## 3. `claimSingletonJob` ran the same claim UPDATE verbatim twice

Both blocks were byte-identical. A change to the staleness predicate had to land in both or the post-INSERT-race retry would diverge from the primary claim. Hoisted to a local `tryClaim()` called at both sites; the SQL is unchanged.

## 4. Unreachable try/catch around base64 decoding in `saved.uploadFile`

Node's base64 decoder silently skips characters outside the alphabet and never throws (`Buffer.from("!!!not base64@@@","base64")` returns a 6-byte buffer), so the `catch` could not fire. Garbage already fell through to `convertUploadedFile`, whose own catch produces the `BAD_REQUEST` — the user-visible error is unchanged, and there's now an integration test pinning it.

## 5. Unreachable null-session guard in the authenticated rate-limit middleware — **auth-adjacent, please read carefully**

`createAuthenticatedRateLimitMiddleware` re-checked for a null session. It's a module-private function with exactly two construction sites (`expensiveProtectedProcedure`, `expensiveConfirmedProtectedProcedure`), both chained after `authMiddleware` (which throws `UNAUTHORIZED` on `!ctx.session || !ctx.sessionToken`) *and* `sessionOnlyMiddleware`. There is no path that reaches it without `authMiddleware` first. Replaced with the `ctx.session!` / `ctx.sessionToken!` narrowing every sibling middleware already uses (`sessionOnlyMiddleware`, `confirmedMiddleware`, `createScopeMiddleware`), so the "who guarantees non-null" story is now the same everywhere.

## 6. `brokenFeeds.retryFetch` threw a raw `Error`

`throw new Error("Feed not found or not subscribed")` surfaced as a 500 (and as a Sentry-reported server bug) for an ordinary not-found. Now `errors.feedNotFound()` → 404 with a `FEED_NOT_FOUND` cause code.

## Tests

- `tests/unit/worker.test.ts`: `onJobError` fires **exactly once** per failed job, with the job attached, for both a rejected handler and a timeout. (The Sentry call itself isn't asserted directly — `createWorker`'s real `processJob` isn't reachable without a DB and the real handlers.)
- `tests/integration/saved-articles.test.ts`: content that isn't really base64 still yields a 400, not a 500, and persists nothing.
- `tests/integration/broken-feeds.test.ts` (new): `retryFetch` resets the counters for a subscribed feed, and returns 404/`FEED_NOT_FOUND` both for another user's feed and for a nonexistent one.

`pnpm typecheck`, `pnpm lint`, `pnpm knip` clean. Unit: 3224 passed (161 files). Integration: 800 passed, 15 skipped (58 files).

## Follow-up, not fixed here

`WorkerStats.totalSucceeded`/`totalFailed` mean "the handler didn't throw", not "the job succeeded": a handler returning `{success: false}` (feed backoff, a `not_found` OPML import) increments `totalSucceeded`. The Prometheus path (`trackJobProcessed`) is correct; only these in-process stats — shown in the shutdown log and `/health` — mislead. Worth a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
