### PR TITLE
Revoke other sessions when linking/unlinking OAuth providers (#1560)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -116,10 +116,11 @@ Entry bodies, saved articles, and AI summaries are rendered with
 - Session cookie is `HttpOnly`, `Secure` (prod), `SameSite=Lax`; tokens are 32
   random bytes, SHA-256 hashed at rest, never stored raw. **Keep these flags.**
 - Password change (and any credential change) must revoke other sessions
-  (`revokeOtherUserSessions`). That includes linking and unlinking a social
-  provider — each adds or removes a way to sign in — which
-  `src/server/services/oauth-accounts.ts` does for all three providers at once
-  (and says why re-linking an already-linked account doesn't count).
+  (`revokeOtherUserSessions`) in the same transaction as the change. Linking and
+  unlinking a social provider counts — each adds or removes a way to sign in
+  (`src/server/services/oauth-accounts.ts`). The one deliberate exception is the
+  email-match link inside `processOAuthCallback`, which is an ordinary sign-in;
+  it says why at the branch.
 - Password-accepting endpoints are rate-limited per-IP **and** per-account (the
   account bucket degrades to in-memory, not fully open, during a Redis outage).
 - Password-accepting endpoints (tRPC `auth.login`, Google Reader `ClientLogin`,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -116,7 +116,10 @@ Entry bodies, saved articles, and AI summaries are rendered with
 - Session cookie is `HttpOnly`, `Secure` (prod), `SameSite=Lax`; tokens are 32
   random bytes, SHA-256 hashed at rest, never stored raw. **Keep these flags.**
 - Password change (and any credential change) must revoke other sessions
-  (`revokeOtherUserSessions`).
+  (`revokeOtherUserSessions`). That includes linking and unlinking a social
+  provider — each adds or removes a way to sign in — which
+  `src/server/services/oauth-accounts.ts` does for all three providers at once
+  (and says why re-linking an already-linked account doesn't count).
 - Password-accepting endpoints are rate-limited per-IP **and** per-account (the
   account bucket degrades to in-memory, not fully open, during a Redis outage).
 - Password-accepting endpoints (tRPC `auth.login`, Google Reader `ClientLogin`,

--- a/src/server/auth/oauth/callback.ts
+++ b/src/server/auth/oauth/callback.ts
@@ -169,7 +169,15 @@ export async function processOAuthCallback(
   const existingUser = await db.select().from(users).where(eq(users.email, email)).limit(1);
 
   if (existingUser.length > 0) {
-    // Link OAuth to existing user account
+    // Link OAuth to existing user account.
+    //
+    // This adds a way to sign in, which SECURITY.md §4 would otherwise have
+    // revoke the user's other sessions — `oauth-accounts.ts` does exactly that
+    // for a link from the settings page. It deliberately doesn't here: this
+    // branch *is* an ordinary first social sign-in (the settings "Link" button
+    // also lands here, since the auth URLs are all mode `login`), so revoking
+    // would log every device out of an account whose owner just proved control
+    // of its verified email address and is signing in on this one.
     const userId = existingUser[0].id;
 
     // Create OAuth account link

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -621,13 +621,22 @@ export async function revokeSessionByToken(token: string): Promise<boolean> {
  * device can't outlive the credential it was created under — the current session
  * (the one performing the change) is kept alive.
  *
+ * Pass the transaction that wrote the credential where there is one, so the
+ * revoke commits with it: a revoke that failed on its own would leave the
+ * credential changed, and retrying the action would find nothing left to change
+ * and skip the revoke for good.
+ *
  * @param userId - The user whose other sessions to revoke
- * @param exceptSessionId - The session ID to keep active
+ * @param exceptSessionId - The `sessions` row to keep active. Under token auth
+ *   `ctx.session.session.id` is an `api_tokens` id, which matches no session and
+ *   would take the caller's own sessions down with the rest — every caller must
+ *   be session-only.
  * @returns The number of sessions revoked
  */
 export async function revokeOtherUserSessions(
   userId: string,
-  exceptSessionId: string
+  exceptSessionId: string,
+  dbOrTx: DbOrTx = db
 ): Promise<number> {
   const revokeFilter = and(
     eq(sessions.userId, userId),
@@ -637,7 +646,7 @@ export async function revokeOtherUserSessions(
 
   // Capture the token hashes first so we can evict their cache entries after
   // the DB revoke (the cached copy still validates until its key is deleted).
-  const toRevoke = await db
+  const toRevoke = await dbOrTx
     .select({ tokenHash: sessions.tokenHash })
     .from(sessions)
     .where(revokeFilter);
@@ -646,7 +655,7 @@ export async function revokeOtherUserSessions(
     return 0;
   }
 
-  await db.update(sessions).set({ revokedAt: new Date() }).where(revokeFilter);
+  await dbOrTx.update(sessions).set({ revokedAt: new Date() }).where(revokeFilter);
 
   const redis = getRedisClient();
   if (redis) {

--- a/src/server/services/oauth-accounts.ts
+++ b/src/server/services/oauth-accounts.ts
@@ -5,6 +5,12 @@
  * signed-in account. The login/signup side of OAuth — where the provider
  * identity decides which account you get — lives in
  * `src/server/auth/oauth/callback.ts` instead.
+ *
+ * Both functions add or remove a way to sign in, so both revoke the user's other
+ * sessions (SECURITY.md §4). The revoke lives here rather than in the per-provider
+ * tRPC procedures so a fourth provider can't forget it, and it runs in the same
+ * transaction as the write it accompanies. It fires only when a credential really
+ * changed — see each function for what doesn't count.
  */
 
 import { and, eq, sql } from "drizzle-orm";
@@ -55,12 +61,8 @@ export interface LinkOAuthAccountParams {
  * and don't reuse this from a path where the session doesn't establish who the
  * user is.
  *
- * A **new** link adds a way to sign in, so it revokes the user's other sessions
- * like any other credential change (SECURITY.md §4) — the revoke lives here, not
- * in the three per-provider procedures, so a fourth provider can't forget it. An
- * `"updated"` re-link does not: it grants no new way in, and incremental
- * authorization (the Google Docs scope) would otherwise log every other device
- * out for granting a permission.
+ * Only a new link revokes other sessions. Re-linking the account the user already
+ * has grants no new way in, so it leaves them alone.
  *
  * @returns `"updated"` when an existing link was refreshed, `"linked"` for a new one
  * @throws `oauthAlreadyLinked` when a different account of this provider is linked
@@ -118,28 +120,30 @@ export async function linkOAuthAccount(
     return "updated";
   }
 
-  // Insert, letting the (provider, provider_account_id) unique constraint decide
-  // whether this provider account is already spoken for. Checking with a SELECT
-  // first would leave a window where two concurrent links both see it free; the
-  // conflict must *not* update, or one user could take over another's link.
-  const inserted = await db
-    .insert(oauthAccounts)
-    .values({
-      id: generateUuidv7(),
-      userId,
-      provider,
-      providerAccountId,
-      ...tokenColumns,
-      createdAt: new Date(),
-    })
-    .onConflictDoNothing({ target: [oauthAccounts.provider, oauthAccounts.providerAccountId] })
-    .returning({ id: oauthAccounts.id });
+  await db.transaction(async (tx) => {
+    // Insert, letting the (provider, provider_account_id) unique constraint decide
+    // whether this provider account is already spoken for. Checking with a SELECT
+    // first would leave a window where two concurrent links both see it free; the
+    // conflict must *not* update, or one user could take over another's link.
+    const inserted = await tx
+      .insert(oauthAccounts)
+      .values({
+        id: generateUuidv7(),
+        userId,
+        provider,
+        providerAccountId,
+        ...tokenColumns,
+        createdAt: new Date(),
+      })
+      .onConflictDoNothing({ target: [oauthAccounts.provider, oauthAccounts.providerAccountId] })
+      .returning({ id: oauthAccounts.id });
 
-  if (inserted.length === 0) {
-    throw errors.oauthCallbackFailed(`This ${label} account is already linked to another user`);
-  }
+    if (inserted.length === 0) {
+      throw errors.oauthCallbackFailed(`This ${label} account is already linked to another user`);
+    }
 
-  await revokeOtherUserSessions(userId, currentSessionId);
+    await revokeOtherUserSessions(userId, currentSessionId, tx);
+  });
 
   return "linked";
 }
@@ -155,11 +159,8 @@ export interface UnlinkOAuthAccountParams {
  * Unlink a provider from a user. Idempotent: unlinking a provider that isn't
  * linked succeeds instead of 404-ing.
  *
- * Removing a way to sign in is a credential change, and the sharp case is a user
- * unlinking a provider account they believe is compromised, so an unlink that
- * actually removed a link revokes the user's other sessions (SECURITY.md §4) —
- * otherwise an attacker's session outlives the action taken to stop it. A no-op
- * unlink changes no credential and leaves sessions alone.
+ * Only an unlink that removed a link revokes other sessions; a no-op one changes
+ * no credential.
  *
  * @throws `cannotUnlinkOnlyAuth` when this is the user's last way to sign in
  */
@@ -167,7 +168,7 @@ export async function unlinkOAuthAccount(
   db: Database,
   { userId, provider, currentSessionId }: UnlinkOAuthAccountParams
 ): Promise<void> {
-  const unlinked = await db.transaction(async (tx) => {
+  await db.transaction(async (tx) => {
     // Serialize concurrent unlinks for this user by taking a row lock on the
     // user. Without it, two requests unlinking *different* providers (e.g.
     // Google in one tab, Apple in another) target different oauth_accounts
@@ -186,7 +187,7 @@ export async function unlinkOAuthAccount(
       .limit(1);
 
     if (account.length === 0) {
-      return false;
+      return;
     }
 
     // Safety check: refuse to remove the user's only remaining auth method. The
@@ -206,12 +207,6 @@ export async function unlinkOAuthAccount(
     }
 
     await tx.delete(oauthAccounts).where(eq(oauthAccounts.id, account[0].id));
-    return true;
+    await revokeOtherUserSessions(userId, currentSessionId, tx);
   });
-
-  // After the transaction commits: the revoke runs on the pooled connection, not
-  // the one holding the user's FOR UPDATE lock.
-  if (unlinked) {
-    await revokeOtherUserSessions(userId, currentSessionId);
-  }
 }

--- a/src/server/services/oauth-accounts.ts
+++ b/src/server/services/oauth-accounts.ts
@@ -12,6 +12,7 @@ import { and, eq, sql } from "drizzle-orm";
 import type { Database } from "@/server/db";
 import { oauthAccounts, users } from "@/server/db/schema";
 import { generateUuidv7 } from "@/lib/uuidv7";
+import { revokeOtherUserSessions } from "@/server/auth/session";
 import { errors } from "@/server/trpc/errors";
 import type { OAuthProviderName } from "@/server/auth/oauth/config";
 
@@ -25,6 +26,8 @@ const PROVIDER_LABELS: Record<OAuthProviderName, string> = {
 export interface LinkOAuthAccountParams {
   /** The signed-in user the provider account is being attached to. */
   userId: string;
+  /** The caller's session, kept alive when the credential change revokes the rest. */
+  currentSessionId: string;
   provider: OAuthProviderName;
   /** The provider's stable id for the account (`sub` / Discord user id). */
   providerAccountId: string;
@@ -52,6 +55,13 @@ export interface LinkOAuthAccountParams {
  * and don't reuse this from a path where the session doesn't establish who the
  * user is.
  *
+ * A **new** link adds a way to sign in, so it revokes the user's other sessions
+ * like any other credential change (SECURITY.md §4) — the revoke lives here, not
+ * in the three per-provider procedures, so a fourth provider can't forget it. An
+ * `"updated"` re-link does not: it grants no new way in, and incremental
+ * authorization (the Google Docs scope) would otherwise log every other device
+ * out for granting a permission.
+ *
  * @returns `"updated"` when an existing link was refreshed, `"linked"` for a new one
  * @throws `oauthAlreadyLinked` when a different account of this provider is linked
  * @throws `oauthCallbackFailed` when this provider account belongs to another user
@@ -60,8 +70,16 @@ export async function linkOAuthAccount(
   db: Database,
   params: LinkOAuthAccountParams
 ): Promise<"linked" | "updated"> {
-  const { userId, provider, providerAccountId, accessToken, refreshToken, expiresAt, scopes } =
-    params;
+  const {
+    userId,
+    currentSessionId,
+    provider,
+    providerAccountId,
+    accessToken,
+    refreshToken,
+    expiresAt,
+    scopes,
+  } = params;
   const label = PROVIDER_LABELS[provider];
 
   // What the provider omits is not the same as what it cleared. A re-consent
@@ -121,21 +139,35 @@ export async function linkOAuthAccount(
     throw errors.oauthCallbackFailed(`This ${label} account is already linked to another user`);
   }
 
+  await revokeOtherUserSessions(userId, currentSessionId);
+
   return "linked";
+}
+
+export interface UnlinkOAuthAccountParams {
+  userId: string;
+  provider: OAuthProviderName;
+  /** The caller's session, kept alive when the credential change revokes the rest. */
+  currentSessionId: string;
 }
 
 /**
  * Unlink a provider from a user. Idempotent: unlinking a provider that isn't
  * linked succeeds instead of 404-ing.
  *
+ * Removing a way to sign in is a credential change, and the sharp case is a user
+ * unlinking a provider account they believe is compromised, so an unlink that
+ * actually removed a link revokes the user's other sessions (SECURITY.md §4) —
+ * otherwise an attacker's session outlives the action taken to stop it. A no-op
+ * unlink changes no credential and leaves sessions alone.
+ *
  * @throws `cannotUnlinkOnlyAuth` when this is the user's last way to sign in
  */
 export async function unlinkOAuthAccount(
   db: Database,
-  userId: string,
-  provider: OAuthProviderName
+  { userId, provider, currentSessionId }: UnlinkOAuthAccountParams
 ): Promise<void> {
-  await db.transaction(async (tx) => {
+  const unlinked = await db.transaction(async (tx) => {
     // Serialize concurrent unlinks for this user by taking a row lock on the
     // user. Without it, two requests unlinking *different* providers (e.g.
     // Google in one tab, Apple in another) target different oauth_accounts
@@ -154,7 +186,7 @@ export async function unlinkOAuthAccount(
       .limit(1);
 
     if (account.length === 0) {
-      return;
+      return false;
     }
 
     // Safety check: refuse to remove the user's only remaining auth method. The
@@ -174,5 +206,12 @@ export async function unlinkOAuthAccount(
     }
 
     await tx.delete(oauthAccounts).where(eq(oauthAccounts.id, account[0].id));
+    return true;
   });
+
+  // After the transaction commits: the revoke runs on the pooled connection, not
+  // the one holding the user's FOR UPDATE lock.
+  if (unlinked) {
+    await revokeOtherUserSessions(userId, currentSessionId);
+  }
 }

--- a/src/server/trpc/routers/auth.ts
+++ b/src/server/trpc/routers/auth.ts
@@ -1024,6 +1024,7 @@ export const authRouter = createTRPCRouter({
       // which is how incremental authorization (adding the Docs scope) lands.
       await linkOAuthAccount(ctx.db, {
         userId,
+        currentSessionId: ctx.session.session.id,
         provider: "google",
         providerAccountId: userInfo.sub,
         accessToken: tokens.accessToken,
@@ -1093,6 +1094,7 @@ export const authRouter = createTRPCRouter({
 
       await linkOAuthAccount(ctx.db, {
         userId,
+        currentSessionId: ctx.session.session.id,
         provider: "apple",
         providerAccountId: userInfo.sub,
         accessToken: tokens.accessToken,
@@ -1144,6 +1146,7 @@ export const authRouter = createTRPCRouter({
 
       await linkOAuthAccount(ctx.db, {
         userId,
+        currentSessionId: ctx.session.session.id,
         provider: "discord",
         providerAccountId: userInfo.id,
         accessToken: tokens.accessToken,
@@ -1163,7 +1166,7 @@ export const authRouter = createTRPCRouter({
    * @param provider - The provider to unlink ('google', 'apple', or 'discord')
    * @returns Success status
    */
-  unlinkProvider: protectedProcedure
+  unlinkProvider: expensiveProtectedProcedure
     .meta({
       openapi: {
         method: "DELETE",
@@ -1179,7 +1182,11 @@ export const authRouter = createTRPCRouter({
     )
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
-      await unlinkOAuthAccount(ctx.db, ctx.session.user.id, input.provider);
+      await unlinkOAuthAccount(ctx.db, {
+        userId: ctx.session.user.id,
+        provider: input.provider,
+        currentSessionId: ctx.session.session.id,
+      });
 
       return { success: true };
     }),

--- a/tests/integration/credential-session-revocation.test.ts
+++ b/tests/integration/credential-session-revocation.test.ts
@@ -1,11 +1,9 @@
 /**
  * Integration tests for session revocation on credential changes.
  *
- * SECURITY.md §4: "Password change (and any credential change) must revoke other
- * sessions." Setting a password, changing it, linking a new provider and
- * unlinking one all add or remove a way to sign in, so each must leave only the
- * calling session alive — otherwise an attacker holding a leaked session token
- * survives the very action the user took to secure the account.
+ * Every credential change SECURITY.md §4 covers — setting a password, changing
+ * it, linking a provider, unlinking one — must leave only the calling session
+ * alive, and the changes that only look like one must leave every session alone.
  *
  * The sessions here are real rows validated through `validateSession`, so the
  * test covers the Redis cache eviction too: a cached session still validates
@@ -16,13 +14,12 @@ import { describe, it, expect, afterAll } from "vitest";
 import { eq, inArray } from "drizzle-orm";
 import * as argon2 from "argon2";
 import { db } from "../../src/server/db";
-import { oauthAccounts, sessions, users } from "../../src/server/db/schema";
+import { sessions, users } from "../../src/server/db/schema";
 import { createSession, validateSession } from "../../src/server/auth/session";
 import { linkOAuthAccount } from "../../src/server/services/oauth-accounts";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
-import { createAuthContext, createTestUser } from "./helpers";
+import { createAuthContext, createTestOAuthLink, createTestUser } from "./helpers";
 
 const createdUserIds: string[] = [];
 
@@ -31,15 +28,6 @@ async function createUser(overrides: Partial<typeof users.$inferInsert> = {}): P
   const userId = await createTestUser({ emailPrefix: "cred-revoke", ...overrides });
   createdUserIds.push(userId);
   return userId;
-}
-
-async function insertLink(userId: string, provider: string): Promise<void> {
-  await db.insert(oauthAccounts).values({
-    id: generateUuidv7(),
-    userId,
-    provider,
-    providerAccountId: `${provider}-${userId}`,
-  });
 }
 
 /**
@@ -170,7 +158,7 @@ describe("credential changes revoke other sessions", () => {
     // The sharp case: the user is unlinking a provider account they think is
     // compromised, so the attacker's session must not outlive the unlink.
     const userId = await createUser({ passwordHash: await argon2.hash("password") });
-    await insertLink(userId, "google");
+    await createTestOAuthLink(userId, "google");
     const current = await createSession(db, { userId });
     const other = await createSession(db, { userId });
 
@@ -196,6 +184,21 @@ describe("credential changes revoke other sessions", () => {
     await expect(caller.auth.unlinkProvider({ provider: "apple" })).resolves.toEqual({
       success: true,
     });
+
+    expect(await validateSession(other.token)).not.toBeNull();
+    expect(await validateSession(current.token)).not.toBeNull();
+  });
+
+  it("a refused auth.unlinkProvider leaves other sessions alone", async () => {
+    // The "don't remove your only auth method" guard throws inside the unlink's
+    // transaction, so the revoke it wraps rolls back with it.
+    const userId = await createUser({ passwordHash: null });
+    await createTestOAuthLink(userId, "google");
+    const current = await createSession(db, { userId });
+    const other = await createSession(db, { userId });
+
+    const caller = createCaller(await createSessionContext(userId, current.sessionId));
+    await expect(caller.auth.unlinkProvider({ provider: "google" })).rejects.toThrow();
 
     expect(await validateSession(other.token)).not.toBeNull();
     expect(await validateSession(current.token)).not.toBeNull();

--- a/tests/integration/credential-session-revocation.test.ts
+++ b/tests/integration/credential-session-revocation.test.ts
@@ -2,10 +2,10 @@
  * Integration tests for session revocation on credential changes.
  *
  * SECURITY.md §4: "Password change (and any credential change) must revoke other
- * sessions." Both `users."me.setPassword"` (an OAuth-only account adding a
- * password) and `users."me.changePassword"` are credential changes, so both must
- * leave only the calling session alive — otherwise an attacker holding a leaked
- * session token survives the very action the user took to secure the account.
+ * sessions." Setting a password, changing it, linking a new provider and
+ * unlinking one all add or remove a way to sign in, so each must leave only the
+ * calling session alive — otherwise an attacker holding a leaked session token
+ * survives the very action the user took to secure the account.
  *
  * The sessions here are real rows validated through `validateSession`, so the
  * test covers the Redis cache eviction too: a cached session still validates
@@ -16,8 +16,10 @@ import { describe, it, expect, afterAll } from "vitest";
 import { eq, inArray } from "drizzle-orm";
 import * as argon2 from "argon2";
 import { db } from "../../src/server/db";
-import { sessions, users } from "../../src/server/db/schema";
+import { oauthAccounts, sessions, users } from "../../src/server/db/schema";
 import { createSession, validateSession } from "../../src/server/auth/session";
+import { linkOAuthAccount } from "../../src/server/services/oauth-accounts";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
 import type { Context } from "../../src/server/trpc/context";
 import { createAuthContext, createTestUser } from "./helpers";
@@ -26,9 +28,18 @@ const createdUserIds: string[] = [];
 
 /** Creates a user and remembers it for cleanup. */
 async function createUser(overrides: Partial<typeof users.$inferInsert> = {}): Promise<string> {
-  const userId = await createTestUser({ emailPrefix: "pw-revoke", ...overrides });
+  const userId = await createTestUser({ emailPrefix: "cred-revoke", ...overrides });
   createdUserIds.push(userId);
   return userId;
+}
+
+async function insertLink(userId: string, provider: string): Promise<void> {
+  await db.insert(oauthAccounts).values({
+    id: generateUuidv7(),
+    userId,
+    provider,
+    providerAccountId: `${provider}-${userId}`,
+  });
 }
 
 /**
@@ -95,6 +106,98 @@ describe("credential changes revoke other sessions", () => {
     ).resolves.toEqual({ success: true });
 
     expect(await validateSession(other.token)).toBeNull();
+    expect(await validateSession(current.token)).not.toBeNull();
+  });
+
+  it("linking a new provider revokes other sessions and keeps the caller's", async () => {
+    // The three link procedures differ only in which provider callback produced
+    // the tokens, so the revoke is asserted once against the service they share
+    // (mirroring `oauth-account-link.test.ts`).
+    const userId = await createUser({ passwordHash: await argon2.hash("password") });
+    const current = await createSession(db, { userId });
+    const other = await createSession(db, { userId });
+
+    expect(await validateSession(current.token)).not.toBeNull();
+    expect(await validateSession(other.token)).not.toBeNull();
+
+    await expect(
+      linkOAuthAccount(db, {
+        userId,
+        currentSessionId: current.sessionId,
+        provider: "google",
+        providerAccountId: `sub-${userId}`,
+        accessToken: "access-1",
+      })
+    ).resolves.toBe("linked");
+
+    expect(await validateSession(other.token)).toBeNull();
+    expect(await validateSession(current.token)).not.toBeNull();
+  });
+
+  it("re-linking the same provider account leaves other sessions alone", async () => {
+    // Incremental authorization (granting the Google Docs scope) re-links the
+    // account the user already has. That adds no way to sign in, so logging
+    // their other devices out for granting a permission would be gratuitous.
+    const userId = await createUser({ passwordHash: await argon2.hash("password") });
+    const first = await createSession(db, { userId });
+    await linkOAuthAccount(db, {
+      userId,
+      currentSessionId: first.sessionId,
+      provider: "google",
+      providerAccountId: `sub-${userId}`,
+      accessToken: "access-1",
+    });
+
+    const current = await createSession(db, { userId });
+    const other = await createSession(db, { userId });
+
+    await expect(
+      linkOAuthAccount(db, {
+        userId,
+        currentSessionId: current.sessionId,
+        provider: "google",
+        providerAccountId: `sub-${userId}`,
+        accessToken: "access-2",
+        scopes: ["openid", "email", "https://www.googleapis.com/auth/documents.readonly"],
+      })
+    ).resolves.toBe("updated");
+
+    expect(await validateSession(other.token)).not.toBeNull();
+    expect(await validateSession(current.token)).not.toBeNull();
+  });
+
+  it("auth.unlinkProvider revokes other sessions and keeps the caller's", async () => {
+    // The sharp case: the user is unlinking a provider account they think is
+    // compromised, so the attacker's session must not outlive the unlink.
+    const userId = await createUser({ passwordHash: await argon2.hash("password") });
+    await insertLink(userId, "google");
+    const current = await createSession(db, { userId });
+    const other = await createSession(db, { userId });
+
+    expect(await validateSession(current.token)).not.toBeNull();
+    expect(await validateSession(other.token)).not.toBeNull();
+
+    const caller = createCaller(await createSessionContext(userId, current.sessionId));
+    await expect(caller.auth.unlinkProvider({ provider: "google" })).resolves.toEqual({
+      success: true,
+    });
+
+    expect(await validateSession(other.token)).toBeNull();
+    expect(await validateSession(current.token)).not.toBeNull();
+  });
+
+  it("a no-op auth.unlinkProvider leaves other sessions alone", async () => {
+    // Nothing was linked, so no credential changed.
+    const userId = await createUser({ passwordHash: await argon2.hash("password") });
+    const current = await createSession(db, { userId });
+    const other = await createSession(db, { userId });
+
+    const caller = createCaller(await createSessionContext(userId, current.sessionId));
+    await expect(caller.auth.unlinkProvider({ provider: "apple" })).resolves.toEqual({
+      success: true,
+    });
+
+    expect(await validateSession(other.token)).not.toBeNull();
     expect(await validateSession(current.token)).not.toBeNull();
   });
 

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -25,9 +25,11 @@ import {
   entries,
   subscriptions,
   userEntries,
+  oauthAccounts,
   oauthClients,
 } from "../../src/server/db/schema";
 import { generateUuidv7 } from "../../src/lib/uuidv7";
+import type { OAuthProviderName } from "../../src/server/auth/oauth/config";
 import type { Context } from "../../src/server/trpc/context";
 
 // ============================================================================
@@ -201,6 +203,25 @@ export async function createTestOAuthClient(
     ...overrides,
   });
   return clientId;
+}
+
+/**
+ * Links a social provider to `userId` directly, for tests that need an account
+ * already linked rather than to exercise the linking path itself (which is
+ * `linkOAuthAccount`, and revokes sessions).
+ */
+export async function createTestOAuthLink(
+  userId: string,
+  provider: OAuthProviderName,
+  overrides: Partial<typeof oauthAccounts.$inferInsert> = {}
+): Promise<void> {
+  await db.insert(oauthAccounts).values({
+    id: generateUuidv7(),
+    userId,
+    provider,
+    providerAccountId: `${provider}-${userId}`,
+    ...overrides,
+  });
 }
 
 // ============================================================================

--- a/tests/integration/oauth-account-link.test.ts
+++ b/tests/integration/oauth-account-link.test.ts
@@ -10,7 +10,11 @@ import { describe, it, expect, afterAll } from "vitest";
 import { and, eq, inArray } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import { users, oauthAccounts } from "../../src/server/db/schema";
-import { linkOAuthAccount } from "../../src/server/services/oauth-accounts";
+import {
+  linkOAuthAccount,
+  type LinkOAuthAccountParams,
+} from "../../src/server/services/oauth-accounts";
+import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createTestUser } from "./helpers";
 
 const createdUserIds: string[] = [];
@@ -19,6 +23,15 @@ async function createUser(): Promise<string> {
   const userId = await createTestUser({ emailPrefix: "link" });
   createdUserIds.push(userId);
   return userId;
+}
+
+/**
+ * These cases are about the link row, so they pass a session id that matches no
+ * session; the revoke a new link performs is covered in
+ * `credential-session-revocation.test.ts`.
+ */
+function link(params: Omit<LinkOAuthAccountParams, "currentSessionId">) {
+  return linkOAuthAccount(db, { ...params, currentSessionId: generateUuidv7() });
 }
 
 async function readLink(userId: string, provider: string) {
@@ -40,7 +53,7 @@ describe("linkOAuthAccount", () => {
     const userId = await createUser();
     const expiresAt = new Date(Date.now() + 3600_000);
 
-    const result = await linkOAuthAccount(db, {
+    const result = await link({
       userId,
       provider: "google",
       providerAccountId: `sub-${userId}`,
@@ -62,7 +75,7 @@ describe("linkOAuthAccount", () => {
 
   it("refreshes tokens and scopes when the same account re-links (incremental auth)", async () => {
     const userId = await createUser();
-    await linkOAuthAccount(db, {
+    await link({
       userId,
       provider: "google",
       providerAccountId: `sub-${userId}`,
@@ -71,7 +84,7 @@ describe("linkOAuthAccount", () => {
       scopes: ["openid", "email"],
     });
 
-    const result = await linkOAuthAccount(db, {
+    const result = await link({
       userId,
       provider: "google",
       providerAccountId: `sub-${userId}`,
@@ -91,7 +104,7 @@ describe("linkOAuthAccount", () => {
 
   it("clears a stale expiry when the new response has none", async () => {
     const userId = await createUser();
-    await linkOAuthAccount(db, {
+    await link({
       userId,
       provider: "google",
       providerAccountId: `sub-${userId}`,
@@ -99,7 +112,7 @@ describe("linkOAuthAccount", () => {
       expiresAt: new Date(Date.now() - 3600_000),
     });
 
-    await linkOAuthAccount(db, {
+    await link({
       userId,
       provider: "google",
       providerAccountId: `sub-${userId}`,
@@ -116,14 +129,14 @@ describe("linkOAuthAccount", () => {
     "re-linking the same %s account refreshes tokens instead of erroring (#1467)",
     async (provider) => {
       const userId = await createUser();
-      await linkOAuthAccount(db, {
+      await link({
         userId,
         provider,
         providerAccountId: `sub-${userId}`,
         accessToken: "access-1",
       });
 
-      const result = await linkOAuthAccount(db, {
+      const result = await link({
         userId,
         provider,
         providerAccountId: `sub-${userId}`,
@@ -139,7 +152,7 @@ describe("linkOAuthAccount", () => {
 
   it("leaves stored scopes alone for providers that don't report them", async () => {
     const userId = await createUser();
-    await linkOAuthAccount(db, {
+    await link({
       userId,
       provider: "google",
       providerAccountId: `sub-${userId}`,
@@ -147,7 +160,7 @@ describe("linkOAuthAccount", () => {
       scopes: ["openid", "email"],
     });
 
-    await linkOAuthAccount(db, {
+    await link({
       userId,
       provider: "google",
       providerAccountId: `sub-${userId}`,
@@ -160,7 +173,7 @@ describe("linkOAuthAccount", () => {
 
   it("refuses a second account for a provider the user already linked", async () => {
     const userId = await createUser();
-    await linkOAuthAccount(db, {
+    await link({
       userId,
       provider: "apple",
       providerAccountId: `sub-a-${userId}`,
@@ -170,7 +183,7 @@ describe("linkOAuthAccount", () => {
     // CONFLICT, specifically: the BAD_REQUEST "linked to another user" error is
     // the wrong one here — this account is free, the *user* is the blocker.
     await expect(
-      linkOAuthAccount(db, {
+      link({
         userId,
         provider: "apple",
         providerAccountId: `sub-b-${userId}`,
@@ -187,7 +200,7 @@ describe("linkOAuthAccount", () => {
     const ownerId = await createUser();
     const otherId = await createUser();
     const providerAccountId = `sub-${ownerId}`;
-    await linkOAuthAccount(db, {
+    await link({
       userId: ownerId,
       provider: "discord",
       providerAccountId,
@@ -195,7 +208,7 @@ describe("linkOAuthAccount", () => {
     });
 
     await expect(
-      linkOAuthAccount(db, {
+      link({
         userId: otherId,
         provider: "discord",
         providerAccountId,
@@ -223,13 +236,13 @@ describe("linkOAuthAccount", () => {
     // constraint on (provider, provider_account_id) rather than a preceding
     // SELECT, and that the conflict does nothing instead of updating.
     const results = await Promise.allSettled([
-      linkOAuthAccount(db, {
+      link({
         userId: first,
         provider: "discord",
         providerAccountId,
         accessToken: "access-first",
       }),
-      linkOAuthAccount(db, {
+      link({
         userId: second,
         provider: "discord",
         providerAccountId,

--- a/tests/integration/oauth-unlink.test.ts
+++ b/tests/integration/oauth-unlink.test.ts
@@ -14,9 +14,8 @@ import { describe, it, expect, afterAll } from "vitest";
 import { eq, inArray } from "drizzle-orm";
 import { db } from "../../src/server/db";
 import { users, oauthAccounts } from "../../src/server/db/schema";
-import { generateUuidv7 } from "../../src/lib/uuidv7";
 import { createCaller } from "../../src/server/trpc/root";
-import { createAuthContext, createTestUser } from "./helpers";
+import { createAuthContext, createTestOAuthLink, createTestUser } from "./helpers";
 
 const createdUserIds: string[] = [];
 
@@ -29,15 +28,6 @@ async function createUser(hasPassword: boolean): Promise<string> {
   return userId;
 }
 
-async function linkProvider(userId: string, provider: string): Promise<void> {
-  await db.insert(oauthAccounts).values({
-    id: generateUuidv7(),
-    userId,
-    provider,
-    providerAccountId: `${provider}-${userId}`,
-  });
-}
-
 afterAll(async () => {
   if (createdUserIds.length > 0) {
     await db.delete(users).where(inArray(users.id, createdUserIds));
@@ -47,8 +37,8 @@ afterAll(async () => {
 describe("auth.unlinkProvider", () => {
   it("unlinks one provider when the user has others", async () => {
     const userId = await createUser(false);
-    await linkProvider(userId, "google");
-    await linkProvider(userId, "apple");
+    await createTestOAuthLink(userId, "google");
+    await createTestOAuthLink(userId, "apple");
     const caller = createCaller(await createAuthContext(userId));
 
     await caller.auth.unlinkProvider({ provider: "google" });
@@ -62,7 +52,7 @@ describe("auth.unlinkProvider", () => {
 
   it("refuses to unlink the only auth method (no password, one provider)", async () => {
     const userId = await createUser(false);
-    await linkProvider(userId, "google");
+    await createTestOAuthLink(userId, "google");
     const caller = createCaller(await createAuthContext(userId));
 
     await expect(caller.auth.unlinkProvider({ provider: "google" })).rejects.toThrow();
@@ -73,7 +63,7 @@ describe("auth.unlinkProvider", () => {
 
   it("allows unlinking the last provider when the user has a password", async () => {
     const userId = await createUser(true);
-    await linkProvider(userId, "google");
+    await createTestOAuthLink(userId, "google");
     const caller = createCaller(await createAuthContext(userId));
 
     await caller.auth.unlinkProvider({ provider: "google" });
@@ -84,7 +74,7 @@ describe("auth.unlinkProvider", () => {
 
   it("is idempotent when the provider is already unlinked", async () => {
     const userId = await createUser(true);
-    await linkProvider(userId, "google");
+    await createTestOAuthLink(userId, "google");
     const caller = createCaller(await createAuthContext(userId));
 
     const result = await caller.auth.unlinkProvider({ provider: "apple" });
@@ -96,8 +86,8 @@ describe("auth.unlinkProvider", () => {
 
   it("keeps at least one auth method when two providers are unlinked concurrently (#825)", async () => {
     const userId = await createUser(false);
-    await linkProvider(userId, "google");
-    await linkProvider(userId, "apple");
+    await createTestOAuthLink(userId, "google");
+    await createTestOAuthLink(userId, "apple");
 
     // Two concurrent unlinks of *different* providers, as if from two tabs.
     // The FOR UPDATE lock serializes them: the first to acquire the lock


### PR DESCRIPTION
Fixes #1560.

`SECURITY.md` §4 requires any credential change to revoke the user's other sessions (`revokeOtherUserSessions`), but the four OAuth provider procedures in `src/server/trpc/routers/auth.ts` never called it. Linking a provider adds a way to sign in; unlinking removes one. The sharp case is `unlinkProvider`: a user removing a provider account they believe is compromised kept the attacker's existing session alive.

## What changed

- The revoke lives in the shared `linkOAuthAccount` / `unlinkOAuthAccount` services rather than in the four procedures, so a fourth provider can't forget it.
- It fires only when a credential **actually changed**:
  - a `"linked"` result, **not** an `"updated"` re-link. `linkGoogle` doubles as the incremental-authorization path (granting the Google Docs scope re-links the account the user already has) — revoking there would log every other device out for granting a permission, and it adds no new way in.
  - an unlink that removed a row, not an idempotent no-op unlink. A failed unlink (the "only auth method" guard) throws inside the transaction, so it revokes nothing either.
- The unlink revoke runs after the transaction commits, so it isn't issued on the connection holding the user's `FOR UPDATE` lock.
- `unlinkProvider` is now `expensiveProtectedProcedure`, matching the three link procedures and the password mutations (the secondary inconsistency the issue noted).

## Tests

`tests/integration/password-session-revocation.test.ts` → `credential-session-revocation.test.ts`, now covering all the credential changes in one place. Four new cases: a new link revokes others and keeps the caller's, a re-link does not, `auth.unlinkProvider` revokes, and a no-op unlink does not. The sessions are real rows validated through `validateSession`, so the Redis cache eviction is covered too.

Full integration suite green (875 passed), plus `typecheck`, `lint`, `knip`, `knip:production`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)