### PR TITLE
build: Pin rustc to the version production compiles with (#1579)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/cache@v6.1.0
         with:
           path: native/*/*.node
-          key: native-modules-${{ runner.os }}-${{ hashFiles('native/**') }}
+          key: native-modules-${{ runner.os }}-${{ hashFiles('native/**', 'rust-toolchain.toml') }}
 
       - uses: pnpm/action-setup@v6.0.10
         if: steps.native-cache.outputs.cache-hit != 'true'
@@ -150,6 +150,13 @@ jobs:
       - name: Run clippy
         if: ${{ !cancelled() }}
         run: ./scripts/cargo-native.sh clippy --workspace --all-targets -- -D warnings
+
+      # The stage is just `apk add rust` plus the check, so this costs a pull
+      # and no cargo build. Without it, a base-image bump that moves Alpine's
+      # rustc off the pin is green here and red in the deploy build.
+      - name: Check the pin still matches the image's rustc
+        if: ${{ !cancelled() }}
+        run: docker build --target rust-base .
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
+      # No toolchain setup step: the runner's rustup installs the version
+      # rust-toolchain.toml pins on the first cargo call.
       - uses: Swatinem/rust-cache@v2.9.2
         with:
           # Without this a red run saves nothing, so a PR iterating on a Rust

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,9 @@ export PATH="$PWD/.node26/bin:$PATH"
 
 ## Rust Version
 
-Pinned in `rust-toolchain.toml`, which explains what it must stay equal to and
-when to bump it. Read it before changing the Rust toolchain or the Dockerfile's
-`native-builder` base image.
+Pinned to the rustc Alpine ships in the Dockerfile's `rust-base` stage
+(`rust-toolchain.toml`, which says why). Bump the two together — CI fails
+otherwise.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,12 @@ mkdir -p .node26 && curl -sL https://nodejs.org/dist/v26.7.0/node-v26.7.0-linux-
 export PATH="$PWD/.node26/bin:$PATH"
 ```
 
+## Rust Version
+
+Pinned in `rust-toolchain.toml`, which explains what it must stay equal to and
+when to bump it. Read it before changing the Rust toolchain or the Dockerfile's
+`native-builder` base image.
+
 ## Commands
 
 - `pnpm build:native` - Build the native Rust modules (sanitizer, readability, feed-parser, markdown). **Required once per checkout before tests or the app** — if tests fail with "Failed to load the native …", run this. Needs the Rust toolchain (`cargo` — if missing from PATH, try `~/.cargo/bin`). The SessionStart hook starts it in the background, so it may already be done or in flight (log: `/tmp/lion-reader-build-native.log`).

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,19 +40,14 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --ignore-scripts
 
 # =============================================================================
-# Stage 3: Build the native (Rust) modules for this image's platform (musl)
+# Stage 3a: The Rust toolchain production compiles with
 # =============================================================================
-# A separate stage keyed only on native/ sources: pure-TS deploys hit the layer
-# cache and skip the Rust toolchain install and cargo build entirely, and when
-# Rust does change, BuildKit runs this stage in parallel with the JS build.
-# The build.mjs scripts are plain `node` + `cargo` — no pnpm/node_modules needed.
-# Cache mounts keep crate downloads and incremental build artifacts across
-# builds (each build.mjs copies its artifact out of target/ to <name>.node).
-# The Alpine version is pinned (the other stages float) because apk's rustc is
-# the compiler production ships, and CI has to compile against that same
-# version to be a gate at all. rust-toolchain.toml pins CI to it; the check
-# below fails the build if bumping this tag moves rustc out from under it.
-FROM node:26-alpine3.24 AS native-builder
+# The Alpine version is pinned here (the other stages float) so this rustc only
+# moves when someone edits this line; rust-toolchain.toml says why CI has to
+# match it. Its own stage so CI can run the check below with
+# `docker build --target rust-base .` in seconds — otherwise the bump that
+# breaks the pin passes CI and fails the deploy build.
+FROM node:26-alpine3.24 AS rust-base
 
 WORKDIR /app
 
@@ -64,9 +59,21 @@ RUN pinned="$(sed -n 's/^channel *= *"\([^"]*\)".*/\1/p' rust-toolchain.toml)" &
     case "$actual" in \
       "$pinned" | "$pinned".*) ;; \
       *) echo "Alpine ships rustc $actual but rust-toolchain.toml pins $pinned." \
-              "Set channel = \"$actual\" there (and re-run CI) or pin an Alpine tag that ships $pinned." >&2; \
+              "Set channel = \"${actual%.*}\" there (and re-run CI) or pin an" \
+              "Alpine tag that ships $pinned." >&2; \
          exit 1 ;; \
     esac
+
+# =============================================================================
+# Stage 3b: Build the native (Rust) modules for this image's platform (musl)
+# =============================================================================
+# A separate stage keyed only on native/ sources: pure-TS deploys hit the layer
+# cache and skip the Rust toolchain install and cargo build entirely, and when
+# Rust does change, BuildKit runs this stage in parallel with the JS build.
+# The build.mjs scripts are plain `node` + `cargo` — no pnpm/node_modules needed.
+# Cache mounts keep crate downloads and incremental build artifacts across
+# builds (each build.mjs copies its artifact out of target/ to <name>.node).
+FROM rust-base AS native-builder
 
 # .dockerignore excludes native/*/target/ and native/*/*.node so local build
 # artifacts can't leak into (or bust the cache of) this layer.

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,25 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # The build.mjs scripts are plain `node` + `cargo` — no pnpm/node_modules needed.
 # Cache mounts keep crate downloads and incremental build artifacts across
 # builds (each build.mjs copies its artifact out of target/ to <name>.node).
-FROM node:26-alpine AS native-builder
+# The Alpine version is pinned (the other stages float) because apk's rustc is
+# the compiler production ships, and CI has to compile against that same
+# version to be a gate at all. rust-toolchain.toml pins CI to it; the check
+# below fails the build if bumping this tag moves rustc out from under it.
+FROM node:26-alpine3.24 AS native-builder
 
 WORKDIR /app
 
 RUN apk add --no-cache rust cargo
+
+COPY rust-toolchain.toml ./
+RUN pinned="$(sed -n 's/^channel *= *"\([^"]*\)".*/\1/p' rust-toolchain.toml)" && \
+    actual="$(rustc --version | cut -d' ' -f2)" && \
+    case "$actual" in \
+      "$pinned" | "$pinned".*) ;; \
+      *) echo "Alpine ships rustc $actual but rust-toolchain.toml pins $pinned." \
+              "Set channel = \"$actual\" there (and re-run CI) or pin an Alpine tag that ships $pinned." >&2; \
+         exit 1 ;; \
+    esac
 
 # .dockerignore excludes native/*/target/ and native/*/*.node so local build
 # artifacts can't leak into (or bust the cache of) this layer.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,13 @@
 # The Rust compiler version, for CI and local dev. Deliberately equal to the
-# rustc Alpine ships in the Dockerfile's pinned native-builder base image: the
-# native crates are compiled with that rustc in production, so CI has to use it
-# too, or a call to an API stabilized later passes every check here and only
-# fails when the image is built. Bump this together with that Alpine tag — the
-# native-builder stage fails the build if the two disagree.
+# rustc Alpine ships in the Dockerfile's pinned rust-base stage: the native
+# crates are compiled with that rustc in production, so CI has to use it too,
+# or a call to an API stabilized later passes every check here and only fails
+# when the image is built. Bump this together with that Alpine tag — CI builds
+# the rust-base stage, which fails if the two disagree.
+#
+# rustup honors this; a distro-installed cargo ignores it, which is why the
+# check lives in the image rather than here.
 [toolchain]
 channel = "1.96"
+profile = "minimal"
 components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+# The Rust compiler version, for CI and local dev. Deliberately equal to the
+# rustc Alpine ships in the Dockerfile's pinned native-builder base image: the
+# native crates are compiled with that rustc in production, so CI has to use it
+# too, or a call to an API stabilized later passes every check here and only
+# fails when the image is built. Bump this together with that Alpine tag — the
+# native-builder stage fails the build if the two disagree.
+[toolchain]
+channel = "1.96"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Fixes #1579.

## Problem

The Rust compiler version floated in two places independently:

- **CI** used `ubuntu-latest`'s bundled stable (~1.97/1.98).
- **Production** used whatever `apk add rust` gives in `node:26-alpine` (Alpine 3.24 → rustc **1.96.1** today).

CI ran the *newer* compiler, so it structurally could not catch a call to an API stabilized after Alpine's rustc — that only failed later, in the Docker build. And a clippy release could redden unrelated PRs.

## Fix

- **`rust-toolchain.toml`** pins CI and local dev to `1.96` — Alpine's rustc. What CI compiles is now what production compiles, and clippy no longer floats. CI needs no setup step: the runner's rustup installs the pinned version on the first cargo call.
- **`Dockerfile`**: the `native-builder` stage pins `node:26-alpine3.24` and asserts apk's rustc still matches `rust-toolchain.toml`, so bumping that tag past the pinned compiler fails the build with a message naming the fix instead of drifting silently. Only that stage pins its Alpine version — the other stages keep floating so the runtime image still picks up base-image updates.

### Why not `rust-version` in the manifests?

The issue suggested it to enable `clippy::incompatible_msrv`. Pinning the toolchain is a strictly stronger gate: that lint only knows about stdlib APIs, while the pinned compiler also rejects newer language, edition and cargo features — and it keeps one version number instead of eight (four crates plus their cores).

## Testing

- `./scripts/cargo-native.sh test --workspace` and `clippy --workspace --all-targets -- -D warnings` pass under 1.96.1.
- `podman build --target native-builder .` succeeds: the guard passes and all four `.node` modules build.
- Exercised the guard's comparison directly: `1.96` vs `1.96.1`/`1.96` pass; `1.97.0`, `1.9`, and pin `1.96.1` vs `1.96.2` all trip it.

Note for review: if Dependabot later bumps the pinned Alpine tag, that PR's Docker build is expected to fail until `rust-toolchain.toml` moves with it — that is the intended signal, but it surfaces at deploy time rather than in PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)