### PR TITLE
Delete parsed-but-unused Cache-Control directives (#1576)

### DIFF
--- a/src/lib/hooks/useKeyboardShortcuts.ts
+++ b/src/lib/hooks/useKeyboardShortcuts.ts
@@ -157,7 +157,7 @@ export interface UseKeyboardShortcutsResult {
  * @example
  * ```tsx
  * function EntryListPage() {
- *   const [openEntryId, setOpenEntryId] = useState<string | null>(null);
+ *   const { openEntryId, setOpenEntryId, closeEntry } = useEntryUrlState();
  *
  *   const {
  *     selectedEntryId,
@@ -165,7 +165,7 @@ export interface UseKeyboardShortcutsResult {
  *   } = useKeyboardShortcuts({
  *     entries,
  *     onOpenEntry: setOpenEntryId,
- *     onClose: () => setOpenEntryId(null),
+ *     onClose: closeEntry,
  *     isEntryOpen: !!openEntryId,
  *     onToggleRead: (id, read) => markReadMutation.mutate({ ids: [id], read: !read }),
  *     onToggleStar: (id, starred) => starred ? unstarMutation.mutate({ id }) : starMutation.mutate({ id }),

--- a/src/server/feed/cache-headers.ts
+++ b/src/server/feed/cache-headers.ts
@@ -13,44 +13,26 @@ export interface CacheControl {
   sMaxAge?: number;
   /** Whether the response must not be cached (no-store) */
   noStore: boolean;
-  /** Whether the response must be revalidated (no-cache) */
-  noCache: boolean;
-  /** Whether the response is private (private) */
-  private: boolean;
-  /** Whether the response is public (public) */
-  public: boolean;
-  /** Whether revalidation is required when stale (must-revalidate) */
-  mustRevalidate: boolean;
-  /** Whether the response is immutable (immutable) */
-  immutable: boolean;
-  /** Stale-while-revalidate window in seconds */
-  staleWhileRevalidate?: number;
-  /** Stale-if-error window in seconds */
-  staleIfError?: number;
 }
 
 /**
- * Parses a Cache-Control header value into structured directives.
+ * Parses a Cache-Control header value into structured directives. Only the
+ * directives feed scheduling acts on are kept; every other directive is ignored.
  *
  * @param header - The Cache-Control header value (e.g., "max-age=3600, public")
  * @returns Parsed cache control directives
  *
  * @example
  * parseCacheControl("max-age=3600, public")
- * // => { maxAge: 3600, public: true, ... }
+ * // => { maxAge: 3600, noStore: false }
  *
  * @example
- * parseCacheControl("no-store, no-cache, private")
- * // => { noStore: true, noCache: true, private: true, ... }
+ * parseCacheControl("no-store, no-cache")
+ * // => { noStore: true }
  */
 export function parseCacheControl(header: string | null | undefined): CacheControl {
   const result: CacheControl = {
     noStore: false,
-    noCache: false,
-    private: false,
-    public: false,
-    mustRevalidate: false,
-    immutable: false,
   };
 
   if (!header) {
@@ -88,39 +70,10 @@ export function parseCacheControl(header: string | null | undefined): CacheContr
             result.sMaxAge = numValue;
           }
           break;
-        case "stale-while-revalidate":
-          if (!isNaN(numValue) && numValue >= 0) {
-            result.staleWhileRevalidate = numValue;
-          }
-          break;
-        case "stale-if-error":
-          if (!isNaN(numValue) && numValue >= 0) {
-            result.staleIfError = numValue;
-          }
-          break;
       }
-    } else {
-      // Boolean directives (no value)
-      switch (directive) {
-        case "no-store":
-          result.noStore = true;
-          break;
-        case "no-cache":
-          result.noCache = true;
-          break;
-        case "private":
-          result.private = true;
-          break;
-        case "public":
-          result.public = true;
-          break;
-        case "must-revalidate":
-          result.mustRevalidate = true;
-          break;
-        case "immutable":
-          result.immutable = true;
-          break;
-      }
+    } else if (directive === "no-store") {
+      // Boolean directive (no value)
+      result.noStore = true;
     }
   }
 

--- a/tests/unit/cache-headers.test.ts
+++ b/tests/unit/cache-headers.test.ts
@@ -29,48 +29,6 @@ describe("parseCacheControl", () => {
 
       expect(result.noStore).toBe(true);
     });
-
-    it("parses no-cache directive", () => {
-      const result = parseCacheControl("no-cache");
-
-      expect(result.noCache).toBe(true);
-    });
-
-    it("parses private directive", () => {
-      const result = parseCacheControl("private");
-
-      expect(result.private).toBe(true);
-    });
-
-    it("parses public directive", () => {
-      const result = parseCacheControl("public");
-
-      expect(result.public).toBe(true);
-    });
-
-    it("parses must-revalidate directive", () => {
-      const result = parseCacheControl("must-revalidate");
-
-      expect(result.mustRevalidate).toBe(true);
-    });
-
-    it("parses immutable directive", () => {
-      const result = parseCacheControl("immutable");
-
-      expect(result.immutable).toBe(true);
-    });
-
-    it("parses stale-while-revalidate directive", () => {
-      const result = parseCacheControl("stale-while-revalidate=86400");
-
-      expect(result.staleWhileRevalidate).toBe(86400);
-    });
-
-    it("parses stale-if-error directive", () => {
-      const result = parseCacheControl("stale-if-error=172800");
-
-      expect(result.staleIfError).toBe(172800);
-    });
   });
 
   describe("multiple directives", () => {
@@ -78,72 +36,60 @@ describe("parseCacheControl", () => {
       const result = parseCacheControl("max-age=3600, public, must-revalidate");
 
       expect(result.maxAge).toBe(3600);
-      expect(result.public).toBe(true);
-      expect(result.mustRevalidate).toBe(true);
+      expect(result.noStore).toBe(false);
     });
 
     it("parses common CDN header", () => {
       const result = parseCacheControl("public, max-age=31536000, s-maxage=31536000, immutable");
 
-      expect(result.public).toBe(true);
       expect(result.maxAge).toBe(31536000);
       expect(result.sMaxAge).toBe(31536000);
-      expect(result.immutable).toBe(true);
-    });
-
-    it("parses no-cache response with revalidation", () => {
-      const result = parseCacheControl("no-cache, must-revalidate");
-
-      expect(result.noCache).toBe(true);
-      expect(result.mustRevalidate).toBe(true);
     });
 
     it("parses private cache response", () => {
       const result = parseCacheControl("private, max-age=0, no-cache");
 
-      expect(result.private).toBe(true);
       expect(result.maxAge).toBe(0);
-      expect(result.noCache).toBe(true);
+      expect(result.noStore).toBe(false);
     });
   });
 
   describe("whitespace handling", () => {
     it("handles extra spaces around values", () => {
-      const result = parseCacheControl("  max-age = 3600  ,  public  ");
+      const result = parseCacheControl("  max-age = 3600  ,  no-store  ");
 
       expect(result.maxAge).toBe(3600);
-      expect(result.public).toBe(true);
+      expect(result.noStore).toBe(true);
     });
 
     it("handles no spaces between directives", () => {
-      const result = parseCacheControl("max-age=3600,public,no-cache");
+      const result = parseCacheControl("max-age=3600,public,no-store");
 
       expect(result.maxAge).toBe(3600);
-      expect(result.public).toBe(true);
-      expect(result.noCache).toBe(true);
+      expect(result.noStore).toBe(true);
     });
 
     it("handles multiple spaces", () => {
-      const result = parseCacheControl("max-age=3600   ,   public");
+      const result = parseCacheControl("max-age=3600   ,   no-store");
 
       expect(result.maxAge).toBe(3600);
-      expect(result.public).toBe(true);
+      expect(result.noStore).toBe(true);
     });
   });
 
   describe("case insensitivity", () => {
     it("handles uppercase directives", () => {
-      const result = parseCacheControl("MAX-AGE=3600, PUBLIC");
+      const result = parseCacheControl("MAX-AGE=3600, NO-STORE");
 
       expect(result.maxAge).toBe(3600);
-      expect(result.public).toBe(true);
+      expect(result.noStore).toBe(true);
     });
 
     it("handles mixed case directives", () => {
-      const result = parseCacheControl("Max-Age=3600, No-Cache");
+      const result = parseCacheControl("Max-Age=3600, No-Store");
 
       expect(result.maxAge).toBe(3600);
-      expect(result.noCache).toBe(true);
+      expect(result.noStore).toBe(true);
     });
   });
 
@@ -162,11 +108,6 @@ describe("parseCacheControl", () => {
       expect(result.maxAge).toBeUndefined();
       expect(result.sMaxAge).toBeUndefined();
       expect(result.noStore).toBe(false);
-      expect(result.noCache).toBe(false);
-      expect(result.private).toBe(false);
-      expect(result.public).toBe(false);
-      expect(result.mustRevalidate).toBe(false);
-      expect(result.immutable).toBe(false);
     });
 
     it("returns defaults for undefined input", () => {
@@ -201,11 +142,12 @@ describe("parseCacheControl", () => {
       expect(result.maxAge).toBe(0);
     });
 
-    it("ignores unknown directives", () => {
-      const result = parseCacheControl("max-age=3600, unknown-directive, public");
+    it("ignores directives we don't act on", () => {
+      const result = parseCacheControl(
+        "max-age=3600, unknown-directive, public, private, no-cache, must-revalidate, immutable, stale-while-revalidate=86400, stale-if-error=172800"
+      );
 
-      expect(result.maxAge).toBe(3600);
-      expect(result.public).toBe(true);
+      expect(result).toEqual({ maxAge: 3600, noStore: false });
     });
 
     it("handles empty directive (trailing comma)", () => {
@@ -226,7 +168,6 @@ describe("parseCacheControl", () => {
     it("parses typical blog feed header", () => {
       const result = parseCacheControl("public, max-age=900");
 
-      expect(result.public).toBe(true);
       expect(result.maxAge).toBe(900); // 15 minutes
     });
 
@@ -235,19 +176,14 @@ describe("parseCacheControl", () => {
         "public, max-age=14400, s-maxage=14400, stale-while-revalidate=86400"
       );
 
-      expect(result.public).toBe(true);
       expect(result.maxAge).toBe(14400);
       expect(result.sMaxAge).toBe(14400);
-      expect(result.staleWhileRevalidate).toBe(86400);
     });
 
     it("parses no-cache API response", () => {
       const result = parseCacheControl("private, no-cache, no-store, must-revalidate");
 
-      expect(result.private).toBe(true);
-      expect(result.noCache).toBe(true);
       expect(result.noStore).toBe(true);
-      expect(result.mustRevalidate).toBe(true);
     });
 
     it("parses GitHub raw content header", () => {
@@ -271,7 +207,7 @@ describe("parseCacheHeaders", () => {
     expect(result.etag).toBe('"abc123"');
     expect(result.lastModified).toBe("Wed, 21 Oct 2015 07:28:00 GMT");
     expect(result.cacheControl.maxAge).toBe(3600);
-    expect(result.cacheControl.public).toBe(true);
+    expect(result.cacheControl.noStore).toBe(false);
   });
 
   it("handles missing ETag", () => {
@@ -335,25 +271,19 @@ describe("getEffectiveMaxAge", () => {
   it("returns undefined for no-store", () => {
     const cacheControl: CacheControl = {
       noStore: true,
-      noCache: false,
-      private: false,
-      public: false,
-      mustRevalidate: false,
-      immutable: false,
       maxAge: 3600,
     };
 
     expect(getEffectiveMaxAge(cacheControl)).toBeUndefined();
   });
 
+  it("keeps max-age for no-cache, which only asks us to revalidate", () => {
+    expect(getEffectiveMaxAge(parseCacheControl("no-cache, max-age=600"))).toBe(600);
+  });
+
   it("returns s-maxage over max-age when both present", () => {
     const cacheControl: CacheControl = {
       noStore: false,
-      noCache: false,
-      private: false,
-      public: true,
-      mustRevalidate: false,
-      immutable: false,
       maxAge: 3600,
       sMaxAge: 7200,
     };
@@ -364,11 +294,6 @@ describe("getEffectiveMaxAge", () => {
   it("returns max-age when s-maxage is not present", () => {
     const cacheControl: CacheControl = {
       noStore: false,
-      noCache: false,
-      private: false,
-      public: true,
-      mustRevalidate: false,
-      immutable: false,
       maxAge: 3600,
     };
 
@@ -378,11 +303,6 @@ describe("getEffectiveMaxAge", () => {
   it("returns undefined when neither max-age nor s-maxage present", () => {
     const cacheControl: CacheControl = {
       noStore: false,
-      noCache: false,
-      private: false,
-      public: true,
-      mustRevalidate: false,
-      immutable: false,
     };
 
     expect(getEffectiveMaxAge(cacheControl)).toBeUndefined();
@@ -391,11 +311,6 @@ describe("getEffectiveMaxAge", () => {
   it("returns 0 for max-age=0", () => {
     const cacheControl: CacheControl = {
       noStore: false,
-      noCache: false,
-      private: false,
-      public: false,
-      mustRevalidate: false,
-      immutable: false,
       maxAge: 0,
     };
 
@@ -405,11 +320,6 @@ describe("getEffectiveMaxAge", () => {
   it("returns s-maxage=0 when set", () => {
     const cacheControl: CacheControl = {
       noStore: false,
-      noCache: false,
-      private: false,
-      public: true,
-      mustRevalidate: false,
-      immutable: false,
       maxAge: 3600,
       sMaxAge: 0,
     };

--- a/tests/unit/scheduling.test.ts
+++ b/tests/unit/scheduling.test.ts
@@ -25,11 +25,6 @@ import type { CacheControl } from "../../src/server/feed/cache-headers";
 function createCacheControl(overrides: Partial<CacheControl> = {}): CacheControl {
   return {
     noStore: false,
-    noCache: false,
-    private: false,
-    public: false,
-    mustRevalidate: false,
-    immutable: false,
     ...overrides,
   };
 }
@@ -370,7 +365,7 @@ describe("calculateNextFetch", () => {
 
     it("uses default interval when cacheControl has no max-age", () => {
       const result = calculateNextFetch({
-        cacheControl: createCacheControl({ public: true }), // no max-age
+        cacheControl: createCacheControl(), // no max-age
         now: fixedNow,
         randomSource: noJitter,
       });
@@ -769,7 +764,7 @@ describe("real-world scenarios", () => {
 
   it("typical blog with 2 hour cache", () => {
     const result = calculateNextFetch({
-      cacheControl: createCacheControl({ maxAge: 7200, public: true }),
+      cacheControl: createCacheControl({ maxAge: 7200 }),
       now: fixedNow,
       randomSource: noJitter,
     });
@@ -780,7 +775,7 @@ describe("real-world scenarios", () => {
 
   it("high-frequency news feed with 5 minute cache gets clamped to 10 min", () => {
     const result = calculateNextFetch({
-      cacheControl: createCacheControl({ maxAge: 300, public: true }),
+      cacheControl: createCacheControl({ maxAge: 300 }),
       now: fixedNow,
       randomSource: noJitter,
     });
@@ -791,7 +786,7 @@ describe("real-world scenarios", () => {
 
   it("cache headers allow 15-minute polling when server specifies it", () => {
     const result = calculateNextFetch({
-      cacheControl: createCacheControl({ maxAge: 900, public: true }), // 15 minutes
+      cacheControl: createCacheControl({ maxAge: 900 }), // 15 minutes
       now: fixedNow,
       randomSource: noJitter,
     });
@@ -813,7 +808,7 @@ describe("real-world scenarios", () => {
 
   it("infrequently updated feed with 1 day cache", () => {
     const result = calculateNextFetch({
-      cacheControl: createCacheControl({ maxAge: 86400, public: true }),
+      cacheControl: createCacheControl({ maxAge: 86400 }),
       now: fixedNow,
       randomSource: noJitter,
     });


### PR DESCRIPTION
Closes out the last open item of #1576 (item 6). The maintainer's decision on that item:

> Decision: We should delete the unused cache header logic.

## Cache-header parser (item 6)

`src/server/feed/cache-headers.ts` parsed seven directives into `CacheControl` that nothing read: `noCache`, `private`, `public`, `mustRevalidate`, `immutable`, `staleWhileRevalidate`, `staleIfError`. I grepped each name across the whole repo (`public`/`private` carefully, since they collide with the TS keywords, a `wallabag/parse.ts` field and a `signup-providers` test fixture) — every hit outside `cache-headers.ts` itself was in `tests/unit/cache-headers.test.ts` or the `createCacheControl` helper in `tests/unit/scheduling.test.ts`. All seven were genuinely unread, so all seven are gone.

The only production consumer of `CacheControl` is `getEffectiveMaxAge` (feed scheduling, via `scheduling.ts`), which uses `noStore`, `sMaxAge` and `maxAge`. Those stay.

Behavior is unchanged: the parser ignored unrecognized directives before and still does, and a test now pins that a header full of the removed directives parses to exactly `{ maxAge, noStore }`. `getEffectiveMaxAge`'s comment explaining that `no-cache` deliberately does *not* suppress a max-age (every poll already sends a conditional GET) is still accurate now that `no-cache` isn't parsed at all, and gains a test: `no-cache, max-age=600` still yields `600`.

No doc changes were needed — `src/server/feed/CLAUDE.md` and `docs/DESIGN.md` describe Cache-Control-driven scheduling, which is exactly the part that survives; nothing documented the directive list.

## Drive-by, unrelated to the above

`src/lib/hooks/useKeyboardShortcuts.ts` — the JSDoc usage example still showed `onClose: () => setOpenEntryId(null)`, the history-stranding anti-pattern that #1592 removed from the real call site (#1571). It was the last occurrence in the repo and the obvious copy-paste source for the next one, so the example now uses `useEntryUrlState`'s `closeEntry`, matching `EntryListContainer.tsx`. Included here under the root CLAUDE.md "keep docs current both ways" rule rather than as its own PR.

## Verification

`pnpm typecheck`, `pnpm test:unit` (177 files / 3216 tests), `pnpm lint`, `pnpm format:check`, `pnpm knip`, `pnpm knip:production` — all pass. Not run: `pnpm test:e2e` (this environment is on Node 22, not the required Node 26).

Fixes #1576

🤖 Generated with [Claude Code](https://claude.com/claude-code)