### PR TITLE
Gate Rust formatting in CI and the pre-commit hook (#1580)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,20 @@ jobs:
             native/readability
             native/sanitizer
 
+      # First because it compiles nothing: a misformatted PR fails in seconds
+      # rather than after the test and clippy builds. The husky pre-commit hook
+      # also formats Rust, but it is bypassable (`--no-verify`, or edits from
+      # tools that skip hooks), so gate it here.
+      - name: Check formatting
+        run: ./scripts/cargo-native.sh fmt --all --check
+
+      # These run even when an earlier check fails, so one push surfaces every
+      # problem instead of one per round-trip.
+      #
       # Invoked directly rather than through `pnpm test:native` / `pnpm
       # lint:native` so the job needs no Node toolchain; keep them in sync.
       - name: Run Rust tests
+        if: ${{ !cancelled() }}
         run: ./scripts/cargo-native.sh test --workspace
 
       - name: Run clippy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ otherwise.
 - `pnpm build:native` - Build the native Rust modules (sanitizer, readability, feed-parser, markdown). **Required once per checkout before tests or the app** — if tests fail with "Failed to load the native …", run this. Needs the Rust toolchain (`cargo` — if missing from PATH, try `~/.cargo/bin`). The SessionStart hook starts it in the background, so it may already be done or in flight (log: `/tmp/lion-reader-build-native.log`).
 - `pnpm typecheck` - Run before committing (no `any`, no `@ts-ignore`)
 - `pnpm test:unit` - Pure logic tests (fast, no DB)
-- `pnpm test:native` / `pnpm lint:native` - `cargo test` / `cargo clippy -D warnings` across all four native crates. Both gate CI.
+- `pnpm test:native` / `pnpm lint:native` / `pnpm format:native` - `cargo test` / `cargo clippy -D warnings` / `cargo fmt` across all four native crates. All three gate CI.
 - `pnpm test:integration` - Backend tests against real Postgres/Redis (docker-compose)
 - `pnpm test:e2e` - Playwright browser tests against a real app server (docker-compose)
 - `pnpm knip` - Unused files, exports, and dependencies

--- a/native/feed-parser/core/src/opml.rs
+++ b/native/feed-parser/core/src/opml.rs
@@ -139,7 +139,10 @@ mod tests {
         );
         assert_eq!(result.feeds[2].category, None);
         assert_eq!(result.feeds[2].xml_url, "https://solo.com/feed");
-        assert_eq!(result.feeds[2].html_url.as_deref(), Some("https://solo.com"));
+        assert_eq!(
+            result.feeds[2].html_url.as_deref(),
+            Some("https://solo.com")
+        );
     }
 
     #[test]

--- a/native/feed-parser/core/src/rss.rs
+++ b/native/feed-parser/core/src/rss.rs
@@ -149,9 +149,7 @@ impl SaxHandler for RssHandler {
             match tag {
                 "title" => self.state = State::InChannelTitle,
                 // `!attribs.rel` — absent OR empty (falsy) rel counts.
-                "link" if attrs.get_nonempty("rel").is_none() => {
-                    self.state = State::InChannelLink
-                }
+                "link" if attrs.get_nonempty("rel").is_none() => self.state = State::InChannelLink,
                 "description" => self.state = State::InChannelDescription,
                 "ttl" => self.state = State::InChannelTtl,
                 "sy:updateperiod" => self.state = State::InChannelSyUpdatePeriod,
@@ -431,9 +429,8 @@ mod tests {
     fn end_tag_dispatch_matches_htmlparser2_stack_semantics() {
         // An end tag closes down to its nearest open match (</item> closes
         // the unclosed <title> first)...
-        let feed =
-            parse_rss("<rss><channel><item><title>Post</item><item><guid>g2</guid></item>")
-                .unwrap();
+        let feed = parse_rss("<rss><channel><item><title>Post</item><item><guid>g2</guid></item>")
+            .unwrap();
         assert_eq!(feed.entries.len(), 2);
         assert_eq!(feed.entries[0].title.as_deref(), Some("Post"));
         assert_eq!(feed.entries[1].guid.as_deref(), Some("g2"));

--- a/native/feed-parser/core/src/xml.rs
+++ b/native/feed-parser/core/src/xml.rs
@@ -248,9 +248,7 @@ pub fn decode_xml_entities(input: &str) -> std::borrow::Cow<'_, str> {
             let name = &after[..semi];
             if !name.is_empty()
                 && name.len() <= 32
-                && name
-                    .chars()
-                    .all(|c| c.is_ascii_alphanumeric() || c == '#')
+                && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '#')
             {
                 out.push_str(&resolve_entity_ref(name));
                 rest = &after[semi + 1..];
@@ -281,13 +279,14 @@ fn is_js_whitespace(c: char) -> bool {
             | '\u{0020}'
             | '\u{00A0}'
             | '\u{1680}'
-            | '\u{2000}'..='\u{200A}'
-            | '\u{2028}'
-            | '\u{2029}'
-            | '\u{202F}'
-            | '\u{205F}'
-            | '\u{3000}'
-            | '\u{FEFF}'
+            | '\u{2000}'
+            ..='\u{200A}'
+                | '\u{2028}'
+                | '\u{2029}'
+                | '\u{202F}'
+                | '\u{205F}'
+                | '\u{3000}'
+                | '\u{FEFF}'
     )
 }
 

--- a/native/markdown/core/src/lib.rs
+++ b/native/markdown/core/src/lib.rs
@@ -270,7 +270,11 @@ fn math_to_mathml(tex: &str, display: bool) -> String {
     };
 
     let mut mathml = String::new();
-    match push_mathml(&mut mathml, events.into_iter().map(Ok::<_, Infallible>), config) {
+    match push_mathml(
+        &mut mathml,
+        events.into_iter().map(Ok::<_, Infallible>),
+        config,
+    ) {
         Ok(()) => mathml,
         Err(_) => escaped_tex(tex),
     }
@@ -366,7 +370,10 @@ mod tests {
         let out = html("| a | b |\n|---|---|\n| 1 | 2 |\n\n- [x] done\n- [ ] todo\n");
         assert!(out.contains("<table>"), "{out}");
         assert!(out.contains("<th>a</th>"), "{out}");
-        assert!(out.contains(r#"<input type="checkbox" checked="" disabled="" />"#), "{out}");
+        assert!(
+            out.contains(r#"<input type="checkbox" checked="" disabled="" />"#),
+            "{out}"
+        );
         // The reader CSS styles the checkbox via `li > input:first-child` (it has
         // to replace the bullet), so the checkbox being a *direct, leading* child
         // of the `<li>` is a contract, not an incidental detail of comrak's
@@ -378,7 +385,10 @@ mod tests {
         );
         // Alignment rows land on the cells, which the sanitizer allow-lists.
         let aligned = html("| a | b |\n| :-: | --: |\n| 1 | 2 |\n");
-        assert!(aligned.contains(r#"<th align="center">a</th>"#), "{aligned}");
+        assert!(
+            aligned.contains(r#"<th align="center">a</th>"#),
+            "{aligned}"
+        );
         assert!(aligned.contains(r#"<th align="right">b</th>"#), "{aligned}");
     }
 
@@ -543,7 +553,10 @@ mod tests {
             max_input_bytes: 8,
             max_output_bytes: UNLIMITED.max_output_bytes,
         };
-        assert_eq!(render("more than eight bytes", limits), Err(RenderError::InputTooLarge));
+        assert_eq!(
+            render("more than eight bytes", limits),
+            Err(RenderError::InputTooLarge)
+        );
         assert!(render("tiny", limits).is_ok());
     }
 

--- a/native/markdown/src/lib.rs
+++ b/native/markdown/src/lib.rs
@@ -47,7 +47,8 @@ fn run(markdown: &str, limits: &MarkdownLimits) -> RenderedMarkdown {
     // process, so it stops here. Rendering has no partial result worth
     // salvaging, so an unexpected panic is reported as the over-budget case —
     // the caller already handles it, and it can't be mistaken for success.
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| render(markdown, limits)));
+    let result =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| render(markdown, limits)));
 
     match result {
         Ok(Ok(html)) => RenderedMarkdown {

--- a/native/readability/src/lib.rs
+++ b/native/readability/src/lib.rs
@@ -84,16 +84,22 @@ fn run_extract(html: &str, options: Option<&ExtractOptions>) -> Result<Option<Ex
     // partial_cmp().unwrap() sites on f32 scores) would otherwise unwind
     // across the N-API boundary and abort the whole Node process; treat it
     // as an ordinary extraction failure instead.
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| extract_inner(html, options)))
-        .unwrap_or(Ok(None))
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        extract_inner(html, options)
+    }))
+    .unwrap_or(Ok(None))
 }
 
 fn extract_inner(html: &str, options: Option<&ExtractOptions>) -> Result<Option<ExtractedArticle>> {
     // No document URL: relative-URL resolution (including <base href>) is done
     // by the caller's absolutizeUrls post-pass, exactly as with the old
     // linkedom pipeline, so URL policy stays in one place.
-    let mut reader = Readability::new(html, None, Some(build_config(options)))
-        .map_err(|e| Error::new(Status::GenericFailure, format!("readability init failed: {e}")))?;
+    let mut reader = Readability::new(html, None, Some(build_config(options))).map_err(|e| {
+        Error::new(
+            Status::GenericFailure,
+            format!("readability init failed: {e}"),
+        )
+    })?;
     if exceeds_max_depth(&reader) {
         return Ok(None);
     }

--- a/native/sanitizer/core/src/depth.rs
+++ b/native/sanitizer/core/src/depth.rs
@@ -56,7 +56,11 @@ mod tests {
     use super::*;
 
     fn depth_html(levels: usize) -> String {
-        format!("<svg>{}x{}</svg>", "<g>".repeat(levels), "</g>".repeat(levels))
+        format!(
+            "<svg>{}x{}</svg>",
+            "<g>".repeat(levels),
+            "</g>".repeat(levels)
+        )
     }
 
     #[test]
@@ -79,13 +83,17 @@ mod tests {
 
     #[test]
     fn deep_markup_is_over_the_limit() {
-        assert!(exceeds_max_depth(&Html::parse_fragment(&depth_html(MAX_DOM_DEPTH + 50))));
+        assert!(exceeds_max_depth(&Html::parse_fragment(&depth_html(
+            MAX_DOM_DEPTH + 50
+        ))));
     }
 
     #[test]
     fn pathological_depth_does_not_overflow_the_stack() {
         // The whole point: the depth check runs on input deep enough to
         // overflow a recursive walk (this is the crashing repro's depth).
-        assert!(exceeds_max_depth(&Html::parse_fragment(&depth_html(20_000))));
+        assert!(exceeds_max_depth(&Html::parse_fragment(&depth_html(
+            20_000
+        ))));
     }
 }

--- a/native/sanitizer/core/src/embeds.rs
+++ b/native/sanitizer/core/src/embeds.rs
@@ -93,8 +93,16 @@ static YOUTUBE_PATH_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^/embed/([A-Za-z0-9_-]{1,64})$").unwrap());
 
 const YOUTUBE_PARAMS: &[&str] = &[
-    "start", "end", "list", "listType", "loop", "playlist", "rel", "cc_load_policy",
-    "cc_lang_pref", "hl",
+    "start",
+    "end",
+    "list",
+    "listType",
+    "loop",
+    "playlist",
+    "rel",
+    "cc_load_policy",
+    "cc_lang_pref",
+    "hl",
 ];
 
 pub fn normalize_youtube_embed_url(src: &str) -> Option<String> {
@@ -135,8 +143,10 @@ fn normalize_vimeo_embed_url(src: &str) -> Option<String> {
 // --- Spotify ----------------------------------------------------------------
 
 static SPOTIFY_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^/embed(?:-podcast)?/(track|album|playlist|episode|show|artist)/([A-Za-z0-9]{1,64})$")
-        .unwrap()
+    Regex::new(
+        r"^/embed(?:-podcast)?/(track|album|playlist|episode|show|artist)/([A-Za-z0-9]{1,64})$",
+    )
+    .unwrap()
 });
 
 const SPOTIFY_PARAMS: &[&str] = &["theme", "t"];
@@ -159,8 +169,15 @@ fn normalize_spotify_embed_url(src: &str) -> Option<String> {
 static SOUNDCLOUD_PATH_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^/player/?$").unwrap());
 
 const SOUNDCLOUD_PARAMS: &[&str] = &[
-    "color", "hide_related", "show_comments", "show_user", "show_reposts", "show_teaser",
-    "visual", "start_track", "single_active",
+    "color",
+    "hide_related",
+    "show_comments",
+    "show_user",
+    "show_reposts",
+    "show_teaser",
+    "visual",
+    "start_track",
+    "single_active",
 ];
 
 fn is_soundcloud_resource_url(value: &str) -> bool {
@@ -280,9 +297,14 @@ mod tests {
 
     #[test]
     fn youtube_normalizes_to_nocookie() {
-        let embed = normalize_embed("https://www.youtube.com/embed/dQw4w9WgXcQ?start=10&autoplay=1").unwrap();
+        let embed =
+            normalize_embed("https://www.youtube.com/embed/dQw4w9WgXcQ?start=10&autoplay=1")
+                .unwrap();
         assert_eq!(embed.provider, "YouTube");
-        assert_eq!(embed.src, "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?start=10");
+        assert_eq!(
+            embed.src,
+            "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?start=10"
+        );
     }
 
     #[test]
@@ -300,7 +322,9 @@ mod tests {
 
     #[test]
     fn soundcloud_requires_soundcloud_resource() {
-        assert!(normalize_embed("https://w.soundcloud.com/player/?url=https://evil.com/x").is_none());
+        assert!(
+            normalize_embed("https://w.soundcloud.com/player/?url=https://evil.com/x").is_none()
+        );
         let ok = normalize_embed(
             "https://w.soundcloud.com/player/?url=https://api.soundcloud.com/tracks/123&visual=true",
         )
@@ -312,16 +336,31 @@ mod tests {
     #[test]
     fn every_canonical_host_is_listed() {
         let outputs = [
-            normalize_embed("https://www.youtube.com/embed/abc").unwrap().src,
-            normalize_embed("https://player.vimeo.com/video/1").unwrap().src,
-            normalize_embed("https://open.spotify.com/embed/track/abc123").unwrap().src,
-            normalize_embed("https://w.soundcloud.com/player/?url=https://soundcloud.com/x").unwrap().src,
-            normalize_embed("https://bandcamp.com/EmbeddedPlayer/album=123/size=large/").unwrap().src,
-            normalize_embed("https://codepen.io/user/embed/abcDEF").unwrap().src,
+            normalize_embed("https://www.youtube.com/embed/abc")
+                .unwrap()
+                .src,
+            normalize_embed("https://player.vimeo.com/video/1")
+                .unwrap()
+                .src,
+            normalize_embed("https://open.spotify.com/embed/track/abc123")
+                .unwrap()
+                .src,
+            normalize_embed("https://w.soundcloud.com/player/?url=https://soundcloud.com/x")
+                .unwrap()
+                .src,
+            normalize_embed("https://bandcamp.com/EmbeddedPlayer/album=123/size=large/")
+                .unwrap()
+                .src,
+            normalize_embed("https://codepen.io/user/embed/abcDEF")
+                .unwrap()
+                .src,
         ];
         for src in outputs {
             let url = Url::parse(&src).unwrap();
-            assert!(EMBED_CANONICAL_HOSTNAMES.contains(&url.host_str().unwrap()), "{src}");
+            assert!(
+                EMBED_CANONICAL_HOSTNAMES.contains(&url.host_str().unwrap()),
+                "{src}"
+            );
         }
     }
 }

--- a/native/sanitizer/core/src/idrefs.rs
+++ b/native/sanitizer/core/src/idrefs.rs
@@ -196,7 +196,10 @@ mod tests {
     #[test]
     fn rewrites_func_iri_references() {
         assert_eq!(prefix_func_iris("url(#grad)"), "url(#uc-grad)");
-        assert_eq!(prefix_func_iris(r##"url("#grad")"##), r##"url("#uc-grad")"##);
+        assert_eq!(
+            prefix_func_iris(r##"url("#grad")"##),
+            r##"url("#uc-grad")"##
+        );
         assert_eq!(prefix_func_iris("url('#grad')"), "url('#uc-grad')");
         // Paint fallback after the reference survives.
         assert_eq!(prefix_func_iris("url(#grad) red"), "url(#uc-grad) red");

--- a/native/sanitizer/core/src/lib.rs
+++ b/native/sanitizer/core/src/lib.rs
@@ -132,7 +132,11 @@ mod tests {
         // dies. Sanitization is per-read, so one such stored entry would
         // crash the server on every read of it.
         for html in [
-            format!("<svg>{}x{}</svg>", "<g>".repeat(20_000), "</g>".repeat(20_000)),
+            format!(
+                "<svg>{}x{}</svg>",
+                "<g>".repeat(20_000),
+                "</g>".repeat(20_000)
+            ),
             format!(
                 "<mjx-container><mjx-math>{}x{}</mjx-math></mjx-container>",
                 "<mjx-mrow>".repeat(20_000),
@@ -143,7 +147,11 @@ mod tests {
             let out = sanitize_entry_html(&html, &mut warnings).expect("must not fail");
             // Degraded, not crashed: the markup is gone, the text survives,
             // and the degradation is reported.
-            assert!(!out.contains('<'), "no markup should survive: {}", &out[..out.len().min(80)]);
+            assert!(
+                !out.contains('<'),
+                "no markup should survive: {}",
+                &out[..out.len().min(80)]
+            );
             assert!(out.contains('x'), "text content should survive");
             assert_eq!(warnings.len(), 1, "{warnings:?}");
             assert!(warnings[0].contains("nested deeper"), "{warnings:?}");
@@ -155,9 +163,8 @@ mod tests {
         // The HTML and SVG passes prefix independently (SVG is extracted, run
         // through its own allow-list, then spliced back), so an HTML link to an
         // id defined *inside* an SVG only resolves if both agree.
-        let out = run(
-            "<a href=\"#chart\">see chart</a><svg><title id=\"chart\">Chart</title></svg>",
-        );
+        let out =
+            run("<a href=\"#chart\">see chart</a><svg><title id=\"chart\">Chart</title></svg>");
         assert!(out.contains("href=\"#uc-chart\""), "{out}");
         assert!(out.contains("id=\"uc-chart\""), "{out}");
     }

--- a/native/sanitizer/core/src/mathjax.rs
+++ b/native/sanitizer/core/src/mathjax.rs
@@ -45,8 +45,20 @@ fn token_tag(tag: &str) -> Option<&'static str> {
 /// Layout-only wrappers whose children are unwrapped in place without being
 /// reported as unknown.
 const KNOWN_LAYOUT_TAGS: &[&str] = &[
-    "mjx-texatom", "mjx-mrow", "mjx-mstyle", "mjx-mpadded", "mjx-box", "mjx-row", "mjx-block",
-    "mjx-spacer", "mjx-strut", "mjx-nstrut", "mjx-dstrut", "mjx-tstrut", "mjx-line", "mjx-mark",
+    "mjx-texatom",
+    "mjx-mrow",
+    "mjx-mstyle",
+    "mjx-mpadded",
+    "mjx-box",
+    "mjx-row",
+    "mjx-block",
+    "mjx-spacer",
+    "mjx-strut",
+    "mjx-nstrut",
+    "mjx-dstrut",
+    "mjx-tstrut",
+    "mjx-line",
+    "mjx-mark",
 ];
 
 struct ConvertContext {
@@ -56,7 +68,8 @@ struct ConvertContext {
 static CODEPOINT_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\bmjx-c([0-9A-Fa-f]{2,6})\b").unwrap());
 
-static MSPACE_WIDTH_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"width:\s*([^;]+)").unwrap());
+static MSPACE_WIDTH_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"width:\s*([^;]+)").unwrap());
 
 /// The Unicode character a glyph element represents, from its `mjx-c<HEX>`
 /// class. Surrogate codepoints are rejected (`char::from_u32` refuses them
@@ -69,7 +82,9 @@ fn codepoint_char(el: ElementRef) -> String {
     let Ok(codepoint) = u32::from_str_radix(&captures[1], 16) else {
         return String::new();
     };
-    char::from_u32(codepoint).map(String::from).unwrap_or_default()
+    char::from_u32(codepoint)
+        .map(String::from)
+        .unwrap_or_default()
 }
 
 /// Concatenated text of all descendant text nodes.
@@ -174,7 +189,13 @@ fn find_fraction_parts(frac: ElementRef) -> (Option<ElementRef>, Option<ElementR
 fn find_script_parts(
     el: ElementRef,
 ) -> (Option<ElementRef>, Option<ElementRef>, Option<ElementRef>) {
-    const LAYOUT: &[&str] = &["mjx-row", "mjx-box", "mjx-munder", "mjx-mover", "mjx-munderover"];
+    const LAYOUT: &[&str] = &[
+        "mjx-row",
+        "mjx-box",
+        "mjx-munder",
+        "mjx-mover",
+        "mjx-munderover",
+    ];
     fn visit<'a>(
         node: ElementRef<'a>,
         base: &mut Option<ElementRef<'a>>,
@@ -295,7 +316,9 @@ fn convert_element(el: ElementRef, ctx: &mut ConvertContext, out: &mut Vec<MNode
             .attr("style")
             .and_then(|style| MSPACE_WIDTH_RE.captures(style))
             .map(|captures| captures[1].trim().to_string());
-        let attrs = width.map(|w| vec![("width".to_string(), w)]).unwrap_or_default();
+        let attrs = width
+            .map(|w| vec![("width".to_string(), w)])
+            .unwrap_or_default();
         out.push(MNode::elem_with_attrs("mspace", attrs, Vec::new()));
         return;
     }
@@ -304,7 +327,9 @@ fn convert_element(el: ElementRef, ctx: &mut ConvertContext, out: &mut Vec<MNode
     // script stacks sup then sub, separated by <mjx-spacer>.
     if tag == "mjx-msup" || tag == "mjx-msub" || tag == "mjx-msubsup" {
         let (base_nodes, script) = partition_script(el, ctx);
-        let groups = script.map(|s| split_script_groups(s, ctx)).unwrap_or_default();
+        let groups = script
+            .map(|s| split_script_groups(s, ctx))
+            .unwrap_or_default();
         if tag == "mjx-msubsup" && groups.len() >= 2 {
             let mut groups = groups.into_iter();
             let sup = groups.next().unwrap(); // stacked above
@@ -333,14 +358,20 @@ fn convert_element(el: ElementRef, ctx: &mut ConvertContext, out: &mut Vec<MNode
         let (base, over, under) = find_script_parts(el);
         if base.is_none() && over.is_none() && under.is_none() {
             let (base_nodes, script) = partition_script(el, ctx);
-            let groups = script.map(|s| split_script_groups(s, ctx)).unwrap_or_default();
+            let groups = script
+                .map(|s| split_script_groups(s, ctx))
+                .unwrap_or_default();
             if tag == "mjx-munderover" && groups.len() >= 2 {
                 let mut groups = groups.into_iter();
                 let over_g = groups.next().unwrap(); // stacked above
                 let under_g = groups.next().unwrap(); // stacked below
                 out.push(MNode::elem(
                     "munderover",
-                    vec![group_nodes(base_nodes), group_nodes(under_g), group_nodes(over_g)],
+                    vec![
+                        group_nodes(base_nodes),
+                        group_nodes(under_g),
+                        group_nodes(over_g),
+                    ],
                 ));
                 return;
             }
@@ -390,7 +421,10 @@ fn convert_element(el: ElementRef, ctx: &mut ConvertContext, out: &mut Vec<MNode
     // Square roots: radicand in <mjx-box>, radical glyph in <mjx-surd>.
     if tag == "mjx-msqrt" || tag == "mjx-sqrt" {
         if let Some(radicand) = first_descendant(el, "mjx-box") {
-            out.push(MNode::elem("msqrt", vec![convert_group(Some(radicand), ctx)]));
+            out.push(MNode::elem(
+                "msqrt",
+                vec![convert_group(Some(radicand), ctx)],
+            ));
             return;
         }
         convert_children(el, ctx, out);
@@ -404,7 +438,10 @@ fn convert_element(el: ElementRef, ctx: &mut ConvertContext, out: &mut Vec<MNode
         if let (Some(index), Some(radicand)) = (index, radicand) {
             out.push(MNode::elem(
                 "mroot",
-                vec![convert_group(Some(radicand), ctx), convert_group(Some(index), ctx)],
+                vec![
+                    convert_group(Some(radicand), ctx),
+                    convert_group(Some(index), ctx),
+                ],
             ));
             return;
         }
@@ -505,7 +542,9 @@ pub fn convert_mathjax_chtml(html: &str, warnings: &mut Vec<String>) -> Option<S
         return None;
     }
 
-    let mut ctx = ConvertContext { unknown_tags: BTreeSet::new() };
+    let mut ctx = ConvertContext {
+        unknown_tags: BTreeSet::new(),
+    };
     let mut result = String::with_capacity(html.len());
     let mut cursor = 0usize;
     let mut converted = false;
@@ -658,7 +697,10 @@ mod tests {
         let html = r#"<mjx-container><mjx-math><mjx-future><mjx-mi><mjx-c class="mjx-c31"></mjx-c></mjx-mi></mjx-future></mjx-math></mjx-container>"#;
         let mut warnings = Vec::new();
         let out = convert_mathjax_chtml(html, &mut warnings).unwrap();
-        assert_eq!(out, format!(r#"<math xmlns="{MATHML_NS}"><mi>1</mi></math>"#));
+        assert_eq!(
+            out,
+            format!(r#"<math xmlns="{MATHML_NS}"><mi>1</mi></math>"#)
+        );
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].contains("mjx-future"));
     }
@@ -713,8 +755,15 @@ mod tests {
         let mut warnings = Vec::new();
         let out = convert_mathjax_chtml(&html, &mut warnings).expect("second container converts");
         let expected = format!(r#"<math xmlns="{MATHML_NS}"><mn>1</mn></math>"#);
-        assert!(out.ends_with(&expected), "tail: {}", &out[out.len() - expected.len().min(out.len())..]);
-        assert!(out.starts_with("<mjx-container>"), "deep container must survive verbatim");
+        assert!(
+            out.ends_with(&expected),
+            "tail: {}",
+            &out[out.len() - expected.len().min(out.len())..]
+        );
+        assert!(
+            out.starts_with("<mjx-container>"),
+            "deep container must survive verbatim"
+        );
         assert_eq!(warnings.len(), 1, "{warnings:?}");
     }
 

--- a/native/sanitizer/core/src/sanitize.rs
+++ b/native/sanitizer/core/src/sanitize.rs
@@ -45,19 +45,86 @@ use crate::urls::{decode_attr, is_image_url_allowed};
 /// Tags allowed in entry content (sanitize.ts ALLOWED_TAGS + MATHML_TAGS).
 const ALLOWED_TAGS: &[&str] = &[
     // Sections & blocks
-    "p", "div", "span", "section", "article", "header", "footer", "main", "aside", "nav",
-    "h1", "h2", "h3", "h4", "h5", "h6", "blockquote", "pre", "hr", "br", "figure",
-    "figcaption", "details", "summary", "address",
+    "p",
+    "div",
+    "span",
+    "section",
+    "article",
+    "header",
+    "footer",
+    "main",
+    "aside",
+    "nav",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "blockquote",
+    "pre",
+    "hr",
+    "br",
+    "figure",
+    "figcaption",
+    "details",
+    "summary",
+    "address",
     // Inline text semantics
-    "a", "b", "strong", "i", "em", "u", "s", "strike", "del", "ins", "mark", "small", "sub",
-    "sup", "abbr", "cite", "q", "code", "kbd", "samp", "var", "time", "wbr", "bdi", "bdo",
-    "ruby", "rt", "rp", "dfn",
+    "a",
+    "b",
+    "strong",
+    "i",
+    "em",
+    "u",
+    "s",
+    "strike",
+    "del",
+    "ins",
+    "mark",
+    "small",
+    "sub",
+    "sup",
+    "abbr",
+    "cite",
+    "q",
+    "code",
+    "kbd",
+    "samp",
+    "var",
+    "time",
+    "wbr",
+    "bdi",
+    "bdo",
+    "ruby",
+    "rt",
+    "rp",
+    "dfn",
     // Lists
-    "ul", "ol", "li", "dl", "dt", "dd",
+    "ul",
+    "ol",
+    "li",
+    "dl",
+    "dt",
+    "dd",
     // Tables
-    "table", "thead", "tbody", "tfoot", "tr", "th", "td", "caption", "colgroup", "col",
+    "table",
+    "thead",
+    "tbody",
+    "tfoot",
+    "tr",
+    "th",
+    "td",
+    "caption",
+    "colgroup",
+    "col",
     // Media
-    "img", "picture", "source", "audio", "video", "track",
+    "img",
+    "picture",
+    "source",
+    "audio",
+    "video",
+    "track",
     // `input` is allowed ONLY as an inert GFM task-list checkbox (issue #1439):
     // handle_input drops every attribute, keeps `checked`, and forces
     // `type="checkbox" disabled`, so it can carry no name/value/form binding and
@@ -72,10 +139,35 @@ const ALLOWED_TAGS: &[&str] = &[
     // allow-list (and no `href`): `semantics` is unwrapped so its presentation
     // child renders; `annotation`/`annotation-xml` are dropped with content
     // (see DROP_WITH_CONTENT — raw-TeX-source leak + mXSS vector).
-    "math", "mrow", "mi", "mo", "mn", "ms", "mtext", "mspace", "msup", "msub", "msubsup",
-    "mfrac", "msqrt", "mroot", "mover", "munder", "munderover", "mmultiscripts",
-    "mprescripts", "mtable", "mtr", "mtd", "mlabeledtr", "mpadded", "mphantom", "menclose",
-    "mstyle", "merror", "maction",
+    "math",
+    "mrow",
+    "mi",
+    "mo",
+    "mn",
+    "ms",
+    "mtext",
+    "mspace",
+    "msup",
+    "msub",
+    "msubsup",
+    "mfrac",
+    "msqrt",
+    "mroot",
+    "mover",
+    "munder",
+    "munderover",
+    "mmultiscripts",
+    "mprescripts",
+    "mtable",
+    "mtr",
+    "mtd",
+    "mlabeledtr",
+    "mpadded",
+    "mphantom",
+    "menclose",
+    "mstyle",
+    "merror",
+    "maction",
 ];
 
 /// Disallowed tags whose content is dropped along with them, rather than
@@ -96,7 +188,15 @@ const ALLOWED_TAGS: &[&str] = &[
 /// allow-listed and handled separately in `handle_iframe`, so it never
 /// reaches here.)
 const DROP_WITH_CONTENT: &[&str] = &[
-    "script", "style", "textarea", "option", "title", "xmp", "noembed", "noframes", "noscript",
+    "script",
+    "style",
+    "textarea",
+    "option",
+    "title",
+    "xmp",
+    "noembed",
+    "noframes",
+    "noscript",
     "plaintext",
     // MathML annotations. `<semantics>` is unwrapped (its presentation-MathML
     // child renders natively), but its annotations must be dropped WITH content,
@@ -107,7 +207,8 @@ const DROP_WITH_CONTENT: &[&str] = &[
     // subtree is strictly safer than unwrapping (keeping children). Neither is
     // used for visual rendering or screen-reader a11y — those use the
     // presentation MathML we keep.
-    "annotation", "annotation-xml",
+    "annotation",
+    "annotation-xml",
 ];
 
 /// Global attributes allowed on any element (`data-*` and `aria-*` handled
@@ -121,11 +222,40 @@ const GLOBAL_ATTRS: &[&str] = &["class", "id", "title", "dir", "lang", "role"];
 /// MathML presentation attributes — allowed on every element, matching
 /// sanitize.ts's `allowedAttributes["*"]` (no `href`, no event handlers).
 const MATHML_ATTRS: &[&str] = &[
-    "displaystyle", "scriptlevel", "mathvariant", "mathcolor", "mathbackground", "dir",
-    "display", "linethickness", "fence", "separator", "stretchy", "symmetric", "largeop",
-    "movablelimits", "accent", "accentunder", "lspace", "rspace", "width", "height", "depth",
-    "voffset", "open", "close", "separators", "notation", "columnalign", "rowalign",
-    "columnspan", "rowspan", "columnlines", "rowlines", "subscriptshift", "superscriptshift",
+    "displaystyle",
+    "scriptlevel",
+    "mathvariant",
+    "mathcolor",
+    "mathbackground",
+    "dir",
+    "display",
+    "linethickness",
+    "fence",
+    "separator",
+    "stretchy",
+    "symmetric",
+    "largeop",
+    "movablelimits",
+    "accent",
+    "accentunder",
+    "lspace",
+    "rspace",
+    "width",
+    "height",
+    "depth",
+    "voffset",
+    "open",
+    "close",
+    "separators",
+    "notation",
+    "columnalign",
+    "rowalign",
+    "columnspan",
+    "rowspan",
+    "columnlines",
+    "rowlines",
+    "subscriptshift",
+    "superscriptshift",
 ];
 
 const SAFE_SCHEMES: &[&str] = &["http", "https", "mailto", "tel"];
@@ -272,7 +402,8 @@ fn srcset_urls(value: &str) -> Vec<String> {
             return false;
         }
         let (num, suffix) = desc.split_at(desc.len() - 1);
-        matches!(suffix, "w" | "x") && num.chars().all(|c| c.is_ascii_digit() || c == '.')
+        matches!(suffix, "w" | "x")
+            && num.chars().all(|c| c.is_ascii_digit() || c == '.')
             && num.chars().any(|c| c.is_ascii_digit())
     }
     fn looks_like_new_entry(s: &str) -> bool {
@@ -312,7 +443,9 @@ fn srcset_urls(value: &str) -> Vec<String> {
 /// sandbox/allow/loading. Anything unrecognized is removed with its content.
 fn handle_iframe(el: &mut Element) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let src = el.get_attribute("src");
-    let embed = src.as_deref().and_then(|s| normalize_embed(&decode_attr(s)));
+    let embed = src
+        .as_deref()
+        .and_then(|s| normalize_embed(&decode_attr(s)));
     let Some(embed) = embed else {
         el.remove();
         return Ok(());
@@ -657,14 +790,20 @@ fn rewrite_dropping_disallowed_end_tags(html: &str) -> String {
     while let Some(lt) = find_byte(bytes, i, b'<') {
         i = lt + 1;
         if bytes[lt..].starts_with(b"<!--") {
-            i = find_bytes(bytes, lt + 4, b"-->").map(|p| p + 3).unwrap_or(bytes.len());
+            i = find_bytes(bytes, lt + 4, b"-->")
+                .map(|p| p + 3)
+                .unwrap_or(bytes.len());
         } else if i < bytes.len() && matches!(bytes[i], b'!' | b'?') {
             // Bogus comment / doctype: ends at the first `>`.
-            i = find_byte(bytes, i, b'>').map(|p| p + 1).unwrap_or(bytes.len());
+            i = find_byte(bytes, i, b'>')
+                .map(|p| p + 1)
+                .unwrap_or(bytes.len());
         } else if i < bytes.len() && bytes[i] == b'/' {
             if !(i + 1 < bytes.len() && bytes[i + 1].is_ascii_alphabetic()) {
                 // `</>` or `</ …`: a bogus comment per spec, not an end tag.
-                i = find_byte(bytes, i + 1, b'>').map(|p| p + 1).unwrap_or(bytes.len());
+                i = find_byte(bytes, i + 1, b'>')
+                    .map(|p| p + 1)
+                    .unwrap_or(bytes.len());
                 continue;
             }
             let after_name = tag_name_end(bytes, lt + 2);
@@ -674,10 +813,7 @@ fn rewrite_dropping_disallowed_end_tags(html: &str) -> String {
             i = bare_end.unwrap_or_else(|| scan_to_tag_end(bytes, after_name).0);
             let name = &bytes[lt + 2..after_name];
             if let Some(end) = bare_end {
-                if foreign_depth == 0
-                    && !tag_allowed_bytes(name)
-                    && !cut_would_splice(bytes, lt)
-                {
+                if foreign_depth == 0 && !tag_allowed_bytes(name) && !cut_would_splice(bytes, lt) {
                     out.get_or_insert_with(|| String::with_capacity(html.len()))
                         .push_str(&html[kept_to..lt]);
                     kept_to = end;
@@ -872,7 +1008,10 @@ mod tests {
         let out = sanitize(
             r#"<iframe width="560" src="https://www.youtube.com/embed/abc123?autoplay=1"></iframe>"#,
         );
-        assert!(out.contains(r#"src="https://www.youtube-nocookie.com/embed/abc123""#), "{out}");
+        assert!(
+            out.contains(r#"src="https://www.youtube-nocookie.com/embed/abc123""#),
+            "{out}"
+        );
         assert!(out.contains(r#"width="560""#));
         assert!(out.contains("sandbox="));
         assert!(!out.contains("autoplay"));
@@ -943,7 +1082,15 @@ mod tests {
         // so unwrapping would re-emit it verbatim and the browser would
         // re-parse it as a live element (mXSS). All such non-allow-listed
         // elements must drop their whole subtree.
-        for tag in ["title", "xmp", "noembed", "noframes", "noscript", "plaintext", "textarea"] {
+        for tag in [
+            "title",
+            "xmp",
+            "noembed",
+            "noframes",
+            "noscript",
+            "plaintext",
+            "textarea",
+        ] {
             let input = format!("<p>ok</p><{tag}><img src=x onerror=alert(1)></{tag}>");
             let out = sanitize(&input);
             assert!(
@@ -958,7 +1105,10 @@ mod tests {
     fn img_src_rejects_mailto_tel_but_keeps_data() {
         // img/source src is http/https/data only (parity with the old
         // allowedSchemesByTag) — mailto/tel are not image sources.
-        assert_eq!(sanitize(r#"<img src="mailto:x@y.com">"#), r#"<img loading="lazy">"#);
+        assert_eq!(
+            sanitize(r#"<img src="mailto:x@y.com">"#),
+            r#"<img loading="lazy">"#
+        );
         assert_eq!(
             sanitize(r#"<img src="data:image/png;base64,AAA=">"#),
             r#"<img src="data:image/png;base64,AAA=" loading="lazy">"#
@@ -1075,14 +1225,23 @@ mod tests {
         // The end-tag pass reads the allow-list through a bucketed index, so a
         // tag that lands in no bucket would silently lose its end tags.
         for tag in ALLOWED_TAGS {
-            assert!(tag_allowed_bytes(tag.as_bytes()), "{tag} missing from the index");
+            assert!(
+                tag_allowed_bytes(tag.as_bytes()),
+                "{tag} missing from the index"
+            );
             assert!(
                 tag_allowed_bytes(tag.to_ascii_uppercase().as_bytes()),
                 "{tag} not matched case-insensitively"
             );
         }
-        for tag in DROP_WITH_CONTENT.iter().chain(&["body", "html", "head", ""]) {
-            assert!(!tag_allowed_bytes(tag.as_bytes()), "{tag} wrongly allow-listed");
+        for tag in DROP_WITH_CONTENT
+            .iter()
+            .chain(&["body", "html", "head", ""])
+        {
+            assert!(
+                !tag_allowed_bytes(tag.as_bytes()),
+                "{tag} wrongly allow-listed"
+            );
         }
     }
 
@@ -1204,21 +1363,53 @@ mod tests {
         // specially, quotes where an attribute name goes, raw text and foreign
         // content, half a character reference, a payload to notice going live.
         const PIECES: &[&str] = &[
-            "<", ">", "/", "=", "\"", "'", "&", " ", "a", "x=y", "</body>", "</html>", "</o",
-            "<p>", "</p>", "<img src=q onerror=alert(1)>", "<script>alert(1)</script>", "&am",
-            "p;", "&#3", "9;", "-->", "]]>", "😀", "<div title=", "</iframe>", "<math>",
-            "<mtext>", "<svg>", "</svg>", "</ ", "</>",
+            "<",
+            ">",
+            "/",
+            "=",
+            "\"",
+            "'",
+            "&",
+            " ",
+            "a",
+            "x=y",
+            "</body>",
+            "</html>",
+            "</o",
+            "<p>",
+            "</p>",
+            "<img src=q onerror=alert(1)>",
+            "<script>alert(1)</script>",
+            "&am",
+            "p;",
+            "&#3",
+            "9;",
+            "-->",
+            "]]>",
+            "😀",
+            "<div title=",
+            "</iframe>",
+            "<math>",
+            "<mtext>",
+            "<svg>",
+            "</svg>",
+            "</ ",
+            "</>",
             r#"<iframe src="https://www.youtube.com/embed/abc123">"#,
         ];
         // A deterministic LCG, so a failure reproduces from its seed alone.
         let mut seed = 0x2545_F491_4F6C_DD1Du64;
         let mut next = move || {
-            seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1_442_695_040_888_963);
+            seed = seed
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963);
             (seed >> 33) as usize
         };
         let mut cut_something = 0usize;
         for _ in 0..50_000 {
-            let input: String = (0..2 + next() % 8).map(|_| PIECES[next() % PIECES.len()]).collect();
+            let input: String = (0..2 + next() % 8)
+                .map(|_| PIECES[next() % PIECES.len()])
+                .collect();
             let Some(out) = drop_disallowed_end_tags(&input) else {
                 continue;
             };
@@ -1240,7 +1431,10 @@ mod tests {
         }
         // Guard against the generator drifting into shapes that never cut, which
         // would leave the property above vacuously true.
-        assert!(cut_something > 1_000, "only {cut_something} inputs were cut");
+        assert!(
+            cut_something > 1_000,
+            "only {cut_something} inputs were cut"
+        );
     }
 
     #[test]

--- a/native/sanitizer/core/src/scanner.rs
+++ b/native/sanitizer/core/src/scanner.rs
@@ -103,9 +103,14 @@ pub(crate) fn skip_raw_text(bytes: &[u8], from: usize, name: &str) -> usize {
         if name_end <= bytes.len()
             && bytes[name_start..name_end].eq_ignore_ascii_case(name_bytes)
             && (name_end == bytes.len()
-                || matches!(bytes[name_end], b'>' | b'/' | b' ' | b'\t' | b'\n' | b'\r' | b'\x0c'))
+                || matches!(
+                    bytes[name_end],
+                    b'>' | b'/' | b' ' | b'\t' | b'\n' | b'\r' | b'\x0c'
+                ))
         {
-            return find_byte(bytes, name_end, b'>').map(|p| p + 1).unwrap_or(bytes.len());
+            return find_byte(bytes, name_end, b'>')
+                .map(|p| p + 1)
+                .unwrap_or(bytes.len());
         }
         i = lt + 2;
     }
@@ -239,22 +244,30 @@ pub fn find_top_level_ranges(
             continue;
         }
         if bytes[i..].starts_with(b"<!--") {
-            i = find_bytes(bytes, i + 4, b"-->").map(|p| p + 3).unwrap_or(bytes.len());
+            i = find_bytes(bytes, i + 4, b"-->")
+                .map(|p| p + 3)
+                .unwrap_or(bytes.len());
             continue;
         }
         if i + 1 < bytes.len() && (bytes[i + 1] == b'!' || bytes[i + 1] == b'?') {
             // Bogus comment / doctype: ends at the first `>`.
-            i = find_byte(bytes, i + 1, b'>').map(|p| p + 1).unwrap_or(bytes.len());
+            i = find_byte(bytes, i + 1, b'>')
+                .map(|p| p + 1)
+                .unwrap_or(bytes.len());
             continue;
         }
         if i + 1 < bytes.len() && bytes[i + 1] == b'/' {
             if !(i + 2 < bytes.len() && bytes[i + 2].is_ascii_alphabetic()) {
                 // `</>` or `</ …`: bogus comment per spec, ends at first `>`.
-                i = find_byte(bytes, i + 2, b'>').map(|p| p + 1).unwrap_or(bytes.len());
+                i = find_byte(bytes, i + 2, b'>')
+                    .map(|p| p + 1)
+                    .unwrap_or(bytes.len());
                 continue;
             }
             let (name, after) = read_tag_name(bytes, i + 2);
-            let close_end = find_byte(bytes, after, b'>').map(|p| p + 1).unwrap_or(bytes.len());
+            let close_end = find_byte(bytes, after, b'>')
+                .map(|p| p + 1)
+                .unwrap_or(bytes.len());
             if depth > 0 {
                 if name == target {
                     depth -= 1;
@@ -339,10 +352,16 @@ mod tests {
     use super::*;
 
     fn ranges(html: &str, target: &str) -> Vec<(usize, usize, bool)> {
-        find_top_level_ranges(html, target, &["mjx-math"], true, Recovery::AtLastInnerClose)
-            .into_iter()
-            .map(|r| (r.start, r.end, r.explicit_close))
-            .collect()
+        find_top_level_ranges(
+            html,
+            target,
+            &["mjx-math"],
+            true,
+            Recovery::AtLastInnerClose,
+        )
+        .into_iter()
+        .map(|r| (r.start, r.end, r.explicit_close))
+        .collect()
     }
 
     #[test]
@@ -356,7 +375,10 @@ mod tests {
         let html = "<mjx-container><mjx-container>x</mjx-container></mjx-container>tail";
         let r = ranges(html, "mjx-container");
         assert_eq!(r.len(), 1);
-        assert_eq!(&html[r[0].0..r[0].1], "<mjx-container><mjx-container>x</mjx-container></mjx-container>");
+        assert_eq!(
+            &html[r[0].0..r[0].1],
+            "<mjx-container><mjx-container>x</mjx-container></mjx-container>"
+        );
     }
 
     #[test]
@@ -418,7 +440,10 @@ mod tests {
         let html = "a<svg><circle>";
         let r = find_top_level_ranges(html, "svg", &[], false, Recovery::ToEof);
         assert_eq!(r.len(), 1);
-        assert_eq!((r[0].start, r[0].end, r[0].explicit_close), (1, html.len(), false));
+        assert_eq!(
+            (r[0].start, r[0].end, r[0].explicit_close),
+            (1, html.len(), false)
+        );
     }
 
     #[test]

--- a/native/sanitizer/core/src/serialize.rs
+++ b/native/sanitizer/core/src/serialize.rs
@@ -42,7 +42,11 @@ pub enum MNode {
 
 impl MNode {
     pub fn elem(name: &'static str, children: Vec<MNode>) -> MNode {
-        MNode::Elem { name, attrs: Vec::new(), children }
+        MNode::Elem {
+            name,
+            attrs: Vec::new(),
+            children,
+        }
     }
 
     pub fn elem_with_attrs(
@@ -50,7 +54,11 @@ impl MNode {
         attrs: Vec<(String, String)>,
         children: Vec<MNode>,
     ) -> MNode {
-        MNode::Elem { name, attrs, children }
+        MNode::Elem {
+            name,
+            attrs,
+            children,
+        }
     }
 }
 
@@ -60,7 +68,11 @@ pub fn serialize_mnodes(nodes: &[MNode], out: &mut String) {
     for node in nodes {
         match node {
             MNode::Text(t) => escape_text(t, out),
-            MNode::Elem { name, attrs, children } => {
+            MNode::Elem {
+                name,
+                attrs,
+                children,
+            } => {
                 out.push('<');
                 out.push_str(name);
                 for (k, v) in attrs {

--- a/native/sanitizer/core/src/svg.rs
+++ b/native/sanitizer/core/src/svg.rs
@@ -27,54 +27,269 @@ use crate::serialize::{attr_display_name, escape_attr, escape_text};
 use crate::urls::{is_data_image, url_scheme};
 
 const ALLOWED_SVG_TAGS: &[&str] = &[
-    "svg", "a", "altglyph", "altglyphdef", "altglyphitem", "circle", "clippath", "defs", "desc",
-    "ellipse", "filter", "font", "g", "glyph", "glyphref", "hkern", "image", "line",
-    "lineargradient", "marker", "mask", "metadata", "path", "pattern", "polygon", "polyline",
-    "radialgradient", "rect", "stop", "switch", "symbol", "text", "textpath", "title", "tref",
-    "tspan", "view", "vkern",
+    "svg",
+    "a",
+    "altglyph",
+    "altglyphdef",
+    "altglyphitem",
+    "circle",
+    "clippath",
+    "defs",
+    "desc",
+    "ellipse",
+    "filter",
+    "font",
+    "g",
+    "glyph",
+    "glyphref",
+    "hkern",
+    "image",
+    "line",
+    "lineargradient",
+    "marker",
+    "mask",
+    "metadata",
+    "path",
+    "pattern",
+    "polygon",
+    "polyline",
+    "radialgradient",
+    "rect",
+    "stop",
+    "switch",
+    "symbol",
+    "text",
+    "textpath",
+    "title",
+    "tref",
+    "tspan",
+    "view",
+    "vkern",
     // Filter primitives (safe; static rendering only).
-    "feblend", "fecolormatrix", "fecomponenttransfer", "fecomposite", "feconvolvematrix",
-    "fediffuselighting", "fedisplacementmap", "fedistantlight", "fedropshadow", "feflood",
-    "fefunca", "fefuncb", "fefuncg", "fefuncr", "fegaussianblur", "feimage", "femerge",
-    "femergenode", "femorphology", "feoffset", "fepointlight", "fespecularlighting",
-    "fespotlight", "fetile", "feturbulence",
+    "feblend",
+    "fecolormatrix",
+    "fecomponenttransfer",
+    "fecomposite",
+    "feconvolvematrix",
+    "fediffuselighting",
+    "fedisplacementmap",
+    "fedistantlight",
+    "fedropshadow",
+    "feflood",
+    "fefunca",
+    "fefuncb",
+    "fefuncg",
+    "fefuncr",
+    "fegaussianblur",
+    "feimage",
+    "femerge",
+    "femergenode",
+    "femorphology",
+    "feoffset",
+    "fepointlight",
+    "fespecularlighting",
+    "fespotlight",
+    "fetile",
+    "feturbulence",
 ];
 
 const ALLOWED_SVG_ATTRS: &[&str] = &[
-    "accent-height", "accumulate", "additive", "alignment-baseline", "amplitude", "ascent",
-    "attributename", "attributetype", "azimuth", "basefrequency", "baseline-shift", "begin",
-    "bias", "by", "class", "clip", "clippathunits", "clip-path", "clip-rule", "color",
-    "color-interpolation", "color-interpolation-filters", "color-profile", "color-rendering",
-    "cx", "cy", "d", "dx", "dy", "diffuseconstant", "direction", "display", "divisor", "dur",
-    "edgemode", "elevation", "end", "exponent", "fill", "fill-opacity", "fill-rule", "filter",
-    "filterunits", "flood-color", "flood-opacity", "font-family", "font-size",
-    "font-size-adjust", "font-stretch", "font-style", "font-variant", "font-weight", "fx",
-    "fy", "g1", "g2", "glyph-name", "glyphref", "gradientunits", "gradienttransform",
-    "height", "href", "id", "image-rendering", "in", "in2", "intercept", "k", "k1", "k2",
-    "k3", "k4", "kerning", "keypoints", "keysplines", "keytimes", "lang", "lengthadjust",
-    "letter-spacing", "kernelmatrix", "kernelunitlength", "lighting-color", "local",
-    "marker-end", "marker-mid", "marker-start", "markerheight", "markerunits", "markerwidth",
-    "maskcontentunits", "maskunits", "max", "mask", "mask-type", "media", "method", "mode",
-    "min", "name", "numoctaves", "offset", "operator", "opacity", "order", "orient",
-    "orientation", "origin", "overflow", "paint-order", "path", "pathlength",
-    "patterncontentunits", "patterntransform", "patternunits", "points", "preservealpha",
-    "preserveaspectratio", "primitiveunits", "r", "rx", "ry", "radius", "refx", "refy",
-    "repeatcount", "repeatdur", "restart", "result", "rotate", "scale", "seed",
-    "shape-rendering", "slope", "specularconstant", "specularexponent", "spreadmethod",
-    "startoffset", "stddeviation", "stitchtiles", "stop-color", "stop-opacity",
-    "stroke-dasharray", "stroke-dashoffset", "stroke-linecap", "stroke-linejoin",
-    "stroke-miterlimit", "stroke-opacity", "stroke", "stroke-width", "surfacescale",
-    "systemlanguage", "tabindex", "tablevalues", "targetx", "targety", "transform",
-    "transform-origin", "text-anchor", "text-decoration", "text-rendering", "textlength",
-    "type", "u1", "u2", "unicode", "values", "viewbox", "visibility", "version",
-    "vert-adv-y", "vert-origin-x", "vert-origin-y", "width", "word-spacing", "wrap",
-    "writing-mode", "xchannelselector", "ychannelselector", "x", "x1", "x2", "xmlns", "y",
-    "y1", "y2", "z", "zoomandpan",
+    "accent-height",
+    "accumulate",
+    "additive",
+    "alignment-baseline",
+    "amplitude",
+    "ascent",
+    "attributename",
+    "attributetype",
+    "azimuth",
+    "basefrequency",
+    "baseline-shift",
+    "begin",
+    "bias",
+    "by",
+    "class",
+    "clip",
+    "clippathunits",
+    "clip-path",
+    "clip-rule",
+    "color",
+    "color-interpolation",
+    "color-interpolation-filters",
+    "color-profile",
+    "color-rendering",
+    "cx",
+    "cy",
+    "d",
+    "dx",
+    "dy",
+    "diffuseconstant",
+    "direction",
+    "display",
+    "divisor",
+    "dur",
+    "edgemode",
+    "elevation",
+    "end",
+    "exponent",
+    "fill",
+    "fill-opacity",
+    "fill-rule",
+    "filter",
+    "filterunits",
+    "flood-color",
+    "flood-opacity",
+    "font-family",
+    "font-size",
+    "font-size-adjust",
+    "font-stretch",
+    "font-style",
+    "font-variant",
+    "font-weight",
+    "fx",
+    "fy",
+    "g1",
+    "g2",
+    "glyph-name",
+    "glyphref",
+    "gradientunits",
+    "gradienttransform",
+    "height",
+    "href",
+    "id",
+    "image-rendering",
+    "in",
+    "in2",
+    "intercept",
+    "k",
+    "k1",
+    "k2",
+    "k3",
+    "k4",
+    "kerning",
+    "keypoints",
+    "keysplines",
+    "keytimes",
+    "lang",
+    "lengthadjust",
+    "letter-spacing",
+    "kernelmatrix",
+    "kernelunitlength",
+    "lighting-color",
+    "local",
+    "marker-end",
+    "marker-mid",
+    "marker-start",
+    "markerheight",
+    "markerunits",
+    "markerwidth",
+    "maskcontentunits",
+    "maskunits",
+    "max",
+    "mask",
+    "mask-type",
+    "media",
+    "method",
+    "mode",
+    "min",
+    "name",
+    "numoctaves",
+    "offset",
+    "operator",
+    "opacity",
+    "order",
+    "orient",
+    "orientation",
+    "origin",
+    "overflow",
+    "paint-order",
+    "path",
+    "pathlength",
+    "patterncontentunits",
+    "patterntransform",
+    "patternunits",
+    "points",
+    "preservealpha",
+    "preserveaspectratio",
+    "primitiveunits",
+    "r",
+    "rx",
+    "ry",
+    "radius",
+    "refx",
+    "refy",
+    "repeatcount",
+    "repeatdur",
+    "restart",
+    "result",
+    "rotate",
+    "scale",
+    "seed",
+    "shape-rendering",
+    "slope",
+    "specularconstant",
+    "specularexponent",
+    "spreadmethod",
+    "startoffset",
+    "stddeviation",
+    "stitchtiles",
+    "stop-color",
+    "stop-opacity",
+    "stroke-dasharray",
+    "stroke-dashoffset",
+    "stroke-linecap",
+    "stroke-linejoin",
+    "stroke-miterlimit",
+    "stroke-opacity",
+    "stroke",
+    "stroke-width",
+    "surfacescale",
+    "systemlanguage",
+    "tabindex",
+    "tablevalues",
+    "targetx",
+    "targety",
+    "transform",
+    "transform-origin",
+    "text-anchor",
+    "text-decoration",
+    "text-rendering",
+    "textlength",
+    "type",
+    "u1",
+    "u2",
+    "unicode",
+    "values",
+    "viewbox",
+    "visibility",
+    "version",
+    "vert-adv-y",
+    "vert-origin-x",
+    "vert-origin-y",
+    "width",
+    "word-spacing",
+    "wrap",
+    "writing-mode",
+    "xchannelselector",
+    "ychannelselector",
+    "x",
+    "x1",
+    "x2",
+    "xmlns",
+    "y",
+    "y1",
+    "y2",
+    "z",
+    "zoomandpan",
     // Namespaced attributes preserved for well-formed SVG.
-    "xlink:href", "xml:space", "xml:lang", "xmlns:xlink",
+    "xlink:href",
+    "xml:space",
+    "xml:lang",
+    "xmlns:xlink",
     // Link attributes on SVG <a> (SVG2); rel/target are forced to safe
     // values for external links.
-    "target", "rel",
+    "target",
+    "rel",
 ];
 
 const HREF_HTTP_SCHEMES: &[&str] = &["http", "https", "mailto", "tel"];
@@ -138,9 +353,7 @@ fn emit_svg_element(el: ElementRef, out: &mut String) {
         if !ALLOWED_SVG_ATTRS.contains(&attr_lower.as_str()) {
             continue;
         }
-        if (attr_lower == "href" || attr_lower == "xlink:href")
-            && !is_href_allowed(&lower, value)
-        {
+        if (attr_lower == "href" || attr_lower == "xlink:href") && !is_href_allowed(&lower, value) {
             continue;
         }
         // Namespace ids and the references that reach them, so an SVG's
@@ -272,7 +485,11 @@ fn contains_svg(html: &str) -> bool {
 /// collects non-fatal diagnostics for the caller to log.
 pub fn extract_inline_svg(html: &str, warnings: &mut Vec<String>) -> SvgExtraction {
     if !contains_svg(html) {
-        return SvgExtraction { html: html.to_string(), svgs: Vec::new(), nonce: String::new() };
+        return SvgExtraction {
+            html: html.to_string(),
+            svgs: Vec::new(),
+            nonce: String::new(),
+        };
     }
     let nonce = random_nonce();
     // Inside <svg>, foreign-content parsing keeps <style>/<script> as
@@ -280,7 +497,11 @@ pub fn extract_inline_svg(html: &str, warnings: &mut Vec<String>) -> SvgExtracti
     // matching the old htmlparser2 implied-close behavior.
     let ranges = find_top_level_ranges(html, "svg", &[], false, Recovery::ToEof);
     if ranges.is_empty() {
-        return SvgExtraction { html: html.to_string(), svgs: Vec::new(), nonce };
+        return SvgExtraction {
+            html: html.to_string(),
+            svgs: Vec::new(),
+            nonce,
+        };
     }
 
     let mut svgs: Vec<String> = Vec::new();
@@ -308,10 +529,18 @@ pub fn extract_inline_svg(html: &str, warnings: &mut Vec<String>) -> SvgExtracti
         ));
     }
     if svgs.is_empty() {
-        return SvgExtraction { html: html.to_string(), svgs, nonce };
+        return SvgExtraction {
+            html: html.to_string(),
+            svgs,
+            nonce,
+        };
     }
     result.push_str(&html[cursor..]);
-    SvgExtraction { html: result, svgs, nonce }
+    SvgExtraction {
+        html: result,
+        svgs,
+        nonce,
+    }
 }
 
 /// Substitute the sanitized SVG markup back in for the placeholder tokens,
@@ -363,7 +592,9 @@ mod tests {
 
     #[test]
     fn drops_script_and_event_handlers() {
-        let out = roundtrip(r#"<svg onload="alert(1)"><script>alert(1)</script><circle onclick="x" r="1"/></svg>"#);
+        let out = roundtrip(
+            r#"<svg onload="alert(1)"><script>alert(1)</script><circle onclick="x" r="1"/></svg>"#,
+        );
         assert!(!out.contains("script"), "{out}");
         assert!(!out.contains("onload"), "{out}");
         assert!(!out.contains("onclick"), "{out}");
@@ -372,7 +603,9 @@ mod tests {
 
     #[test]
     fn drops_foreign_object_subtree() {
-        let out = roundtrip(r#"<svg><foreignObject><img src="x" onerror="alert(1)"></foreignObject><rect width="5"/></svg>"#);
+        let out = roundtrip(
+            r#"<svg><foreignObject><img src="x" onerror="alert(1)"></foreignObject><rect width="5"/></svg>"#,
+        );
         assert!(!out.to_lowercase().contains("foreignobject"), "{out}");
         assert!(!out.contains("img"), "{out}");
         assert!(out.contains("<rect width=\"5\"/>"), "{out}");
@@ -415,7 +648,10 @@ mod tests {
         );
         let mut warnings = Vec::new();
         let extraction = extract_inline_svg(&deep, &mut warnings);
-        assert!(extraction.svgs.is_empty(), "over-deep SVG must be dropped, not emitted");
+        assert!(
+            extraction.svgs.is_empty(),
+            "over-deep SVG must be dropped, not emitted"
+        );
         assert_eq!(warnings.len(), 1, "{warnings:?}");
         assert!(warnings[0].contains("nested deeper"), "{warnings:?}");
     }
@@ -428,7 +664,11 @@ mod tests {
         let mut warnings = Vec::new();
         let extraction = extract_inline_svg(&html, &mut warnings);
         assert_eq!(extraction.svgs.len(), 1, "{:?}", extraction.svgs);
-        assert!(extraction.svgs[0].contains("id=\"uc-ok\""), "{:?}", extraction.svgs);
+        assert!(
+            extraction.svgs[0].contains("id=\"uc-ok\""),
+            "{:?}",
+            extraction.svgs
+        );
         assert_eq!(warnings.len(), 1, "{warnings:?}");
     }
 
@@ -445,7 +685,12 @@ mod tests {
             "</g>".repeat(levels)
         );
         let out = roundtrip(&deep);
-        assert_eq!(out.matches("<g").count(), levels, "{}", &out[..out.len().min(200)]);
+        assert_eq!(
+            out.matches("<g").count(),
+            levels,
+            "{}",
+            &out[..out.len().min(200)]
+        );
         assert!(out.contains("<circle r=\"1\"/>"), "{out}");
     }
 
@@ -534,7 +779,9 @@ mod tests {
 
     #[test]
     fn leaves_non_reference_paint_values_alone() {
-        let out = roundtrip("<svg><rect fill=\"#ff0000\" stroke=\"none\" clip-path=\"circle(50%)\"/></svg>");
+        let out = roundtrip(
+            "<svg><rect fill=\"#ff0000\" stroke=\"none\" clip-path=\"circle(50%)\"/></svg>",
+        );
         assert!(out.contains("fill=\"#ff0000\""), "{out}");
         assert!(out.contains("stroke=\"none\""), "{out}");
         assert!(out.contains("clip-path=\"circle(50%)\""), "{out}");

--- a/native/sanitizer/core/src/urls.rs
+++ b/native/sanitizer/core/src/urls.rs
@@ -92,10 +92,22 @@ mod tests {
 
     #[test]
     fn detects_schemes_through_obfuscation() {
-        assert_eq!(url_scheme("javascript:alert(1)").as_deref(), Some("javascript"));
-        assert_eq!(url_scheme("JAVASCRIPT:alert(1)").as_deref(), Some("javascript"));
-        assert_eq!(url_scheme("java\tscript:alert(1)").as_deref(), Some("javascript"));
-        assert_eq!(url_scheme("  javascript:alert(1)").as_deref(), Some("javascript"));
+        assert_eq!(
+            url_scheme("javascript:alert(1)").as_deref(),
+            Some("javascript")
+        );
+        assert_eq!(
+            url_scheme("JAVASCRIPT:alert(1)").as_deref(),
+            Some("javascript")
+        );
+        assert_eq!(
+            url_scheme("java\tscript:alert(1)").as_deref(),
+            Some("javascript")
+        );
+        assert_eq!(
+            url_scheme("  javascript:alert(1)").as_deref(),
+            Some("javascript")
+        );
         assert_eq!(
             url_scheme(&decode_attr("java&#115;cript:alert(1)")).as_deref(),
             Some("javascript")
@@ -116,7 +128,10 @@ mod tests {
         assert!(is_url_allowed("/relative", &["http", "https"]));
         assert!(!is_url_allowed("javascript:x", &["http", "https"]));
         assert!(!is_url_allowed("data:text/html,x", &["http", "https"]));
-        assert!(is_url_allowed("data:image/png;base64,x", &["http", "https", "data"]));
+        assert!(is_url_allowed(
+            "data:image/png;base64,x",
+            &["http", "https", "data"]
+        ));
     }
 
     #[test]

--- a/native/sanitizer/src/lib.rs
+++ b/native/sanitizer/src/lib.rs
@@ -21,7 +21,10 @@ pub struct SanitizeOutput {
 fn run_pipeline(html: &str) -> Result<SanitizeOutput> {
     let mut warnings = Vec::new();
     match core::sanitize_entry_html(html, &mut warnings) {
-        Ok(sanitized) => Ok(SanitizeOutput { html: sanitized, warnings }),
+        Ok(sanitized) => Ok(SanitizeOutput {
+            html: sanitized,
+            warnings,
+        }),
         Err(message) => Err(Error::new(
             Status::GenericFailure,
             format!("sanitizer failed: {message}"),

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "lint:native": "bash scripts/cargo-native.sh clippy --workspace --all-targets -- -D warnings",
+    "format:native": "bash scripts/cargo-native.sh fmt --all",
     "check:colors": "node scripts/check-raw-colors.mjs",
     "knip": "knip --include files,dependencies,devDependencies,exports",
     "knip:production": "knip -c knip.production.json --production --workspace . --tags=-testonly --include files,exports,types",
@@ -59,6 +60,9 @@
     ],
     "*.{json,md,css,scss,yaml,yml,html}": [
       "prettier --write"
+    ],
+    "*.rs": [
+      "bash scripts/rustfmt-staged.sh"
     ]
   },
   "dependencies": {

--- a/scripts/rustfmt-staged.sh
+++ b/scripts/rustfmt-staged.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Format the .rs files lint-staged hands us, for the husky pre-commit hook.
+#
+# `cargo fmt` formats a whole crate, not the paths lint-staged passes, so call
+# rustfmt directly. Its `--edition` has to match the owning crate's, or the hook
+# formats to a different dialect than `cargo fmt` does in CI; derive it from the
+# nearest Cargo.toml rather than hardcoding one, so a crate that moves editions
+# does not silently start disagreeing with the CI gate. Staged files can span
+# several crates, hence the grouping.
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+  exit 0
+fi
+
+if ! command -v rustfmt >/dev/null 2>&1; then
+  if [ -x "${HOME:-}/.cargo/bin/rustfmt" ]; then
+    export PATH="$HOME/.cargo/bin:$PATH"
+  else
+    echo "rustfmt not found on PATH or in ~/.cargo/bin; install the Rust toolchain" >&2
+    exit 69
+  fi
+fi
+
+edition_of() {
+  local dir
+  dir="$(cd "$(dirname "$1")" && pwd)"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/Cargo.toml" ]; then
+      local edition
+      edition="$(sed -n 's/^edition[[:space:]]*=[[:space:]]*"\([0-9]\{4\}\)".*/\1/p' "$dir/Cargo.toml" | head -1)"
+      if [ -n "$edition" ]; then
+        echo "$edition"
+        return
+      fi
+    fi
+    dir="$(dirname "$dir")"
+  done
+  # A .rs file outside any crate; rustfmt's own default.
+  echo 2015
+}
+
+editions=()
+for file in "$@"; do
+  editions+=("$(edition_of "$file")")
+done
+
+for edition in $(printf '%s\n' "${editions[@]}" | sort -u); do
+  group=()
+  for i in "${!editions[@]}"; do
+    if [ "${editions[$i]}" = "$edition" ]; then
+      group+=("${@:i+1:1}")
+    fi
+  done
+  rustfmt --edition "$edition" "${group[@]}"
+done


### PR DESCRIPTION
Fixes #1580

`cargo fmt` was gated nowhere: the `lint` job's prettier pass doesn't touch `.rs`, `rust-checks` ran only `cargo test` and `cargo clippy`, and `lint-staged` had no `*.rs` glob.

Two commits, so the mechanical churn is separable from the real change.

## Reformatting the sanitizer is behaviour-safe

Most of the churn lands in `native/sanitizer`, our primary XSS defense (SECURITY.md §1), and **39 of its 72 hunks are in production rather than test code** — so this deserves saying up front. rustfmt is a purely syntactic transformation, and I confirmed it empirically: after `cargo fmt --all`, the sanitizer's own allow-list and escaping suite is **107 passed, 0 failed**. The full native suite is green too (sanitizer 107, markdown 26, feed-parser 11) and clippy `-D warnings` is clean.

## Why no `rustfmt.toml`

The plan going in was to add a config blessing the existing ~100-column style, on the theory that stock `fn_call_width = 60` was fighting it. **Measurement said otherwise** — `fn_call_width = 100` removes only ~11% of the diff:

| Config | `rustfmt --check` diff lines |
|---|---|
| stock (no `rustfmt.toml`) | **1,573** |
| `fn_call_width = 100` | 1,405 |
| `use_small_heuristics = "Max"` | 1,531 |
| `Max` + `single_line_if_else_max_width = 0` + `short_array_element_width_threshold = 100` | **1,059** ← best of ~20 configs |

I swept `max_width` ∈ {90, 100, 110, 120} against `use_small_heuristics`, plus each width knob individually (`chain_width`, `struct_lit_width`, `array_width`, `attr_fn_like_width`, `single_line_if_else_max_width`, `short_array_element_width_threshold` at 0 and 100). Nothing got below 1,059.

The reason is that the tree has no single existing style to bless — hunks pull in **both directions**. In one file `EMBED_CANONICAL_HOSTNAMES` is one-element-per-line while `VIMEO_PARAMS` is packed horizontally, so no `short_array_element_width_threshold` satisfies both; and some source lines run to 208 columns, which no sane `max_width` leaves alone. A config would add non-obvious knobs and still rewrite the same files, so stock rustfmt it is. Stock `max_width` is already 100, which matches the code's intent anyway.

(For the record, a root `rustfmt.toml` *would* have worked mechanically: `rustfmt --print-config current .` in each of the four crates picks up a repo-root file, despite there being no Cargo workspace. It just doesn't help here.)

Per-crate reformat, for scale:

| Crate | diff lines | LOC | % |
|---|---|---|---|
| sanitizer | 1,418 | 4,212 | 33.7% |
| feed-parser | 68 | 1,683 | 4.0% |
| markdown | 59 | 702 | 8.4% |
| readability | 28 | 154 | 18.2% |

## The gate

**CI** — `./scripts/cargo-native.sh fmt --all --check` goes first in `rust-checks`; it compiles nothing, so a misformatted PR fails in seconds instead of after the test and clippy builds. The steps after it gain `if: !cancelled()` so one push still surfaces every problem, matching the `lint` job's existing convention.

**Pre-commit** — `cargo fmt` is crate-oriented and lint-staged hands over file paths, so `scripts/rustfmt-staged.sh` calls `rustfmt` on those paths directly. It groups them by owning crate to derive `--edition` from the nearest `Cargo.toml`; hardcoding `2021` would silently diverge from what `cargo fmt` does in CI after an edition bump. Grouping also makes a commit spanning several crates work. The hook stays best-effort (`--no-verify` bypasses it), so CI is the real gate.

Also adds `pnpm format:native` for symmetry with `test:native`/`lint:native`, and a one-phrase CLAUDE.md update so the Commands section no longer understates what gates CI.

## Toolchain

`rust-toolchain.toml` pins `1.96`; locally `rustc 1.96.1 (31fca3adb 2026-06-26)` and `rustfmt 1.9.0-stable (31fca3adb2 2026-06-26)` — **same commit hash**, and the runner's rustup installs from that same pin, so CI will agree with what was verified here. No version-skew risk.

## Verification

- `./scripts/cargo-native.sh fmt --all --check` → exit 0; and deliberately misformatting a file makes it exit 1, so the gate actually bites
- `pnpm test:native` → 144 tests, 0 failures
- `pnpm lint:native` → clean
- `pnpm format:native` → idempotent (no diff on re-run)
- Hook verified end to end by staging misformatted `.rs` files and committing: once in a single crate, then across three crates at once. Both formatted the staged content before it was committed and left the worktree clean.
- Not run: `pnpm test:e2e` (Node 22 here; needs 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)