### PR TITLE
Small cleanups: clip frontmatter excerpts, race-safe placeholder rows (#1576)

### DIFF
--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -345,8 +345,11 @@ function buildTools(): Tool[] {
 
     {
       name: "star_entries",
-      description:
-        "Star or unstar entries (bulk operation). Starred entries remain visible after unsubscribing.",
+      // Single-entry, unlike mark_entries_read: the schema takes one `entryId`
+      // (and `toInputSchema` emits `additionalProperties: false`, so an `entryIds`
+      // array is an InvalidParams error, not a bulk call). The tool name is part
+      // of the published MCP surface, so it stays as-is.
+      description: "Star or unstar an entry. Starred entries remain visible after unsubscribing.",
       inputSchema: toInputSchema(starEntriesArgs),
       handler: async (db, userId, args) => {
         const params = parseArgs(starEntriesArgs, args);

--- a/src/server/services/saved-excerpt.ts
+++ b/src/server/services/saved-excerpt.ts
@@ -54,7 +54,9 @@ export function computeSavedArticleExcerpt(params: {
   }
   if (preCleanedContent?.summary) {
     // Use the summary from the source metadata (frontmatter / docx description).
-    return preCleanedContent.summary;
+    // It's plain text and copied verbatim from the source, so it's just clipped
+    // — an uploaded file's `description:` is arbitrarily long.
+    return truncateText(preCleanedContent.summary, MAX_EXCERPT_LENGTH) || null;
   }
   if (cleaned) {
     return summarizeCleanedContent(cleaned) || null;

--- a/src/server/trpc/routers/narration.ts
+++ b/src/server/trpc/routers/narration.ts
@@ -10,6 +10,7 @@ import { eq } from "drizzle-orm";
 import { createHash } from "node:crypto";
 
 import { createTRPCRouter, confirmedProtectedProcedure as protectedProcedure } from "../trpc";
+import { errors } from "../errors";
 import { uuidSchema } from "../validation";
 import { narrationContent } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
@@ -168,30 +169,39 @@ export const narrationRouter = createTRPCRouter({
         };
       }
 
-      // Look up existing narration by content hash
-      let narration = await ctx.db
-        .select()
-        .from(narrationContent)
-        .where(eq(narrationContent.contentHash, contentHash))
-        .limit(1);
-
-      // Create placeholder record if not found
-      if (narration.length === 0) {
-        const newId = generateUuidv7();
-        await ctx.db.insert(narrationContent).values({
-          id: newId,
-          contentHash,
-          createdAt: new Date(),
-        });
-
-        narration = await ctx.db
+      const selectByContentHash = () =>
+        ctx.db
           .select()
           .from(narrationContent)
-          .where(eq(narrationContent.id, newId))
+          .where(eq(narrationContent.contentHash, contentHash))
           .limit(1);
+
+      // Look up existing narration by content hash
+      let narrationRecord = (await selectByContentHash())[0];
+
+      // Create the placeholder row if there isn't one yet. `content_hash` is
+      // *globally* unique (the cache is deduplicated across users), so two
+      // users narrating the same article at once both miss the SELECT above and
+      // race here; let the constraint arbitrate and re-read the winner's row
+      // rather than surfacing a raw unique-violation 500.
+      if (!narrationRecord) {
+        const inserted = await ctx.db
+          .insert(narrationContent)
+          .values({
+            id: generateUuidv7(),
+            contentHash,
+            createdAt: new Date(),
+          })
+          .onConflictDoNothing({ target: narrationContent.contentHash })
+          .returning();
+        narrationRecord = inserted[0] ?? (await selectByContentHash())[0];
       }
 
-      const narrationRecord = narration[0];
+      if (!narrationRecord) {
+        // Only reachable if the conflicting row was deleted between the insert
+        // and the re-read; nothing useful to narrate against, so surface it.
+        throw errors.internal("Failed to create narration record");
+      }
 
       // Return cached narration if available — with the map persisted at
       // generation time, which is the only one guaranteed to align with this

--- a/src/server/trpc/routers/summarization.ts
+++ b/src/server/trpc/routers/summarization.ts
@@ -254,36 +254,45 @@ export const summarizationRouter = createTRPCRouter({
         throw errors.validation("Entry has no content to summarize");
       }
 
-      // Look up existing summary by user + content hash
-      let summary =
-        cachedFeedSummary ??
-        (await ctx.db
+      const selectByUserAndContentHash = () =>
+        ctx.db
           .select()
           .from(entrySummaries)
           .where(
             and(eq(entrySummaries.userId, userId), eq(entrySummaries.contentHash, contentHash))
           )
-          .limit(1));
-
-      // Create placeholder record if not found
-      if (summary.length === 0) {
-        const newId = generateUuidv7();
-        await ctx.db.insert(entrySummaries).values({
-          id: newId,
-          userId,
-          contentHash,
-          promptVersion: CURRENT_PROMPT_VERSION,
-          createdAt: new Date(),
-        });
-
-        summary = await ctx.db
-          .select()
-          .from(entrySummaries)
-          .where(eq(entrySummaries.id, newId))
           .limit(1);
+
+      // Look up existing summary by user + content hash
+      let summaryRecord = (cachedFeedSummary ?? (await selectByUserAndContentHash()))[0];
+
+      // Create the placeholder row if there isn't one yet. Two requests for the
+      // same (user, content) at once — a double-click, or the web client and
+      // MCP together — both miss the SELECT above and race here, so let the
+      // `(user_id, content_hash)` unique constraint arbitrate and re-read the
+      // winner's row rather than surfacing a raw unique-violation 500.
+      if (!summaryRecord) {
+        const inserted = await ctx.db
+          .insert(entrySummaries)
+          .values({
+            id: generateUuidv7(),
+            userId,
+            contentHash,
+            promptVersion: CURRENT_PROMPT_VERSION,
+            createdAt: new Date(),
+          })
+          .onConflictDoNothing({
+            target: [entrySummaries.userId, entrySummaries.contentHash],
+          })
+          .returning();
+        summaryRecord = inserted[0] ?? (await selectByUserAndContentHash())[0];
       }
 
-      const summaryRecord = summary[0];
+      if (!summaryRecord) {
+        // Only reachable if the conflicting row was deleted between the insert
+        // and the re-read; there is nothing to record the generation against.
+        throw errors.internal("Failed to create summary record");
+      }
 
       // Check if settings have changed since this summary was generated.
       // promptVersionChanged also gates cache reuse below (a built-in prompt

--- a/src/server/trpc/routers/sync.ts
+++ b/src/server/trpc/routers/sync.ts
@@ -275,8 +275,6 @@ export const syncRouter = createTRPCRouter({
       const entriesCursor = input.cursors?.entries ?? null;
       const subscriptionsCursor = input.cursors?.subscriptions ?? null;
       const tagsCursor = input.cursors?.tags ?? null;
-      // Date versions for JavaScript comparisons (categorization, sorting)
-      const tagsCursorDate = tagsCursor ? new Date(tagsCursor) : null;
 
       // If no cursors provided, return empty events (initial cursor establishment
       // is handled by sync.cursors endpoint)
@@ -687,6 +685,9 @@ export const syncRouter = createTRPCRouter({
       // Tag changes
       // ========================================================================
       if (tagsCursor) {
+        // Date version for the JavaScript created-vs-updated comparison below;
+        // the query itself keeps the string cursor for µs precision (#680).
+        const tagsCursorDate = new Date(tagsCursor);
         const tagResults = await ctx.db
           .select({
             id: tags.id,
@@ -710,7 +711,7 @@ export const syncRouter = createTRPCRouter({
               updatedAt: updatedAtIso,
               _sortTime: row.updatedAtInstant,
             });
-          } else if (tagsCursorDate && row.createdAt > tagsCursorDate) {
+          } else if (row.createdAt > tagsCursorDate) {
             allEvents.push({
               type: "tag_created" as const,
               tag: {

--- a/tests/integration/narration.test.ts
+++ b/tests/integration/narration.test.ts
@@ -320,3 +320,47 @@ describe("narration.generate entry visibility", () => {
     await expect(caller.narration.generate({ id: entryId })).rejects.toThrow("Entry not found");
   });
 });
+
+/**
+ * The narration cache is deduplicated across users — `narration_content.content_hash`
+ * is *globally* unique — so two users narrating the same article at the same
+ * time both miss the cache lookup and both try to insert the placeholder row.
+ * The loser must get the winner's row, not a unique-violation 500.
+ */
+describe("narration.generate concurrent placeholder creation", () => {
+  it("lets two users narrate the same content at once", async () => {
+    // Unique per run so a leftover row from a previous run can't turn this into
+    // a cache hit that never reaches the insert.
+    const contentCleaned = `<p>Shared article body ${generateUuidv7()}.</p>`;
+    const contentHash = narrationHash(contentCleaned);
+    createdNarrationHashes.push(contentHash);
+
+    const userIds = await Promise.all([
+      createTestUser({ emailPrefix: "narr" }),
+      createTestUser({ emailPrefix: "narr" }),
+    ]);
+    createdUserIds.push(...userIds);
+
+    const callers = await Promise.all(
+      userIds.map(async (userId) => {
+        const entryId = await createVisibleEntry(userId, { contentCleaned });
+        const caller = createCaller(await createAuthContext(userId));
+        return { caller, entryId };
+      })
+    );
+
+    const results = await Promise.all(
+      callers.map(({ caller, entryId }) => caller.narration.generate({ id: entryId }))
+    );
+
+    for (const result of results) {
+      expect(result.narration).toContain("Shared article body");
+    }
+    // Both requests ended up on the one shared row.
+    const rows = await db
+      .select()
+      .from(narrationContent)
+      .where(eq(narrationContent.contentHash, contentHash));
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/tests/integration/summarization.test.ts
+++ b/tests/integration/summarization.test.ts
@@ -296,3 +296,49 @@ describe("summarization.generate regenerate bypasses the cache", () => {
     );
   });
 });
+
+/**
+ * `entry_summaries` is unique on `(user_id, content_hash)`, so two requests for
+ * the same entry from one user at the same time (a double-click, or the web
+ * client and an MCP client together) both miss the cache lookup and both try to
+ * insert the placeholder row. The loser must get the winner's row, not a
+ * unique-violation 500.
+ *
+ * The user is pointed at a Groq model while only the Anthropic server key is
+ * set, so both requests fail deterministically at "Groq API key not configured"
+ * — past the placeholder insert, with no network call.
+ *
+ * Nothing here forces the two requests to interleave *inside* the insert
+ * window, so this asserts that concurrent requests converge on one row; the
+ * narration test of the same shape is the one that reliably reproduces the
+ * constraint violation (its cache key is global, so two users collide).
+ */
+describe("summarization.generate concurrent placeholder creation", () => {
+  it("survives two concurrent requests for the same entry", async () => {
+    const userId = await createTestUser({
+      emailPrefix: "summ",
+      summarizationModel: "groq:llama-3.3-70b-versatile",
+    });
+    createdUserIds.push(userId);
+    const contentHash = `hash-${generateUuidv7()}`;
+    const entryId = await createVisibleEntry(userId, contentHash);
+    const callers = await Promise.all([
+      createAuthContext(userId).then(createCaller),
+      createAuthContext(userId).then(createCaller),
+    ]);
+
+    const results = await Promise.allSettled(
+      callers.map((caller) => caller.summarization.generate({ entryId }))
+    );
+
+    // Both got as far as the (unconfigured) LLM call rather than a duplicate-key error.
+    for (const result of results) {
+      expect(result.status).toBe("rejected");
+      expect(String((result as PromiseRejectedResult).reason)).toContain(
+        "Groq API key not configured"
+      );
+    }
+    const rows = await db.select().from(entrySummaries).where(eq(entrySummaries.userId, userId));
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/tests/unit/saved-article-excerpt.test.ts
+++ b/tests/unit/saved-article-excerpt.test.ts
@@ -77,6 +77,23 @@ describe("computeSavedArticleExcerpt", () => {
     expect(excerpt).toBe("Frontmatter wins");
   });
 
+  it("clips a long pre-cleaned source summary to the summary length", () => {
+    // `processMarkdown` copies frontmatter `description:` verbatim, so an
+    // uploaded file can carry a multi-kilobyte one; it must not become a
+    // multi-kilobyte entries.summary.
+    const longDescription = "Frontmatter description ".repeat(40).trim(); // > 300 chars
+    const excerpt = computeSavedArticleExcerpt({
+      preCleanedContent: { summary: longDescription },
+      cleaned: null,
+      pluginContent: null,
+      html: "<p>Raw</p>",
+    });
+    expect(excerpt).not.toBeNull();
+    expect(excerpt!.length).toBeLessThanOrEqual(303); // 300 + "..."
+    expect(excerpt!.endsWith("...")).toBe(true);
+    expect(excerpt!.startsWith("Frontmatter description")).toBe(true);
+  });
+
   it("uses Readability output when it ran, even for plugin content (arXiv ToC bug #1398)", () => {
     // Raw arXiv HTML opens with a table-of-contents nav; Readability strips it and
     // extracts the article body. Because Readability ran (cleaned is non-null), the


### PR DESCRIPTION
Refs #1576 — four of the six items in that issue. **Not** `Fixes`, because item 6 is deliberately left open (see below).

| Item | Status |
| --- | --- |
| 1. Unbounded pre-cleaned-summary excerpt (`saved-excerpt.ts`) | done here |
| 2. Duplicated "already saved" branch (`saved.ts`) | already fixed on master — `selectExistingSavedArticle` is the only copy, called from both `saveArticle` and `savePlaceholderArticle` |
| 3. Placeholder INSERT-then-SELECT + unique-constraint race (`summarization.ts`, `narration.ts`) | done here, race included |
| 4. Misleading `star_entries` MCP description | done here |
| 5. Dead `tagsCursorDate &&` condition (`sync.ts`) | done here |
| 6. Seven parsed-but-unused directives (`cache-headers.ts`) | **left open by design** — the issue calls it "a decision, not a cleanup" |

## What changed

**Item 1 — unbounded excerpt.** The pre-cleaned-summary branch of `computeSavedArticleExcerpt` was the only source not clipped to `MAX_EXCERPT_LENGTH`; it now goes through `truncateText` like its siblings. `processMarkdown` copies frontmatter `description:` verbatim, so a 4 KB one became a 4 KB `entries.summary`.

**Item 3 — placeholder rows.** Both routers inserted a placeholder row and then re-SELECTed it by the id they had just generated. They now use `.onConflictDoNothing(...).returning()`, which drops the round-trip *and* handles the race, following the repo convention (CLAUDE.md: prefer `onConflictDoNothing()`/`onConflictDoUpdate()` over check-then-act). On a conflict the row is re-read by its natural key, so the loser gets the winner's row instead of a 500:

- `narration_content.content_hash` is **globally** unique (the narration cache is deduplicated across users), so two users narrating the same article concurrently really did produce an unhandled `23505`. The new integration test reproduces that on master (`duplicate key value violates unique constraint \"narration_content_content_hash_unique\"`) and passes with the fix.
- `entry_summaries` is unique on `(user_id, content_hash)`, so the same shape applies to one user firing two concurrent requests (double-click, or web + MCP).

No product decision was needed: the conflict resolution is the existing dedup semantics (one cache row per key), so it's a mechanical fix.

**Item 4 — MCP tool description.** `star_entries` is now described as single-entry, which is what `starEntriesArgs` and the underlying `entries.setStarred` accept; a model following the old "(bulk operation)" wording and passing `entryIds` got `InvalidParams` (`z.toJSONSchema` emits `additionalProperties: false`). The tool **name** is unchanged — renaming it would break clients.

**Item 5 — dead condition.** `tagsCursorDate &&` was unreachable-as-false inside `if (tagsCursor)`. The Date is now derived inside that block, mirroring `subscriptionsCursorDate`. No behaviour change.

## Tests

- `tests/unit/saved-article-excerpt.test.ts`: a long frontmatter `description:` is clipped (item 1).
- `tests/integration/narration.test.ts`: two users narrating the same content concurrently converge on one row — fails on master with the `23505`, passes here (item 3).
- `tests/integration/summarization.test.ts`: two concurrent requests for the same entry converge on one row. Nothing forces the interleaving inside the insert window, so this one is a convergence check rather than a deterministic reproduction; the comment says so.
- Item 5 has no observable behaviour change, so no new test; the existing `sync.events` tag coverage still passes.

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | pass |
| `pnpm test:unit` | pass (176 files, 3217 tests) |
| `pnpm test:integration:local` | pass (66 files, 871 tests, 2/15 pre-existing skips) |
| `pnpm lint` | pass |
| `pnpm format:check` | pass |
| `pnpm knip` / `pnpm knip:production` | pass |

Not run: `pnpm test:e2e` (this sandbox is on Node 22, not the required Node 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)