### PR TITLE
Fix browser Back after closing an entry, search-cache placeholders, and first-click feed preview

### DIFF
--- a/src/components/subscribe/SubscribeContent.tsx
+++ b/src/components/subscribe/SubscribeContent.tsx
@@ -58,6 +58,10 @@ export function SubscribeContent() {
   const [selectedFeedUrl, setSelectedFeedUrl] = useState<string | null>(null);
   const [discoveryError, setDiscoveryError] = useState<string | null>(null);
   const [feedBuilderUrl, setFeedBuilderUrl] = useState<string | null>(null);
+  // Preview of a *discovered* feed runs outside `previewQuery` (see
+  // handleSelectFeed), so it needs its own pending/error state.
+  const [isPreviewingSelection, setIsPreviewingSelection] = useState(false);
+  const [selectionError, setSelectionError] = useState<string | null>(null);
 
   const utils = trpc.useUtils();
 
@@ -118,6 +122,7 @@ export function SubscribeContent() {
     setDiscoveredFeeds([]);
     setDiscoveryError(null);
     setFeedBuilderUrl(null);
+    setSelectionError(null);
   }, []);
 
   /**
@@ -185,14 +190,25 @@ export function SubscribeContent() {
 
   const handleSelectFeed = async (feedUrl: string) => {
     setSelectedFeedUrl(feedUrl);
-
-    // Preview the selected feed
-    const result = await previewQuery.refetch();
-
-    if (result.data) {
+    setSelectionError(null);
+    setIsPreviewingSelection(true);
+    try {
+      // Fetch by explicit input rather than previewQuery.refetch(): the query's
+      // key only picks up the new `selectedFeedUrl` after the re-render this
+      // setState schedules, so a refetch here would re-run the *previous* URL
+      // and settle onto a key nothing is reading — leaving the first click on a
+      // discovered feed a visible no-op. The result lands in the cache under
+      // the key previewQuery adopts on that re-render, so it renders the
+      // preview step without a second request.
+      await utils.feeds.preview.fetch({ url: feedUrl }, { retry: false });
       setStep("preview");
+    } catch (error) {
+      setSelectionError(
+        error instanceof Error ? error.message : "Failed to load a preview for this feed."
+      );
+    } finally {
+      setIsPreviewingSelection(false);
     }
-    // If preview fails, error will be shown via previewQuery.error
   };
 
   const handleSubscribe = () => {
@@ -232,7 +248,7 @@ export function SubscribeContent() {
     }
   };
 
-  const isLoading = previewQuery.isFetching || discoverQuery.isFetching;
+  const isLoading = previewQuery.isFetching || discoverQuery.isFetching || isPreviewingSelection;
 
   return (
     <div className="mx-auto max-w-2xl px-4 py-4 sm:p-6">
@@ -325,9 +341,9 @@ export function SubscribeContent() {
             <p className="ui-text-sm text-muted mb-4">Select a feed to preview and subscribe:</p>
 
             {/* Show error if preview of selected feed failed */}
-            {selectedFeedUrl && previewQuery.error && (
+            {selectionError && (
               <Alert variant="error" className="mb-4">
-                {previewQuery.error.message}
+                {selectionError}
               </Alert>
             )}
 

--- a/src/lib/cache/entry-cache.ts
+++ b/src/lib/cache/entry-cache.ts
@@ -914,6 +914,15 @@ interface TypedInfiniteData {
 
 /**
  * Finds a cached query matching specific filters.
+ *
+ * Search results and Recently Read are never usable as placeholder data, no
+ * matter how their remaining filters line up: search membership depends on a
+ * `query` this code can't evaluate, and `sortBy: "readChanged"` orders by a
+ * field the placeholder path has no way to re-sort by. Neither `filtersEqual`
+ * nor `areFiltersCompatible` looks at those two keys, so without this guard a
+ * cached `/all?q=react` list is an "exact match" for plain `/all` and its
+ * handful of hits render, unfiltered, as All Items. Same guard as
+ * `insertEntryIntoListCaches`, for the same reason.
  */
 function findCachedQuery(
   queries: [readonly unknown[], InfiniteData | undefined][],
@@ -924,6 +933,10 @@ function findCachedQuery(
 
     const keyMeta = queryKey[1] as TRPCQueryKey | undefined;
     const parentFilters: EntryListFilters = keyMeta?.input ?? {};
+
+    if (parentFilters.query || (parentFilters.sortBy && parentFilters.sortBy !== "published")) {
+      continue;
+    }
 
     if (matchFilters(parentFilters)) {
       return data;

--- a/src/lib/hooks/useEntryUrlState.ts
+++ b/src/lib/hooks/useEntryUrlState.ts
@@ -8,9 +8,32 @@
 
 "use client";
 
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo } from "react";
 import { clientPush, clientReplace } from "@/lib/navigation";
 import { useAppHref, useAppPathname, useAppSearchParams } from "./useAppLocation";
+
+/**
+ * Marker stamped onto the history entry that opening an entry pushed, so
+ * `closeEntry` can pop that entry instead of stranding it.
+ *
+ * It lives in history state rather than a ref because the hook is instantiated
+ * per component: the instance that opens an entry (the list) is not the one
+ * that closes it (the reader), so a per-instance ref is always false where it
+ * is read, and closing would silently replace — leaving a dead history entry
+ * that made the user's next Back press look like a no-op.
+ */
+const ENTRY_OPENED_STATE = { entryOpened: true };
+
+/** Whether the current history entry is one we pushed to open an entry. */
+function isEntryOpenedHistoryEntry(): boolean {
+  if (typeof window === "undefined") return false;
+  const state: unknown = window.history.state;
+  return (
+    typeof state === "object" &&
+    state !== null &&
+    (state as { entryOpened?: unknown }).entryOpened === true
+  );
+}
 
 export interface UseEntryUrlStateResult {
   /** The currently open entry ID, or null if no entry is open */
@@ -47,10 +70,6 @@ export function useEntryUrlState(): UseEntryUrlStateResult {
   const pathname = useAppPathname();
   const appHref = useAppHref();
 
-  // Track whether we pushed to history when opening an entry
-  // This allows us to use history.back() when closing, which preserves React state
-  const pushedToHistoryRef = useRef(false);
-
   // Get the current entry ID from the URL
   const openEntryId = useMemo(() => {
     return searchParams.get("entry");
@@ -82,10 +101,13 @@ export function useEntryUrlState(): UseEntryUrlStateResult {
       // Use replace when navigating between entries to avoid history bloat
       if (entryId && !currentEntryId) {
         // Opening an entry from list view - add to history
-        pushedToHistoryRef.current = true;
-        clientPush(newUrl);
+        clientPush(newUrl, ENTRY_OPENED_STATE);
+      } else if (entryId) {
+        // Navigating between entries - replace to avoid history bloat, but keep
+        // the marker so closing still pops the entry that opening pushed.
+        clientReplace(newUrl, isEntryOpenedHistoryEntry() ? ENTRY_OPENED_STATE : null);
       } else {
-        // Navigating between entries or closing - replace to avoid history bloat
+        // Closing without popping (no pushed entry to return to)
         clientReplace(newUrl);
       }
     },
@@ -95,8 +117,7 @@ export function useEntryUrlState(): UseEntryUrlStateResult {
   // Close the entry - uses history.back() if we pushed when opening, to preserve React state
   // This makes "Back to list" behave identically to the browser back button
   const closeEntry = useCallback(() => {
-    if (pushedToHistoryRef.current && typeof window !== "undefined") {
-      pushedToHistoryRef.current = false;
+    if (isEntryOpenedHistoryEntry()) {
       window.history.back();
     } else {
       setOpenEntryId(null);

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -9,17 +9,24 @@ import { type MouseEvent } from "react";
 /**
  * Navigate using pushState without triggering SSR.
  * UnifiedEntriesContent reads usePathname() to determine what to render.
+ *
+ * `state` is stored on the created history entry, so a later handler can tell
+ * which entry it created (see `useEntryUrlState`). Next's app router merges its
+ * own internal keys into whatever we pass, so an object is safe here.
  */
-export function clientPush(href: string): void {
-  window.history.pushState(null, "", href);
+export function clientPush(href: string, state: unknown = null): void {
+  window.history.pushState(state, "", href);
 }
 
 /**
  * Navigate using replaceState without triggering SSR.
  * UnifiedEntriesContent reads usePathname() to determine what to render.
+ *
+ * Note that replacing overwrites the current entry's state, so callers that
+ * need to keep a marker set by `clientPush` must pass it through again.
  */
-export function clientReplace(href: string): void {
-  window.history.replaceState(null, "", href);
+export function clientReplace(href: string, state: unknown = null): void {
+  window.history.replaceState(state, "", href);
 }
 
 /**

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -142,3 +142,36 @@ test("does not reset the entry-list scroll when opening and closing an entry", a
   await expect(centerEntry).toBeVisible();
   await expect.poll(() => mainScrollTop(page)).toBeGreaterThan(0);
 });
+
+test("closing an entry pops its history entry, so browser Back still works", async ({
+  page,
+  baseURL,
+}) => {
+  const db = getDb();
+  const user = await createConfirmedUser(db);
+  const feed = await createSubscribedFeed(db, user.id);
+  const entry = await createUnreadEntry(db, {
+    feedId: feed.feedId,
+    userId: user.id,
+    title: "Only Post",
+  });
+  await starEntry(db, user.id, entry.id);
+
+  await loginAs(page.context(), user, baseURL!);
+  await page.goto("/starred");
+  await expect(page.locator('[aria-label*="article: Only Post"]')).toBeVisible();
+
+  // Soft-navigate to All, so there is a real previous page to go back to.
+  await page.getByRole("link", { name: /All Items/ }).click();
+  await expect(page).toHaveURL(/\/all$/);
+
+  // Opening pushes a history entry; closing must pop it rather than replacing
+  // it, or the stranded entry swallows the user's next Back press.
+  await page.locator(`[data-entry-id="${entry.id}"]`).click();
+  await expect(page).toHaveURL(new RegExp(`entry=${entry.id}`));
+  await page.getByRole("button", { name: /back to list/i }).click();
+  await expect(page).toHaveURL(/\/all$/);
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/starred$/);
+});

--- a/tests/unit/frontend/cache/parent-list-placeholder.test.ts
+++ b/tests/unit/frontend/cache/parent-list-placeholder.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for findParentListPlaceholderData — the cache read behind
+ * EntryListFallback, which paints a list view from a cached parent list while
+ * the real query loads.
+ *
+ * The load-bearing cases here are the *rejections*: neither of the predicates
+ * it uses (`filtersEqual`, `areFiltersCompatible`) looks at `query` or
+ * `sortBy`, so a cached search or Recently Read list otherwise reads as a
+ * perfectly good parent and its rows get painted as "All Items". Membership in
+ * a search can't be evaluated client-side, and Recently Read is ordered by a
+ * field the placeholder path can't re-sort by.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import {
+  findParentListPlaceholderData,
+  type EntryListFilters,
+  type EntryListItem,
+} from "@/lib/cache/entry-cache";
+import { _resetSubscriptionLookupMap } from "@/lib/cache/count-cache";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+let queryClient: QueryClient;
+
+beforeEach(() => {
+  _resetSubscriptionLookupMap();
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+});
+
+function makeRow(id: string, overrides: Partial<EntryListItem> = {}): EntryListItem {
+  return {
+    id,
+    feedId: "feed-1",
+    subscriptionId: "sub-1",
+    type: "web",
+    url: `https://example.com/${id}`,
+    title: id,
+    author: null,
+    summary: null,
+    publishedAt: new Date("2024-06-01T00:00:00Z"),
+    fetchedAt: new Date("2024-06-01T00:00:00Z"),
+    updatedAt: new Date("2024-06-01T00:00:00Z"),
+    read: false,
+    starred: false,
+    feedTitle: "Feed One",
+    siteName: null,
+    ...overrides,
+  };
+}
+
+/** Seeds an entries.list infinite query cache the way tRPC keys it. */
+function seedList(
+  filters: EntryListFilters,
+  pages: Array<{ items: EntryListItem[]; nextCursor?: string }>
+): void {
+  queryClient.setQueryData([["entries", "list"], { input: filters, type: "infinite" }], {
+    pages,
+    pageParams: pages.map((_, i) => (i === 0 ? undefined : `cursor-${i}`)),
+  });
+}
+
+/** The flattened placeholder rows for `filters`, or undefined if none was offered. */
+function placeholderIds(filters: EntryListFilters): string[] | undefined {
+  const result = findParentListPlaceholderData(queryClient, filters);
+  return result?.pages.flatMap((page) => page.items.map((item) => item.id));
+}
+
+// ============================================================================
+// Rejections: caches whose membership/order can't be reproduced client-side
+// ============================================================================
+
+describe("findParentListPlaceholderData - unusable caches", () => {
+  it("does not treat a search cache as an exact match for the same view without a search", () => {
+    // Reload on /all?q=react, then clear the search. The un-searched key is
+    // uncached, so the fallback renders — and must not paint the handful of
+    // search hits as the whole unread list.
+    seedList({ query: "react", unreadOnly: true, sortOrder: "newest" }, [
+      { items: [makeRow("hit-1"), makeRow("hit-2")] },
+    ]);
+
+    expect(placeholderIds({ unreadOnly: true, sortOrder: "newest" })).toBeUndefined();
+  });
+
+  it("does not use a search cache as a compatible parent list", () => {
+    // A search over everything (unreadOnly=false) is a filter-superset of the
+    // unread-only list by every field the compatibility check looks at.
+    seedList({ query: "react", unreadOnly: false }, [
+      { items: [makeRow("hit-1"), makeRow("hit-2", { read: true })] },
+    ]);
+
+    expect(placeholderIds({ unreadOnly: true })).toBeUndefined();
+  });
+
+  it("does not use a search cache for a subscription page", () => {
+    seedList({ query: "react" }, [{ items: [makeRow("hit-1", { subscriptionId: "sub-1" })] }]);
+
+    expect(placeholderIds({ subscriptionId: "sub-1" })).toBeUndefined();
+  });
+
+  it("does not use the Recently Read cache, which is ordered by read time", () => {
+    seedList({ sortBy: "readChanged", unreadOnly: false }, [
+      { items: [makeRow("recent-1", { read: true }), makeRow("recent-2", { read: true })] },
+    ]);
+
+    expect(placeholderIds({ unreadOnly: false })).toBeUndefined();
+  });
+
+  it("prefers a real list over a search cache seeded before it", () => {
+    seedList({ query: "react", unreadOnly: true }, [{ items: [makeRow("hit-1")] }]);
+    seedList({ unreadOnly: true }, [{ items: [makeRow("all-1"), makeRow("all-2")] }]);
+
+    expect(placeholderIds({ unreadOnly: true })).toEqual(["all-1", "all-2"]);
+  });
+});
+
+// ============================================================================
+// Ordinary placeholder selection still works
+// ============================================================================
+
+describe("findParentListPlaceholderData - usable caches", () => {
+  it("returns the cached pages verbatim on an exact filter match", () => {
+    seedList({ unreadOnly: true, sortOrder: "newest" }, [
+      { items: [makeRow("a"), makeRow("b")], nextCursor: "cursor-1" },
+      { items: [makeRow("c")] },
+    ]);
+
+    const result = findParentListPlaceholderData(queryClient, {
+      unreadOnly: true,
+      sortOrder: "newest",
+    });
+
+    // Both pages survive, cursors included — an exact hit needs no re-filtering.
+    expect(result?.pages.map((page) => page.items.map((item) => item.id))).toEqual([
+      ["a", "b"],
+      ["c"],
+    ]);
+    expect(result?.pages[0].nextCursor).toBe("cursor-1");
+  });
+
+  it("filters the All list down to a subscription page", () => {
+    seedList({ unreadOnly: true }, [
+      {
+        items: [
+          makeRow("mine-1", { subscriptionId: "sub-1" }),
+          makeRow("theirs", { subscriptionId: "sub-2" }),
+          makeRow("mine-2", { subscriptionId: "sub-1" }),
+        ],
+      },
+    ]);
+
+    expect(placeholderIds({ subscriptionId: "sub-1", unreadOnly: true })).toEqual([
+      "mine-1",
+      "mine-2",
+    ]);
+  });
+
+  it("drops read entries when the unread-only list borrows an all-entries cache", () => {
+    seedList({ unreadOnly: false }, [
+      { items: [makeRow("unread-1"), makeRow("read-1", { read: true })] },
+    ]);
+
+    expect(placeholderIds({ unreadOnly: true })).toEqual(["unread-1"]);
+  });
+
+  it("still accepts a cache that sorts by published date", () => {
+    // The guard rejects a non-default sortBy, not the presence of the key.
+    seedList({ sortBy: "published", unreadOnly: true }, [{ items: [makeRow("a")] }]);
+
+    expect(placeholderIds({ unreadOnly: true })).toEqual(["a"]);
+  });
+});

--- a/tests/unit/frontend/components/SubscribeContent.test.tsx
+++ b/tests/unit/frontend/components/SubscribeContent.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * The subscribe flow's discovery step: entering a site URL that isn't itself a
+ * feed lists the feeds found on the page, and picking one must show its preview
+ * on the FIRST click (a disabled query's `refetch()` re-runs the key from the
+ * previous render, so the click used to be a visible no-op until repeated).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { renderWithTrpc, type ProcedureHandlers } from "../../../utils/component-test-helpers";
+
+// sonner's toast is a side-effecting singleton (renders a portal); stub it so
+// tests assert on component behavior, not the toast implementation.
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(""),
+  usePathname: () => "/subscribe",
+}));
+
+const { SubscribeContent } = await import("@/components/subscribe/SubscribeContent");
+
+const SITE_URL = "https://example.com/";
+const FEED_URL = "https://example.com/feed.xml";
+const OTHER_FEED_URL = "https://example.com/comments.xml";
+
+/** A feed preview shaped like the `feeds.preview` output. */
+function preview(url: string, title: string) {
+  return {
+    feed: {
+      url,
+      title,
+      description: "A feed about things",
+      siteUrl: "https://example.com",
+      iconUrl: null,
+      sampleEntries: [
+        {
+          guid: "e1",
+          link: "https://example.com/1",
+          title: "First post",
+          author: null,
+          summary: "Summary of the first post",
+          pubDate: new Date("2024-06-01T00:00:00Z"),
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Handlers for the standard flow: the site URL is HTML (preview fails with the
+ * message that triggers discovery), discovery finds two feeds, and previewing
+ * either of them succeeds.
+ */
+function discoveryHandlers(overrides: ProcedureHandlers = {}): ProcedureHandlers {
+  return {
+    "feeds.preview": (input: never) => {
+      const { url } = input as { url: string };
+      if (url === FEED_URL) return preview(FEED_URL, "Example Blog");
+      if (url === OTHER_FEED_URL) return preview(OTHER_FEED_URL, "Example Comments");
+      throw new Error("No feeds found at this URL");
+    },
+    "feeds.discover": () => ({
+      feeds: [
+        { url: FEED_URL, type: "rss", title: "Example Blog" },
+        { url: OTHER_FEED_URL, type: "atom", title: "Example Comments" },
+      ],
+      feedBuilderUrl: null,
+    }),
+    ...overrides,
+  };
+}
+
+/** Runs the input step through to the discovery list. */
+async function reachDiscoveryStep(): Promise<void> {
+  fireEvent.change(screen.getByLabelText(/feed url/i), { target: { value: SITE_URL } });
+  fireEvent.click(screen.getByRole("button", { name: /preview feed/i }));
+  await screen.findByRole("heading", { name: /we found 2 feeds on this site/i });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("scrollTo", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("SubscribeContent discovery step", () => {
+  it("shows the feed preview on the first click of a discovered feed", async () => {
+    const { callsFor } = renderWithTrpc(<SubscribeContent />, {
+      handlers: discoveryHandlers(),
+    });
+
+    await reachDiscoveryStep();
+
+    fireEvent.click(screen.getByRole("button", { name: /Example Blog/ }));
+
+    expect(await screen.findByRole("heading", { name: "Example Blog" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^subscribe$/i })).toBeInTheDocument();
+    expect(screen.getByText(FEED_URL)).toBeInTheDocument();
+
+    // The preview after selection was fetched for the selected feed, not the
+    // page URL we started from.
+    const previewCalls = callsFor("feeds.preview").map(
+      (call) => (call.input as { url: string }).url
+    );
+    expect(previewCalls).toEqual([SITE_URL, FEED_URL]);
+  });
+
+  it("previews the feed the user actually clicked when several were discovered", async () => {
+    renderWithTrpc(<SubscribeContent />, { handlers: discoveryHandlers() });
+
+    await reachDiscoveryStep();
+    fireEvent.click(screen.getByRole("button", { name: /Example Comments/ }));
+
+    expect(await screen.findByRole("heading", { name: "Example Comments" })).toBeInTheDocument();
+  });
+
+  it("surfaces an error and stays on the discovery list when the preview fails", async () => {
+    renderWithTrpc(<SubscribeContent />, {
+      handlers: discoveryHandlers({
+        "feeds.preview": (input: never) => {
+          const { url } = input as { url: string };
+          if (url === FEED_URL) throw new Error("Feed server returned 500");
+          throw new Error("No feeds found at this URL");
+        },
+      }),
+    });
+
+    await reachDiscoveryStep();
+    fireEvent.click(screen.getByRole("button", { name: /Example Blog/ }));
+
+    expect(await screen.findByText("Feed server returned 500")).toBeInTheDocument();
+    // Still on discovery, so the user can pick the other feed.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Example Comments/ })).toBeEnabled()
+    );
+  });
+});

--- a/tests/unit/frontend/hooks/useEntryUrlState.test.tsx
+++ b/tests/unit/frontend/hooks/useEntryUrlState.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Opening an entry pushes a history entry; closing it must pop that entry, not
+ * replace it — otherwise the pushed entry is stranded and the user's next
+ * browser Back press appears to do nothing.
+ *
+ * The hook is instantiated per component and the instance that opens an entry
+ * (the list) is not the one that closes it (the reader), so these tests drive
+ * two independent instances the way the app does.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+let mockPathname = "/all";
+let mockSearch = "";
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useSearchParams: () => new URLSearchParams(mockSearch),
+}));
+
+const { useEntryUrlState } = await import("@/lib/hooks/useEntryUrlState");
+
+beforeEach(() => {
+  mockPathname = "/all";
+  mockSearch = "";
+  window.history.replaceState(null, "", "/all");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Points the mocked location at `search` and re-runs the given hook renders. */
+function navigate(search: string, ...rerenders: Array<() => void>): void {
+  mockSearch = search;
+  for (const rerender of rerenders) act(() => rerender());
+}
+
+describe("useEntryUrlState", () => {
+  it("pops the pushed history entry when a different instance closes the entry", () => {
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    // Two instances, as in the app: the list opens, the reader closes.
+    const list = renderHook(() => useEntryUrlState());
+    const reader = renderHook(() => useEntryUrlState());
+
+    act(() => list.result.current.setOpenEntryId("entry-1"));
+    expect(window.location.search).toBe("?entry=entry-1");
+    navigate("entry=entry-1", list.rerender, reader.rerender);
+
+    const replaceState = vi.spyOn(window.history, "replaceState");
+    act(() => reader.result.current.closeEntry());
+
+    expect(back).toHaveBeenCalledTimes(1);
+    expect(replaceState).not.toHaveBeenCalled();
+  });
+
+  it("marks the history entry it pushes when opening from the list", () => {
+    const { result } = renderHook(() => useEntryUrlState());
+
+    act(() => result.current.setOpenEntryId("entry-1"));
+
+    expect(window.history.state).toMatchObject({ entryOpened: true });
+  });
+
+  it("keeps the marker across entry-to-entry navigation, which replaces", () => {
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const { result, rerender } = renderHook(() => useEntryUrlState());
+    const lengthBeforeOpen = window.history.length;
+
+    act(() => result.current.setOpenEntryId("entry-1"));
+    navigate("entry=entry-1", rerender);
+    act(() => result.current.setOpenEntryId("entry-2"));
+    navigate("entry=entry-2", rerender);
+
+    expect(window.location.search).toBe("?entry=entry-2");
+    // Swiping between entries replaces rather than pushing, so exactly one
+    // history entry was added by the open.
+    expect(window.history.length).toBe(lengthBeforeOpen + 1);
+
+    act(() => result.current.closeEntry());
+    expect(back).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces instead of popping when nothing was pushed (deep link into an entry)", () => {
+    // Landing directly on ?entry=… : going back would leave the app entirely.
+    mockSearch = "entry=entry-1";
+    window.history.replaceState(null, "", "/all?entry=entry-1");
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const { result } = renderHook(() => useEntryUrlState());
+
+    act(() => result.current.closeEntry());
+
+    expect(back).not.toHaveBeenCalled();
+    expect(window.location.search).toBe("");
+  });
+
+  it("preserves the other query params when opening and closing", () => {
+    mockPathname = "/all";
+    mockSearch = "unread=false";
+    window.history.replaceState(null, "", "/all?unread=false");
+    const { result, rerender } = renderHook(() => useEntryUrlState());
+
+    act(() => result.current.setOpenEntryId("entry-1"));
+    expect(window.location.search).toBe("?unread=false&entry=entry-1");
+
+    navigate("unread=false&entry=entry-1", rerender);
+    expect(result.current.openEntryId).toBe("entry-1");
+    expect(result.current.entryHref("entry-2")).toBe("/all?unread=false&entry=entry-2");
+  });
+});


### PR DESCRIPTION
Three independent, verified frontend bugs. Each fix comes with a regression test that fails on `master`.

## 1. Browser Back does nothing after closing an entry

**Symptom:** open an entry from a list, close it (or press Escape), then press the browser Back button — nothing happens. Opening pushed a history entry; closing replaced it, leaving a dead entry that swallows the next Back press.

`useEntryUrlState` tracked "did we push?" in a `useRef`, but the hook is instantiated per component: the instance that opens an entry (`EntryListContainer`) is never the instance that closes it (`UnifiedEntriesContent`, which owns `closeEntry`/`onBack`). The ref was therefore permanently `false` where it was read, and the `history.back()` branch was unreachable.

**Fix:** stamp the marker onto the pushed history entry (`pushState({ entryOpened: true }, …)`) instead of tracking it per instance, and have `closeEntry` check `window.history.state`. Entry-to-entry navigation (swipe/j-k) still replaces rather than pushes, but carries the marker forward so closing after a swipe pops too. `clientPush`/`clientReplace` grow an optional `state` argument, defaulted to `null` so every other caller is unchanged.

Deleting the dead branch and always replacing was the alternative, but back-after-open is what users expect from a list→detail transition (and what the mobile swipe-back gesture does), so the branch is worth making reachable rather than removing.

## 2. A search cache is used as placeholder data for a non-search list

**Symptom:** deep-link or reload on `/all?q=react`, then clear the search. The un-searched list is uncached, so `EntryListFallback` paints from a "parent" cache — and picks the search cache, rendering its handful of hits, unfiltered, as "All Items". `/recently-read` has the same problem in the other direction: it is keyed only by `sortBy: "readChanged"`, so it reads as a plain All list and lends its read-time ordering to `/all`.

Neither predicate the placeholder path uses (`filtersEqual`, `areFiltersCompatible`) compares `query` or `sortBy`. `insertEntryIntoListCaches` already carries exactly this guard, for exactly this reason; the placeholder path never got it.

**Fix:** one guard in `findCachedQuery`, covering both the exact-match and compatible-parent paths: skip any cached candidate with a `query`, or a `sortBy` other than `"published"`.

**`findParentListPlaceholderData` had zero tests before this PR.** It now has 9, five of which fail without the guard. Scope is deliberately just the guard — #1549 tracks the broader problem of this function being an untested reimplementation of server-side filtering.

## 3. The first click on a discovered feed is a visible no-op

**Symptom:** enter a site URL that isn't itself a feed, get the "we found N feeds" list, click one — nothing renders. No preview, no error, no spinner outcome. Clicking the same feed a second time works.

`handleSelectFeed` called `setSelectedFeedUrl(feedUrl)` and then synchronously `await previewQuery.refetch()`. The observer's key is `{ url: selectedFeedUrl || url }` and `observer.setOptions` only runs in an effect, i.e. after the re-render the `setState` schedules — so the refetch re-ran the *previous* (failing) URL, and by the time it settled the observer had moved to the new, never-fetched key: `data` undefined, `error` undefined, `step` stuck on `"discovery"`.

**Fix:** fetch by explicit input (`utils.feeds.preview.fetch({ url: feedUrl })`), which lands in the cache under the key `previewQuery` adopts on that re-render, so the preview step renders without a second request. The selection now carries its own pending flag (so the row spinner and disabled state still work) and its own error state (so a failing preview still shows a message and leaves the user on the discovery list).

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean
- `pnpm test:unit` — 164 files, 3239 tests passed
- `pnpm test:e2e:local` — 77 passed (full suite)

Each new test was confirmed to fail against the pre-fix code: 5/9 placeholder tests, 2/5 `useEntryUrlState` tests, 3/3 `SubscribeContent` tests, and the new `navigation.spec.ts` Back-button e2e.

## Note

Escape-to-close (`EntryListContainer`'s `onClose`) calls `setOpenEntryId(null)` directly rather than `closeEntry`, so it still replaces instead of popping. That file is being edited concurrently, so it is left alone here; routing it through `closeEntry` would be a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
