### PR TITLE
Fetch a repo's README from GitHub's own endpoint, and percent-encode gist filenames in URLs

### DIFF
--- a/src/server/plugins/github.ts
+++ b/src/server/plugins/github.ts
@@ -349,38 +349,45 @@ function decodeContents(contents: ContentsResponse | null): string | null {
   return Buffer.from(contents.content, "base64").toString("utf-8");
 }
 
+/** How a Contents API URL is fetched, taken as a parameter — see `fetchReadme`. */
+type ContentsFetch = (
+  url: string,
+  context: Record<string, string | undefined>
+) => Promise<ContentsResponse | null>;
+
 /**
- * The README a Contents API `/readme` response carries, under whatever name the
- * repo gave it. Taking `name` from the response rather than assuming one is the
- * point: probing a hardcoded list of filenames missed `README.rst` (most Python
- * projects), `README.markdown`, `README.MD` and `README.adoc`, and a repo whose
- * README we can't find degrades into a scrape of GitHub's page chrome (#1460).
+ * Fetch a repo's README, as the repo path it lives at.
+ *
+ * GitHub resolves which file that is, so this is **one** request whatever the
+ * README is called — worth caring about on the 60/hr unauthenticated per-IP
+ * budget, and the reason we don't probe a list of filenames: such a list missed
+ * `README.rst` (most Python projects), `README.markdown`, `README.MD` and
+ * `README.adoc`, and a repo whose README we can't find degrades into a scrape of
+ * GitHub's page chrome (#1460).
+ *
+ * The **`path`**, not the `name`: GitHub prefers a README in `.github/` over the
+ * root over `docs/`, so `name` is `README.md` while the file is at
+ * `.github/README.md`. The path is the base its relative references resolve
+ * against (`absolutizeGitHubUrls`), so taking `name` points every image and link
+ * in such a README one directory too high.
+ *
+ * `fetchContents` is a parameter so tests can observe the request this makes
+ * against an in-memory implementation, the way `followRedirects` takes its fetch.
  */
-export function readmeFromContents(
-  contents: ContentsResponse | null
-): { content: string; filename: string } | null {
+export async function fetchReadme(
+  owner: string,
+  repo: string,
+  fetchContents: ContentsFetch
+): Promise<{ content: string; path: string } | null> {
+  const contents = await fetchContents(`https://api.github.com/repos/${owner}/${repo}/readme`, {
+    owner,
+    repo,
+  });
   if (!contents) {
     return null;
   }
   const content = decodeContents(contents);
-  return content === null ? null : { content, filename: contents.name };
-}
-
-/**
- * Fetch a repo's README.
- *
- * GitHub resolves which file that is, so this is one request whatever the README
- * is called — worth caring about on the 60/hr unauthenticated per-IP budget.
- */
-async function fetchReadme(
-  owner: string,
-  repo: string
-): Promise<{ content: string; filename: string } | null> {
-  const contents = await fetchContentsApi(`https://api.github.com/repos/${owner}/${repo}/readme`, {
-    owner,
-    repo,
-  });
-  return readmeFromContents(contents);
+  return content === null ? null : { content, path: contents.path };
 }
 
 // ============================================================================
@@ -745,17 +752,17 @@ async function fetchGitHubContent(url: URL): Promise<SavedArticleContent | null>
     }
 
     case "repo-root": {
-      const readme = await fetchReadme(parsed.owner, parsed.repo);
+      const readme = await fetchReadme(parsed.owner, parsed.repo, fetchContentsApi);
       if (!readme) {
         logger.debug("No README found for repo", { owner: parsed.owner, repo: parsed.repo });
         return null;
       }
 
-      const file = await processFileContent(readme.content, readme.filename, null, {
+      const file = await processFileContent(readme.content, readme.path, null, {
         kind: "repo",
         owner: parsed.owner,
         repo: parsed.repo,
-        path: readme.filename,
+        path: readme.path,
       });
       // Use extracted title from README, fall back to repo name
       const title = file.title || `${parsed.owner}/${parsed.repo}`;

--- a/src/server/plugins/github.ts
+++ b/src/server/plugins/github.ts
@@ -260,6 +260,28 @@ async function fetchGist(gistId: string): Promise<GistResponse | null> {
 }
 
 /**
+ * GET a Contents API URL, which is any endpoint answering with a file's metadata
+ * plus its bytes.
+ */
+async function fetchContentsApi(
+  url: string,
+  context: Record<string, string | undefined>
+): Promise<ContentsResponse | null> {
+  const response = await fetchGitHubApi(url);
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      logger.debug("Repo content not found", context);
+      return null;
+    }
+    logApiFailure(response.status, context);
+    return null;
+  }
+
+  return (await response.json()) as ContentsResponse;
+}
+
+/**
  * Fetch file contents from a repo via the Contents API.
  */
 async function fetchRepoContents(
@@ -273,18 +295,7 @@ async function fetchRepoContents(
     url += `?ref=${encodeURIComponent(ref)}`;
   }
 
-  const response = await fetchGitHubApi(url);
-
-  if (!response.ok) {
-    if (response.status === 404) {
-      logger.debug("Repo content not found", { owner, repo, path, ref });
-      return null;
-    }
-    logApiFailure(response.status, { owner, repo, path });
-    return null;
-  }
-
-  return (await response.json()) as ContentsResponse;
+  return fetchContentsApi(url, { owner, repo, path, ref });
 }
 
 /**
@@ -327,24 +338,49 @@ async function fetchRawContent(rawUrl: string): Promise<string | null> {
 }
 
 /**
- * Try to fetch README from a repo root.
- * Tries common README variants in order.
+ * The text of a Contents API response, or null when GitHub didn't inline the
+ * bytes — `encoding` is `"none"` with an empty `content` for a file over 1MB,
+ * which is the blob path's cue to fall back to the raw host.
+ */
+function decodeContents(contents: ContentsResponse | null): string | null {
+  if (!contents?.content || contents.encoding !== "base64") {
+    return null;
+  }
+  return Buffer.from(contents.content, "base64").toString("utf-8");
+}
+
+/**
+ * The README a Contents API `/readme` response carries, under whatever name the
+ * repo gave it. Taking `name` from the response rather than assuming one is the
+ * point: probing a hardcoded list of filenames missed `README.rst` (most Python
+ * projects), `README.markdown`, `README.MD` and `README.adoc`, and a repo whose
+ * README we can't find degrades into a scrape of GitHub's page chrome (#1460).
+ */
+export function readmeFromContents(
+  contents: ContentsResponse | null
+): { content: string; filename: string } | null {
+  if (!contents) {
+    return null;
+  }
+  const content = decodeContents(contents);
+  return content === null ? null : { content, filename: contents.name };
+}
+
+/**
+ * Fetch a repo's README.
+ *
+ * GitHub resolves which file that is, so this is one request whatever the README
+ * is called — worth caring about on the 60/hr unauthenticated per-IP budget.
  */
 async function fetchReadme(
   owner: string,
   repo: string
 ): Promise<{ content: string; filename: string } | null> {
-  const readmeVariants = ["README.md", "readme.md", "Readme.md", "README", "readme", "README.txt"];
-
-  for (const variant of readmeVariants) {
-    const contents = await fetchRepoContents(owner, repo, variant);
-    if (contents?.content && contents.encoding === "base64") {
-      const content = Buffer.from(contents.content, "base64").toString("utf-8");
-      return { content, filename: variant };
-    }
-  }
-
-  return null;
+  const contents = await fetchContentsApi(`https://api.github.com/repos/${owner}/${repo}/readme`, {
+    owner,
+    repo,
+  });
+  return readmeFromContents(contents);
 }
 
 // ============================================================================
@@ -608,18 +644,26 @@ export async function buildGistHtml(
    * resolves them exactly as a sibling reference inside a file would be.
    */
   const renderFile = async (file: GistFile): Promise<ProcessedRepoFile> => {
+    /**
+     * The reference is a URL path segment, so the filename is percent-encoded
+     * before it's escaped: `#` and `?` are legal in a filename and survive
+     * HTML escaping, and `new URL()` would then read `C# notes.pdf` as the
+     * *directory* plus a fragment. (Spaces are the exception — `new URL`
+     * encodes those itself.) Visible text and `alt` keep the plain filename.
+     */
+    const reference = escapeHtml(encodeURIComponent(file.filename));
     const name = escapeHtml(file.filename);
     const empty = { title: null, author: null, excerpt: null };
 
     if (file.type.startsWith("image/")) {
       return {
-        html: absolutizeGistUrls(`<img src="${name}" alt="${name}">`, locate(file)),
+        html: absolutizeGistUrls(`<img src="${reference}" alt="${name}">`, locate(file)),
         ...empty,
       };
     }
     if (isBinaryMediaType(file.type)) {
       return {
-        html: absolutizeGistUrls(`<p><a href="${name}">${name}</a></p>`, locate(file)),
+        html: absolutizeGistUrls(`<p><a href="${reference}">${name}</a></p>`, locate(file)),
         ...empty,
       };
     }
@@ -726,71 +770,41 @@ async function fetchGitHubContent(url: URL): Promise<SavedArticleContent | null>
       };
     }
 
-    case "blob": {
-      const contents = await fetchRepoContents(parsed.owner, parsed.repo, parsed.path, parsed.ref);
-      const filename = parsed.path.split("/").pop() ?? parsed.path;
-
-      if (!contents?.content || contents.encoding !== "base64") {
-        // Try raw URL as fallback
-        const rawUrl = `https://raw.githubusercontent.com/${parsed.owner}/${parsed.repo}/${parsed.ref}/${parsed.path}`;
-        const rawContent = await fetchRawContent(rawUrl);
-        if (!rawContent) {
-          return null;
-        }
-
-        const file = await processFileContent(rawContent, parsed.path, null, {
-          kind: "repo",
-          ...parsed,
-        });
-        const title = file.title || filename;
-        return {
-          html: file.html,
-          title,
-          excerpt: file.excerpt,
-          author: file.author ?? parsed.owner,
-          publishedAt: null,
-          canonicalUrl: `https://github.com/${parsed.owner}/${parsed.repo}/blob/${parsed.ref}/${parsed.path}`,
-        };
-      }
-
-      const content = Buffer.from(contents.content, "base64").toString("utf-8");
-      const file = await processFileContent(content, parsed.path, null, {
-        kind: "repo",
-        ...parsed,
-      });
-      const title = file.title || filename;
-
-      return {
-        html: file.html,
-        title,
-        excerpt: file.excerpt,
-        author: file.author ?? parsed.owner,
-        publishedAt: null,
-        canonicalUrl: `https://github.com/${parsed.owner}/${parsed.repo}/blob/${parsed.ref}/${parsed.path}`,
-      };
-    }
-
+    // Both name one file at one ref, and render identically; they differ only in
+    // where the bytes come from. A blob reads the Contents API, falling back to
+    // the raw host when the API didn't inline the content (over 1MB, or a rate
+    // limit); a raw URL is that host already.
+    case "blob":
     case "raw": {
-      const rawUrl = `https://raw.githubusercontent.com/${parsed.owner}/${parsed.repo}/${parsed.ref}/${parsed.path}`;
-      const content = await fetchRawContent(rawUrl);
+      const { owner, repo, ref, path } = parsed;
+      const inlined =
+        parsed.type === "blob"
+          ? decodeContents(await fetchRepoContents(owner, repo, path, ref))
+          : null;
+      const content =
+        inlined ??
+        (await fetchRawContent(
+          `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}`
+        ));
       if (!content) {
         return null;
       }
 
-      const filename = parsed.path.split("/").pop() ?? parsed.path;
-      const file = await processFileContent(content, parsed.path, null, {
+      const file = await processFileContent(content, path, null, {
         kind: "repo",
-        ...parsed,
+        owner,
+        repo,
+        ref,
+        path,
       });
-      const title = file.title || filename;
 
       return {
         html: file.html,
-        title,
+        title: file.title || (path.split("/").pop() ?? path),
         excerpt: file.excerpt,
-        author: file.author ?? parsed.owner,
+        author: file.author ?? owner,
         publishedAt: null,
-        canonicalUrl: `https://github.com/${parsed.owner}/${parsed.repo}/blob/${parsed.ref}/${parsed.path}`,
+        canonicalUrl: `https://github.com/${owner}/${repo}/blob/${ref}/${path}`,
       };
     }
   }

--- a/tests/unit/github-plugin.test.ts
+++ b/tests/unit/github-plugin.test.ts
@@ -13,7 +13,7 @@ import {
   processFileContent,
   buildGistHtml,
   shouldRetryUnauthenticated,
-  readmeFromContents,
+  fetchReadme,
 } from "../../src/server/plugins/github";
 import type { GistFile, GistResponse } from "../../src/server/plugins/github";
 
@@ -870,46 +870,90 @@ describe("buildGistHtml", () => {
   });
 });
 
-describe("readmeFromContents (#1575)", () => {
-  const contents = (name: string, text: string) => ({
-    name,
-    path: name,
+describe("fetchReadme (#1575)", () => {
+  /** A Contents API response for a README at `path`, as GitHub sends it. */
+  const contents = (path: string, text = "# Title") => ({
+    name: path.split("/").pop() ?? path,
+    path,
     content: Buffer.from(text, "utf-8").toString("base64"),
     encoding: "base64",
-    download_url: `https://raw.githubusercontent.com/o/r/HEAD/${name}`,
+    download_url: `https://raw.githubusercontent.com/o/r/HEAD/${path}`,
   });
 
-  // Probing a hardcoded list of names missed these, and a repo whose README we
-  // can't find degrades into a scrape of GitHub's page chrome (#1460).
+  /** Records the URLs fetched, answering each from `byUrl` (404 = null). */
+  const recorder = (byUrl: Record<string, ReturnType<typeof contents>>) => {
+    const urls: string[] = [];
+    return {
+      urls,
+      fetch: (url: string) => {
+        urls.push(url);
+        return Promise.resolve(byUrl[url] ?? null);
+      },
+    };
+  };
+
+  const readmeUrl = "https://api.github.com/repos/o/r/readme";
+
+  // GitHub resolves which file the README is, so probing candidate filenames is
+  // both wrong (it missed .rst/.adoc/.markdown/.MD) and six times the cost on the
+  // 60/hr unauthenticated budget.
+  it("asks GitHub for the repo's README once, instead of probing filenames", async () => {
+    const { urls, fetch } = recorder({ [readmeUrl]: contents("README.rst") });
+    await fetchReadme("o", "r", fetch);
+    expect(urls).toEqual([readmeUrl]);
+  });
+
+  it("makes no further request when the repo has no README", async () => {
+    const { urls, fetch } = recorder({});
+    expect(await fetchReadme("o", "r", fetch)).toBeNull();
+    expect(urls).toEqual([readmeUrl]);
+  });
+
   it.each(["README.md", "README.rst", "README.markdown", "README.MD", "README.adoc", "readme"])(
-    "takes the README GitHub resolved, named %s",
-    (name) => {
-      expect(readmeFromContents(contents(name, "# Title"))).toEqual({
-        content: "# Title",
-        filename: name,
-      });
+    "returns the README GitHub resolved, named %s",
+    async (name) => {
+      const { fetch } = recorder({ [readmeUrl]: contents(name) });
+      expect(await fetchReadme("o", "r", fetch)).toEqual({ content: "# Title", path: name });
     }
   );
 
-  it("decodes the base64 body as UTF-8", () => {
-    expect(readmeFromContents(contents("README.md", "Grüße — 🦁"))?.content).toBe("Grüße — 🦁");
+  // GitHub prefers a README in .github/ over the root over docs/, so `name` alone
+  // would point every relative reference in it one directory too high.
+  it("returns the path of a README that isn't at the repo root", async () => {
+    const { fetch } = recorder({ [readmeUrl]: contents(".github/README.md") });
+    expect(await fetchReadme("o", "r", fetch)).toEqual({
+      content: "# Title",
+      path: ".github/README.md",
+    });
   });
 
-  it("has no README when the repo has none", () => {
-    expect(readmeFromContents(null)).toBeNull();
+  it("resolves a nested README's relative references against its own directory", async () => {
+    const { fetch } = recorder({
+      [readmeUrl]: contents(".github/README.md", "![arch](diagrams/arch.png)"),
+    });
+    const readme = await fetchReadme("o", "r", fetch);
+    const { html } = await processFileContent(readme!.content, readme!.path, null, {
+      kind: "repo",
+      owner: "o",
+      repo: "r",
+      path: readme!.path,
+    });
+    expect(html).toContain(
+      'src="https://raw.githubusercontent.com/o/r/HEAD/.github/diagrams/arch.png"'
+    );
+  });
+
+  it("decodes the base64 body as UTF-8", async () => {
+    const { fetch } = recorder({ [readmeUrl]: contents("README.md", "Grüße — 🦁") });
+    expect((await fetchReadme("o", "r", fetch))?.content).toBe("Grüße — 🦁");
   });
 
   // GitHub stops inlining bytes past 1MB, answering `encoding: "none"`.
-  it("has no README when GitHub didn't inline the bytes", () => {
-    expect(
-      readmeFromContents({
-        name: "README.md",
-        path: "README.md",
-        content: "",
-        encoding: "none",
-        download_url: "https://raw.githubusercontent.com/o/r/HEAD/README.md",
-      })
-    ).toBeNull();
+  it("has no README when GitHub didn't inline the bytes", async () => {
+    const { fetch } = recorder({
+      [readmeUrl]: { ...contents("README.md"), content: "", encoding: "none" },
+    });
+    expect(await fetchReadme("o", "r", fetch)).toBeNull();
   });
 });
 

--- a/tests/unit/github-plugin.test.ts
+++ b/tests/unit/github-plugin.test.ts
@@ -13,6 +13,7 @@ import {
   processFileContent,
   buildGistHtml,
   shouldRetryUnauthenticated,
+  readmeFromContents,
 } from "../../src/server/plugins/github";
 import type { GistFile, GistResponse } from "../../src/server/plugins/github";
 
@@ -837,6 +838,25 @@ describe("buildGistHtml", () => {
       expect(html).not.toContain('<b>.png"');
       expect(html).toContain("&quot;");
     });
+
+    // HTML escaping leaves URL syntax alone, so an unencoded `#` used to end the
+    // reference and resolve the link to the gist's raw directory (#1575).
+    it("percent-encodes URL syntax in a linked binary's filename", async () => {
+      const { html } = await buildGistHtml(
+        gist([gistFile("C# notes.pdf", base64Png, "application/pdf")])
+      );
+      expect(html).toContain(`href="${rawBase}/C%23%20notes.pdf"`);
+      // The reader still sees the filename GitHub shows.
+      expect(html).toContain(">C# notes.pdf</a>");
+    });
+
+    it("percent-encodes URL syntax in an image's filename", async () => {
+      const { html } = await buildGistHtml(
+        gist([gistFile("chart #1?.png", base64Png, "image/png")])
+      );
+      expect(html).toContain(`src="${rawBase}/chart%20%231%3F.png"`);
+      expect(html).toContain('alt="chart #1?.png"');
+    });
   });
 
   it("pins to the newest revision in the gist's history", async () => {
@@ -847,6 +867,49 @@ describe("buildGistHtml", () => {
       )
     );
     expect(html).toContain(`src="${rawBase}/${"a".repeat(40)}/chart.png"`);
+  });
+});
+
+describe("readmeFromContents (#1575)", () => {
+  const contents = (name: string, text: string) => ({
+    name,
+    path: name,
+    content: Buffer.from(text, "utf-8").toString("base64"),
+    encoding: "base64",
+    download_url: `https://raw.githubusercontent.com/o/r/HEAD/${name}`,
+  });
+
+  // Probing a hardcoded list of names missed these, and a repo whose README we
+  // can't find degrades into a scrape of GitHub's page chrome (#1460).
+  it.each(["README.md", "README.rst", "README.markdown", "README.MD", "README.adoc", "readme"])(
+    "takes the README GitHub resolved, named %s",
+    (name) => {
+      expect(readmeFromContents(contents(name, "# Title"))).toEqual({
+        content: "# Title",
+        filename: name,
+      });
+    }
+  );
+
+  it("decodes the base64 body as UTF-8", () => {
+    expect(readmeFromContents(contents("README.md", "Grüße — 🦁"))?.content).toBe("Grüße — 🦁");
+  });
+
+  it("has no README when the repo has none", () => {
+    expect(readmeFromContents(null)).toBeNull();
+  });
+
+  // GitHub stops inlining bytes past 1MB, answering `encoding: "none"`.
+  it("has no README when GitHub didn't inline the bytes", () => {
+    expect(
+      readmeFromContents({
+        name: "README.md",
+        path: "README.md",
+        content: "",
+        encoding: "none",
+        download_url: "https://raw.githubusercontent.com/o/r/HEAD/README.md",
+      })
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
Fixes #1575.

Two contained GitHub-plugin bugs, plus the cleanup the issue describes at the end.

### 1. README probing → the `/readme` endpoint

`fetchReadme` looped over `["README.md", "readme.md", "Readme.md", "README", "readme", "README.txt"]`, so `README.rst` (most Python projects), `README.markdown`, `README.MD` and `README.adoc` all missed — and a repo whose README we can't find degrades into the HTML-chrome scrape #1460 exists to prevent. It also spent up to 6 of the 60/hr unauthenticated per-IP budget getting there.

`GET /repos/{owner}/{repo}/readme` returns the real README under any name in the `{name, path, content, encoding}` shape we already declare, in **one** request. We take its **`path`**, not its `name`: GitHub returns its *preferred* README, and `.github/` outranks the root (`docs/` comes last), so `name` is `README.md` while the file is at `.github/README.md`. `path` is what `RepoFileLocation.path` feeds to `absolutizeGitHubUrls` as the base, so taking `name` would point every relative image and link in such a README one directory too high.

`fetchReadme` takes the Contents-API fetch as a parameter — the same shape `followRedirects` uses in `ssrf.ts` — so the tests drive the real function against an in-memory implementation and can assert on the outbound URLs, with no mocked internal code.

**New output shape worth knowing about:** a `.rst`/`.adoc` README now reaches a render path it never hit before. It's neither `isMarkdownFile` nor `isHtmlFile`, so `processFileContent` renders it as escaped source in `<pre><code>` with `title: null` and `excerpt: null` — the article title falls back to `owner/repo`, there's no excerpt, and `<pre>` won't reflow for projects that don't hard-wrap. That's deliberate here: it's the file's actual text instead of a scrape of GitHub's page chrome, which is what the issue asks for. Rendering reStructuredText/AsciiDoc properly would be a separate change.

### 2. Gist filenames are now percent-encoded in URL attributes

`escapeHtml(file.filename)` was used both as link text and as the `src`/`href`. HTML escaping leaves URL syntax alone, so a file named `C# notes.pdf` rendered `<a href="C# notes.pdf">` and `absolutizeGistUrls` → `new URL()` read the `#` as a fragment, resolving the link to the gist's raw *directory* rather than the file. (Spaces survive because `new URL` encodes them; `#` and `?` don't.) The attribute now uses `escapeHtml(encodeURIComponent(...))`; visible text and `alt` keep the plain escaped filename.

### 3. Cleanup

The `blob` and `raw` cases name one file at one ref and render identically — they differ only in where the bytes come from. They now share one result block (three copies of the same object literal, and two copies of the `raw.githubusercontent.com` URL construction, are gone). Behaviour is unchanged: a blob still reads the Contents API and falls back to the raw host when the API didn't inline the content.

### Tests

`tests/unit/github-plugin.test.ts`:
- `fetchReadme` issues exactly one request, to `https://api.github.com/repos/{o}/{r}/readme` — asserted on the recorded outbound URLs, so reinstating a probe loop fails the suite.
- It returns the README GitHub resolved under each of `README.md` / `.rst` / `.markdown` / `.MD` / `.adoc` / `readme`, reports the **path** for a `.github/README.md`, and (end to end through `processFileContent`) resolves that README's `diagrams/arch.png` to `.../HEAD/.github/diagrams/arch.png`. Both path cases fail against `name`.
- UTF-8 decoding, no README at all, and `encoding: "none"` (over 1MB) are covered too.
- Gist filenames with `#`/`?`/spaces resolve to the right raw URL while the reader still sees the plain filename (the existing escaping test only covered `"`/`<`/`>`).

### Verification

- `pnpm typecheck` — pass
- `pnpm test:unit` — pass (176 files, 3230 tests)
- `pnpm lint`, `pnpm format:check` — pass
- `pnpm knip`, `pnpm knip:production` — pass
- e2e not run (Node 22 in this sandbox; the plugin has no e2e coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)