### PR TITLE
Route every LessWrong GraphQL lookup through one helper so 429 always throws (#1548)

### DIFF
--- a/src/server/feed/lesswrong.ts
+++ b/src/server/feed/lesswrong.ts
@@ -146,10 +146,14 @@ const graphqlEnvelopeSchema = z.object({
  * contract:
  *
  * - A non-OK status, an invalid body, GraphQL `errors`, a timeout, or a network
- *   failure logs a warning and returns null.
+ *   failure logs a warning and returns null; `data: null` returns null silently
+ *   (the caller logs its own "not found").
  * - HTTP 429 **throws** `HttpFetchError` instead. Returning null would let a
  *   caller fall back to fetching the same throttled site, or persist a result
  *   with data missing that's indistinguishable from the data not existing.
+ *
+ * Callers pass an object schema, so a null return always means "no data", never
+ * a legitimately-null value.
  *
  * `endpoint` is a parameter so tests can drive this against a loopback server.
  */
@@ -191,7 +195,7 @@ export async function lessWrongGraphql<T extends z.ZodType>(
 
     const envelope = graphqlEnvelopeSchema.safeParse(await response.json());
     if (!envelope.success) {
-      logger.warn("LessWrong GraphQL response validation failed", {
+      logger.warn("LessWrong GraphQL response is not a GraphQL envelope", {
         ...logContext,
         error: envelope.error.message,
       });
@@ -212,7 +216,7 @@ export async function lessWrongGraphql<T extends z.ZodType>(
 
     const data = dataSchema.safeParse(envelope.data.data);
     if (!data.success) {
-      logger.warn("LessWrong GraphQL response validation failed", {
+      logger.warn("LessWrong GraphQL data does not match schema", {
         ...logContext,
         error: data.error.message,
       });

--- a/src/server/feed/lesswrong.ts
+++ b/src/server/feed/lesswrong.ts
@@ -127,56 +127,151 @@ export function extractUserSlug(url: string): string | null {
 }
 
 // ============================================================================
-// GraphQL Types
+// GraphQL Transport
 // ============================================================================
 
 /**
- * Zod schema for the GraphQL response.
+ * The response envelope every GraphQL request comes back in; `data` is validated
+ * separately against the caller's schema.
  */
-const graphqlResponseSchema = z.object({
-  data: z
+const graphqlEnvelopeSchema = z.object({
+  data: z.unknown().nullable(),
+  errors: z.array(z.object({ message: z.string() })).optional(),
+});
+
+/**
+ * Sends one query to the LessWrong GraphQL API and returns its validated `data`.
+ *
+ * Every lookup in this module goes through here so they all share one failure
+ * contract:
+ *
+ * - A non-OK status, an invalid body, GraphQL `errors`, a timeout, or a network
+ *   failure logs a warning and returns null.
+ * - HTTP 429 **throws** `HttpFetchError` instead. Returning null would let a
+ *   caller fall back to fetching the same throttled site, or persist a result
+ *   with data missing that's indistinguishable from the data not existing.
+ *
+ * `endpoint` is a parameter so tests can drive this against a loopback server.
+ */
+export async function lessWrongGraphql<T extends z.ZodType>(
+  request: {
+    query: string;
+    variables: Record<string, string>;
+    dataSchema: T;
+    /** Included in every log line for this request (e.g. `{ operation, postId }`). */
+    logContext: Record<string, string>;
+  },
+  endpoint: string = LESSWRONG_GRAPHQL_ENDPOINT
+): Promise<z.output<T> | null> {
+  const { query, variables, dataSchema, logContext } = request;
+
+  try {
+    const response = await fetchWithSsrfProtection(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      logger.warn("LessWrong GraphQL request failed", {
+        ...logContext,
+        status: response.status,
+        statusText: response.statusText,
+      });
+      if (response.status === 429) {
+        throw new HttpFetchError(response.status, response.statusText, endpoint);
+      }
+      return null;
+    }
+
+    const envelope = graphqlEnvelopeSchema.safeParse(await response.json());
+    if (!envelope.success) {
+      logger.warn("LessWrong GraphQL response validation failed", {
+        ...logContext,
+        error: envelope.error.message,
+      });
+      return null;
+    }
+
+    if (envelope.data.errors && envelope.data.errors.length > 0) {
+      logger.warn("LessWrong GraphQL returned errors", {
+        ...logContext,
+        errors: envelope.data.errors.map((e) => e.message),
+      });
+      return null;
+    }
+
+    if (envelope.data.data == null) {
+      return null;
+    }
+
+    const data = dataSchema.safeParse(envelope.data.data);
+    if (!data.success) {
+      logger.warn("LessWrong GraphQL response validation failed", {
+        ...logContext,
+        error: data.error.message,
+      });
+      return null;
+    }
+
+    return data.data;
+  } catch (error) {
+    if (error instanceof HttpFetchError) {
+      throw error;
+    }
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
+      logger.warn("LessWrong GraphQL request timed out", logContext);
+    } else {
+      logger.warn("LessWrong GraphQL request error", {
+        ...logContext,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return null;
+  }
+}
+
+/**
+ * The `user` shape LessWrong returns on posts and comments.
+ */
+const authorSchema = z.object({
+  displayName: z.string().nullable(),
+  username: z.string().nullable(),
+});
+
+/**
+ * Picks the name to show for an author: display name, falling back to username.
+ */
+function authorName(user: z.output<typeof authorSchema> | null | undefined): string | null {
+  return user?.displayName || user?.username || null;
+}
+
+// ============================================================================
+// Post Content
+// ============================================================================
+
+const postDataSchema = z.object({
+  post: z
     .object({
-      post: z
+      result: z
         .object({
-          result: z
-            .object({
-              _id: z.string(),
-              title: z.string().nullable(),
-              slug: z.string().nullable(),
-              pageUrl: z.string().nullable(),
-              postedAt: z.string().nullable(),
-              user: z
-                .object({
-                  displayName: z.string().nullable(),
-                  username: z.string().nullable(),
-                })
-                .nullable(),
-              coauthors: z
-                .array(
-                  z.object({
-                    displayName: z.string().nullable(),
-                    username: z.string().nullable(),
-                  })
-                )
-                .nullable(),
-              contents: z
-                .object({
-                  html: z.string().nullable(),
-                })
-                .nullable(),
-            })
-            .nullable(),
+          _id: z.string(),
+          title: z.string().nullable(),
+          slug: z.string().nullable(),
+          pageUrl: z.string().nullable(),
+          postedAt: z.string().nullable(),
+          user: authorSchema.nullable(),
+          coauthors: z.array(authorSchema).nullable(),
+          contents: z.object({ html: z.string().nullable() }).nullable(),
         })
         .nullable(),
     })
     .nullable(),
-  errors: z
-    .array(
-      z.object({
-        message: z.string(),
-      })
-    )
-    .optional(),
 });
 
 /**
@@ -196,73 +291,6 @@ interface LessWrongPostContent {
   /** Canonical URL */
   url: string | null;
 }
-
-/**
- * Zod schema for the comment GraphQL response.
- */
-const commentGraphqlResponseSchema = z.object({
-  data: z
-    .object({
-      comment: z
-        .object({
-          result: z
-            .object({
-              _id: z.string(),
-              postId: z.string().nullable(),
-              pageUrl: z.string().nullable(),
-              postedAt: z.string().nullable(),
-              user: z
-                .object({
-                  displayName: z.string().nullable(),
-                  username: z.string().nullable(),
-                })
-                .nullable(),
-              post: z
-                .object({
-                  title: z.string().nullable(),
-                })
-                .nullable(),
-              contents: z
-                .object({
-                  html: z.string().nullable(),
-                })
-                .nullable(),
-            })
-            .nullable(),
-        })
-        .nullable(),
-    })
-    .nullable(),
-  errors: z
-    .array(
-      z.object({
-        message: z.string(),
-      })
-    )
-    .optional(),
-});
-
-/**
- * Result from fetching LessWrong comment content.
- */
-interface LessWrongCommentContent {
-  /** Comment ID */
-  commentId: string;
-  /** Parent post title (for context) */
-  postTitle: string | null;
-  /** HTML content of the comment */
-  html: string;
-  /** Author display name */
-  author: string | null;
-  /** Comment post date */
-  publishedAt: Date | null;
-  /** Canonical URL */
-  url: string | null;
-}
-
-// ============================================================================
-// GraphQL Fetching
-// ============================================================================
 
 /**
  * GraphQL query to fetch post content.
@@ -298,109 +326,80 @@ const POST_QUERY = `
  *
  * @param postId - The LessWrong post ID (17-character alphanumeric)
  * @returns Post content including HTML, or null if fetch fails
+ * @throws HttpFetchError when LessWrong rate limits us (see `lessWrongGraphql`)
  */
 async function fetchLessWrongPost(postId: string): Promise<LessWrongPostContent | null> {
-  try {
-    const response = await fetchWithSsrfProtection(LESSWRONG_GRAPHQL_ENDPOINT, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "User-Agent": USER_AGENT,
-        Accept: "application/json",
-      },
-      body: JSON.stringify({
-        query: POST_QUERY,
-        variables: { postId },
-      }),
-      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
-    });
+  const data = await lessWrongGraphql({
+    query: POST_QUERY,
+    variables: { postId },
+    dataSchema: postDataSchema,
+    logContext: { operation: "post", postId },
+  });
 
-    if (!response.ok) {
-      logger.warn("LessWrong GraphQL request failed", {
-        postId,
-        status: response.status,
-        statusText: response.statusText,
-      });
-      // Throw on rate limiting so callers can handle it specifically
-      // (returning null would cause a pointless fallback fetch to the same site)
-      if (response.status === 429) {
-        throw new HttpFetchError(response.status, response.statusText, LESSWRONG_GRAPHQL_ENDPOINT);
-      }
-      return null;
-    }
-
-    const json = await response.json();
-    const parsed = graphqlResponseSchema.safeParse(json);
-
-    if (!parsed.success) {
-      logger.warn("LessWrong GraphQL response validation failed", {
-        postId,
-        error: parsed.error.message,
-      });
-      return null;
-    }
-
-    // Check for GraphQL errors
-    if (parsed.data.errors && parsed.data.errors.length > 0) {
-      logger.warn("LessWrong GraphQL returned errors", {
-        postId,
-        errors: parsed.data.errors.map((e) => e.message),
-      });
-      return null;
-    }
-
-    const post = parsed.data.data?.post?.result;
-    if (!post) {
-      logger.debug("LessWrong post not found", { postId });
-      return null;
-    }
-
-    const html = post.contents?.html;
-    if (!html) {
-      logger.debug("LessWrong post has no content", { postId });
-      return null;
-    }
-
-    // Build author string from user and coauthors
-    const authors: string[] = [];
-    if (post.user?.displayName) {
-      authors.push(post.user.displayName);
-    } else if (post.user?.username) {
-      authors.push(post.user.username);
-    }
-    if (post.coauthors) {
-      for (const coauthor of post.coauthors) {
-        if (coauthor.displayName) {
-          authors.push(coauthor.displayName);
-        } else if (coauthor.username) {
-          authors.push(coauthor.username);
-        }
-      }
-    }
-
-    return {
-      postId: post._id,
-      title: post.title,
-      html,
-      author: authors.length > 0 ? authors.join(", ") : null,
-      publishedAt: post.postedAt ? new Date(post.postedAt) : null,
-      url: post.pageUrl,
-    };
-  } catch (error) {
-    // Let HttpFetchError propagate (e.g., 429 rate limiting)
-    if (error instanceof HttpFetchError) {
-      throw error;
-    }
-    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
-      logger.warn("LessWrong GraphQL request timed out", { postId });
-    } else {
-      logger.warn("LessWrong GraphQL request error", {
-        postId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+  const post = data?.post?.result;
+  if (!post) {
+    logger.debug("LessWrong post not found", { postId });
     return null;
   }
+
+  const html = post.contents?.html;
+  if (!html) {
+    logger.debug("LessWrong post has no content", { postId });
+    return null;
+  }
+
+  const authors = [post.user, ...(post.coauthors ?? [])]
+    .map(authorName)
+    .filter((name): name is string => name !== null);
+
+  return {
+    postId: post._id,
+    title: post.title,
+    html,
+    author: authors.length > 0 ? authors.join(", ") : null,
+    publishedAt: post.postedAt ? new Date(post.postedAt) : null,
+    url: post.pageUrl,
+  };
+}
+
+// ============================================================================
+// Comment Content
+// ============================================================================
+
+const commentDataSchema = z.object({
+  comment: z
+    .object({
+      result: z
+        .object({
+          _id: z.string(),
+          postId: z.string().nullable(),
+          pageUrl: z.string().nullable(),
+          postedAt: z.string().nullable(),
+          user: authorSchema.nullable(),
+          post: z.object({ title: z.string().nullable() }).nullable(),
+          contents: z.object({ html: z.string().nullable() }).nullable(),
+        })
+        .nullable(),
+    })
+    .nullable(),
+});
+
+/**
+ * Result from fetching LessWrong comment content.
+ */
+interface LessWrongCommentContent {
+  /** Comment ID */
+  commentId: string;
+  /** Parent post title (for context) */
+  postTitle: string | null;
+  /** HTML content of the comment */
+  html: string;
+  /** Author display name */
+  author: string | null;
+  /** Comment post date */
+  publishedAt: Date | null;
+  /** Canonical URL */
+  url: string | null;
 }
 
 /**
@@ -435,93 +434,36 @@ const COMMENT_QUERY = `
  *
  * @param commentId - The LessWrong comment ID
  * @returns Comment content including HTML, or null if fetch fails
+ * @throws HttpFetchError when LessWrong rate limits us (see `lessWrongGraphql`)
  */
 async function fetchLessWrongComment(commentId: string): Promise<LessWrongCommentContent | null> {
-  try {
-    const response = await fetchWithSsrfProtection(LESSWRONG_GRAPHQL_ENDPOINT, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "User-Agent": USER_AGENT,
-        Accept: "application/json",
-      },
-      body: JSON.stringify({
-        query: COMMENT_QUERY,
-        variables: { commentId },
-      }),
-      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
-    });
+  const data = await lessWrongGraphql({
+    query: COMMENT_QUERY,
+    variables: { commentId },
+    dataSchema: commentDataSchema,
+    logContext: { operation: "comment", commentId },
+  });
 
-    if (!response.ok) {
-      logger.warn("LessWrong GraphQL comment request failed", {
-        commentId,
-        status: response.status,
-        statusText: response.statusText,
-      });
-      if (response.status === 429) {
-        throw new HttpFetchError(response.status, response.statusText, LESSWRONG_GRAPHQL_ENDPOINT);
-      }
-      return null;
-    }
-
-    const json = await response.json();
-    const parsed = commentGraphqlResponseSchema.safeParse(json);
-
-    if (!parsed.success) {
-      logger.warn("LessWrong GraphQL comment response validation failed", {
-        commentId,
-        error: parsed.error.message,
-      });
-      return null;
-    }
-
-    // Check for GraphQL errors
-    if (parsed.data.errors && parsed.data.errors.length > 0) {
-      logger.warn("LessWrong GraphQL comment returned errors", {
-        commentId,
-        errors: parsed.data.errors.map((e) => e.message),
-      });
-      return null;
-    }
-
-    const comment = parsed.data.data?.comment?.result;
-    if (!comment) {
-      logger.debug("LessWrong comment not found", { commentId });
-      return null;
-    }
-
-    const html = comment.contents?.html;
-    if (!html) {
-      logger.debug("LessWrong comment has no content", { commentId });
-      return null;
-    }
-
-    // Get author name
-    const author = comment.user?.displayName || comment.user?.username || null;
-
-    return {
-      commentId: comment._id,
-      postTitle: comment.post?.title ?? null,
-      html,
-      author,
-      publishedAt: comment.postedAt ? new Date(comment.postedAt) : null,
-      url: comment.pageUrl,
-    };
-  } catch (error) {
-    // Let HttpFetchError propagate (e.g., 429 rate limiting)
-    if (error instanceof HttpFetchError) {
-      throw error;
-    }
-    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
-      logger.warn("LessWrong GraphQL comment request timed out", { commentId });
-    } else {
-      logger.warn("LessWrong GraphQL comment request error", {
-        commentId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+  const comment = data?.comment?.result;
+  if (!comment) {
+    logger.debug("LessWrong comment not found", { commentId });
     return null;
   }
+
+  const html = comment.contents?.html;
+  if (!html) {
+    logger.debug("LessWrong comment has no content", { commentId });
+    return null;
+  }
+
+  return {
+    commentId: comment._id,
+    postTitle: comment.post?.title ?? null,
+    html,
+    author: authorName(comment.user),
+    publishedAt: comment.postedAt ? new Date(comment.postedAt) : null,
+    url: comment.pageUrl,
+  };
 }
 
 /**
@@ -538,6 +480,7 @@ export type LessWrongContent =
  *
  * @param url - The LessWrong URL (post or comment)
  * @returns Content including HTML, or null if URL is invalid or fetch fails
+ * @throws HttpFetchError when LessWrong rate limits us (see `lessWrongGraphql`)
  */
 export async function fetchLessWrongContentFromUrl(url: string): Promise<LessWrongContent | null> {
   if (!isLessWrongUrl(url)) {
@@ -573,32 +516,18 @@ export async function fetchLessWrongContentFromUrl(url: string): Promise<LessWro
 // User Lookup
 // ============================================================================
 
-/**
- * Zod schema for the user GraphQL response.
- */
-const userGraphqlResponseSchema = z.object({
-  data: z
+const userDataSchema = z.object({
+  user: z
     .object({
-      user: z
+      result: z
         .object({
-          result: z
-            .object({
-              _id: z.string(),
-              displayName: z.string().nullable(),
-              slug: z.string().nullable(),
-            })
-            .nullable(),
+          _id: z.string(),
+          displayName: z.string().nullable(),
+          slug: z.string().nullable(),
         })
         .nullable(),
     })
     .nullable(),
-  errors: z
-    .array(
-      z.object({
-        message: z.string(),
-      })
-    )
-    .optional(),
 });
 
 /**
@@ -629,79 +558,65 @@ const USER_BY_SLUG_QUERY = `
 `;
 
 /**
+ * GraphQL query to fetch user by ID.
+ */
+const USER_BY_ID_QUERY = `
+  query GetUserById($userId: String!) {
+    user(input: { selector: { _id: $userId } }) {
+      result {
+        _id
+        displayName
+        slug
+      }
+    }
+  }
+`;
+
+async function fetchLessWrongUser(
+  query: string,
+  variables: Record<string, string>,
+  logContext: Record<string, string>
+): Promise<LessWrongUser | null> {
+  const data = await lessWrongGraphql({ query, variables, dataSchema: userDataSchema, logContext });
+
+  const user = data?.user?.result;
+  if (!user) {
+    logger.debug("LessWrong user not found", logContext);
+    return null;
+  }
+
+  return {
+    userId: user._id,
+    displayName: user.displayName,
+    slug: user.slug,
+  };
+}
+
+/**
  * Fetches a LessWrong user by their slug using the GraphQL API.
  *
  * @param slug - The user's URL slug (e.g., "brendan-long")
  * @returns User info including ID, or null if not found
+ * @throws HttpFetchError when LessWrong rate limits us (see `lessWrongGraphql`)
  */
 export async function fetchLessWrongUserBySlug(slug: string): Promise<LessWrongUser | null> {
-  try {
-    const response = await fetchWithSsrfProtection(LESSWRONG_GRAPHQL_ENDPOINT, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "User-Agent": USER_AGENT,
-        Accept: "application/json",
-      },
-      body: JSON.stringify({
-        query: USER_BY_SLUG_QUERY,
-        variables: { slug },
-      }),
-      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
-    });
-
-    if (!response.ok) {
-      logger.warn("LessWrong GraphQL user request failed", {
-        slug,
-        status: response.status,
-        statusText: response.statusText,
-      });
-      return null;
-    }
-
-    const json = await response.json();
-    const parsed = userGraphqlResponseSchema.safeParse(json);
-
-    if (!parsed.success) {
-      logger.warn("LessWrong GraphQL user response validation failed", {
-        slug,
-        error: parsed.error.message,
-      });
-      return null;
-    }
-
-    // Check for GraphQL errors
-    if (parsed.data.errors && parsed.data.errors.length > 0) {
-      logger.warn("LessWrong GraphQL user returned errors", {
-        slug,
-        errors: parsed.data.errors.map((e) => e.message),
-      });
-      return null;
-    }
-
-    const user = parsed.data.data?.user?.result;
-    if (!user) {
-      logger.debug("LessWrong user not found", { slug });
-      return null;
-    }
-
-    return {
-      userId: user._id,
-      displayName: user.displayName,
-      slug: user.slug,
-    };
-  } catch (error) {
-    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
-      logger.warn("LessWrong GraphQL user request timed out", { slug });
-    } else {
-      logger.warn("LessWrong GraphQL user request error", {
-        slug,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-    return null;
-  }
+  return fetchLessWrongUser(USER_BY_SLUG_QUERY, { slug }, { operation: "userBySlug", slug });
 }
+
+/**
+ * Fetches a LessWrong user by their ID using the GraphQL API.
+ *
+ * @param userId - The user's internal ID
+ * @returns User info, or null if not found
+ * @throws HttpFetchError when LessWrong rate limits us (see `lessWrongGraphql`)
+ */
+export async function fetchLessWrongUserById(userId: string): Promise<LessWrongUser | null> {
+  return fetchLessWrongUser(USER_BY_ID_QUERY, { userId }, { operation: "userById", userId });
+}
+
+// ============================================================================
+// Feed URLs
+// ============================================================================
 
 /**
  * Builds the RSS feed URL for a LessWrong user.
@@ -776,126 +691,22 @@ export function extractUserIdFromFeedUrl(url: string): string | null {
   }
 }
 
-/**
- * GraphQL query to fetch user by ID.
- */
-const USER_BY_ID_QUERY = `
-  query GetUserById($userId: String!) {
-    user(input: { selector: { _id: $userId } }) {
-      result {
-        _id
-        displayName
-        slug
-      }
-    }
-  }
-`;
-
-/**
- * Fetches a LessWrong user by their ID using the GraphQL API.
- *
- * @param userId - The user's internal ID
- * @returns User info, or null if not found
- */
-export async function fetchLessWrongUserById(userId: string): Promise<LessWrongUser | null> {
-  try {
-    const response = await fetchWithSsrfProtection(LESSWRONG_GRAPHQL_ENDPOINT, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "User-Agent": USER_AGENT,
-        Accept: "application/json",
-      },
-      body: JSON.stringify({
-        query: USER_BY_ID_QUERY,
-        variables: { userId },
-      }),
-      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
-    });
-
-    if (!response.ok) {
-      logger.warn("LessWrong GraphQL user-by-id request failed", {
-        userId,
-        status: response.status,
-        statusText: response.statusText,
-      });
-      return null;
-    }
-
-    const json = await response.json();
-    const parsed = userGraphqlResponseSchema.safeParse(json);
-
-    if (!parsed.success) {
-      logger.warn("LessWrong GraphQL user-by-id response validation failed", {
-        userId,
-        error: parsed.error.message,
-      });
-      return null;
-    }
-
-    // Check for GraphQL errors
-    if (parsed.data.errors && parsed.data.errors.length > 0) {
-      logger.warn("LessWrong GraphQL user-by-id returned errors", {
-        userId,
-        errors: parsed.data.errors.map((e) => e.message),
-      });
-      return null;
-    }
-
-    const user = parsed.data.data?.user?.result;
-    if (!user) {
-      logger.debug("LessWrong user not found by id", { userId });
-      return null;
-    }
-
-    return {
-      userId: user._id,
-      displayName: user.displayName,
-      slug: user.slug,
-    };
-  } catch (error) {
-    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
-      logger.warn("LessWrong GraphQL user-by-id request timed out", { userId });
-    } else {
-      logger.warn("LessWrong GraphQL user-by-id request error", {
-        userId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-    return null;
-  }
-}
-
 // ============================================================================
 // Post Metadata Lookup (for shortform detection)
 // ============================================================================
 
-/**
- * Zod schema for the post metadata GraphQL response.
- */
-const postMetadataGraphqlResponseSchema = z.object({
-  data: z
+const postMetadataDataSchema = z.object({
+  post: z
     .object({
-      post: z
+      result: z
         .object({
-          result: z
-            .object({
-              _id: z.string(),
-              shortform: z.boolean().nullable(),
-              userId: z.string().nullable(),
-            })
-            .nullable(),
+          _id: z.string(),
+          shortform: z.boolean().nullable(),
+          userId: z.string().nullable(),
         })
         .nullable(),
     })
     .nullable(),
-  errors: z
-    .array(
-      z.object({
-        message: z.string(),
-      })
-    )
-    .optional(),
 });
 
 /**
@@ -930,73 +741,27 @@ const POST_METADATA_QUERY = `
  *
  * @param postId - The LessWrong post ID (17-character alphanumeric)
  * @returns Post metadata including shortform status, or null if fetch fails
+ * @throws HttpFetchError when LessWrong rate limits us (see `lessWrongGraphql`)
  */
 export async function fetchLessWrongPostMetadata(
   postId: string
 ): Promise<LessWrongPostMetadata | null> {
-  try {
-    const response = await fetchWithSsrfProtection(LESSWRONG_GRAPHQL_ENDPOINT, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "User-Agent": USER_AGENT,
-        Accept: "application/json",
-      },
-      body: JSON.stringify({
-        query: POST_METADATA_QUERY,
-        variables: { postId },
-      }),
-      signal: AbortSignal.timeout(GRAPHQL_TIMEOUT_MS),
-    });
+  const data = await lessWrongGraphql({
+    query: POST_METADATA_QUERY,
+    variables: { postId },
+    dataSchema: postMetadataDataSchema,
+    logContext: { operation: "postMetadata", postId },
+  });
 
-    if (!response.ok) {
-      logger.warn("LessWrong GraphQL post metadata request failed", {
-        postId,
-        status: response.status,
-        statusText: response.statusText,
-      });
-      return null;
-    }
-
-    const json = await response.json();
-    const parsed = postMetadataGraphqlResponseSchema.safeParse(json);
-
-    if (!parsed.success) {
-      logger.warn("LessWrong GraphQL post metadata response validation failed", {
-        postId,
-        error: parsed.error.message,
-      });
-      return null;
-    }
-
-    if (parsed.data.errors && parsed.data.errors.length > 0) {
-      logger.warn("LessWrong GraphQL post metadata returned errors", {
-        postId,
-        errors: parsed.data.errors.map((e) => e.message),
-      });
-      return null;
-    }
-
-    const post = parsed.data.data?.post?.result;
-    if (!post) {
-      logger.debug("LessWrong post not found for metadata", { postId });
-      return null;
-    }
-
-    return {
-      postId: post._id,
-      shortform: post.shortform ?? false,
-      userId: post.userId,
-    };
-  } catch (error) {
-    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
-      logger.warn("LessWrong GraphQL post metadata request timed out", { postId });
-    } else {
-      logger.warn("LessWrong GraphQL post metadata request error", {
-        postId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+  const post = data?.post?.result;
+  if (!post) {
+    logger.debug("LessWrong post not found for metadata", { postId });
     return null;
   }
+
+  return {
+    postId: post._id,
+    shortform: post.shortform ?? false,
+    userId: post.userId,
+  };
 }

--- a/src/server/plugins/lesswrong.ts
+++ b/src/server/plugins/lesswrong.ts
@@ -51,6 +51,9 @@ export const lessWrongPlugin: UrlPlugin = {
   capabilities: {
     feed: {
       async transformToFeedUrl(url: URL): Promise<URL | null> {
+        // A 429 from the lookups below propagates (see lessWrongGraphql): the
+        // fallbacks — fetching the profile page, or guessing the comment feed for
+        // a post that may be a shortform — would be wrong or hit the same limit
         const href = url.href;
 
         // Front page → frontpage feed

--- a/src/server/trpc/errors.ts
+++ b/src/server/trpc/errors.ts
@@ -358,9 +358,9 @@ export function getAppErrorCode(error: unknown): string | undefined {
  * URL, so it must not be reported to Sentry even though `SITE_BLOCKED` maps to
  * HTTP 502 (an honest status to return to the client).
  *
- * 4xx-mapped app codes (e.g. `SAVED_ARTICLE_FETCH_ERROR`, `UPSTREAM_RATE_LIMITED`,
- * `CONTENT_TOO_LARGE`) are already treated as client errors by their HTTP status
- * and don't need to be listed here.
+ * App codes that map to a tRPC code the middleware already exempts (`BAD_REQUEST`,
+ * `TOO_MANY_REQUESTS`, ... — see the list in `src/server/trpc/trpc.ts`) don't need
+ * to be listed here.
  */
 const EXPECTED_CLIENT_ERROR_CODES: ReadonlySet<string> = new Set([ErrorCodes.SITE_BLOCKED]);
 

--- a/src/server/trpc/routers/feeds.ts
+++ b/src/server/trpc/routers/feeds.ts
@@ -19,6 +19,7 @@ import {
   ACCEPT_ENCODING,
 } from "@/server/http/fetch";
 import { fetchWithSsrfProtection } from "@/server/http/ssrf";
+import { HttpFetchError } from "@/server/http/fetch";
 import { usageLimitsConfig } from "@/server/config/env";
 import { stripHtml } from "@/server/html/strip-html";
 import { USER_AGENT } from "@/server/http/user-agent";
@@ -240,6 +241,11 @@ async function transformPageUrlToFeed(url: string): Promise<string | null> {
     const feedUrl = await transform(new URL(url));
     return feedUrl?.href ?? null;
   } catch (error) {
+    // Don't fall through to fetching the page itself: that's a second request
+    // to the site that just throttled us
+    if (error instanceof HttpFetchError && error.isRateLimited()) {
+      throw errors.upstreamRateLimited(url);
+    }
     logger.warn("Failed to transform page URL to feed URL", {
       url,
       error: error instanceof Error ? error.message : String(error),

--- a/src/server/trpc/routers/feeds.ts
+++ b/src/server/trpc/routers/feeds.ts
@@ -13,13 +13,13 @@ import { errors } from "../errors";
 import { feedUrlSchema } from "../validation";
 import {
   fetchUrl,
+  HttpFetchError,
   isHtmlContent,
   readResponseWithSizeLimit,
   FEED_FETCH_TIMEOUT_MS,
   ACCEPT_ENCODING,
 } from "@/server/http/fetch";
 import { fetchWithSsrfProtection } from "@/server/http/ssrf";
-import { HttpFetchError } from "@/server/http/fetch";
 import { usageLimitsConfig } from "@/server/config/env";
 import { stripHtml } from "@/server/html/strip-html";
 import { USER_AGENT } from "@/server/http/user-agent";

--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -24,7 +24,11 @@ import { generateUuidv7 } from "@/lib/uuidv7";
 import { parseFeedAsync } from "@/server/feed/parser";
 import { discoverFeeds } from "@/server/feed/discovery";
 import { getDomainFromUrl } from "@/server/feed/types";
-import { extractUserIdFromFeedUrl, fetchLessWrongUserById } from "@/server/feed/lesswrong";
+import {
+  extractUserIdFromFeedUrl,
+  fetchLessWrongUserById,
+  type LessWrongUser,
+} from "@/server/feed/lesswrong";
 import { generateOpml, OpmlParseError, type OpmlSubscription } from "@/server/feed/opml";
 import { scheduleFeedRefreshNow } from "@/server/jobs/queue";
 import { shouldRefetchOnSubscribe } from "@/server/feed/scheduling";
@@ -155,16 +159,19 @@ async function fetchAndResolveFeed(inputUrl: string): Promise<{
   let feedTitle = parsedFeed.title || getDomainFromUrl(finalFeedUrl);
   const lessWrongUserId = extractUserIdFromFeedUrl(finalFeedUrl);
   if (lessWrongUserId && feedTitle) {
-    let lwUser;
+    let lwUser: LessWrongUser | null = null;
     try {
       lwUser = await fetchLessWrongUserById(lessWrongUserId);
     } catch (error) {
-      // Subscribing anyway would store the title without its author suffix for
-      // good, indistinguishable from the user having no display name
-      if (error instanceof HttpFetchError && error.isRateLimited()) {
-        throw errors.upstreamRateLimited(finalFeedUrl);
+      // The feed itself fetched fine, so don't fail the subscribe over the title
+      // decoration: the next poll appends the author via transformFeedTitle
+      if (!(error instanceof HttpFetchError && error.isRateLimited())) {
+        throw error;
       }
-      throw error;
+      logger.warn("LessWrong rate limited the user lookup; subscribing without author suffix", {
+        feedUrl: finalFeedUrl,
+        userId: lessWrongUserId,
+      });
     }
     if (lwUser?.displayName) {
       feedTitle = `${feedTitle} - ${lwUser.displayName}`;

--- a/src/server/trpc/routers/subscriptions.ts
+++ b/src/server/trpc/routers/subscriptions.ts
@@ -18,7 +18,7 @@ import {
 import { API_TOKEN_SCOPES } from "@/server/auth/api-token";
 import { errors } from "../errors";
 import { feedUrlSchema, uuidSchema } from "../validation";
-import { fetchUrl, isHtmlContent } from "@/server/http/fetch";
+import { fetchUrl, HttpFetchError, isHtmlContent } from "@/server/http/fetch";
 import { feeds, subscriptions, tags, subscriptionTags, blockedSenders } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
 import { parseFeedAsync } from "@/server/feed/parser";
@@ -155,7 +155,17 @@ async function fetchAndResolveFeed(inputUrl: string): Promise<{
   let feedTitle = parsedFeed.title || getDomainFromUrl(finalFeedUrl);
   const lessWrongUserId = extractUserIdFromFeedUrl(finalFeedUrl);
   if (lessWrongUserId && feedTitle) {
-    const lwUser = await fetchLessWrongUserById(lessWrongUserId);
+    let lwUser;
+    try {
+      lwUser = await fetchLessWrongUserById(lessWrongUserId);
+    } catch (error) {
+      // Subscribing anyway would store the title without its author suffix for
+      // good, indistinguishable from the user having no display name
+      if (error instanceof HttpFetchError && error.isRateLimited()) {
+        throw errors.upstreamRateLimited(finalFeedUrl);
+      }
+      throw error;
+    }
     if (lwUser?.displayName) {
       feedTitle = `${feedTitle} - ${lwUser.displayName}`;
     }

--- a/src/server/trpc/trpc.ts
+++ b/src/server/trpc/trpc.ts
@@ -101,11 +101,14 @@ const timingMiddleware = t.middleware(async ({ path, type, next, ctx }) => {
     const isTRPCError = error instanceof TRPCError;
 
     // Only log unexpected errors (not client errors like UNAUTHORIZED, NOT_FOUND,
-    // nor expected upstream conditions like SITE_BLOCKED that map to a 5xx status
-    // but aren't server bugs — see isExpectedClientError)
+    // nor rate limiting — ours or an upstream site's — nor expected upstream
+    // conditions like SITE_BLOCKED that map to a 5xx status but aren't server
+    // bugs — see isExpectedClientError)
     if (
       !isTRPCError ||
-      (!["UNAUTHORIZED", "NOT_FOUND", "BAD_REQUEST", "FORBIDDEN"].includes(error.code) &&
+      (!["UNAUTHORIZED", "NOT_FOUND", "BAD_REQUEST", "FORBIDDEN", "TOO_MANY_REQUESTS"].includes(
+        error.code
+      ) &&
         !isExpectedClientError(error))
     ) {
       logger.error("tRPC request failed", {

--- a/tests/integration/lesswrong-graphql.test.ts
+++ b/tests/integration/lesswrong-graphql.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration tests for `lessWrongGraphql`, the one transport every LessWrong
+ * lookup (posts, comments, users, post metadata) goes through.
+ *
+ * The contract worth pinning is the failure handling, because it used to be
+ * copied per lookup and drifted (#1548): every failure returns null except a
+ * 429, which must throw so callers don't fall back to re-fetching the site
+ * that just throttled them. Driven against a loopback server (`.env.test` sets
+ * ALLOW_PRIVATE_NETWORK_FETCH) rather than mocked.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { type AddressInfo } from "node:net";
+import { z } from "zod";
+import { lessWrongGraphql } from "../../src/server/feed/lesswrong";
+import { HttpFetchError } from "../../src/server/http/fetch";
+import { USER_AGENT } from "../../src/server/http/user-agent";
+
+const userDataSchema = z.object({
+  user: z.object({ result: z.object({ _id: z.string() }).nullable() }).nullable(),
+});
+
+const QUERY =
+  "query GetUser($slug: String!) { user(input: { selector: { slug: $slug } }) { result { _id } } }";
+
+interface RecordedRequest {
+  method: string | undefined;
+  headers: IncomingMessage["headers"];
+  body: string;
+}
+
+let server: Server;
+let baseUrl: string;
+let lastRequest: RecordedRequest | null = null;
+
+function respond(path: string): { status: number; body: string } {
+  switch (path) {
+    case "/ok":
+      return { status: 200, body: JSON.stringify({ data: { user: { result: { _id: "u1" } } } }) };
+    case "/missing":
+      return { status: 200, body: JSON.stringify({ data: { user: { result: null } } }) };
+    case "/graphql-errors":
+      return {
+        status: 200,
+        body: JSON.stringify({ data: null, errors: [{ message: "not allowed" }] }),
+      };
+    case "/wrong-shape":
+      return { status: 200, body: JSON.stringify({ data: { user: { result: { _id: 42 } } } }) };
+    case "/not-json":
+      return { status: 200, body: "<html>maintenance</html>" };
+    case "/rate-limited":
+      return { status: 429, body: "slow down" };
+    default:
+      return { status: 500, body: "boom" };
+  }
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      lastRequest = {
+        method: req.method,
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString("utf8"),
+      };
+      const { status, body } = respond(req.url ?? "/");
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(body);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function query(path: string) {
+  return lessWrongGraphql(
+    {
+      query: QUERY,
+      variables: { slug: "alice" },
+      dataSchema: userDataSchema,
+      logContext: { operation: "test", slug: "alice" },
+    },
+    `${baseUrl}${path}`
+  );
+}
+
+describe("lessWrongGraphql", () => {
+  it("posts the query as JSON with our User-Agent and returns the validated data", async () => {
+    const data = await query("/ok");
+
+    expect(data).toEqual({ user: { result: { _id: "u1" } } });
+    expect(lastRequest?.method).toBe("POST");
+    expect(lastRequest?.headers["content-type"]).toBe("application/json");
+    expect(lastRequest?.headers["user-agent"]).toBe(USER_AGENT);
+    expect(JSON.parse(lastRequest?.body ?? "")).toEqual({
+      query: QUERY,
+      variables: { slug: "alice" },
+    });
+  });
+
+  it("returns the data as-is when the lookup finds nothing, leaving that to the caller", async () => {
+    expect(await query("/missing")).toEqual({ user: { result: null } });
+  });
+
+  it("throws HttpFetchError on 429 so callers can't fall back to the same throttled site", async () => {
+    const error = await query("/rate-limited").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(HttpFetchError);
+    expect((error as HttpFetchError).isRateLimited()).toBe(true);
+    expect((error as HttpFetchError).url).toBe(`${baseUrl}/rate-limited`);
+  });
+
+  it("returns null on other HTTP failures", async () => {
+    expect(await query("/server-error")).toBeNull();
+  });
+
+  it("returns null when the response carries GraphQL errors", async () => {
+    expect(await query("/graphql-errors")).toBeNull();
+  });
+
+  it("returns null when the data doesn't match the schema", async () => {
+    expect(await query("/wrong-shape")).toBeNull();
+  });
+
+  it("returns null when the body isn't JSON", async () => {
+    expect(await query("/not-json")).toBeNull();
+  });
+});

--- a/tests/integration/lesswrong-graphql.test.ts
+++ b/tests/integration/lesswrong-graphql.test.ts
@@ -40,6 +40,8 @@ function respond(path: string): { status: number; body: string } {
       return { status: 200, body: JSON.stringify({ data: { user: { result: { _id: "u1" } } } }) };
     case "/missing":
       return { status: 200, body: JSON.stringify({ data: { user: { result: null } } }) };
+    case "/null-data":
+      return { status: 200, body: JSON.stringify({ data: null }) };
     case "/graphql-errors":
       return {
         status: 200,
@@ -51,8 +53,10 @@ function respond(path: string): { status: number; body: string } {
       return { status: 200, body: "<html>maintenance</html>" };
     case "/rate-limited":
       return { status: 429, body: "slow down" };
-    default:
+    case "/server-error":
       return { status: 500, body: "boom" };
+    default:
+      return { status: 404, body: "no such route" };
   }
 }
 
@@ -112,13 +116,20 @@ describe("lessWrongGraphql", () => {
   it("throws HttpFetchError on 429 so callers can't fall back to the same throttled site", async () => {
     const error = await query("/rate-limited").catch((e: unknown) => e);
 
-    expect(error).toBeInstanceOf(HttpFetchError);
-    expect((error as HttpFetchError).isRateLimited()).toBe(true);
-    expect((error as HttpFetchError).url).toBe(`${baseUrl}/rate-limited`);
+    if (!(error instanceof HttpFetchError)) {
+      throw new Error(`expected HttpFetchError, got ${String(error)}`);
+    }
+    expect(error.isRateLimited()).toBe(true);
+    expect(error.url).toBe(`${baseUrl}/rate-limited`);
   });
 
   it("returns null on other HTTP failures", async () => {
     expect(await query("/server-error")).toBeNull();
+    expect(await query("/nonexistent")).toBeNull();
+  });
+
+  it("returns null when data is null without errors", async () => {
+    expect(await query("/null-data")).toBeNull();
   });
 
   it("returns null when the response carries GraphQL errors", async () => {


### PR DESCRIPTION
Fixes #1548.

## What changed

- `src/server/feed/lesswrong.ts`: the five hand-rolled GraphQL request bodies collapse into one `lessWrongGraphql` helper that owns the transport (SSRF-protected POST, headers, timeout) and the failure contract: **null on any failure except HTTP 429, which throws `HttpFetchError`**. The per-lookup functions are now just query + schema + result mapping. The user-by-slug and user-by-id lookups share one implementation; the `errors` block and the author `{displayName, username}` shape are declared once.
- `src/server/trpc/routers/feeds.ts`: `transformPageUrlToFeed` caught every error and returned null, which would have turned the new throw straight back into the "re-fetch the throttled page" fallback the issue describes. A rate-limited transform now surfaces as `UPSTREAM_RATE_LIMITED`. This is a user-visible change for post URLs too: a 429 on the shortform-metadata lookup used to silently fall back to the post's comment feed, which is wrong when the post is a shortform; it now fails the preview/discover with the rate-limit error.
- `src/server/trpc/routers/subscriptions.ts`: a rate-limited `fetchLessWrongUserById` during subscribe now logs a warning and subscribes with the plain title. The issue's claim that the missing author suffix is permanent turned out to be wrong: the feed poller re-runs `transformFeedTitle` from entry authors on every successful fetch and writes the result back to `feeds.title`, so it self-heals on the next poll. Failing the whole subscribe after the feed itself fetched fine would discard completed work.
- `src/server/trpc/trpc.ts` / `errors.ts`: `TOO_MANY_REQUESTS` is now exempt from `logger.error` + Sentry in the tRPC middleware. The new throws would otherwise have reported every LessWrong throttle as a server bug (this already affected `saved.ts` and our own rate limiter). The `errors.ts` comment claiming 4xx-mapped codes were already exempt by status was wrong and is corrected.
- `tests/integration/lesswrong-graphql.test.ts`: drives the helper against a loopback server (same pattern as the arXiv plugin test, no mocks). Pins: request shape, 429 throws `HttpFetchError`, other HTTP errors / GraphQL `errors` / `data: null` / schema mismatch / non-JSON all return null.

## Verification

- `pnpm typecheck`, eslint, knip: clean
- LessWrong unit tests + the new loopback test: 90 passed
- Reviewed by an independent Opus reviewer; its must-fix findings (subscribe hard-failing on 429, Sentry noise) are addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)