### PR TITLE
Close the entry through closeEntry on Escape (#1571)

### DIFF
--- a/src/components/entries/EntryListContainer.tsx
+++ b/src/components/entries/EntryListContainer.tsx
@@ -41,7 +41,7 @@ interface EntryListContainerProps {
 }
 
 export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
-  const { openEntryId, setOpenEntryId, entryHref } = useEntryUrlState();
+  const { openEntryId, setOpenEntryId, closeEntry, entryHref } = useEntryUrlState();
   const { showUnreadOnly, sortOrder, toggleShowUnreadOnly } = useUrlViewPreferences();
   const { enabled: keyboardShortcutsEnabled } = useKeyboardShortcutsContext();
   const utils = trpc.useUtils();
@@ -192,7 +192,10 @@ export function EntryListContainer({ emptyMessage }: EntryListContainerProps) {
   const { selectedEntryId, setSelectedEntryId } = useKeyboardShortcuts({
     entries,
     onOpenEntry: setOpenEntryId,
-    onClose: () => setOpenEntryId(null),
+    // Escape must close the same way the reader's back affordance does — via
+    // `closeEntry`, which pops the history entry opening pushed instead of
+    // replacing it and stranding it (#1571).
+    onClose: closeEntry,
     isEntryOpen: !!openEntryId,
     openEntryId,
     enabled: keyboardShortcutsEnabled,

--- a/tests/unit/frontend/hooks/useEntryUrlState.test.tsx
+++ b/tests/unit/frontend/hooks/useEntryUrlState.test.tsx
@@ -13,7 +13,18 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, fireEvent, screen } from "@testing-library/react";
+import { UnifiedEntriesContent } from "@/components/entries/UnifiedEntriesContent";
+import { EntryContentOptionsProvider } from "@/components/entries/EntryContentOptions";
+import { KeyboardShortcutsProvider } from "@/components/keyboard/KeyboardShortcutsProvider";
+import { AppearanceProvider } from "@/lib/appearance/AppearanceProvider";
+import { AppLocationProvider } from "@/lib/hooks/useAppLocation";
+import { createDemoStore } from "@/app/(public)/demo/store";
+import { renderWithTrpc, stubMemoryLocalStorage } from "../../../utils/component-test-helpers";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
 
 let mockPathname = "/all";
 let mockSearch = "";
@@ -142,5 +153,56 @@ describe("useEntryUrlState", () => {
     navigate("unread=false&entry=entry-1", rerender);
     expect(result.current.openEntryId).toBe("entry-1");
     expect(result.current.entryHref("entry-2")).toBe("/all?unread=false&entry=entry-2");
+  });
+});
+
+/**
+ * Escape-to-close must go through the same `closeEntry` the reader's back
+ * affordance uses, or it replaces the pushed history entry instead of popping
+ * it and the user's next Back press looks like a no-op again (#1571). The
+ * wiring lives in `EntryListContainer`, so this drives the real reader tree
+ * (as the demo does) and presses the key.
+ */
+describe("Escape closes the entry through closeEntry", () => {
+  beforeEach(() => {
+    stubMemoryLocalStorage();
+    mockPathname = "/demo/all";
+  });
+
+  function renderReader() {
+    const store = createDemoStore();
+    return renderWithTrpc(<UnifiedEntriesContent />, {
+      handlers: store.handlers,
+      wrapper: (children) => (
+        <AppLocationProvider basePath="/demo">
+          <EntryContentOptionsProvider value={{ hideNarration: true }}>
+            <AppearanceProvider>
+              <KeyboardShortcutsProvider>{children}</KeyboardShortcutsProvider>
+            </AppearanceProvider>
+          </EntryContentOptionsProvider>
+        </AppLocationProvider>
+      ),
+    });
+  }
+
+  it("pops the history entry that opening pushed", async () => {
+    window.history.replaceState(null, "", "/demo/all");
+    const { rerender } = renderReader();
+
+    // Open the article the way a click does, then let the mocked location catch up.
+    fireEvent.click(await screen.findByRole("link", { name: "Welcome to Lion Reader" }));
+    expect(window.history.state).toMatchObject({ entryOpened: true });
+    mockSearch = "entry=welcome";
+    rerender(<UnifiedEntriesContent />);
+    expect(
+      await screen.findByRole("heading", { name: "Welcome to Lion Reader", level: 1 })
+    ).toBeVisible();
+
+    const back = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const replaceState = vi.spyOn(window.history, "replaceState");
+    fireEvent.keyDown(document, { key: "Escape", code: "Escape" });
+
+    expect(back).toHaveBeenCalledTimes(1);
+    expect(replaceState).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #1571

## Symptom

Closing an open entry with **Escape** left a dead history entry behind: the next browser Back press appeared to do nothing. This is the same bug #1569 fixed for the reader's back affordance — the keyboard path was left out because `EntryListContainer.tsx` was being edited concurrently by another PR.

## Cause

`EntryListContainer` passed `onClose: () => setOpenEntryId(null)` to `useKeyboardShortcuts`, bypassing `closeEntry` from `useEntryUrlState`. `setOpenEntryId(null)` *replaces* the current history entry; only `closeEntry` sees the `{ entryOpened: true }` marker and *pops* the entry that opening pushed.

## Fix

Route the Escape handler through `closeEntry`.

## Test

Extended `tests/unit/frontend/hooks/useEntryUrlState.test.tsx` (the tests added in #1569) with a case that drives the real reader tree over the demo store: click an article open, press Escape, and assert `history.back()` ran and nothing was replaced. It fails on the pre-fix code (`expected "back" to be called 1 times, but got 0 times`), so the two close paths can't silently diverge again.

## Verification

- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm test:unit` — pass (176 files, 3217 tests)
- `pnpm test:e2e` not run: Node here is v22, where the suite fails at collection for unrelated reasons.

No UI/visual change, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)