### PR TITLE
fix: Give the narration settings switches an accessible name

### DIFF
--- a/src/components/narration/NarrationSettings.tsx
+++ b/src/components/narration/NarrationSettings.tsx
@@ -198,13 +198,16 @@ export function NarrationSettings() {
       {/* Enable/Disable Toggle */}
       <div className="flex items-center justify-between">
         <div>
-          <h3 className="ui-text-sm text-body font-medium">Enable narration</h3>
+          <h3 id="narration-enabled-label" className="ui-text-sm text-body font-medium">
+            Enable narration
+          </h3>
           <p className="ui-text-sm text-muted mt-1">Listen to articles using text-to-speech.</p>
         </div>
         <button
           type="button"
           role="switch"
           aria-checked={settings.enabled}
+          aria-labelledby="narration-enabled-label"
           onClick={() => setSettings((prev) => ({ ...prev, enabled: !prev.enabled }))}
           className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out ${
             settings.enabled ? "bg-primary-solid" : "bg-fill-muted"
@@ -424,7 +427,9 @@ export function NarrationSettings() {
               {/* LLM Normalization Toggle */}
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="ui-text-sm text-body">Use AI text processing</p>
+                  <p id="narration-llm-label" className="ui-text-sm text-body">
+                    Use AI text processing
+                  </p>
                   <p className="ui-text-xs text-muted">
                     Improves narration quality by expanding abbreviations and formatting content
                   </p>
@@ -433,6 +438,7 @@ export function NarrationSettings() {
                   type="button"
                   role="switch"
                   aria-checked={settings.useLlmNormalization}
+                  aria-labelledby="narration-llm-label"
                   onClick={() =>
                     setSettings((prev) => ({
                       ...prev,
@@ -461,13 +467,16 @@ export function NarrationSettings() {
             {/* Highlight Current Paragraph Toggle */}
             <div className="flex items-center justify-between">
               <div>
-                <p className="ui-text-sm text-body">Highlight current paragraph</p>
+                <p id="narration-highlight-label" className="ui-text-sm text-body">
+                  Highlight current paragraph
+                </p>
                 <p className="ui-text-xs text-muted">Visually highlight the paragraph being read</p>
               </div>
               <button
                 type="button"
                 role="switch"
                 aria-checked={settings.highlightEnabled}
+                aria-labelledby="narration-highlight-label"
                 onClick={() =>
                   setSettings((prev) => ({ ...prev, highlightEnabled: !prev.highlightEnabled }))
                 }
@@ -487,7 +496,9 @@ export function NarrationSettings() {
             {/* Auto-scroll to Current Paragraph Toggle */}
             <div className="flex items-center justify-between">
               <div>
-                <p className="ui-text-sm text-body">Auto-scroll to current paragraph</p>
+                <p id="narration-autoscroll-label" className="ui-text-sm text-body">
+                  Auto-scroll to current paragraph
+                </p>
                 <p className="ui-text-xs text-muted">
                   Automatically scroll the page to keep the current paragraph visible
                 </p>
@@ -496,6 +507,7 @@ export function NarrationSettings() {
                 type="button"
                 role="switch"
                 aria-checked={settings.autoScrollEnabled}
+                aria-labelledby="narration-autoscroll-label"
                 onClick={() =>
                   setSettings((prev) => ({ ...prev, autoScrollEnabled: !prev.autoScrollEnabled }))
                 }

--- a/tests/unit/frontend/components/NarrationSettingsSwitches.test.tsx
+++ b/tests/unit/frontend/components/NarrationSettingsSwitches.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Accessibility tests for the four hand-rolled `role="switch"` toggles in
+ * NarrationSettings.
+ *
+ * Each is a button whose only child is an `aria-hidden` knob, with its visible
+ * caption in an unlinked sibling element — so a screen reader announced
+ * "switch, not checked" with no indication of what it toggles. The fix links
+ * the caption with `aria-labelledby`; these tests query each switch *by name*,
+ * which is precisely what failed before.
+ *
+ * The sibling toggles in EmailSettingsContent and KeyboardShortcutsSettings are
+ * covered in SettingsSwitches.test.tsx. There is no shared `Switch` primitive
+ * yet (issue #1550), so each site is covered separately.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { NarrationSettings } from "@/components/narration/NarrationSettings";
+import {
+  renderWithTrpc,
+  stubMemoryLocalStorage,
+  type ProcedureHandlers,
+} from "../../../utils/component-test-helpers";
+
+// jsdom implements neither Web Speech API surface, and getNarrationSupportInfo
+// gates the whole panel on speechSynthesis being present.
+function stubSpeechSynthesis() {
+  vi.stubGlobal("speechSynthesis", {
+    getVoices: () => [],
+    speak: vi.fn(),
+    cancel: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+  vi.stubGlobal(
+    "SpeechSynthesisUtterance",
+    class {
+      text = "";
+    }
+  );
+}
+
+const handlers: ProcedureHandlers = {
+  "narration.isAiTextProcessingAvailable": () => ({ available: true }),
+};
+
+describe("NarrationSettings switches", () => {
+  beforeEach(() => {
+    stubMemoryLocalStorage();
+    stubSpeechSynthesis();
+  });
+
+  // Narration defaults to enabled, so all four toggles render on first paint.
+  const names = [
+    /enable narration/i,
+    /use ai text processing/i,
+    /highlight current paragraph/i,
+    /auto-scroll to current paragraph/i,
+  ];
+
+  it.each(names)("announces the %s switch with the caption it belongs to", async (name) => {
+    renderWithTrpc(<NarrationSettings />, { handlers });
+
+    const toggle = await screen.findByRole("switch", { name });
+    expect(toggle.tagName).toBe("BUTTON");
+    expect(toggle).toHaveAttribute("type", "button");
+  });
+
+  it("reflects and flips the checked state of a named switch", async () => {
+    renderWithTrpc(<NarrationSettings />, { handlers });
+
+    const toggle = await screen.findByRole("switch", { name: /highlight current paragraph/i });
+    expect(toggle).toBeChecked();
+
+    fireEvent.click(toggle);
+    expect(
+      await screen.findByRole("switch", { name: /highlight current paragraph/i })
+    ).not.toBeChecked();
+  });
+});


### PR DESCRIPTION
The four `role="switch"` toggles in `NarrationSettings.tsx` each contain only an `aria-hidden` knob span, with the visible caption in an unlinked sibling element. A screen reader announces **"switch, not checked"** with no indication of what it toggles:

- Enable narration
- Use AI text processing
- Highlight current paragraph
- Auto-scroll to current paragraph

Each caption now carries an `id` and each button an `aria-labelledby`, matching the fix applied to the `EmailSettingsContent` and `KeyboardShortcutsSettings` toggles in #1572.

### Why this was not in #1572

Same defect, same fix — but `NarrationSettings.tsx` lives in `src/components/narration/`, which was fenced off from that agent because another PR (#1563) was editing the directory concurrently. It correctly declined to touch it and flagged the gap. No open PR touches this file, so it lands cleanly on its own.

### Tests

`tests/unit/frontend/components/NarrationSettingsSwitches.test.tsx` queries each switch **by accessible name**, which is precisely what failed before. Verified against `master`:

```
### WITHOUT THE FIX ###
 Test Files  1 failed (1)
      Tests  5 failed (5)

### WITH THE FIX ###
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

The sibling toggles are covered in `SettingsSwitches.test.tsx` (added by #1572); this file covers the narration ones.

### Verification

- `pnpm typecheck` — clean
- `eslint --max-warnings 0` on both changed files — clean
- `prettier --check` — clean
- Frontend unit suite — `Test Files 49 passed (49)` / `Tests 705 passed (705)`

### Related

There is still no shared `Switch` primitive in `src/components/ui/`, which is why this markup has been hand-rolled six times — #1550 covers that. This PR fixes the last four instances; it does not build the primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)