### PR TITLE
Fix re-opening an entry after Back (Next mutates the pushState state object)

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -6,16 +6,31 @@
 
 import { type MouseEvent } from "react";
 
+/** Serializable state stored on a history entry. */
+export type HistoryState = Record<string, unknown>;
+
+/**
+ * Next's patched pushState/replaceState write their internal keys (`__NA`,
+ * `__PRIVATE_NEXTJS_INTERNALS_TREE`) *into the object we pass* rather than
+ * copying it, and then treat any object that already carries `__NA` as one of
+ * their own internal calls — updating the URL but skipping the router sync that
+ * makes `usePathname`/`useSearchParams` see it. Handing the same object over
+ * twice therefore makes the second navigation a silent no-op, so every call
+ * gets a fresh copy.
+ */
+function freshHistoryState(state: HistoryState | null): HistoryState | null {
+  return state === null ? null : { ...state };
+}
+
 /**
  * Navigate using pushState without triggering SSR.
  * UnifiedEntriesContent reads usePathname() to determine what to render.
  *
  * `state` is stored on the created history entry, so a later handler can tell
- * which entry it created (see `useEntryUrlState`). Next's app router merges its
- * own internal keys into whatever we pass, so an object is safe here.
+ * which entry it created (see `useEntryUrlState`).
  */
-export function clientPush(href: string, state: unknown = null): void {
-  window.history.pushState(state, "", href);
+export function clientPush(href: string, state: HistoryState | null = null): void {
+  window.history.pushState(freshHistoryState(state), "", href);
 }
 
 /**
@@ -25,8 +40,8 @@ export function clientPush(href: string, state: unknown = null): void {
  * Note that replacing overwrites the current entry's state, so callers that
  * need to keep a marker set by `clientPush` must pass it through again.
  */
-export function clientReplace(href: string, state: unknown = null): void {
-  window.history.replaceState(state, "", href);
+export function clientReplace(href: string, state: HistoryState | null = null): void {
+  window.history.replaceState(freshHistoryState(state), "", href);
 }
 
 /**

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -7,16 +7,17 @@
 import { type MouseEvent } from "react";
 
 /** Serializable state stored on a history entry. */
-export type HistoryState = Record<string, unknown>;
+type HistoryState = Record<string, unknown>;
 
 /**
- * Next's patched pushState/replaceState write their internal keys (`__NA`,
- * `__PRIVATE_NEXTJS_INTERNALS_TREE`) *into the object we pass* rather than
- * copying it, and then treat any object that already carries `__NA` as one of
- * their own internal calls — updating the URL but skipping the router sync that
- * makes `usePathname`/`useSearchParams` see it. Handing the same object over
- * twice therefore makes the second navigation a silent no-op, so every call
- * gets a fresh copy.
+ * Next's patched pushState/replaceState carry their internal keys (`__NA`,
+ * `__PRIVATE_NEXTJS_INTERNALS_TREE`) forward from the current history entry by
+ * writing them *into the object we pass* rather than copying it, and then treat
+ * any object that already carries `__NA` as one of their own internal calls —
+ * updating the URL but skipping the router sync that makes
+ * `usePathname`/`useSearchParams` see it. Handing the same object over twice
+ * therefore makes the second navigation a silent no-op, so every call gets a
+ * fresh copy.
  */
 function freshHistoryState(state: HistoryState | null): HistoryState | null {
   return state === null ? null : { ...state };

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -175,3 +175,32 @@ test("closing an entry pops its history entry, so browser Back still works", asy
   await page.goBack();
   await expect(page).toHaveURL(/\/starred$/);
 });
+
+test("can re-open an entry after closing it", async ({ page, baseURL }) => {
+  const db = getDb();
+  const user = await createConfirmedUser(db);
+  const feed = await createSubscribedFeed(db, user.id);
+  const entry = await createUnreadEntry(db, {
+    feedId: feed.feedId,
+    userId: user.id,
+    title: "Only Post",
+  });
+
+  await loginAs(page.context(), user, baseURL!);
+  await page.goto("/all");
+  const row = page.locator(`[data-entry-id="${entry.id}"]`);
+  await expect(row).toBeVisible();
+
+  await row.click();
+  await expect(page).toHaveURL(new RegExp(`entry=${entry.id}`));
+  await page.getByRole("button", { name: /back to list/i }).click();
+  await expect(page).toHaveURL(/\/all$/);
+  await expect(row).toBeVisible();
+
+  // Opening pushes history state; Next's router patch mutates that object, so
+  // reusing it made this second open change the URL without rendering anything.
+  await row.click();
+  await expect(page).toHaveURL(new RegExp(`entry=${entry.id}`));
+  await expect(page.getByRole("button", { name: /back to list/i })).toBeVisible();
+  await expect(row).toBeHidden();
+});

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -2,13 +2,16 @@
  * E2E tests for client-side navigation behavior.
  *
  * In-app navigation is shallow (`pushState` + AppRouter re-deriving from
- * `usePathname()`), so there's no browser-native scroll reset. These tests
- * pin the behaviors that need to be reproduced by hand:
+ * `usePathname()`), so there's no browser-native scroll reset and the history
+ * stack is ours to manage. These tests pin the behaviors that need to be
+ * reproduced by hand:
  *
  * - list→list navigation resets the entry-list scroll container to the top
  *   (issue #1013), while
  * - opening/closing an entry (a `?entry=` search-param change, same pathname)
- *   does NOT reset it — the list stays put under the reader.
+ *   does NOT reset it — the list stays put under the reader;
+ * - opening an entry pushes one history entry and closing pops it, and the
+ *   cycle can repeat — Next's router patch mutates the pushed state object.
  */
 
 import { test, expect, type Page } from "@playwright/test";
@@ -143,7 +146,7 @@ test("does not reset the entry-list scroll when opening and closing an entry", a
   await expect.poll(() => mainScrollTop(page)).toBeGreaterThan(0);
 });
 
-test("closing an entry pops its history entry, so browser Back still works", async ({
+test("opening and closing an entry can repeat, and closing pops its history entry", async ({
   page,
   baseURL,
 }) => {
@@ -167,40 +170,24 @@ test("closing an entry pops its history entry, so browser Back still works", asy
 
   // Opening pushes a history entry; closing must pop it rather than replacing
   // it, or the stranded entry swallows the user's next Back press.
-  await page.locator(`[data-entry-id="${entry.id}"]`).click();
+  const row = page.locator(`[data-entry-id="${entry.id}"]`);
+  const backToList = page.getByRole("button", { name: /back to list/i });
+  await row.click();
   await expect(page).toHaveURL(new RegExp(`entry=${entry.id}`));
-  await page.getByRole("button", { name: /back to list/i }).click();
+  await backToList.click();
+  await expect(page).toHaveURL(/\/all$/);
+  await expect(row).toBeVisible();
+
+  // Opening again must render the reader, not just change the URL: Next's
+  // router patch mutates the state object pushed, so reusing it made the
+  // second open a silent no-op.
+  await row.click();
+  await expect(page).toHaveURL(new RegExp(`entry=${entry.id}`));
+  await expect(backToList).toBeVisible();
+  await expect(row).toBeHidden();
+  await backToList.click();
   await expect(page).toHaveURL(/\/all$/);
 
   await page.goBack();
   await expect(page).toHaveURL(/\/starred$/);
-});
-
-test("can re-open an entry after closing it", async ({ page, baseURL }) => {
-  const db = getDb();
-  const user = await createConfirmedUser(db);
-  const feed = await createSubscribedFeed(db, user.id);
-  const entry = await createUnreadEntry(db, {
-    feedId: feed.feedId,
-    userId: user.id,
-    title: "Only Post",
-  });
-
-  await loginAs(page.context(), user, baseURL!);
-  await page.goto("/all");
-  const row = page.locator(`[data-entry-id="${entry.id}"]`);
-  await expect(row).toBeVisible();
-
-  await row.click();
-  await expect(page).toHaveURL(new RegExp(`entry=${entry.id}`));
-  await page.getByRole("button", { name: /back to list/i }).click();
-  await expect(page).toHaveURL(/\/all$/);
-  await expect(row).toBeVisible();
-
-  // Opening pushes history state; Next's router patch mutates that object, so
-  // reusing it made this second open change the URL without rendering anything.
-  await row.click();
-  await expect(page).toHaveURL(new RegExp(`entry=${entry.id}`));
-  await expect(page.getByRole("button", { name: /back to list/i })).toBeVisible();
-  await expect(row).toBeHidden();
 });

--- a/tests/unit/frontend/hooks/useEntryUrlState.test.tsx
+++ b/tests/unit/frontend/hooks/useEntryUrlState.test.tsx
@@ -58,6 +58,34 @@ describe("useEntryUrlState", () => {
     expect(replaceState).not.toHaveBeenCalled();
   });
 
+  it("re-opens an entry after Back when pushState mutates the state it is given", () => {
+    // Next's patched pushState/replaceState add their internal `__NA` key to the
+    // object they are handed and skip the router sync (the part that updates
+    // usePathname/useSearchParams) for any object that already has it. Mirror
+    // that, and count the syncs: open → back → open must sync twice.
+    let routerSyncs = 0;
+    const originalPushState = window.history.pushState.bind(window.history);
+    vi.spyOn(window.history, "pushState").mockImplementation((data, unused, url) => {
+      if (data?.__NA) return originalPushState(data, unused, url);
+      data = data ?? {};
+      data.__NA = true;
+      routerSyncs++;
+      return originalPushState(data, unused, url);
+    });
+    const { result, rerender } = renderHook(() => useEntryUrlState());
+
+    act(() => result.current.setOpenEntryId("entry-1"));
+    expect(routerSyncs).toBe(1);
+
+    // Browser Back: the list is showing again with no entry open.
+    window.history.replaceState(null, "", "/all");
+    navigate("", rerender);
+
+    act(() => result.current.setOpenEntryId("entry-1"));
+    expect(routerSyncs).toBe(2);
+    expect(window.location.search).toBe("?entry=entry-1");
+  });
+
   it("marks the history entry it pushes when opening from the list", () => {
     const { result } = renderHook(() => useEntryUrlState());
 

--- a/tests/unit/frontend/hooks/useEntryUrlState.test.tsx
+++ b/tests/unit/frontend/hooks/useEntryUrlState.test.tsx
@@ -59,26 +59,30 @@ describe("useEntryUrlState", () => {
   });
 
   it("re-opens an entry after Back when pushState mutates the state it is given", () => {
-    // Next's patched pushState/replaceState add their internal `__NA` key to the
-    // object they are handed and skip the router sync (the part that updates
-    // usePathname/useSearchParams) for any object that already has it. Mirror
-    // that, and count the syncs: open → back → open must sync twice.
+    // Next's patched pushState copies its internal `__NA` key from the current
+    // history entry *onto the object it is handed*, and skips the router sync
+    // (the part that updates usePathname/useSearchParams) for any object that
+    // already carries it. Mirror that, with every entry Next-managed (so `__NA`
+    // is set, as in the app), and count the syncs: open → back → open must sync
+    // twice. A shared state object gets `__NA` on the first open and is then
+    // mistaken for an internal call on the second.
     let routerSyncs = 0;
     const originalPushState = window.history.pushState.bind(window.history);
     vi.spyOn(window.history, "pushState").mockImplementation((data, unused, url) => {
       if (data?.__NA) return originalPushState(data, unused, url);
       data = data ?? {};
-      data.__NA = true;
+      if (window.history.state?.__NA) data.__NA = true;
       routerSyncs++;
       return originalPushState(data, unused, url);
     });
+    window.history.replaceState({ __NA: true }, "", "/all");
     const { result, rerender } = renderHook(() => useEntryUrlState());
 
     act(() => result.current.setOpenEntryId("entry-1"));
     expect(routerSyncs).toBe(1);
 
-    // Browser Back: the list is showing again with no entry open.
-    window.history.replaceState(null, "", "/all");
+    // Browser Back restores the list's entry, which Next had stamped too.
+    window.history.replaceState({ __NA: true }, "", "/all");
     navigate("", rerender);
 
     act(() => result.current.setOpenEntryId("entry-1"));


### PR DESCRIPTION
## Summary

Follow-up to #1569, which made `useEntryUrlState` push a marker object as history state so closing an entry can pop the entry it pushed. The marker was a **module-level constant**, and Next's patched `pushState`/`replaceState` mutate the state object they're handed (adding `__NA` and `__PRIVATE_NEXTJS_INTERNALS_TREE`) and then treat any object that already has `__NA` as one of their own internal calls, skipping the router sync that updates `usePathname`/`useSearchParams`.

Net effect: the first open worked. After going back, every subsequent click on an entry changed the URL to `?entry=…` but rendered nothing.

## Fix

`clientPush`/`clientReplace` now hand the History API a fresh shallow copy of whatever state they're given, so Next's mutation never leaks into a later call. The type is tightened from `unknown` to `Record<string, unknown> | null` to make the copy well-defined.

## Tests

- Unit: `useEntryUrlState.test.tsx` gets a test that mirrors Next's mutating patch and asserts open → Back → open syncs the router twice.
- E2E: `navigation.spec.ts` gets "can re-open an entry after closing it". Verified it fails on master (`element(s) not found` for the reader) and passes with the fix.
- `pnpm typecheck`, the hook unit tests, and the full navigation e2e spec pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)